### PR TITLE
Add warning if train has no locomotive but is required

### DIFF
--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -3850,6 +3850,7 @@ namespace Orts.Simulation.Physics
                 if (Cars[idx].IsDriveable)
                     return Cars[idx];
             }
+            Trace.TraceWarning("Train {0} ({1}) has no locomotive!", Name, Number);
             return null;
         }
 


### PR DESCRIPTION
This trace message helps little bit when finding cause of NullReferenceException...

Feature request: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)