### PR TITLE
20190714 correct next station window

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -197,7 +197,7 @@ IF "%Mode%" == "Stable" (
 
 REM Create binary and source zips.
 CALL :delete "OpenRails-%Mode%*.zip" || GOTO :error
-PUSHD "Program" && 7za.exe a -r -tzip "..\OpenRails-%Mode%.zip" . && POPD || GOTO :error
+PUSHD "Program" && 7za.exe a -r -tzip -x^^!*.xml "..\OpenRails-%Mode%.zip" . && POPD || GOTO :error
 7za.exe a -r -tzip -x^^!.* -x^^!obj -x^^!lib -x^^!_build -x^^!*.bak -x^^!Website "OpenRails-%Mode%-Source.zip" "Source" || GOTO :error
 
 ENDLOCAL

--- a/Source/RunActivity/Viewer3D/Popups/NextStationWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/NextStationWindow.cs
@@ -361,20 +361,46 @@ namespace Orts.Viewer3D.Popups
                             }
                         }
 
+                        // attach details
+                        if (playerTimetableTrain.AttachDetails != null)
+                        {
+                            bool attachDetailsValid = false;
+
+                            // attach is not at station - details valid
+                            if (playerTimetableTrain.AttachDetails.StationPlatformReference < 0)
+                            {
+                                attachDetailsValid = true;
+                            }
+                            // no further stations - details valid
+                            if (playerTimetableTrain.StationStops == null || playerTimetableTrain.StationStops.Count <= 0)
+                            {
+                                attachDetailsValid = true;
+                            }
+                            // attach is at next station - details valid
+                            else if (playerTimetableTrain.AttachDetails.StationPlatformReference == playerTimetableTrain.StationStops[0].PlatformReference)
+                            {
+                                attachDetailsValid = true;
+                            }
+
+                            if (attachDetailsValid)
+                            {
+                                if (playerTimetableTrain.AttachDetails.Valid)
+                                {
+                                    Message.Text = Viewer.Catalog.GetString("Train is to attach to : ");
+                                    Message.Text = String.Concat(Message.Text, playerTimetableTrain.AttachDetails.AttachTrainName);
+                                    Message.Color = Color.Orange;
+                                }
+                                else
+                                {
+                                    Message.Text = Viewer.Catalog.GetString("Train is to attach to : ");
+                                    Message.Text = String.Concat(Message.Text, playerTimetableTrain.AttachDetails.AttachTrainName);
+                                    Message.Text = String.Concat(Message.Text, Viewer.Catalog.GetString(" ; other train not yet ready"));
+                                    Message.Color = Color.Orange;
+                                }
+                            }
+                        }
+
                         // general details
-                        if (playerTimetableTrain.AttachDetails != null && playerTimetableTrain.AttachDetails.Valid)
-                        {
-                            Message.Text = Viewer.Catalog.GetString("Train is to attach to : ");
-                            Message.Text = String.Concat(Message.Text, playerTimetableTrain.AttachDetails.AttachTrainName);
-                            Message.Color = Color.Orange;
-                        }
-                        else if (playerTimetableTrain.AttachDetails != null)
-                        {
-                            Message.Text = Viewer.Catalog.GetString("Train is to attach to : ");
-                            Message.Text = String.Concat(Message.Text, playerTimetableTrain.AttachDetails.AttachTrainName);
-                            Message.Text = String.Concat(Message.Text, Viewer.Catalog.GetString(" ; other train not yet ready"));
-                            Message.Color = Color.Orange;
-                        }
                         else if (playerTimetableTrain.PickUpStaticOnForms)
                         {
                             Message.Text = Viewer.Catalog.GetString("Train is to pickup train at end of path");


### PR DESCRIPTION
Display of text "Train is to attach to <other train> at next stop" will only be displayed for correct stop. See bug report #1838235.