### PR TITLE
CopyCreate LAA-exe .config file

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -134,6 +134,7 @@ IF "%ERRORLEVEL%" == "9009" GOTO :error
 
 CALL :copy "Program\RunActivity.exe" "Program\RunActivityLAA.exe" || GOTO :error
 editbin /NOLOGO /LARGEADDRESSAWARE "Program\RunActivityLAA.exe" || GOTO :error
+copy "Program\RunActivity.exe.config" "Program\RunActivityLAA.exe.config" || GOTO :error
 ECHO Created large address aware version of RunActivity.exe.
 
 REM Copy version number from OpenRails.exe into all other 1st party files


### PR DESCRIPTION
the LAA-exe is missing a .exe.config file when creating, and does not seem to run without the config. Extending the build script to create an .exe.config for the LAA-exe by copying the one from non-LAA version. Thanks to mbm_OR@ET for reporting and providing a fix

https://bugs.launchpad.net/or/+bug/1828232