### PR TITLE
20190714 preset signal script

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -197,7 +197,7 @@ IF "%Mode%" == "Stable" (
 
 REM Create binary and source zips.
 CALL :delete "OpenRails-%Mode%*.zip" || GOTO :error
-PUSHD "Program" && 7za.exe a -r -tzip "..\OpenRails-%Mode%.zip" . && POPD || GOTO :error
+PUSHD "Program" && 7za.exe a -r -tzip -x^^!*.xml "..\OpenRails-%Mode%.zip" . && POPD || GOTO :error
 7za.exe a -r -tzip -x^^!.* -x^^!obj -x^^!lib -x^^!_build -x^^!*.bak -x^^!Website "OpenRails-%Mode%-Source.zip" "Source" || GOTO :error
 
 ENDLOCAL

--- a/Source/Orts.Simulation/Simulation/Signalling/SIGSCRfile.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/SIGSCRfile.cs
@@ -67,7 +67,7 @@ namespace Orts.Simulation.Signalling
         public static string dpe_fileLoc = @"C:\temp\";     /* file path for debug files */
 #endif
 
-        SignalScripts SignalScripts;
+        public SignalScripts SignalScripts;
 
         //================================================================================================//
         //
@@ -92,13 +92,11 @@ namespace Orts.Simulation.Signalling
 
         public static void SH_update(SignalHead thisHead, SIGSCRfile sigscr)
         {
-
-            SignalScripts.SCRScripts signalScript;
             if (thisHead.signalType == null)
                 return;
-            if (sigscr.SignalScripts.Scripts.TryGetValue(thisHead.signalType, out signalScript))
+            if (thisHead.usedSigScript != null)
             {
-                sigscr.SH_process_script(thisHead, signalScript, sigscr);
+                sigscr.SH_process_script(thisHead, thisHead.usedSigScript, sigscr);
             }
             else
             {

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -12514,6 +12514,7 @@ namespace Orts.Simulation.Signalling
     public class SignalHead
     {
         public SignalType signalType;           // from sigcfg file
+        public SignalScripts.SCRScripts usedSigScript = null;   // used sigscript
         public MstsSignalAspect state = MstsSignalAspect.STOP;
         public int draw_state;
         public int trItemIndex;                 // Index to trItem   
@@ -12623,7 +12624,11 @@ namespace Orts.Simulation.Signalling
             // set signal type
             if (sigCFG.SignalTypes.ContainsKey(sigItem.SignalType))
             {
+                // set signal type
                 signalType = sigCFG.SignalTypes[sigItem.SignalType];
+
+                // get related signalscript
+                Signals.scrfile.SignalScripts.Scripts.TryGetValue(signalType, out usedSigScript);
 
                 // set signal speeds
                 foreach (SignalAspect thisAspect in signalType.Aspects)


### PR DESCRIPTION
Link signal script to signal head once on initiation, not during update.
See blueprint : https://blueprints.launchpad.net/or/+spec/assign-script-to-signalhead