### PR TITLE
When .s file requires missing .dds file, the equivalent .ace is picked if existing

### DIFF
--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -65,9 +65,21 @@ namespace Orts.Viewer3D
                 try
                 {
                     Texture2D texture;
-                    if (Path.GetExtension(path) == ".dds" && File.Exists(path))
+                    if (Path.GetExtension(path) == ".dds")
                     {
-                        DDSLib.DDSFromFile(path, GraphicsDevice, true, out texture);
+                        if (File.Exists(path))
+                        {
+                            DDSLib.DDSFromFile(path, GraphicsDevice, true, out texture);
+                        }
+                        else
+                        {
+                            var aceTexture = Path.ChangeExtension(path, ".ace");
+                            if (File.Exists(aceTexture))
+                            {
+                                texture = Orts.Formats.Msts.AceFile.Texture2DFromFile(GraphicsDevice, aceTexture);
+                            }
+                            else texture = defaultTexture;
+                        }
                     }
                     else if (Path.GetExtension(path) == ".ace")
                     {


### PR DESCRIPTION
Bug fix for https://bugs.launchpad.net/or/+bug/1830498 .
See also http://www.elvastower.com/forums/index.php?/topic/33071-track-textures/