### PR TITLE
refactor: Reformat all code with dotnet format

### DIFF
--- a/Source/ContentChecker/Loader.cs
+++ b/Source/ContentChecker/Loader.cs
@@ -70,7 +70,7 @@ namespace ContentChecker
         /// <summary> The number of files that were actually loaded </summary>
         public int FilesLoaded { get; protected set; }
         /// <summary> The number of files that were not loaded but skipped </summary>
-        public int FilesSkipped {get; protected set;}
+        public int FilesSkipped { get; protected set; }
 
         /// <summary> The action to take when an additonal file has been identified. This is intended to be set externally </summary>
         protected Action<string, Loader> AddAdditionalFileAction { get; set; }

--- a/Source/ContentChecker/Program.cs
+++ b/Source/ContentChecker/Program.cs
@@ -68,8 +68,9 @@ namespace ContentChecker
         /// <param name="args">The command line arguments that need to be checked for an iption</param>
         /// <param name="optionNames">The list of option names that need to be found</param>
         /// <returns>true if one of the optionNames is given</returns>
-        static bool OptionsContain(string[] args, IEnumerable<string> optionNames) {
-            return optionNames.Any((option) => args.Contains(option, StringComparer.OrdinalIgnoreCase) );
+        static bool OptionsContain(string[] args, IEnumerable<string> optionNames)
+        {
+            return optionNames.Any((option) => args.Contains(option, StringComparer.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -191,7 +192,8 @@ namespace ContentChecker
             {
                 LoadAllFlat();
             }
-            else {
+            else
+            {
                 LoadWithAdditional(additionType);
             }
 
@@ -314,7 +316,7 @@ namespace ContentChecker
             int minimumBuffer = BUFFERMARGIN + Console.CursorTop;
             if (Console.BufferHeight < minimumBuffer)
             {
-                Console.SetBufferSize(Console.BufferWidth, minimumBuffer + BUFFEREXTENSION );
+                Console.SetBufferSize(Console.BufferWidth, minimumBuffer + BUFFEREXTENSION);
             }
 
         }

--- a/Source/ContentChecker/SignalScriptLoader.cs
+++ b/Source/ContentChecker/SignalScriptLoader.cs
@@ -65,7 +65,8 @@ namespace ContentChecker
                 FilesLoaded = 0;
                 Console.WriteLine("signal script files can not be loaded independently. Try the option /d");
             }
-            else {
+            else
+            {
                 // we want to load the signal scripts one by one, not as a group
                 var scriptFiles = new List<string>() { Path.GetFileName(file) };
                 var scrfile = new SIGSCRfile(new SignalScripts(_sigcfg.ScriptPath, scriptFiles,

--- a/Source/ContentChecker/SmsLoader.cs
+++ b/Source/ContentChecker/SmsLoader.cs
@@ -102,8 +102,8 @@ namespace ContentChecker
             basePath = null;
             Stack<string> subDirectories = new Stack<string>();
             string directory = Path.GetDirectoryName(file);
-            var root=Path.GetPathRoot(file);
-            while (directory.Length > root.Length )
+            var root = Path.GetPathRoot(file);
+            while (directory.Length > root.Length)
             {
                 string subdDirectoryName = Path.GetFileName(directory);
                 if (subdDirectoryName.ToLowerInvariant().Equals("routes"))

--- a/Source/ContentChecker/TrackFileLoader.cs
+++ b/Source/ContentChecker/TrackFileLoader.cs
@@ -74,19 +74,21 @@ namespace ContentChecker
 
         void AddAdditionalSMS(string smsFileName)
         {
-            if (smsFileName == null) { return;  }
+            if (smsFileName == null) { return; }
             string smsInRoute = Path.Combine(Path.Combine(routePath, "SOUND"), smsFileName);
             if (File.Exists(smsInRoute))
             {
                 AddAdditionalFileAction.Invoke(smsInRoute, new SmsLoader());
             }
-            else {
+            else
+            {
                 string smsInBase = Path.Combine(Path.Combine(basePath, "SOUND"), smsFileName);
                 AddAdditionalFileAction.Invoke(smsInBase, new SmsLoader());
             }
         }
 
-        protected override void AddAllFiles() {
+        protected override void AddAllFiles()
+        {
             AddMainFiles();
             AddAllActivities();
             AddAllTiles();

--- a/Source/ContentChecker/WavLoader.cs
+++ b/Source/ContentChecker/WavLoader.cs
@@ -37,7 +37,7 @@ namespace ContentChecker
         /// <param name="file">The file that needs to be loaded</param>
         public override void TryLoading(string file)
         {
-           var soundPiece = new SoundPiece(file, false, false);
+            var soundPiece = new SoundPiece(file, false, false);
         }
     }
 }

--- a/Source/ContentChecker/WorldFileLoader.cs
+++ b/Source/ContentChecker/WorldFileLoader.cs
@@ -37,7 +37,7 @@ namespace ContentChecker
         /// <param name="file">The file that needs to be loaded</param>
         public override void TryLoading(string file)
         {
-            var wf = new WorldFile(file); 
+            var wf = new WorldFile(file);
         }
     }
 }

--- a/Source/Contrib/ActivityEditor/AEWizard/ActivityDescr.cs
+++ b/Source/Contrib/ActivityEditor/AEWizard/ActivityDescr.cs
@@ -5,10 +5,10 @@ using LibAE.Formats;
 
 namespace AEWizard
 {
-	/// <summary>
-	/// Represents a single page within a wizard dialog.
-	/// </summary>
-	public class ActivityDescr : SinglePage
+    /// <summary>
+    /// Represents a single page within a wizard dialog.
+    /// </summary>
+    public class ActivityDescr : SinglePage
     {
         private Panel panel1;
         private TextBox textBox1;
@@ -21,7 +21,7 @@ namespace AEWizard
 
         public String RoutePath;
         public ActivityInfo activityInfo { get; set; }
-       // ==================================================================
+        // ==================================================================
         // Public Constructors
         // ==================================================================
 
@@ -30,11 +30,11 @@ namespace AEWizard
         /// class.
         /// </summary>
         public ActivityDescr()
-		{
+        {
             // Required for Windows Form Designer support
             InitializeComponent();
-            
-		}
+
+        }
 
         public void completePage()
         {
@@ -44,13 +44,13 @@ namespace AEWizard
         // ==================================================================
         // Protected Properties
         // ==================================================================
-        
-        
-        
+
+
+
         // ==================================================================
         // Private Methods
         // ==================================================================
-        
+
         #region Windows Form Designer generated code
         /// <summary>
         /// Required method for Designer support - do not modify
@@ -160,13 +160,13 @@ namespace AEWizard
             this.PerformLayout();
 
         }
-		#endregion
+        #endregion
 
 
         // ==================================================================
         // Protected Internal Methods
         // ==================================================================
-        
+
         /// <summary>
         /// Called when the page is no longer the active page.
         /// </summary>
@@ -200,7 +200,7 @@ namespace AEWizard
             // Activate the page
             return true;
         }
-        
+
         /// <summary>
         /// Called when the user clicks the Back button in a wizard.
         /// </summary>
@@ -222,7 +222,7 @@ namespace AEWizard
 
             return WizardForm.NextPage;
         }
-        
+
         /// <summary>
         /// Called when the user clicks the Finish button in a wizard.
         /// </summary>
@@ -242,7 +242,7 @@ namespace AEWizard
                 return false;
             return true;
         }
-        
+
         /// <summary>
         /// Called when the user clicks the Next button in a wizard.
         /// </summary>

--- a/Source/Contrib/ActivityEditor/AEWizard/SelectRoute.cs
+++ b/Source/Contrib/ActivityEditor/AEWizard/SelectRoute.cs
@@ -169,7 +169,7 @@ namespace AEWizard
             routeInfo.route = routePathCB.Text;
             return true;
         }
-        
+
 
     }
 }

--- a/Source/Contrib/ActivityEditor/AEWizard/TrainInfo.cs
+++ b/Source/Contrib/ActivityEditor/AEWizard/TrainInfo.cs
@@ -26,16 +26,16 @@ namespace AEWizard
         {
             this.trainConsistCB.DataSource = activityInfo.trainConsists.Select(o => o.consistName).ToList();
         }
-                // ==================================================================
+        // ==================================================================
         // Protected Properties
         // ==================================================================
-        
+
         /// <summary>
         /// Gets the <see cref="SMS.Windows.Forms.WizardForm">WizardForm</see>
         /// to which this <see cref="SMS.Windows.Forms.WizardPage">WizardPage</see>
         /// belongs.
         /// </summary>
-        
+
         // ==================================================================
         // Private Methods
         // ==================================================================
@@ -99,7 +99,7 @@ namespace AEWizard
             Wizard.SetWizardButtons(WizardButton.Next);
             return WizardForm.NextPage;
         }
-        
+
         #region Windows Form Designer generated code
         /// <summary>
         /// Required method for Designer support - do not modify

--- a/Source/Contrib/ActivityEditor/AEWizard/WizardForm.cs
+++ b/Source/Contrib/ActivityEditor/AEWizard/WizardForm.cs
@@ -22,35 +22,35 @@ namespace AEWizard
     /// Used to identify the various buttons that may appear within a wizard
     /// dialog.  
     /// </summary>
-    [Flags]		
+    [Flags]
     public enum WizardButton
     {
         /// <summary>
         /// Identifies the <b>Back</b> button.
         /// </summary>
-        Back           = 0x00000001,
-        
+        Back = 0x00000001,
+
         /// <summary>
         /// Identifies the <b>Next</b> button.
         /// </summary>
-        Next           = 0x00000002,
-        
+        Next = 0x00000002,
+
         /// <summary>
         /// Identifies the <b>Finish</b> button.
         /// </summary>
-        Finish         = 0x00000004,
-        
+        Finish = 0x00000004,
+
         /// <summary>
         /// Identifies the disabled <b>Finish</b> button.
         /// </summary>
         DisabledFinish = 0x00000008,
     }
-    
+
     /// <summary>
     /// Represents a wizard dialog.
     /// </summary>
     public class WizardForm : Form
-	{
+    {
         ActivityInfo activityInfo;
         RouteInfo routeInfo;
         // ==================================================================
@@ -70,17 +70,17 @@ namespace AEWizard
         /// pressed.
         /// </summary>
         public const string NoPageChange = null;
-	
-	
+
+
         // ==================================================================
         // Private Fields
         // ==================================================================
-        
+
         /// <summary>
         /// Array of wizard pages.
         /// </summary>
         private ArrayList m_pages = new ArrayList();
-        
+
         /// <summary>
         /// Index of the selected page; -1 if no page selected.
         /// </summary>
@@ -90,7 +90,7 @@ namespace AEWizard
         // ==================================================================
         // Protected Fields
         // ==================================================================
-        
+
         /// <summary>
         /// The Back button.
         /// </summary>
@@ -127,15 +127,15 @@ namespace AEWizard
         // ==================================================================
         // Public Constructors
         // ==================================================================
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SMS.Windows.Forms.WizardForm">WizardForm</see>
         /// class.
         /// </summary>
         public WizardForm(ActivityInfo activity)
-		{
-			// Required for Windows Form Designer support
-			InitializeComponent();
+        {
+            // Required for Windows Form Designer support
+            InitializeComponent();
             activityInfo = activity;
             wiz1 = new ActivityDescr();
             wiz1.activityInfo = activity;
@@ -143,13 +143,13 @@ namespace AEWizard
             wiz2 = new TrainInfo();
             wiz2.activityInfo = activity;
             wiz2.completePage();
-            Controls.AddRange(new Control[] 
+            Controls.AddRange(new Control[]
             {
                 wiz1, wiz2
             });
             // Ensure Finish and Next buttons are positioned similarly
-			m_finishButton.Location = m_nextButton.Location;
-		}
+            m_finishButton.Location = m_nextButton.Location;
+        }
         public WizardForm(RouteInfo info)
         {
             InitializeComponent();
@@ -167,14 +167,14 @@ namespace AEWizard
         // ==================================================================
         // Private Methods
         // ==================================================================
-        
+
         #region Windows Form Designer generated code
-		/// <summary>
-		/// Required method for Designer support - do not modify
-		/// the contents of this method with the code editor.
-		/// </summary>
-		private void InitializeComponent()
-		{
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(WizardForm));
             this.m_backButton = new System.Windows.Forms.Button();
             this.m_nextButton = new System.Windows.Forms.Button();
@@ -249,7 +249,7 @@ namespace AEWizard
             this.ResumeLayout(false);
 
         }
-		#endregion
+        #endregion
 
         /// <summary>
         /// Activates the page at the specified index in the page array.
@@ -257,29 +257,29 @@ namespace AEWizard
         /// <param name="newIndex">
         /// Index of new page to be selected.
         /// </param>
-        private void ActivatePage( int newIndex )
+        private void ActivatePage(int newIndex)
         {
             // Ensure the index is valid
-            if( newIndex < 0 || newIndex >= m_pages.Count )
+            if (newIndex < 0 || newIndex >= m_pages.Count)
                 throw new ArgumentOutOfRangeException();
 
             // Deactivate the current page if applicable
             SinglePage currentPage = null;
-            if( m_selectedIndex != -1 )
+            if (m_selectedIndex != -1)
             {
                 currentPage = (SinglePage)m_pages[m_selectedIndex];
-                if( !currentPage.OnKillActive() )
+                if (!currentPage.OnKillActive())
                     return;
             }
 
             // Activate the new page
-            SinglePage newPage = (SinglePage)m_pages[ newIndex ];
-            if( !newPage.OnSetActive() )
+            SinglePage newPage = (SinglePage)m_pages[newIndex];
+            if (!newPage.OnSetActive())
                 return;
 
             // Update state
             m_selectedIndex = newIndex;
-            if( currentPage != null )
+            if (currentPage != null)
                 currentPage.Visible = false;
             newPage.Visible = true;
             newPage.Focus();
@@ -288,32 +288,32 @@ namespace AEWizard
         /// <summary>
         /// Handles the Click event for the Back button.
         /// </summary>
-        private void OnClickBack( object sender, EventArgs e )
+        private void OnClickBack(object sender, EventArgs e)
         {
             // Ensure a page is currently selected
-            if( m_selectedIndex != -1 )
+            if (m_selectedIndex != -1)
             {
                 // Inform selected page that the Back button was clicked
                 string pageName = ((SinglePage)m_pages[
-                    m_selectedIndex ]).OnWizardBack();
-                switch( pageName )
+                    m_selectedIndex]).OnWizardBack();
+                switch (pageName)
                 {
                     // Do nothing
                     case NoPageChange:
                         break;
-                        
+
                     // Activate the next appropriate page
                     case NextPage:
-                        if( m_selectedIndex - 1 >= 0 )
-                            ActivatePage( m_selectedIndex - 1 );
+                        if (m_selectedIndex - 1 >= 0)
+                            ActivatePage(m_selectedIndex - 1);
                         break;
 
                     // Activate the specified page if it exists
                     default:
-                        foreach( SinglePage page in m_pages )
+                        foreach (SinglePage page in m_pages)
                         {
-                            if( page.Name == pageName )
-                                ActivatePage( m_pages.IndexOf( page ) );
+                            if (page.Name == pageName)
+                                ActivatePage(m_pages.IndexOf(page));
                         }
                         break;
                 }
@@ -323,7 +323,7 @@ namespace AEWizard
         /// <summary>
         /// Handles the Click event for the Cancel button.
         /// </summary>
-        private void OnClickCancel( object sender, EventArgs e )
+        private void OnClickCancel(object sender, EventArgs e)
         {
             // Close wizard
             DialogResult = DialogResult.Cancel;
@@ -332,17 +332,17 @@ namespace AEWizard
         /// <summary>
         /// Handles the Click event for the Finish button.
         /// </summary>
-        private void OnClickFinish( object sender, EventArgs e )
+        private void OnClickFinish(object sender, EventArgs e)
         {
             // Ensure a page is currently selected
-            if( m_selectedIndex != -1 )
+            if (m_selectedIndex != -1)
             {
                 // Inform selected page that the Finish button was clicked
-                SinglePage page = (SinglePage)m_pages[ m_selectedIndex ];
-                if( page.OnWizardFinish() )
+                SinglePage page = (SinglePage)m_pages[m_selectedIndex];
+                if (page.OnWizardFinish())
                 {
                     // Deactivate page and close wizard
-                    if( page.OnKillActive() )
+                    if (page.OnKillActive())
                         DialogResult = DialogResult.OK;
                 }
             }
@@ -351,15 +351,15 @@ namespace AEWizard
         /// <summary>
         /// Handles the Click event for the Next button.
         /// </summary>
-        private void OnClickNext( object sender, EventArgs e )
+        private void OnClickNext(object sender, EventArgs e)
         {
             // Ensure a page is currently selected
-            if( m_selectedIndex != -1 )
+            if (m_selectedIndex != -1)
             {
                 // Inform selected page that the Next button was clicked
                 string pageName = ((SinglePage)m_pages[
-                    m_selectedIndex ]).OnWizardNext();
-                switch( pageName )
+                    m_selectedIndex]).OnWizardNext();
+                switch (pageName)
                 {
                     // Do nothing
                     case NoPageChange:
@@ -367,16 +367,16 @@ namespace AEWizard
 
                     // Activate the next appropriate page
                     case NextPage:
-                        if( m_selectedIndex + 1 < m_pages.Count )
-                            ActivatePage( m_selectedIndex + 1 );
+                        if (m_selectedIndex + 1 < m_pages.Count)
+                            ActivatePage(m_selectedIndex + 1);
                         break;
 
                     // Activate the specified page if it exists
                     default:
-                        foreach( SinglePage page in m_pages )
+                        foreach (SinglePage page in m_pages)
                         {
-                            if( page.Name == pageName )
-                                ActivatePage( m_pages.IndexOf( page ) );
+                            if (page.Name == pageName)
+                                ActivatePage(m_pages.IndexOf(page));
                         }
                         break;
                 }
@@ -387,25 +387,25 @@ namespace AEWizard
         // ==================================================================
         // Protected Methods
         // ==================================================================
-        
+
         /// <seealso cref="System.Windows.Forms.Control.OnControlAdded">
         /// System.Windows.Forms.Control.OnControlAdded
         /// </seealso>
-        protected override void OnControlAdded( ControlEventArgs e )
+        protected override void OnControlAdded(ControlEventArgs e)
         {
             // Invoke base class implementation
-            base.OnControlAdded( e );
-            
+            base.OnControlAdded(e);
+
             // Set default properties for all WizardPage instances added to
             // this form
             SinglePage page = e.Control as SinglePage;
-            if( page != null )
+            if (page != null)
             {
                 page.Visible = false;
-                page.Location = new Point( 0, 0 );
-                page.Size = new Size( Width, m_separator.Location.Y );
-                m_pages.Add( page );
-                if( m_selectedIndex == -1 )
+                page.Location = new Point(0, 0);
+                page.Size = new Size(Width, m_separator.Location.Y);
+                m_pages.Add(page);
+                if (m_selectedIndex == -1)
                     m_selectedIndex = 0;
             }
         }
@@ -413,33 +413,33 @@ namespace AEWizard
         /// <seealso cref="System.Windows.Forms.Form.OnLoad">
         /// System.Windows.Forms.Form.OnLoad
         /// </seealso>
-        protected override void OnLoad( EventArgs e )
+        protected override void OnLoad(EventArgs e)
         {
             // Invoke base class implementation
-            base.OnLoad( e );
-            
+            base.OnLoad(e);
+
             // Activate the first page in the wizard
-            if( m_pages.Count > 0 )
-                ActivatePage( 0 );
+            if (m_pages.Count > 0)
+                ActivatePage(0);
         }
 
 
         // ==================================================================
         // Public Methods
         // ==================================================================
-        
+
         /// <summary>
         /// Sets the text in the Finish button.
         /// </summary>
         /// <param name="text">
         /// Text to be displayed on the Finish button.
         /// </param>
-        public void SetFinishText( string text )
+        public void SetFinishText(string text)
         {
             // Set the Finish button text
             m_finishButton.Text = text;
         }
-        
+
         /// <summary>
         /// Enables or disables the Back, Next, or Finish buttons in the
         /// wizard.
@@ -454,7 +454,7 @@ namespace AEWizard
         /// <c>WizardPage.OnSetActive</c>.  You can display a Finish or a
         /// Next button at one time, but not both.
         /// </remarks>
-        public void SetWizardButtons( WizardButton flags )
+        public void SetWizardButtons(WizardButton flags)
         {
             // Enable/disable and show/hide buttons appropriately
             m_backButton.Enabled =
@@ -469,7 +469,7 @@ namespace AEWizard
             m_finishButton.Visible =
                 (flags & WizardButton.Finish) == WizardButton.Finish ||
                 (flags & WizardButton.DisabledFinish) == WizardButton.DisabledFinish;
-                
+
             // Set the AcceptButton depending on whether or not the Finish
             // button is visible or not
             AcceptButton = m_finishButton.Visible ? m_finishButton :

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Engine/AEConfig.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Engine/AEConfig.cs
@@ -55,7 +55,7 @@ namespace ActivityEditor.Engine
         public List<TagWidgetInfo> tagWidgetInfo;
         private TypeEditor typeConfig;
         // Properties
-        
+
         public AERouteConfig aeRouteConfig { get; set; }
         public Viewer2D Viewer { get; set; }
         public PseudoSim simulator { get { return Viewer.Simulator; } protected set { } }
@@ -225,7 +225,7 @@ namespace ActivityEditor.Engine
             tagGBList = new List<GroupBox>();
             stationWidgetInfo = new List<StationWidgetInfo>();
             stationGBList = new List<GroupBox>();
-            
+
             Viewer.actParent.SuspendLayout();
             //System.Drawing.Point current = activityAe.GetPanelPosition();
             foreach (var item in getORWidget())
@@ -236,8 +236,8 @@ namespace ActivityEditor.Engine
                     int cnt = rnd.Next(999999);
                     TagWidgetInfo newTagWidget = new TagWidgetInfo(Viewer, ((TagItem)item), cnt);
                     AddTagWidgetInfo(newTagWidget);
-                    
-                    
+
+
                 }
             }
 

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Engine/AERouteConfig.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Engine/AERouteConfig.cs
@@ -51,7 +51,7 @@ namespace ActivityEditor.Engine
         //  MSTS data
         public TrackNode[] nodes { get { return simulator.nodes; } set { } }
         AEConfig Parent;
-                
+
         public TrackSectionsFile TSectionDat { get { return Viewer.Simulator.TSectionDat; } protected set { } }
         public Viewer2D Viewer { get { return Parent.Viewer; } protected set { } }
         public PseudoSim simulator { get { return Viewer.Simulator; } protected set { } }

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.cs
@@ -65,7 +65,7 @@ namespace ActivityEditor
         private bool loadEnabled = false;
         public List<Viewer2D> viewer2ds;
         public Viewer2D selectedViewer;
-        
+
         //public List<AEActivity> aeActivity;
         //public AEActivity selectedActivity;
         private bool focusOnViewer = false;
@@ -310,7 +310,7 @@ namespace ActivityEditor
 
         }
         #endregion
-        
+
         private void MoveSelected_Click(object sender, EventArgs e)
         {
             DisplayStatusMessage("Please, Place Move Tool");

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Engine/PseudoSim.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Engine/PseudoSim.cs
@@ -156,7 +156,7 @@ namespace ActivityEditor
                         {
                             foundBuffer = new AEBufferItem((TrackNode)currNode);
                             mstsItems.buffers.Add(foundBuffer);
-                       }
+                        }
 #if SHOW_STOPWATCH
                         ts = stopWatch.Elapsed;
                         stopWatch.Reset();
@@ -211,11 +211,11 @@ namespace ActivityEditor
                             {
                                 TrackNode connectedNode = nodes[pin.Link];
                                 int direction = DrawUtility.getDirection(currNode, connectedNode);
-                                if (MSTSCoord.near (currNode.getMSTSCoord(direction), connectedNode.getMSTSCoord(direction)))
+                                if (MSTSCoord.near(currNode.getMSTSCoord(direction), connectedNode.getMSTSCoord(direction)))
                                     continue;
                                 AESegment aeSegment = new AESegment(currNode.getMSTSCoord(direction), connectedNode.getMSTSCoord(direction));
                                 TrackSegment lineSeg = new TrackSegment(aeSegment, currNode, 0, direction, TSectionDat);
-                                addTrItems (lineSeg, currNode);
+                                addTrItems(lineSeg, currNode);
                                 mstsItems.AddSegment(lineSeg);
                             }
 #if SHOW_STOPWATCH
@@ -259,7 +259,7 @@ namespace ActivityEditor
                 maxsize = 2000;
             ZoomFactor = (decimal)maxsize;
 #endif
-#region AddItem
+            #region AddItem
 
 
             Program.actEditor.DisplayStatusMessage("Init data for display...  Load MSTS Items...");
@@ -297,7 +297,7 @@ namespace ActivityEditor
             File.AppendAllText(@"C:\temp\stopwatch.txt", "Signals: " + elapsedTime + "\n");
             stopWatch.Stop();
 #endif
-#endregion
+            #endregion
         }
 
         public void AddSegments(TrackNode node)
@@ -316,7 +316,7 @@ namespace ActivityEditor
                 foreach (var idxTrItem in values)
                 {
                     if (!idxTrItem.Key)
-                            break;
+                        break;
                     foreach (var val in idxTrItem)
                     {
                         var item = TDB.TrackDB.TrItemTable[val.Value];

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Engine/SimpleTextEd.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Engine/SimpleTextEd.cs
@@ -11,14 +11,14 @@ namespace ActivityEditor.Engine
 {
     public partial class SimpleTextEd : Form
     {
-        
+
         public SimpleTextEd()
         {
             InitializeComponent();
         }
-      
 
-        protected void Save_Click(Object sender, EventArgs e) 
+
+        protected void Save_Click(Object sender, EventArgs e)
         {
         }
     }

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Engine/Viewer2D.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Engine/Viewer2D.cs
@@ -103,11 +103,11 @@ namespace ActivityEditor.Engine
         public double snapSize { get; set; }
 
         //  Keep the distance between the map origin and the visible section
-        private PointF RouteScreenOrig = new PointF(0,0);
+        private PointF RouteScreenOrig = new PointF(0, 0);
         private SizeF Distant2Origin = new SizeF(0, 0);
         //  Son équivalent en int pour le forms
         private System.Drawing.SizeF StartDrawing = new System.Drawing.SizeF(0, 0);
-        private SizeF correctY = new SizeF (0,0);
+        private SizeF correctY = new SizeF(0, 0);
 
         private Size routePicture = new Size(0, 0);
 
@@ -128,7 +128,7 @@ namespace ActivityEditor.Engine
 
         //  For Debugging
 
-#region InitViewer
+        #region InitViewer
 
         /// <summary>
         /// Initialise a new instance of the Viewer for ROUTE Configuration,
@@ -213,8 +213,8 @@ namespace ActivityEditor.Engine
             InitData();
             actParent.SelectTools(ViewerMode);
         }
-#endregion
-#region initData
+        #endregion
+        #region initData
 
         private void InitData()
         {
@@ -227,7 +227,7 @@ namespace ActivityEditor.Engine
             Program.actEditor.DisplayStatusMessage("Init data for display...");
             //aeConfig.aeRouteConfig.InitORData(Simulator);
             tilesList = areaRoute.tilesList;
-            
+
 
             sizeX = (Math.Abs(areaRoute.tileMaxX - areaRoute.tileMinX) + 1) * 2048f;
             sizeZ = (Math.Abs(areaRoute.tileMaxZ - areaRoute.tileMinZ) + 1) * 2048f;
@@ -281,9 +281,9 @@ namespace ActivityEditor.Engine
         {
             return usedScale;
         }
-    #endregion
+        #endregion
 
-    #region Draw
+        #region Draw
 
         public bool firstShow = true;
         public bool followTrain = false;
@@ -306,9 +306,9 @@ namespace ActivityEditor.Engine
                 }
                 //  TODO: Check this when the forms is minimized
                 if (routeDrawing.Width <= 0 || routeDrawing.Height <= 0)
-                   routeDrawing.Image = new Bitmap(1, 1);
+                    routeDrawing.Image = new Bitmap(1, 1);
                 else
-                   routeDrawing.Image = new Bitmap(routeDrawing.Width, routeDrawing.Height);
+                    routeDrawing.Image = new Bitmap(routeDrawing.Width, routeDrawing.Height);
                 routePicture = routeDrawing.Size;
                 firstShow = true;
             }
@@ -334,7 +334,7 @@ namespace ActivityEditor.Engine
                 subY = 0; // areaRoute.getMinY() + ViewWindow.Y;
                 g.Clear(Color.White);
                 ComputeStartDrawing();
-                
+
                 usedScale = (currentRules / routeDrawing.Width);
                 usedScale = (float)Math.Round((double)usedScale, 2, MidpointRounding.AwayFromZero);
                 if (usedScale == 0)
@@ -342,7 +342,7 @@ namespace ActivityEditor.Engine
                 if (Program.aePreference.ShowRuler)
                     showRules(g, usedScale);
                 snapSize = (double)(Program.aePreference.getSnapCircle() * usedScale);
-                
+
                 PointF[] points = new PointF[3];
                 Pen p = darkGrayPen;
                 Pen t = bluePen;
@@ -355,7 +355,7 @@ namespace ActivityEditor.Engine
 
                 PointF scaledA = new PointF(0, 0);
                 PointF scaledB = new PointF(0, 0);
-                SizeF decal = (correctY - StartDrawing); 
+                SizeF decal = (correctY - StartDrawing);
                 PointF scaledC = new PointF(0, 0);
                 PointF centerCurve = new PointF(0, 0);
                 #region showItem
@@ -365,8 +365,8 @@ namespace ActivityEditor.Engine
                 {   //  X,Y tile are on center of tile
                     foreach (var tile in tilesList)
                     {
-                        scaledA.X = decal.Width + (((tile.TileX * 2048f) - subX -1024f) / usedScale);
-                        scaledA.Y = decal.Height - (((tile.TileZ *  2048f) - subY + 1024f) / usedScale);
+                        scaledA.X = decal.Width + (((tile.TileX * 2048f) - subX - 1024f) / usedScale);
+                        scaledA.Y = decal.Height - (((tile.TileZ * 2048f) - subY + 1024f) / usedScale);
                         int width = (int)(2048 / usedScale);
                         int height = (int)(2048 / usedScale);
                         g.DrawRectangle(pen, (int)scaledA.X, (int)scaledA.Y, width, height);
@@ -391,7 +391,7 @@ namespace ActivityEditor.Engine
                         }
 
                     }
-                     foreach (var junction in aeItems.getSwitches())
+                    foreach (var junction in aeItems.getSwitches())
                     {
                         junction.SynchroLocation();
                         scaledA.X = decal.Width + (((float)junction.Location.X - subX) / usedScale);
@@ -521,8 +521,8 @@ namespace ActivityEditor.Engine
                     station.Location2D.X = scaledA.X; station.Location2D.Y = scaledA.Y;
 
                     System.Drawing.Rectangle rect = new System.Drawing.Rectangle((int)scaledA.X,
-                                                        (int)scaledA.Y, 
-                                                        (int)(10/usedScale), (int)(10/usedScale));
+                                                        (int)scaledA.Y,
+                                                        (int)(10 / usedScale), (int)(10 / usedScale));
                     if (item.stationWidget.icoAngle != 0f)
                     {
                         myMatrix.RotateAt(item.stationWidget.icoAngle, scaledA, MatrixOrder.Append);
@@ -563,9 +563,9 @@ namespace ActivityEditor.Engine
                             {
                                 System.Drawing.Drawing2D.Matrix matrixSA = new System.Drawing.Drawing2D.Matrix();
 
-                                rect = new System.Drawing.Rectangle((int)X, 
-                                    (int)(Y - (2 / usedScale)), 
-                                    (int)(2/usedScale), (int)(2/usedScale));
+                                rect = new System.Drawing.Rectangle((int)X,
+                                    (int)(Y - (2 / usedScale)),
+                                    (int)(2 / usedScale), (int)(2 / usedScale));
                                 if (SAWidget.getStationConnector().getDirConnector() == AllowedDir.IN)
                                 {
                                     matrixSA.RotateAt((float)SAWidget.getStationConnector().angle, new System.Drawing.Point(X, Y), MatrixOrder.Append);
@@ -600,10 +600,10 @@ namespace ActivityEditor.Engine
                                     {
                                         g.DrawEllipse(Pens.Red, X - 4, Y - 4, 8, 8);
                                     }
-                                    if (SAWidget.getStationConnector().getLabel().Length > 0 && 
+                                    if (SAWidget.getStationConnector().getLabel().Length > 0 &&
                                         Program.aePreference.ShowPlSiLabel && Program.aePreference.PlSiZoom >= usedScale &&
                                         SAWidget.isItSeen())
-                                        g.DrawString(SAWidget.getStationConnector().getLabel(), stationFont, sidingBrush, new System.Drawing.Point(X+15, Y+10));
+                                        g.DrawString(SAWidget.getStationConnector().getLabel(), stationFont, sidingBrush, new System.Drawing.Point(X + 15, Y + 10));
                                 }
                             }
                             else
@@ -634,8 +634,8 @@ namespace ActivityEditor.Engine
                     if (item is PathEventItem)
                     {
                         PointF coord = ((PathEventItem)item).Coord.ConvertToPointF();
-                        scaledA.X = (decal.Width + (coord.X - subX) / usedScale) -8;
-                        scaledA.Y = (decal.Height - ((coord.Y - subY) / usedScale)) -8;
+                        scaledA.X = (decal.Width + (coord.X - subX) / usedScale) - 8;
+                        scaledA.Y = (decal.Height - ((coord.Y - subY) / usedScale)) - 8;
                         if ((scaledA.X < 0) || (scaledA.X > IM_Width) || (scaledA.Y > IM_Height) || (scaledA.Y < 0))
                             continue;
 
@@ -650,7 +650,7 @@ namespace ActivityEditor.Engine
                         }
                     }
                 }
-    #endregion
+                #endregion
 
                 #region showCursor
 
@@ -692,7 +692,7 @@ namespace ActivityEditor.Engine
                         g.DrawImage(tool, rect);
                     }
                 }
-    #endregion
+                #endregion
 
                 float x, y;
                 PointF scaledItem = new PointF(0f, 0f);
@@ -702,7 +702,7 @@ namespace ActivityEditor.Engine
                 if (usedScale < Program.aePreference.getPlSiZoom())
                 {
 #if !DRAW_ALL
-#region drawSignal
+                    #region drawSignal
                     foreach (var s in aeItems.getSignals())
                     {
                         s.SynchroLocation();
@@ -734,11 +734,11 @@ namespace ActivityEditor.Engine
                                 color = Brushes.Red;
                                 pen = redPen;
                             }
-                            System.Drawing.Rectangle rect = new System.Drawing.Rectangle((int)scaledItem.X-12, (int)scaledItem.Y-5, (int)widthDraw, (int)widthDraw);
+                            System.Drawing.Rectangle rect = new System.Drawing.Rectangle((int)scaledItem.X - 12, (int)scaledItem.Y - 5, (int)widthDraw, (int)widthDraw);
                             g.DrawEllipse(Pens.DarkBlue, (int)scaledItem.X - 1, (int)scaledItem.Y - 1, 2, 2);
                             if (s.hasDir)
                             {
-                                System.Drawing.Point rotationLoc = new System.Drawing.Point((int)scaledItem.X-5, (int)scaledItem.Y+5);
+                                System.Drawing.Point rotationLoc = new System.Drawing.Point((int)scaledItem.X - 5, (int)scaledItem.Y + 5);
                                 System.Drawing.Drawing2D.Matrix myMatrix = new System.Drawing.Drawing2D.Matrix();
                                 scaledB.X = decal.Width + (s.Dir.X - subX) / usedScale;
                                 scaledB.Y = decal.Height - (s.Dir.Y - subY) / usedScale;
@@ -789,8 +789,8 @@ namespace ActivityEditor.Engine
                             g.ResetTransform();
                         }
                     }
-#endregion
-#region crossOver
+                    #endregion
+                    #region crossOver
                     foreach (AECrossOver crossOver in aeItems.getCrossOver())
                     {
                         System.Drawing.Drawing2D.Matrix matrixSA = new System.Drawing.Drawing2D.Matrix();
@@ -813,7 +813,7 @@ namespace ActivityEditor.Engine
                     }
                     #endregion
 
-#region drawSiding
+                    #region drawSiding
                     foreach (SideItem siding in aeItems.getSidings())
                     {
                         System.Drawing.Drawing2D.Matrix matrixSA = new System.Drawing.Drawing2D.Matrix();
@@ -840,7 +840,7 @@ namespace ActivityEditor.Engine
                             {
                                 matrixSA.RotateAt((float)tempo, new System.Drawing.Point((int)x, (int)y), MatrixOrder.Append);
                                 g.Transform = matrixSA;
-                                g.DrawString(siding.Name, sidingFont, sidingBrush, x+15, y+10);
+                                g.DrawString(siding.Name, sidingFont, sidingBrush, x + 15, y + 10);
                             }
                         }
                         else
@@ -851,13 +851,13 @@ namespace ActivityEditor.Engine
                             {
                                 matrixSA.RotateAt((float)tempo, new System.Drawing.Point((int)x, (int)y), MatrixOrder.Append);
                                 g.Transform = matrixSA;
-                                g.DrawString(siding.Name, sidingFont, sidingBrush, x+15, y+10);
+                                g.DrawString(siding.Name, sidingFont, sidingBrush, x + 15, y + 10);
                             }
                         }
                         g.ResetTransform();
                     }
                 }
-#endregion
+                #endregion
 #endif
             }
             routeDrawing.Invalidate();
@@ -896,9 +896,9 @@ namespace ActivityEditor.Engine
             g.DrawIcon(Ruler, rect);
             g.ResetTransform();
   
-	#endif        
+#endif
         }
-#endregion
+        #endregion
 
         private void ComputeStartDrawing()
         {
@@ -913,7 +913,7 @@ namespace ActivityEditor.Engine
 
         #region MouseEvent
 
-        private bool zoomed  = false;
+        private bool zoomed = false;
         private void routeDrawingMouseDown(object sender, MouseEventArgs e)
         {
             bool shiftKey = false;
@@ -961,7 +961,7 @@ namespace ActivityEditor.Engine
                     aeConfig.AddORItem(info);
                     stationItem = (StationItem)itemToUpdate;
                     itemToUpdate = info;
-                    
+
                 }
                 else
                 {
@@ -1048,7 +1048,7 @@ namespace ActivityEditor.Engine
             {
                 PointF point = convertScreen2ViewCoord(e.X, e.Y);
                 MSTSCoord coord = Simulator.mstsDataConfig.TileBase.getMstsCoord(point);
-                aeConfig.UpdateItem (itemToUpdate, coord, controlKey, false);
+                aeConfig.UpdateItem(itemToUpdate, coord, controlKey, false);
                 //((StationAreaWidget)itemToUpdate).UpdatePointArea(aeConfig.getSegments(), );
             }
 
@@ -1056,21 +1056,21 @@ namespace ActivityEditor.Engine
             {
                 CurrentMousePosition.X = e.X;
                 CurrentMousePosition.Y = e.Y;
-                if (ToolClicked == ToolClicked.MOVE 
-                        && itemToUpdate != null 
+                if (ToolClicked == ToolClicked.MOVE
+                        && itemToUpdate != null
                         && itemToUpdate.IsMovable())
                 {
                     if (e.X < 10 || e.Y < 10 || e.X > routePicture.Width - 10 || e.Y > routePicture.Height - 10)
                     {
                         dragWindow(e, -1);
                     }
-                    PointF point = convertScreen2ViewCoord (e.X, e.Y);
+                    PointF point = convertScreen2ViewCoord(e.X, e.Y);
                     MSTSCoord coord = Simulator.mstsDataConfig.TileBase.getMstsCoord(point);
                     aeConfig.UpdateItem(itemToUpdate, coord, controlKey, false);
                     //itemToUpdate.configCoord(coord, aeConfig.getSegments(), controlKey);
                 }
                 else if (ToolClicked == ToolClicked.ROTATE
-                        && itemToUpdate != null 
+                        && itemToUpdate != null
                         && itemToUpdate.IsRotable())
                 {
                     PointF point = e.Location;
@@ -1112,7 +1112,7 @@ namespace ActivityEditor.Engine
                 {
                     currentRules *= facteur;
                 }
-                
+
 
                 ZoomAndAlignWindow(coordZoomPoint, refZoomPoint);
             }
@@ -1173,7 +1173,7 @@ namespace ActivityEditor.Engine
                 }
             }
             else if (ToolClicked == ToolClicked.AREA &&
-                itemToUpdate != null && 
+                itemToUpdate != null &&
                 (itemToUpdate.GetType() == typeof(StationItem) ||
                 itemToUpdate.GetType() == typeof(StationAreaItem)))
             {
@@ -1294,9 +1294,9 @@ namespace ActivityEditor.Engine
                     break;
             }
         }
-    #endregion
+        #endregion
 
-#region AlignView
+        #region AlignView
         private void ZoomViewWindow()
         {
             float width = ViewWindow.Width * (currentRules / origRules);
@@ -1307,7 +1307,7 @@ namespace ActivityEditor.Engine
             ComputeUsedScale();
         }
 
-        private void CenterAndZoomWindow ()
+        private void CenterAndZoomWindow()
         {
             PointF point = convertScreen2ViewCoord(ViewWindow.Width / 2f, ViewWindow.Height / 2f);
             MSTSCoord coord = Simulator.mstsDataConfig.TileBase.getMstsCoord(point);
@@ -1320,7 +1320,7 @@ namespace ActivityEditor.Engine
         {
             ZoomViewWindow();
 
-            RealignViewWindow(coord, System.Drawing.Point.Truncate (point));
+            RealignViewWindow(coord, System.Drawing.Point.Truncate(point));
             GenerateView();
         }
 
@@ -1350,9 +1350,9 @@ namespace ActivityEditor.Engine
             Distant2Origin.Height = (Distant2Origin.Height) + ((current.Y - refCoord.Y) * localScale);
             return;
         }
-        
 
-#endregion
+
+        #endregion
 
         #region SaveLoad
         public bool Save()
@@ -1442,7 +1442,7 @@ namespace ActivityEditor.Engine
 
         }
 
-        private void AddActStart (TrackSegment segment, System.Drawing.Point CurrentMousePosition)
+        private void AddActStart(TrackSegment segment, System.Drawing.Point CurrentMousePosition)
         {
             int cnt = rnd.Next(999999);
             double dist;
@@ -1464,7 +1464,7 @@ namespace ActivityEditor.Engine
             tmp.PerformLayout();
         }
 
-        private void AddActStop (TrackSegment segment, System.Drawing.Point CurrentMousePosition)
+        private void AddActStop(TrackSegment segment, System.Drawing.Point CurrentMousePosition)
         {
             int cnt = rnd.Next(999999);
             double dist;
@@ -1478,7 +1478,7 @@ namespace ActivityEditor.Engine
             tmp.PerformLayout();
         }
 
-        private void AddActWait (TrackSegment segment, System.Drawing.Point CurrentMousePosition)
+        private void AddActWait(TrackSegment segment, System.Drawing.Point CurrentMousePosition)
         {
             int cnt = rnd.Next(999999);
             double dist;
@@ -1522,26 +1522,26 @@ namespace ActivityEditor.Engine
                 case (int)ToolClicked.START:
                     item = findSegmentFromMouse(CurrentMousePosition);
                     if (item != null &&
-                        item.GetType () == typeof (TrackSegment) &&
-                        ((TrackSegment)item).isSnap ())
+                        item.GetType() == typeof(TrackSegment) &&
+                        ((TrackSegment)item).isSnap())
                     {
-                        AddActStart ((TrackSegment)item, CurrentMousePosition);
+                        AddActStart((TrackSegment)item, CurrentMousePosition);
                     }
                     break;
                 case (int)ToolClicked.STOP:
                     item = findSegmentFromMouse(CurrentMousePosition);
                     if (item != null &&
-                        item.GetType () == typeof (TrackSegment) &&
-                        ((TrackSegment)item).isSnap ())
+                        item.GetType() == typeof(TrackSegment) &&
+                        ((TrackSegment)item).isSnap())
                     {
-                        AddActStop ((TrackSegment)item, CurrentMousePosition);
+                        AddActStop((TrackSegment)item, CurrentMousePosition);
                     }
 
                     break;
                 case (int)ToolClicked.WAIT:
                     item = findSegmentFromMouse(CurrentMousePosition);
                     if (item != null &&
-                        item.GetType () == typeof (TrackSegment) &&
+                        item.GetType() == typeof(TrackSegment) &&
                         ((TrackSegment)item).isSnap())
                     {
                         AddActWait((TrackSegment)item, CurrentMousePosition);
@@ -1790,7 +1790,7 @@ namespace ActivityEditor.Engine
             if (aeItems != null)
             {
                 PointF pt = convertScreen2ViewCoord((float)CurrentMousePosition.X, (float)CurrentMousePosition.Y);
-                item = aeItems.findSegmentFromMouse(pt, (double)(Program.aePreference.getSnapCircle()/2));
+                item = aeItems.findSegmentFromMouse(pt, (double)(Program.aePreference.getSnapCircle() / 2));
                 // sideItem = aeItems.findSegmentFromMouse(pt, snapSize);
             }
             return item;
@@ -1816,7 +1816,7 @@ namespace ActivityEditor.Engine
             PointF pt = convertScreen2ViewCoord((float)point.X, (float)point.Y);
             //PointF tf2 = new PointF(0f, 0f);
             //GlobalItem componentItem = Simulator.orRouteConfig.findMetadataItem(pt, snapSize, aeItems);
-            GlobalItem item = Simulator.orRouteConfig.FindMetadataItem(pt, (double)(Program.aePreference.getSnapCircle()/2), aeItems);
+            GlobalItem item = Simulator.orRouteConfig.FindMetadataItem(pt, (double)(Program.aePreference.getSnapCircle() / 2), aeItems);
             return item;
         }
 

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Preference/AEPreference.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Preference/AEPreference.cs
@@ -72,7 +72,7 @@ namespace ActivityEditor.Preference
         public bool ShowTrackInfo { get; set; }
         public bool ActivateHorn { get; set; }
         [XmlIgnore]
-        public ActionContainer ActionContainer 
+        public ActionContainer ActionContainer
         {
             get
             {
@@ -82,11 +82,11 @@ namespace ActivityEditor.Preference
                 }
                 return null;
             }
-            protected set { } 
+            protected set { }
         }
         //  Info for AuxAction option window.
         [XmlIgnore]
-        public List<string> AvailableActions 
+        public List<string> AvailableActions
         {
             get
             {
@@ -109,15 +109,15 @@ namespace ActivityEditor.Preference
         }
 
         public bool AllSignalProperty
-        { 
-            get 
-            { 
-                return ShowAllSignal; 
-            } 
-            set 
-            { 
-                ShowAllSignal = value; 
-            } 
+        {
+            get
+            {
+                return ShowAllSignal;
+            }
+            set
+            {
+                ShowAllSignal = value;
+            }
         }
 
         public AEPreference()

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Preference/Options.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Preference/Options.cs
@@ -27,7 +27,7 @@ namespace ActivityEditor.Preference
             this.MSTSPath.Text = Program.aePreference.MSTSPath;
             this.AEPath.Text = Program.aePreference.AEPath;
             ListRoutePaths.DataSource = Program.aePreference.RoutePaths;
-            routePaths = new List<string> ();
+            routePaths = new List<string>();
             this.showTiles.Checked = Program.aePreference.ShowTiles;
             this.snapTrack.Checked = Program.aePreference.ShowSnapLine;
             this.SnapInfo.Checked = Program.aePreference.ShowSnapInfo;
@@ -37,7 +37,7 @@ namespace ActivityEditor.Preference
             this.ListAvailable.DataSource = Program.aePreference.AvailableActions;
             this.ListUsed.DataSource = Program.aePreference.UsedActions;
         }
-        
+
         private void DrawOnTab(object sender, DrawItemEventArgs e)
         {
             Font font;
@@ -51,9 +51,9 @@ namespace ActivityEditor.Preference
                 font = new Font(e.Font, e.Font.Style);
                 back_brush = new SolidBrush(Color.DimGray);
                 fore_brush = new SolidBrush(Color.White);
-                bounds = new Rectangle(bounds.X + (this.tabControl1.Padding.X / 2), 
-                    bounds.Y + this.tabControl1.Padding.Y, 
-                    bounds.Width - this.tabControl1.Padding.X, 
+                bounds = new Rectangle(bounds.X + (this.tabControl1.Padding.X / 2),
+                    bounds.Y + this.tabControl1.Padding.Y,
+                    bounds.Width - this.tabControl1.Padding.X,
                     bounds.Height - (this.tabControl1.Padding.Y * 2));
             }
             else
@@ -132,7 +132,7 @@ namespace ActivityEditor.Preference
             }
         }
 
-        private void configureRoutePath ()
+        private void configureRoutePath()
         {
             if (Program.aePreference.RoutePaths.Count <= 0)
             {
@@ -155,7 +155,7 @@ namespace ActivityEditor.Preference
         {
             this.snapCircle.Enabled = ShowSnap.Checked;
             this.snapCircleLabel.Enabled = ShowSnap.Checked;
-            this.snapCircle.Value = Program.aePreference.getSnapCircle()>0?Program.aePreference.getSnapCircle():2;
+            this.snapCircle.Value = Program.aePreference.getSnapCircle() > 0 ? Program.aePreference.getSnapCircle() : 2;
             Program.aePreference.ShowSnapCircle = ShowSnap.Checked;
         }
 
@@ -201,7 +201,7 @@ namespace ActivityEditor.Preference
         private void optionOK_click(object sender, EventArgs e)
         {
             Close();
-            Program.aePreference.ShowAllSignal = this.checkBox1.Checked ;
+            Program.aePreference.ShowAllSignal = this.checkBox1.Checked;
             Program.aePreference.ShowSnapCircle = this.ShowSnap.Checked;
             Program.aePreference.ShowPlSiLabel = this.ShowLabelPlat.Checked;
             Program.aePreference.MSTSPath = this.MSTSPath.Text;

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Route Metadata/StationDisplay.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Route Metadata/StationDisplay.cs
@@ -24,7 +24,7 @@ namespace ActivityEditor.Route_Metadata
             tablePaths.SuspendLayout();
             StationName.Text = station.nameStation;
             ClearTable();
-            
+
             int cntPath = this.tablePaths.RowCount;
             foreach (var pointArea in item.stationArea)
             {
@@ -49,7 +49,7 @@ namespace ActivityEditor.Route_Metadata
                 {
                     foreach (var possibility in destinPoint.Value)
                     {
-                        AddPathData(originPoint.Key, possibility.Value); 
+                        AddPathData(originPoint.Key, possibility.Value);
                     }
                 }
             }
@@ -129,15 +129,15 @@ namespace ActivityEditor.Route_Metadata
             double yard = Math.Round(path.Platform, 1);
             Label platformLength = new Label() { Text = yard.ToString(), Anchor = AnchorStyles.Left, AutoSize = true };
             this.tablePaths.Controls.Add(platformLength, 2, cntRows);
-            yard = Math.Round (path.Siding,1);
-            Label sidingLength = new Label(){ Text = yard.ToString(), Anchor = AnchorStyles.Left, AutoSize = true };
+            yard = Math.Round(path.Siding, 1);
+            Label sidingLength = new Label() { Text = yard.ToString(), Anchor = AnchorStyles.Left, AutoSize = true };
             this.tablePaths.Controls.Add(sidingLength, 3, cntRows);
 
             Label nbrPlatform = new Label() { Text = path.NbrPlatform.ToString(), Anchor = AnchorStyles.Left, AutoSize = true };
             this.tablePaths.Controls.Add(nbrPlatform, 4, cntRows);
             Label nbrSiding = new Label() { Text = path.NbrSiding.ToString(), Anchor = AnchorStyles.Left, AutoSize = true };
             this.tablePaths.Controls.Add(nbrSiding, 5, cntRows);
-            Label passingYardLength = new Label(){ Text = passingYard.ToString(), Anchor = AnchorStyles.Left, AutoSize = true };
+            Label passingYardLength = new Label() { Text = passingYard.ToString(), Anchor = AnchorStyles.Left, AutoSize = true };
             this.tablePaths.Controls.Add(passingYardLength, 6, cntRows);
             CinBoth = new Label() { Text = "--", Anchor = AnchorStyles.Left, AutoSize = true };
             cntRows++;

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Settings.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Settings.cs
@@ -22,16 +22,18 @@
 
 namespace ActivityEditor.Properties
 {
-    
-    
+
+
     // This class allows you to handle specific events on the settings class:
     //  The SettingChanging event is raised before a setting's value is changed.
     //  The PropertyChanged event is raised after a setting's value is changed.
     //  The SettingsLoaded event is raised after the setting values are loaded.
     //  The SettingsSaving event is raised before the setting values are saved.
-    internal sealed partial class Settings {
-        
-        public Settings() {
+    internal sealed partial class Settings
+    {
+
+        public Settings()
+        {
             // // To add event handlers for saving and changing settings, uncomment the lines below:
             //
             // this.SettingChanging += this.SettingChangingEventHandler;
@@ -39,12 +41,14 @@ namespace ActivityEditor.Properties
             // this.SettingsSaving += this.SettingsSavingEventHandler;
             //
         }
-        
-        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e) {
+
+        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e)
+        {
             // Add code to handle the SettingChangingEvent event here.
         }
-        
-        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e) {
+
+        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e)
+        {
             // Add code to handle the SettingsSaving event here.
         }
     }

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Wizard/ActivityDescr.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Wizard/ActivityDescr.cs
@@ -5,10 +5,10 @@ using LibAE.Formats;
 
 namespace AEWizard
 {
-	/// <summary>
-	/// Represents a single page within a wizard dialog.
-	/// </summary>
-	public class ActivityDescr : SinglePage
+    /// <summary>
+    /// Represents a single page within a wizard dialog.
+    /// </summary>
+    public class ActivityDescr : SinglePage
     {
         private Panel panel1;
         private TextBox textBox1;
@@ -21,7 +21,7 @@ namespace AEWizard
 
         public String RoutePath;
         public ActivityInfo activityInfo { get; set; }
-       // ==================================================================
+        // ==================================================================
         // Public Constructors
         // ==================================================================
 
@@ -30,11 +30,11 @@ namespace AEWizard
         /// class.
         /// </summary>
         public ActivityDescr()
-		{
+        {
             // Required for Windows Form Designer support
             InitializeComponent();
-            
-		}
+
+        }
 
         public void completePage()
         {
@@ -44,13 +44,13 @@ namespace AEWizard
         // ==================================================================
         // Protected Properties
         // ==================================================================
-        
-        
-        
+
+
+
         // ==================================================================
         // Private Methods
         // ==================================================================
-        
+
         #region Windows Form Designer generated code
         /// <summary>
         /// Required method for Designer support - do not modify
@@ -160,13 +160,13 @@ namespace AEWizard
             this.PerformLayout();
 
         }
-		#endregion
+        #endregion
 
 
         // ==================================================================
         // Protected Internal Methods
         // ==================================================================
-        
+
         /// <summary>
         /// Called when the page is no longer the active page.
         /// </summary>
@@ -200,7 +200,7 @@ namespace AEWizard
             // Activate the page
             return true;
         }
-        
+
         /// <summary>
         /// Called when the user clicks the Back button in a wizard.
         /// </summary>
@@ -222,7 +222,7 @@ namespace AEWizard
 
             return WizardForm.NextPage;
         }
-        
+
         /// <summary>
         /// Called when the user clicks the Finish button in a wizard.
         /// </summary>
@@ -242,7 +242,7 @@ namespace AEWizard
                 return false;
             return true;
         }
-        
+
         /// <summary>
         /// Called when the user clicks the Next button in a wizard.
         /// </summary>

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Wizard/SelectRoute.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Wizard/SelectRoute.cs
@@ -169,7 +169,7 @@ namespace AEWizard
             routeInfo.route = routePathCB.Text;
             return true;
         }
-        
+
 
     }
 }

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Wizard/TrainInfo.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Wizard/TrainInfo.cs
@@ -26,16 +26,16 @@ namespace AEWizard
         {
             this.trainConsistCB.DataSource = activityInfo.trainConsists.Select(o => o.consistName).ToList();
         }
-                // ==================================================================
+        // ==================================================================
         // Protected Properties
         // ==================================================================
-        
+
         /// <summary>
         /// Gets the <see cref="SMS.Windows.Forms.WizardForm">WizardForm</see>
         /// to which this <see cref="SMS.Windows.Forms.WizardPage">WizardPage</see>
         /// belongs.
         /// </summary>
-        
+
         // ==================================================================
         // Private Methods
         // ==================================================================

--- a/Source/Contrib/ActivityEditor/ActivityEditor/Wizard/WizardForm.cs
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/Wizard/WizardForm.cs
@@ -22,35 +22,35 @@ namespace AEWizard
     /// Used to identify the various buttons that may appear within a wizard
     /// dialog.  
     /// </summary>
-    [Flags]		
+    [Flags]
     public enum WizardButton
     {
         /// <summary>
         /// Identifies the <b>Back</b> button.
         /// </summary>
-        Back           = 0x00000001,
-        
+        Back = 0x00000001,
+
         /// <summary>
         /// Identifies the <b>Next</b> button.
         /// </summary>
-        Next           = 0x00000002,
-        
+        Next = 0x00000002,
+
         /// <summary>
         /// Identifies the <b>Finish</b> button.
         /// </summary>
-        Finish         = 0x00000004,
-        
+        Finish = 0x00000004,
+
         /// <summary>
         /// Identifies the disabled <b>Finish</b> button.
         /// </summary>
         DisabledFinish = 0x00000008,
     }
-    
+
     /// <summary>
     /// Represents a wizard dialog.
     /// </summary>
     public class WizardForm : Form
-	{
+    {
         ActivityInfo activityInfo;
         RouteInfo routeInfo;
         // ==================================================================
@@ -70,17 +70,17 @@ namespace AEWizard
         /// pressed.
         /// </summary>
         public const string NoPageChange = null;
-	
-	
+
+
         // ==================================================================
         // Private Fields
         // ==================================================================
-        
+
         /// <summary>
         /// Array of wizard pages.
         /// </summary>
         private ArrayList m_pages = new ArrayList();
-        
+
         /// <summary>
         /// Index of the selected page; -1 if no page selected.
         /// </summary>
@@ -90,7 +90,7 @@ namespace AEWizard
         // ==================================================================
         // Protected Fields
         // ==================================================================
-        
+
         /// <summary>
         /// The Back button.
         /// </summary>
@@ -127,15 +127,15 @@ namespace AEWizard
         // ==================================================================
         // Public Constructors
         // ==================================================================
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SMS.Windows.Forms.WizardForm">WizardForm</see>
         /// class.
         /// </summary>
         public WizardForm(ActivityInfo activity)
-		{
-			// Required for Windows Form Designer support
-			InitializeComponent();
+        {
+            // Required for Windows Form Designer support
+            InitializeComponent();
             activityInfo = activity;
             wiz1 = new ActivityDescr();
             wiz1.activityInfo = activity;
@@ -143,13 +143,13 @@ namespace AEWizard
             wiz2 = new TrainInfo();
             wiz2.activityInfo = activity;
             wiz2.completePage();
-            Controls.AddRange(new Control[] 
+            Controls.AddRange(new Control[]
             {
                 wiz1, wiz2
             });
             // Ensure Finish and Next buttons are positioned similarly
-			m_finishButton.Location = m_nextButton.Location;
-		}
+            m_finishButton.Location = m_nextButton.Location;
+        }
         public WizardForm(RouteInfo info)
         {
             InitializeComponent();
@@ -167,14 +167,14 @@ namespace AEWizard
         // ==================================================================
         // Private Methods
         // ==================================================================
-        
+
         #region Windows Form Designer generated code
-		/// <summary>
-		/// Required method for Designer support - do not modify
-		/// the contents of this method with the code editor.
-		/// </summary>
-		private void InitializeComponent()
-		{
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(WizardForm));
             this.m_backButton = new System.Windows.Forms.Button();
             this.m_nextButton = new System.Windows.Forms.Button();
@@ -249,7 +249,7 @@ namespace AEWizard
             this.ResumeLayout(false);
 
         }
-		#endregion
+        #endregion
 
         /// <summary>
         /// Activates the page at the specified index in the page array.
@@ -257,29 +257,29 @@ namespace AEWizard
         /// <param name="newIndex">
         /// Index of new page to be selected.
         /// </param>
-        private void ActivatePage( int newIndex )
+        private void ActivatePage(int newIndex)
         {
             // Ensure the index is valid
-            if( newIndex < 0 || newIndex >= m_pages.Count )
+            if (newIndex < 0 || newIndex >= m_pages.Count)
                 throw new ArgumentOutOfRangeException();
 
             // Deactivate the current page if applicable
             SinglePage currentPage = null;
-            if( m_selectedIndex != -1 )
+            if (m_selectedIndex != -1)
             {
                 currentPage = (SinglePage)m_pages[m_selectedIndex];
-                if( !currentPage.OnKillActive() )
+                if (!currentPage.OnKillActive())
                     return;
             }
 
             // Activate the new page
-            SinglePage newPage = (SinglePage)m_pages[ newIndex ];
-            if( !newPage.OnSetActive() )
+            SinglePage newPage = (SinglePage)m_pages[newIndex];
+            if (!newPage.OnSetActive())
                 return;
 
             // Update state
             m_selectedIndex = newIndex;
-            if( currentPage != null )
+            if (currentPage != null)
                 currentPage.Visible = false;
             newPage.Visible = true;
             newPage.Focus();
@@ -288,32 +288,32 @@ namespace AEWizard
         /// <summary>
         /// Handles the Click event for the Back button.
         /// </summary>
-        private void OnClickBack( object sender, EventArgs e )
+        private void OnClickBack(object sender, EventArgs e)
         {
             // Ensure a page is currently selected
-            if( m_selectedIndex != -1 )
+            if (m_selectedIndex != -1)
             {
                 // Inform selected page that the Back button was clicked
                 string pageName = ((SinglePage)m_pages[
-                    m_selectedIndex ]).OnWizardBack();
-                switch( pageName )
+                    m_selectedIndex]).OnWizardBack();
+                switch (pageName)
                 {
                     // Do nothing
                     case NoPageChange:
                         break;
-                        
+
                     // Activate the next appropriate page
                     case NextPage:
-                        if( m_selectedIndex - 1 >= 0 )
-                            ActivatePage( m_selectedIndex - 1 );
+                        if (m_selectedIndex - 1 >= 0)
+                            ActivatePage(m_selectedIndex - 1);
                         break;
 
                     // Activate the specified page if it exists
                     default:
-                        foreach( SinglePage page in m_pages )
+                        foreach (SinglePage page in m_pages)
                         {
-                            if( page.Name == pageName )
-                                ActivatePage( m_pages.IndexOf( page ) );
+                            if (page.Name == pageName)
+                                ActivatePage(m_pages.IndexOf(page));
                         }
                         break;
                 }
@@ -323,7 +323,7 @@ namespace AEWizard
         /// <summary>
         /// Handles the Click event for the Cancel button.
         /// </summary>
-        private void OnClickCancel( object sender, EventArgs e )
+        private void OnClickCancel(object sender, EventArgs e)
         {
             // Close wizard
             DialogResult = DialogResult.Cancel;
@@ -332,17 +332,17 @@ namespace AEWizard
         /// <summary>
         /// Handles the Click event for the Finish button.
         /// </summary>
-        private void OnClickFinish( object sender, EventArgs e )
+        private void OnClickFinish(object sender, EventArgs e)
         {
             // Ensure a page is currently selected
-            if( m_selectedIndex != -1 )
+            if (m_selectedIndex != -1)
             {
                 // Inform selected page that the Finish button was clicked
-                SinglePage page = (SinglePage)m_pages[ m_selectedIndex ];
-                if( page.OnWizardFinish() )
+                SinglePage page = (SinglePage)m_pages[m_selectedIndex];
+                if (page.OnWizardFinish())
                 {
                     // Deactivate page and close wizard
-                    if( page.OnKillActive() )
+                    if (page.OnKillActive())
                         DialogResult = DialogResult.OK;
                 }
             }
@@ -351,15 +351,15 @@ namespace AEWizard
         /// <summary>
         /// Handles the Click event for the Next button.
         /// </summary>
-        private void OnClickNext( object sender, EventArgs e )
+        private void OnClickNext(object sender, EventArgs e)
         {
             // Ensure a page is currently selected
-            if( m_selectedIndex != -1 )
+            if (m_selectedIndex != -1)
             {
                 // Inform selected page that the Next button was clicked
                 string pageName = ((SinglePage)m_pages[
-                    m_selectedIndex ]).OnWizardNext();
-                switch( pageName )
+                    m_selectedIndex]).OnWizardNext();
+                switch (pageName)
                 {
                     // Do nothing
                     case NoPageChange:
@@ -367,16 +367,16 @@ namespace AEWizard
 
                     // Activate the next appropriate page
                     case NextPage:
-                        if( m_selectedIndex + 1 < m_pages.Count )
-                            ActivatePage( m_selectedIndex + 1 );
+                        if (m_selectedIndex + 1 < m_pages.Count)
+                            ActivatePage(m_selectedIndex + 1);
                         break;
 
                     // Activate the specified page if it exists
                     default:
-                        foreach( SinglePage page in m_pages )
+                        foreach (SinglePage page in m_pages)
                         {
-                            if( page.Name == pageName )
-                                ActivatePage( m_pages.IndexOf( page ) );
+                            if (page.Name == pageName)
+                                ActivatePage(m_pages.IndexOf(page));
                         }
                         break;
                 }
@@ -387,25 +387,25 @@ namespace AEWizard
         // ==================================================================
         // Protected Methods
         // ==================================================================
-        
+
         /// <seealso cref="System.Windows.Forms.Control.OnControlAdded">
         /// System.Windows.Forms.Control.OnControlAdded
         /// </seealso>
-        protected override void OnControlAdded( ControlEventArgs e )
+        protected override void OnControlAdded(ControlEventArgs e)
         {
             // Invoke base class implementation
-            base.OnControlAdded( e );
-            
+            base.OnControlAdded(e);
+
             // Set default properties for all WizardPage instances added to
             // this form
             SinglePage page = e.Control as SinglePage;
-            if( page != null )
+            if (page != null)
             {
                 page.Visible = false;
-                page.Location = new Point( 0, 0 );
-                page.Size = new Size( Width, m_separator.Location.Y );
-                m_pages.Add( page );
-                if( m_selectedIndex == -1 )
+                page.Location = new Point(0, 0);
+                page.Size = new Size(Width, m_separator.Location.Y);
+                m_pages.Add(page);
+                if (m_selectedIndex == -1)
                     m_selectedIndex = 0;
             }
         }
@@ -413,33 +413,33 @@ namespace AEWizard
         /// <seealso cref="System.Windows.Forms.Form.OnLoad">
         /// System.Windows.Forms.Form.OnLoad
         /// </seealso>
-        protected override void OnLoad( EventArgs e )
+        protected override void OnLoad(EventArgs e)
         {
             // Invoke base class implementation
-            base.OnLoad( e );
-            
+            base.OnLoad(e);
+
             // Activate the first page in the wizard
-            if( m_pages.Count > 0 )
-                ActivatePage( 0 );
+            if (m_pages.Count > 0)
+                ActivatePage(0);
         }
 
 
         // ==================================================================
         // Public Methods
         // ==================================================================
-        
+
         /// <summary>
         /// Sets the text in the Finish button.
         /// </summary>
         /// <param name="text">
         /// Text to be displayed on the Finish button.
         /// </param>
-        public void SetFinishText( string text )
+        public void SetFinishText(string text)
         {
             // Set the Finish button text
             m_finishButton.Text = text;
         }
-        
+
         /// <summary>
         /// Enables or disables the Back, Next, or Finish buttons in the
         /// wizard.
@@ -454,7 +454,7 @@ namespace AEWizard
         /// <c>WizardPage.OnSetActive</c>.  You can display a Finish or a
         /// Next button at one time, but not both.
         /// </remarks>
-        public void SetWizardButtons( WizardButton flags )
+        public void SetWizardButtons(WizardButton flags)
         {
             // Enable/disable and show/hide buttons appropriately
             m_backButton.Enabled =
@@ -469,7 +469,7 @@ namespace AEWizard
             m_finishButton.Visible =
                 (flags & WizardButton.Finish) == WizardButton.Finish ||
                 (flags & WizardButton.DisabledFinish) == WizardButton.DisabledFinish;
-                
+
             // Set the AcceptButton depending on whether or not the Finish
             // button is visible or not
             AcceptButton = m_finishButton.Visible ? m_finishButton :

--- a/Source/Contrib/ActivityEditor/LibAE/AEUtility.cs
+++ b/Source/Contrib/ActivityEditor/LibAE/AEUtility.cs
@@ -87,14 +87,14 @@ namespace LibAE
             areaRoute.maxX = Utility.CalcBounds(areaRoute.maxX, ((x + 1f) * 2048f) + 1024f, true);
             areaRoute.maxY = Utility.CalcBounds(areaRoute.maxY, ((z + 1f) * 2048f) + 1024f, true);
 
-            areaRoute.setMinX(Utility.CalcBounds(areaRoute.getMinX(), (x * 2048f) -1024f, false));
-            areaRoute.setMinY(Utility.CalcBounds(areaRoute.getMinY(), (z * 2048f) -1024f, false));
+            areaRoute.setMinX(Utility.CalcBounds(areaRoute.getMinX(), (x * 2048f) - 1024f, false));
+            areaRoute.setMinY(Utility.CalcBounds(areaRoute.getMinY(), (z * 2048f) - 1024f, false));
         }
     }
 
     public static class Utility
     {
-        
+
         /// <summary>
         /// Given a value representing a limit, evaluate if the given value exceeds the current limit.
         /// If so, expand the limit.

--- a/Source/Contrib/ActivityEditor/LibAE/Formats/ActivityInfo.cs
+++ b/Source/Contrib/ActivityEditor/LibAE/Formats/ActivityInfo.cs
@@ -43,7 +43,7 @@ namespace LibAE.Formats
         [JsonProperty("ConsistPath")]
         string consistPath;
 
-        public ConsistInfo (string name, string path)
+        public ConsistInfo(string name, string path)
         {
             consistName = name;
             consistPath = path;
@@ -77,7 +77,7 @@ namespace LibAE.Formats
 
         }
 
-        public void config (List<string> routes)
+        public void config(List<string> routes)
         {
             foreach (string routeParent in routes)
             {
@@ -101,7 +101,7 @@ namespace LibAE.Formats
                     string fullPathConsist = Path.GetFullPath(consist);
                     ConsistFile consistName = new ConsistFile(fullPathConsist);
                     ConsistInfo conInfo = new ConsistInfo(consistName.ToString(), fullPathConsist);
-                    trainConsists.Add(conInfo); 
+                    trainConsists.Add(conInfo);
                 }
             }
         }

--- a/Source/Contrib/ActivityEditor/LibAE/Formats/MSTSDataConfig.cs
+++ b/Source/Contrib/ActivityEditor/LibAE/Formats/MSTSDataConfig.cs
@@ -35,7 +35,7 @@ namespace LibAE
     {
         public MSTSBase TileBase { get; protected set; }
 
-        public MSTSDataConfig(string mstsPath, string Route, TypeEditor interfaceType) : base (mstsPath, Route)
+        public MSTSDataConfig(string mstsPath, string Route, TypeEditor interfaceType) : base(mstsPath, Route)
         {
             string routePath = Path.Combine(Route, TRK.Tr_RouteFile.FileName);
             TileBase = new MSTSBase(TDB);

--- a/Source/Contrib/ActivityEditor/LibAE/Formats/PathEvent.cs
+++ b/Source/Contrib/ActivityEditor/LibAE/Formats/PathEvent.cs
@@ -52,7 +52,7 @@ namespace LibAE.Formats
         ACTIVITY_STOP = 2,
         ACTIVITY_WAIT = 3
     };
-#endregion
+    #endregion
 
     #region PathEventItem
 
@@ -103,7 +103,7 @@ namespace LibAE.Formats
             typeItem = (int)TypeEvent.ACTIVITY_START;
             st = a.GetManifestResourceStream("LibAE.Icon.Start.ico");
             StartIcon = new System.Drawing.Icon(st);
- 
+
         }
 
         public void setNameStart(int info)
@@ -138,7 +138,7 @@ namespace LibAE.Formats
             Assembly a = Assembly.GetExecutingAssembly();
 
             typeItem = (int)TypeEvent.ACTIVITY_STOP;
-           st = a.GetManifestResourceStream("LibAE.Icon.Stop.ico");
+            st = a.GetManifestResourceStream("LibAE.Icon.Stop.ico");
             StopIcon = new System.Drawing.Icon(st);
 
         }

--- a/Source/Contrib/ContentManager/Content.cs
+++ b/Source/Contrib/ContentManager/Content.cs
@@ -114,16 +114,16 @@ namespace ORTS.ContentManager
             {
                 Debug.WriteLine(String.Format("{0} naively scanning for {2} '{1}'", this, name, type));
 #endif
-                foreach (var child in children)
+            foreach (var child in children)
+            {
+                if (child.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (child.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
-                    {
 #if DEBUG_CONTENT_GET_SCAN
                         Debug.WriteLine(String.Format("{0} naive scan found match for {2} '{1}'", this, name, type));
 #endif
-                        return child;
-                    }
+                    return child;
                 }
+            }
 #if DEBUG_CONTENT_GET_SCAN
             }
 #endif

--- a/Source/Contrib/ContentManager/ContentInfo.cs
+++ b/Source/Contrib/ContentManager/ContentInfo.cs
@@ -39,7 +39,8 @@ namespace ORTS.ContentManager
             details.AppendFormat("Name:\t{1}{0}", Environment.NewLine, content.Name);
             details.AppendFormat("Path:\t{1}{0}", Environment.NewLine, content.PathName);
 
-            try {
+            try
+            {
                 var stream = new MemoryStream();
                 var serializer = new BinaryFormatter();
                 serializer.Serialize(stream, content);

--- a/Source/Contrib/ContentManager/Models/Consist.cs
+++ b/Source/Contrib/ContentManager/Models/Consist.cs
@@ -39,11 +39,12 @@ namespace ORTS.ContentManager.Models
                 Name = file.Name;
 
                 Cars = from car in file.Train.TrainCfg.WagonList
-                           select new Car(car);
+                       select new Car(car);
             }
         }
 
-        public enum Direction{
+        public enum Direction
+        {
             Forwards,
             Backwards,
         }

--- a/Source/Contrib/ContentManager/Models/Service.cs
+++ b/Source/Contrib/ContentManager/Models/Service.cs
@@ -102,7 +102,7 @@ namespace ORTS.ContentManager.Models
                     }
                 }
                 ID = serviceColumn.ToString();
-                    var timeRE = new Regex(@"^(\d\d):(\d\d)(?:-(\d\d):(\d\d))?");
+                var timeRE = new Regex(@"^(\d\d):(\d\d)(?:-(\d\d):(\d\d))?");
                 var startTimeMatch = timeRE.Match(file.Strings[startRow][serviceColumn]);
                 if (startTimeMatch.Success)
                 {

--- a/Source/Contrib/TrackViewer/Drawing/BasicShapes.cs
+++ b/Source/Contrib/TrackViewer/Drawing/BasicShapes.cs
@@ -34,11 +34,11 @@ namespace ORTS.TrackViewer.Drawing
     static class BasicShapes
     {
         private static SpriteBatch spriteBatch;
-        
+
         //size of a identifying feature in the texture (in pixels), so we can scale as needed
         private static Dictionary<string, float> textureScales = new Dictionary<string, float>();
         private static Dictionary<string, Vector2> textureOffsets = new Dictionary<string, Vector2>();
-        private static Dictionary<string,Texture2D> textures = new Dictionary<string,Texture2D>();
+        private static Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>();
 
         private static FontManager fontManager;
 
@@ -50,14 +50,14 @@ namespace ORTS.TrackViewer.Drawing
         /// <param name="contentPath">The full directory name where content like .png files can be found</param>
         public static void LoadContent(GraphicsDevice graphicsDevice, SpriteBatch spriteBatchIn, string contentPath)
         {
-            spriteBatch = spriteBatchIn; 
+            spriteBatch = spriteBatchIn;
             textures["blankPixel"] = new Texture2D(graphicsDevice, 1, 1);
             textures["blankPixel"].SetData(new[] { Color.White });
 
             int diameter = 64; // Needs to be power of two for mipmapping
             textures["circle"] = CreateCircleTexture(graphicsDevice, diameter);
             textureScales["circle"] = diameter;
-            textureOffsets["circle"] = new Vector2(diameter/2, diameter/2);
+            textureOffsets["circle"] = new Vector2(diameter / 2, diameter / 2);
 
             textures["disc"] = CreateDiscTexture(graphicsDevice, diameter);
             textureScales["disc"] = diameter;
@@ -72,13 +72,13 @@ namespace ORTS.TrackViewer.Drawing
             textureOffsets["crossedRing"] = new Vector2(diameter / 2, diameter / 2);
 
 
-            LoadAndHighlightTexture(graphicsDevice, contentPath, "signal", "Signal",29, 18);
+            LoadAndHighlightTexture(graphicsDevice, contentPath, "signal", "Signal", 29, 18);
             LoadAndHighlightTexture(graphicsDevice, contentPath, "hazard", "Hazard");
 
-            LoadAndHighlightTexture(graphicsDevice, contentPath, "pathNormal", "pathNormal",31,31);
-            LoadAndHighlightTexture(graphicsDevice, contentPath, "pathStart", "pathStart",31,31);
-            LoadAndHighlightTexture(graphicsDevice, contentPath, "pathEnd", "pathEnd",31,31);
-            LoadAndHighlightTexture(graphicsDevice, contentPath, "pathWait", "pathWait",31,31);
+            LoadAndHighlightTexture(graphicsDevice, contentPath, "pathNormal", "pathNormal", 31, 31);
+            LoadAndHighlightTexture(graphicsDevice, contentPath, "pathStart", "pathStart", 31, 31);
+            LoadAndHighlightTexture(graphicsDevice, contentPath, "pathEnd", "pathEnd", 31, 31);
+            LoadAndHighlightTexture(graphicsDevice, contentPath, "pathWait", "pathWait", 31, 31);
             LoadAndHighlightTexture(graphicsDevice, contentPath, "pathReverse", "pathReverse", 31, 31);
             //LoadAndHighlightTexture(graphicsDevice, contentPath, "pathSiding", "pathSiding", 31, 31);
 
@@ -88,7 +88,7 @@ namespace ORTS.TrackViewer.Drawing
             LoadAndHighlightTexture(graphicsDevice, contentPath, "pickup", "Pickup");
             LoadAndHighlightTexture(graphicsDevice, contentPath, "platform", "Platform", 31, 37);
             LoadAndHighlightTexture(graphicsDevice, contentPath, "sound", "Sound");
-            LoadAndHighlightTexture(graphicsDevice, contentPath, "playerTrain", "steamTrain",31,31);
+            LoadAndHighlightTexture(graphicsDevice, contentPath, "playerTrain", "steamTrain", 31, 31);
 
             PrepareArcDrawing();
             fontManager = FontManager.Instance;
@@ -104,11 +104,11 @@ namespace ORTS.TrackViewer.Drawing
         /// <param name="fileName">the name of the file (without extension)</param>
         private static void LoadAndHighlightTexture(GraphicsDevice graphicsDevice, string contentPath, string textureName, string fileName)
         {
-            LoadAndHighlightTexture( graphicsDevice, contentPath, textureName, fileName, 0, 0);
+            LoadAndHighlightTexture(graphicsDevice, contentPath, textureName, fileName, 0, 0);
         }
         private static void LoadAndHighlightTexture(GraphicsDevice graphicsDevice, string contentPath, string textureName, string fileName, int offsetX, int offsetY)
         {
-            string fullFileName = System.IO.Path.Combine(contentPath, fileName +".png");
+            string fullFileName = System.IO.Path.Combine(contentPath, fileName + ".png");
             Texture2D tempTexture;
             try
             {
@@ -152,8 +152,8 @@ namespace ORTS.TrackViewer.Drawing
         /// <returns>The white texture</returns>
         private static Texture2D CreateCircleTexture(GraphicsDevice graphicsDevice, int outerRadius)
         {
-            int radius = (outerRadius - 2)/2; // So circle doesn't go out of bounds
-            Texture2D texture = new Texture2D(graphicsDevice, outerRadius, outerRadius,  0, TextureUsage.AutoGenerateMipMap, SurfaceFormat.Color);
+            int radius = (outerRadius - 2) / 2; // So circle doesn't go out of bounds
+            Texture2D texture = new Texture2D(graphicsDevice, outerRadius, outerRadius, 0, TextureUsage.AutoGenerateMipMap, SurfaceFormat.Color);
 
             Color[] data = new Color[outerRadius * outerRadius];
 
@@ -209,7 +209,7 @@ namespace ORTS.TrackViewer.Drawing
             texture.SetData(data);
             return texture;
         }
-        
+
         /// <summary>
         /// private method to create a texture2D containing a ring (circle with thick border)
         /// </summary>
@@ -230,7 +230,7 @@ namespace ORTS.TrackViewer.Drawing
                 {
                     int i = (x + radius) * outerRadius + (y + radius);
                     int r2 = x * x + y * y;
-                    if (r2 <= radius * radius &&  r2 > innerRadius * innerRadius)
+                    if (r2 <= radius * radius && r2 > innerRadius * innerRadius)
                     {
                         data[i] = Color.White;
                     }
@@ -282,7 +282,7 @@ namespace ORTS.TrackViewer.Drawing
                             data[i] = Color.White;
                         }
                     }
-                    
+
                 }
             }
 
@@ -337,13 +337,13 @@ namespace ORTS.TrackViewer.Drawing
             float angle = (float)Math.Atan2(point2.Y - point1.Y, point2.X - point1.X);
             float cosAngle = (float)Math.Cos(angle);
             float sinAngle = (float)Math.Sin(angle);
-            
+
             float length = Vector2.Distance(point1, point2);
-            
+
             int pixelsPerSegment = 10; // this is a target value. We will always start and end with a segment.
-            int nsegments = 1 + (int) Math.Floor(length / (2 * pixelsPerSegment));
+            int nsegments = 1 + (int)Math.Floor(length / (2 * pixelsPerSegment));
             float lengthPerSegment = length / (2 * nsegments - 1);
-            Vector2 segmentOffset = 2*lengthPerSegment * new Vector2(cosAngle, sinAngle);
+            Vector2 segmentOffset = 2 * lengthPerSegment * new Vector2(cosAngle, sinAngle);
 
             for (int i = 0; i < nsegments; i++)
             {
@@ -363,8 +363,8 @@ namespace ORTS.TrackViewer.Drawing
         public static void DrawLine(float width, Color color, Vector2 point, float length, float angle)
         {
             // offset to compensate for the width of the line
-            Vector2 offset = new Vector2(width * (float) Math.Sin(angle)/2, -width * (float)Math.Cos(angle)/2);
-            spriteBatch.Draw(textures["blankPixel"], point+offset, null, color,
+            Vector2 offset = new Vector2(width * (float)Math.Sin(angle) / 2, -width * (float)Math.Cos(angle) / 2);
+            spriteBatch.Draw(textures["blankPixel"], point + offset, null, color,
                        angle, Vector2.Zero, new Vector2(length, width),
                        SpriteEffects.None, 0);
         }
@@ -384,14 +384,14 @@ namespace ORTS.TrackViewer.Drawing
             // Positive arcDegree means curving to the left, negative arcDegree means curving to the right
             int sign = (arcDegrees > 0) ? -1 : 1;
             arcDegrees = Math.Abs(arcDegrees);
-            
+
             // We will draw an arc as a succession of straight lines. We do this in a way that reduces the amount
             // of goniometric calculations needed.
             // The idea is to start to find the center of the circle. The direction from center to origin is
             // 90 degrees different from angle
             Vector2 centerToPointDirection = sign * new Vector2(-(float)Math.Sin(angle), (float)Math.Cos(angle)); // unit vector
             Vector2 center = point - radius * centerToPointDirection; ;
-            
+
             // To determine the amount of straight lines we need to calculate we first 
             // determine then lenght of the arc, and divide that by the maximum we allow;
             // All angles go in steps of minAngleDegree
@@ -400,12 +400,12 @@ namespace ORTS.TrackViewer.Drawing
             // Here alpha is the angle drawn for a single arc-segment. Approximately error ~ radius * alpha^2/8.
             // The amount of pixels in the line is about L ~ radius * alpha => L ~ sqrt(8 * radius * error). 
             // We found that for thight curves, error can not be larger than half a pixel (otherwise it becomes visible)
-            maxStraightPixels = (float)Math.Sqrt(4*radius);   
+            maxStraightPixels = (float)Math.Sqrt(4 * radius);
             float numberStraightLines = (float)Math.Ceiling(arcLength / maxStraightPixels);
             // amount of minAngleDegrees we need to cover: 
-            int arcStepsRemaining = (int) (Math.Round(arcDegrees/minAngleDegree)); 
+            int arcStepsRemaining = (int)(Math.Round(arcDegrees / minAngleDegree));
             // amount of minAngleDegrees we cover per straight line:
-            int arcStepsPerLine = (int) (Math.Ceiling(arcDegrees/(minAngleDegree*numberStraightLines)));
+            int arcStepsPerLine = (int)(Math.Ceiling(arcDegrees / (minAngleDegree * numberStraightLines)));
 
             // Add offset in angles
             if (arcDegreesOffset != 0f)
@@ -421,9 +421,9 @@ namespace ORTS.TrackViewer.Drawing
             while (arcStepsRemaining > 0)
             {
                 int arcSteps = Math.Min(arcStepsRemaining, arcStepsPerLine); //angle steps we cover in this line
-                point = center + centerToPointDirection * (radius-sign*width/2);  // correct for width of line
+                point = center + centerToPointDirection * (radius - sign * width / 2);  // correct for width of line
                 float length = radius * arcSteps * minAngleRad + 1; // the +1 to prevent white lines in between arc sections
-                
+
                 spriteBatch.Draw(textures["blankPixel"], point, null, color,
                        angle, Vector2.Zero, new Vector2(length, width),
                        SpriteEffects.None, 0);
@@ -436,8 +436,8 @@ namespace ORTS.TrackViewer.Drawing
                     angle -= sign * arcSteps * minAngleRad;
                     //Rotate the centerToPointDirection, and calculate new point
                     centerToPointDirection = new Vector2(
-                             cosTable[arcSteps] * centerToPointDirection.X + sign*sinTable[arcSteps] * centerToPointDirection.Y,
-                       -sign*sinTable[arcSteps] * centerToPointDirection.X +      cosTable[arcSteps] * centerToPointDirection.Y
+                             cosTable[arcSteps] * centerToPointDirection.X + sign * sinTable[arcSteps] * centerToPointDirection.Y,
+                       -sign * sinTable[arcSteps] * centerToPointDirection.X + cosTable[arcSteps] * centerToPointDirection.Y
                         );
                 }
             }
@@ -507,17 +507,17 @@ namespace ORTS.TrackViewer.Drawing
         private static void PrepareArcDrawing()
         {
             minAngleRad = MathHelper.ToRadians(minAngleDegree);
-            arcTableSize = (int)(Math.Ceiling(maxAngleDegree/minAngleDegree)+1);
+            arcTableSize = (int)(Math.Ceiling(maxAngleDegree / minAngleDegree) + 1);
             cosTable = new float[arcTableSize];
             sinTable = new float[arcTableSize];
             for (int i = 0; i < arcTableSize; i++)
             {
-                cosTable[i] = (float) Math.Cos(i * minAngleRad);
-                sinTable[i] = (float) Math.Sin(i * minAngleRad);
+                cosTable[i] = (float)Math.Cos(i * minAngleRad);
+                sinTable[i] = (float)Math.Sin(i * minAngleRad);
             }
         }
 
-        
+
         private static float minAngleDegree = 0.1f; // we do not care for angles smaller than 0.1 degrees
         private static float maxAngleDegree = 90; // allows for drawing up to 90 degree arcs
         private static float maxStraightPixels; // Maximum amount of pixels in a straight line part of an arc
@@ -544,19 +544,19 @@ namespace ORTS.TrackViewer.Drawing
         private int defaultFontSize;
         /// <summary>Fontsize to be used for exanding text</summary>
         private int expandingFontSize;
-        
+
         /// <summary>The text manager that supports the font(s)</summary>
         private WindowTextManager textManager;
 
         /// <summary>List of fonts</summary>
         private Dictionary<int, WindowTextFont> fonts;
-        
+
         /// <summary>
         /// Constructor, private so only called during class initialization
         /// </summary>
         private FontManager()
         {
-            fontSizes = new int[] {10,11,12,13,14,16,18,20};
+            fontSizes = new int[] { 10, 11, 12, 13, 14, 16, 18, 20 };
             defaultFontSize = 10;
             expandingFontSize = defaultFontSize;
 

--- a/Source/Contrib/TrackViewer/Drawing/CloseToMouse.cs
+++ b/Source/Contrib/TrackViewer/Drawing/CloseToMouse.cs
@@ -77,7 +77,7 @@ namespace ORTS.TrackViewer.Drawing
             dz += 2048 * (location1.TileZ - location2.TileZ);
             return dx * dx + dz * dz;
         }
- 
+
     }
 
     /// <summary>
@@ -96,7 +96,7 @@ namespace ORTS.TrackViewer.Drawing
     /// <summary>
     /// CloseToMouse item specifically for junctions and endnode. But will take any track point
     /// </summary>
-    public class CloseToMouseJunctionOrEnd:CloseToMousePoint
+    public class CloseToMouseJunctionOrEnd : CloseToMousePoint
     {
         /// <summary>Tracknode of the closest junction or end node</summary>
         public TrackNode JunctionOrEndNode { get; private set; }
@@ -158,13 +158,13 @@ namespace ORTS.TrackViewer.Drawing
     /// <summary>
     /// CloseToMouse track item. Stores item as well as its type (name)
     /// </summary>
-    public class CloseToMouseItem:CloseToMousePoint
+    public class CloseToMouseItem : CloseToMousePoint
     {
         /// <summary>Link to the item that is closest to the mouse</summary>
         public DrawableTrackItem DrawableTrackItem { get; protected set; }
-        
+
         /// <summary>The index of the original item in whatever table it was defined</summary>
-        public override uint Index { get { return DrawableTrackItem.Index;} }
+        public override uint Index { get { return DrawableTrackItem.Index; } }
         /// <summary>The X-coordinate within a tile of the original item in the track database</summary>
         public override float X { get { return worldLocation.Location.X; } }
         /// <summary>The Z-coordinate within a tile of the original item in the track database</summary>
@@ -172,7 +172,7 @@ namespace ORTS.TrackViewer.Drawing
 
         /// <summary>The world location of the item that is closest to the mouse</summary>
         private WorldLocation worldLocation;
-        
+
         /// <summary>
         /// Constructor, creating an empty object
         /// </summary>
@@ -200,7 +200,7 @@ namespace ORTS.TrackViewer.Drawing
             base.Reset();
             DrawableTrackItem = null;
             worldLocation = WorldLocation.None;
-       }
+        }
 
         /// <summary>
         /// Check wether this track Item is closest to the mouse location
@@ -313,7 +313,7 @@ namespace ORTS.TrackViewer.Drawing
         /// <param name="vectorSection">the vectorSection that will be stored when indeed it is closest to the mouse location</param>
         /// <param name="tvsi">Current index of the trackvectorsection</param>
         /// <param name="pixelsPerMeter"></param>
-        public void CheckMouseDistance(WorldLocation location, WorldLocation mouseLocation, 
+        public void CheckMouseDistance(WorldLocation location, WorldLocation mouseLocation,
             TrackNode trackNode, TrVectorSection vectorSection, int tvsi, double pixelsPerMeter)
         {
             storedMouseLocation = mouseLocation;
@@ -356,7 +356,7 @@ namespace ORTS.TrackViewer.Drawing
                 TrackSection trackSection = tsectionDat.TrackSections.Get(trackCandidate.vectorSection.SectionIndex);
                 DistanceLon distanceLon = CalcRealDistanceSquared(trackCandidate.vectorSection, trackSection);
                 double realDistanceSquared = (double)distanceLon.distanceSquared;
-                
+
                 // Add the trackCandidate to the sorted list with its new distance squared as key
                 if (!sortedTrackCandidates.ContainsKey(realDistanceSquared))
                 {
@@ -436,7 +436,8 @@ namespace ORTS.TrackViewer.Drawing
     /// <summary>
     /// Struct to store a candidate for the track closest to the mouse, so we can keep an ordered list.
     /// </summary>
-    struct TrackCandidate {
+    struct TrackCandidate
+    {
         public TrackNode trackNode;
         public TrVectorSection vectorSection;
         public int trackVectorSectionIndex;  // which section within a trackNode that is a vector node

--- a/Source/Contrib/TrackViewer/Drawing/DebugWindow.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DebugWindow.cs
@@ -35,7 +35,8 @@ namespace ORTS.TrackViewer.Drawing
         /// <summary>
         /// Draw all available debug windows
         /// </summary>
-        public static void DrawAll() {
+        public static void DrawAll()
+        {
             //Just a safety. Normally there should be no DebugWindows once released.
             if (!System.Diagnostics.Debugger.IsAttached) return;
             foreach (DebugWindow window in debugWindows)

--- a/Source/Contrib/TrackViewer/Drawing/DrawArea.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawArea.cs
@@ -780,7 +780,7 @@ namespace ORTS.TrackViewer.Drawing
         /// <param name="angle">Rotation angle for the texture</param>
         /// <param name="size">Size of the texture in world-meters</param>
         ///<param name="flip">Whether the texture needs to be flipped (vertically)</param>
-        public void DrawTexture(WorldLocation location, string textureName, float size,  float angle, bool flip)
+        public void DrawTexture(WorldLocation location, string textureName, float size, float angle, bool flip)
         {
             if (OutOfArea(location)) return;
             float pixelSize = GetWindowSize(size);
@@ -857,12 +857,12 @@ namespace ORTS.TrackViewer.Drawing
             while (stepIndex >= discreteSteps.Count())
             {
                 stepIndex -= discreteSteps.Count();
-                powerOfTen ++;
+                powerOfTen++;
             }
             while (stepIndex < 0)
             {
                 stepIndex += discreteSteps.Count();
-                powerOfTen --;
+                powerOfTen--;
                 if (powerOfTen < minPowerOfTen)
                 {
                     powerOfTen = minPowerOfTen;
@@ -879,7 +879,7 @@ namespace ORTS.TrackViewer.Drawing
         public void ApproximateTo(double requestedValue)
         {
             powerOfTen = Convert.ToInt32(Math.Floor(Math.Log10(requestedValue))) - 1;
-            double restValue = requestedValue *  Math.Pow(10 , -(double)powerOfTen);
+            double restValue = requestedValue * Math.Pow(10, -(double)powerOfTen);
             for (stepIndex = 0; stepIndex < discreteSteps.Count() && discreteSteps[stepIndex] < restValue; stepIndex++) { };
             if (stepIndex == discreteSteps.Count())
             {   // the value requested is larger than 90. 10^n, which means we get 100.10^n.

--- a/Source/Contrib/TrackViewer/Drawing/DrawColors.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawColors.cs
@@ -38,9 +38,9 @@ namespace ORTS.TrackViewer.Drawing
     static class DrawColors
     {
 
-        public static ColorScheme colorsNormal    = new ColorScheme();
+        public static ColorScheme colorsNormal = new ColorScheme();
         public static ColorScheme colorsHighlight = new ColorScheme(HighlightType.Highlight);
-        public static ColorScheme colorsHotlight  = new ColorScheme(HighlightType.Hotlight);  // even more highlighting
+        public static ColorScheme colorsHotlight = new ColorScheme(HighlightType.Hotlight);  // even more highlighting
         public static ColorScheme colorsRoads = new ColorScheme();
         public static ColorScheme colorsRoadsHighlight = new ColorScheme(HighlightType.Highlight);
         public static ColorScheme colorsRoadsHotlight = new ColorScheme(HighlightType.Hotlight);
@@ -53,7 +53,7 @@ namespace ORTS.TrackViewer.Drawing
         static ColorsGroupTrack roadTrackGroupColoured = new ColorsGroupTrack();
         static ColorsGroupTrack trackGroupTerrain = new ColorsGroupTrack();
         static ColorsGroupTrack roadTrackGroupTerrain = new ColorsGroupTrack();
-        
+
         static ColorsGroupBackground backgroundWithTilesGroup = new ColorsGroupBackground();
         static ColorsGroupBackground backgroundWithoutTilesGroup = new ColorsGroupBackground();
 
@@ -72,7 +72,7 @@ namespace ORTS.TrackViewer.Drawing
             SetShadedColors(preferenceChanger);
 
             SetColoursFromOptions(true, false, false); //just a default
-         }
+        }
 
         private static void SetPathColors(IPreferenceChanger preferenceChanger)
         {
@@ -83,7 +83,7 @@ namespace ORTS.TrackViewer.Drawing
             ColorWithHighlights brokenNode = new ColorWithHighlights(Color.Red, 40);
 
             ColorWithHighlights pathMain = new ColorWithHighlights(Color.Yellow, 20);
-            pathMain.MakeIntoUserPreference(preferenceChanger, "pathmain", 
+            pathMain.MakeIntoUserPreference(preferenceChanger, "pathmain",
                 TrackViewer.catalog.GetString("Select path color (main)"));
             ColorsGroupTrack pathMainGroup = new ColorsGroupTrack
             {
@@ -95,7 +95,7 @@ namespace ORTS.TrackViewer.Drawing
             colorsPathMain.TrackColors = pathMainGroup;
 
             ColorWithHighlights pathSiding = new ColorWithHighlights(Color.Orange, 20);
-            pathSiding.MakeIntoUserPreference(preferenceChanger, "pathsiding", 
+            pathSiding.MakeIntoUserPreference(preferenceChanger, "pathsiding",
                 TrackViewer.catalog.GetString("Select path color (siding)"));
             ColorsGroupTrack pathSidingGroup = new ColorsGroupTrack
             {
@@ -107,7 +107,7 @@ namespace ORTS.TrackViewer.Drawing
             colorsPathSiding.TrackColors = pathSidingGroup;
 
 
-            
+
         }
 
         private static void SetTrackColors(IPreferenceChanger preferenceChanger)
@@ -151,7 +151,7 @@ namespace ORTS.TrackViewer.Drawing
         {
             ColorWithHighlights fixedBackgroundColor = new ColorWithHighlights(Color.White, 20);
             ColorWithHighlights changingBackgroundColor = new ColorWithHighlights(Color.PaleGreen, 20);
-            changingBackgroundColor.MakeIntoUserPreference(preferenceChanger, "background", 
+            changingBackgroundColor.MakeIntoUserPreference(preferenceChanger, "background",
                 TrackViewer.catalog.GetString("Select background color"));
             backgroundWithoutTilesGroup.Tile = changingBackgroundColor;
             backgroundWithoutTilesGroup.ClearWindow = changingBackgroundColor;
@@ -178,37 +178,37 @@ namespace ORTS.TrackViewer.Drawing
             ColorWithHighlights itemColor;
 
             itemColor = new ColorWithHighlights(Color.Black, 40);
-            itemColor.MakeIntoUserPreference(preferenceChanger, "text", 
+            itemColor.MakeIntoUserPreference(preferenceChanger, "text",
                 TrackViewer.catalog.GetString("Select item text color"));
             itemColors.Text = itemColor;
 
             itemColor = new ColorWithHighlights(Color.Blue, 120);
-            itemColor.MakeIntoUserPreference(preferenceChanger, "junction", 
+            itemColor.MakeIntoUserPreference(preferenceChanger, "junction",
                 TrackViewer.catalog.GetString("Select junction color"));
             itemColors.Junction = itemColor;
 
             itemColor = new ColorWithHighlights(Color.LimeGreen, 40);
-            itemColor.MakeIntoUserPreference(preferenceChanger, "endnode", 
+            itemColor.MakeIntoUserPreference(preferenceChanger, "endnode",
                 TrackViewer.catalog.GetString("Select endnode color"));
             itemColors.EndNode = itemColor;
 
             itemColor = new ColorWithHighlights(Color.Sienna, 40);
-            itemColor.MakeIntoUserPreference(preferenceChanger, "siding", 
+            itemColor.MakeIntoUserPreference(preferenceChanger, "siding",
                 TrackViewer.catalog.GetString("Select siding color"));
             itemColors.Siding = itemColor;
 
             itemColor = new ColorWithHighlights(Color.Gray, 40);
-            itemColor.MakeIntoUserPreference(preferenceChanger, "crossing", 
+            itemColor.MakeIntoUserPreference(preferenceChanger, "crossing",
                 TrackViewer.catalog.GetString("Select crossing color"));
             itemColors.Crossing = itemColor;
 
             itemColor = new ColorWithHighlights(Color.DarkGray, 40);
-            itemColor.MakeIntoUserPreference(preferenceChanger, "roadcrossing", 
+            itemColor.MakeIntoUserPreference(preferenceChanger, "roadcrossing",
                 TrackViewer.catalog.GetString("Select road crossing color"));
             itemColors.RoadCrossing = itemColor;
 
             itemColor = new ColorWithHighlights(Color.Purple, 40);
-            itemColor.MakeIntoUserPreference(preferenceChanger, "speedpost", 
+            itemColor.MakeIntoUserPreference(preferenceChanger, "speedpost",
                 TrackViewer.catalog.GetString("Select speedpost color"));
             itemColors.Speedpost = itemColor;
 
@@ -314,7 +314,8 @@ namespace ORTS.TrackViewer.Drawing
     #endregion
 
     #region ColorGroup classes
-    class ColorsGroupBasic {
+    class ColorsGroupBasic
+    {
         public ColorWithHighlights Junction { get; set; }
         public ColorWithHighlights EndNode { get; set; }
         public ColorWithHighlights Crossing { get; set; }
@@ -352,10 +353,10 @@ namespace ORTS.TrackViewer.Drawing
     /// </summary>
     class ColorScheme
     {
-        public ColorsGroupBasic TrackItemColors {get; set;}
+        public ColorsGroupBasic TrackItemColors { get; set; }
         public ColorsGroupBackground BackgroundColors { get; set; }
         public ColorsGroupTrack TrackColors { get; set; }
-        
+
         public Color Junction { get { return TrackItemColors.Junction.Colors[highlightType]; } }
         public Color EndNode { get { return TrackItemColors.EndNode.Colors[highlightType]; } }
         public Color Crossing { get { return TrackItemColors.Crossing.Colors[highlightType]; } }
@@ -373,12 +374,12 @@ namespace ORTS.TrackViewer.Drawing
         public Color TrackCurved { get { return TrackColors.TrackCurved.Colors[highlightType]; } }
         public Color BrokenPath { get { return TrackColors.BrokenPath.Colors[highlightType]; } }
         public Color BrokenNode { get { return TrackColors.BrokenNode.Colors[highlightType]; } }
-        
+
         public Color ClearWindow { get { return BackgroundColors.ClearWindow.Colors[highlightType]; } }
         public Color Tile { get { return BackgroundColors.Tile.Colors[highlightType]; } }
 
-        public Color None { get { return Color.White; } }       
-        
+        public Color None { get { return Color.White; } }
+
         private static Dictionary<HighlightType, string> nameExtensions = new Dictionary<HighlightType, string>
         {
             {HighlightType.Normal, ""},
@@ -423,7 +424,7 @@ namespace ORTS.TrackViewer.Drawing
         Highlight,
         Hotlight,
     }
-    
+
     /// <summary>
     /// Class to store not only a color but also its highlighted variants
     /// </summary>
@@ -432,8 +433,8 @@ namespace ORTS.TrackViewer.Drawing
         /// <summary>
         /// The current normal, highlight and hotlight colors.
         /// </summary>
-        public IDictionary<HighlightType,Color> Colors { get; private set; }
-        
+        public IDictionary<HighlightType, Color> Colors { get; private set; }
+
         //Some things we store to be used when color is changed using preference.
         private byte highlightDelta;
         private Color defaultColor;
@@ -507,7 +508,7 @@ namespace ORTS.TrackViewer.Drawing
             Colors[HighlightType.Hotlight] = hotlightColor;
         }
 
-                /// <summary>
+        /// <summary>
         /// Make this color with highlights changable via some preference changing mechanism
         /// </summary>
         /// <param name="preferenceChanger">The object that can change a preference</param>
@@ -531,7 +532,7 @@ namespace ORTS.TrackViewer.Drawing
             string defaultColorOption = defaultColorName + defaultOptionExtension;
             colorOptions.Insert(0, defaultColorOption);
 
-            var callBack = normalOnly ? new StringPreferenceDelegate(PreferenceChangedCallbackNormalOnly): new StringPreferenceDelegate(PreferenceChangedCallback);
+            var callBack = normalOnly ? new StringPreferenceDelegate(PreferenceChangedCallbackNormalOnly) : new StringPreferenceDelegate(PreferenceChangedCallback);
             preferenceChanger.AddStringPreference(name, description, colorOptions.ToArray(), defaultColorOption, callBack);
         }
 
@@ -573,7 +574,7 @@ namespace ORTS.TrackViewer.Drawing
         /// </summary>
         /// <param name="color">The color for which you want the name</param>
         private static string FindColorName(Color color)
-        {           
+        {
             //
             foreach (KeyValuePair<string, Color> entry in namedColors)
             {
@@ -647,7 +648,7 @@ namespace ORTS.TrackViewer.Drawing
             }
             else
             {
-                newvalue = 255 - ((255-original) * (count + index + 1) / (2 * count));
+                newvalue = 255 - ((255 - original) * (count + index + 1) / (2 * count));
             }
             return (byte)newvalue;
         }

--- a/Source/Contrib/TrackViewer/Drawing/DrawLongitudeLatitude.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawLongitudeLatitude.cs
@@ -48,15 +48,15 @@ namespace ORTS.TrackViewer.Drawing
         public void Draw(WorldLocation mstsLocation)
         {
             if (!Properties.Settings.Default.showLonLat) return;
-            
+
             double latitude = 1f;
             double longitude = 1f;
             worldLoc.ConvertWTC(mstsLocation.TileX, mstsLocation.TileZ, mstsLocation.Location, ref latitude, ref longitude);
             string latitudeDegrees = MathHelper.ToDegrees((float)latitude).ToString("F5", System.Globalization.CultureInfo.CurrentCulture);
             string longitudeDegrees = MathHelper.ToDegrees((float)longitude).ToString("F5", System.Globalization.CultureInfo.CurrentCulture);
-            string locationText = String.Format(System.Globalization.CultureInfo.CurrentCulture, 
+            string locationText = String.Format(System.Globalization.CultureInfo.CurrentCulture,
                 "Lon = {0}; Lat = {1}", longitudeDegrees, latitudeDegrees);
-            BasicShapes.DrawString(lowerLeft, DrawColors.colorsNormal.Text, locationText);           
+            BasicShapes.DrawString(lowerLeft, DrawColors.colorsNormal.Text, locationText);
         }
     }
 }

--- a/Source/Contrib/TrackViewer/Drawing/DrawMultiplePaths.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawMultiplePaths.cs
@@ -34,7 +34,7 @@ namespace ORTS.TrackViewer.Drawing
     /// </summary>
     public class DrawMultiplePaths
     {
-        
+
         /// <summary>For each path name, store the full file name of the .pat file</summary>
         Dictionary<string, string> fullPathNames;
         /// <summary>The paths that have already been loaded (.pat file has been read and parsed)</summary>
@@ -43,14 +43,14 @@ namespace ORTS.TrackViewer.Drawing
         Dictionary<Trainpath, DrawPath> drawPaths;
         /// <summary>List of trainpaths that have been selected</summary>
         List<Trainpath> selectedTrainpaths;
-    
+
         private TrackDB trackDB;
         private TrackSectionsFile tsectionDat;
 
         /// <summary>
         /// Constructor
         /// </summary>
-        public DrawMultiplePaths (RouteData routeData, Collection<Path> paths)
+        public DrawMultiplePaths(RouteData routeData, Collection<Path> paths)
         {
             this.trackDB = routeData.TrackDB;
             this.tsectionDat = routeData.TsectionDat;
@@ -138,7 +138,7 @@ namespace ORTS.TrackViewer.Drawing
                 drawPaths[trainpath].ColorSchemeLast = shadedColor;
             }
         }
- 
+
         /// <summary>
         /// Draws the paths that have been selected
         /// </summary>

--- a/Source/Contrib/TrackViewer/Drawing/DrawScaleRuler.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawScaleRuler.cs
@@ -62,7 +62,7 @@ namespace ORTS.TrackViewer.Drawing
             // here we define, a bit manually, which scales are supported.
             rulerDataMeters.Add(new RulerDatum(5, 100000, " 100km"));
             rulerDataMeters.Add(new RulerDatum(5, 50000, " 50km"));
-            rulerDataMeters.Add(new RulerDatum(4, 20000, " 20km")); 
+            rulerDataMeters.Add(new RulerDatum(4, 20000, " 20km"));
             rulerDataMeters.Add(new RulerDatum(5, 10000, " 10km"));
             rulerDataMeters.Add(new RulerDatum(5, 5000, " 5km"));
             rulerDataMeters.Add(new RulerDatum(4, 2000, " 2km"));
@@ -93,7 +93,7 @@ namespace ORTS.TrackViewer.Drawing
             rulerDataMiles.Add(new RulerDatum(5, 4.57f, " 5yd"));
             rulerDataMiles.Add(new RulerDatum(4, 1.82f, " 2yd"));
             rulerDataMiles.Add(new RulerDatum(5, 0.91f, " 1yd"));
-            
+
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace ORTS.TrackViewer.Drawing
         public void SetLocationAndSize(int xLowerLeft, int yLowerLeft, int fontHeight)
         {
             lowerLeftPoint = new Vector2(xLowerLeft, yLowerLeft);
-            halfFontHeight = (int)(fontHeight/2);
+            halfFontHeight = (int)(fontHeight / 2);
             maxPixelWidth = 11 * fontHeight;
         }
 
@@ -120,20 +120,21 @@ namespace ORTS.TrackViewer.Drawing
 
             List<RulerDatum> rulerData = (Properties.Settings.Default.useMilesNotMeters) ? rulerDataMiles : rulerDataMeters;
 
-              
+
             // to make sure we have something for all zoom levels 
             currentRuler = rulerData.Last();
-            
+
             foreach (RulerDatum rulerDatum in rulerData)
             {
-                int pixelWidth = (int) Math.Round(pixelsPerMeter * rulerDatum.value);
-                if ( pixelWidth < maxPixelWidth ) {
+                int pixelWidth = (int)Math.Round(pixelsPerMeter * rulerDatum.value);
+                if (pixelWidth < maxPixelWidth)
+                {
                     currentRuler = rulerDatum;
                     break;
                 }
             }
 
-            fullPixelWidth = (int) Math.Round(pixelsPerMeter * currentRuler.value);
+            fullPixelWidth = (int)Math.Round(pixelsPerMeter * currentRuler.value);
         }
 
         /// <summary>
@@ -151,7 +152,7 @@ namespace ORTS.TrackViewer.Drawing
 
             Vector2 lowerRightPoint = new Vector2(lowerLeftPoint.X + fullPixelWidth, lowerLeftPoint.Y);
             Vector2 bigMarker = new Vector2(0, -halfFontHeight);
-            Vector2 smallMarker = new Vector2(0, -(int)(halfFontHeight/2));
+            Vector2 smallMarker = new Vector2(0, -(int)(halfFontHeight / 2));
             Color color = DrawColors.colorsNormal.Text;
 
             BasicShapes.DrawLine(1, color, lowerLeftPoint, lowerRightPoint);

--- a/Source/Contrib/TrackViewer/Drawing/DrawTrackDB.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawTrackDB.cs
@@ -87,7 +87,7 @@ namespace ORTS.TrackViewer.Drawing
             }
             catch
             {
-            } 
+            }
 
             string ORfilepath = System.IO.Path.Combine(routePath, "OpenRails");
             if (File.Exists(ORfilepath + @"\sigcfg.dat"))
@@ -317,7 +317,7 @@ namespace ORTS.TrackViewer.Drawing
             foreach (TrackNode tn in trackDB.TrackNodes)
             {
                 if (tn == null) continue;
-                TrVectorNode tvn= tn.TrVectorNode;
+                TrVectorNode tvn = tn.TrVectorNode;
                 if (tvn == null) continue;
                 if (tvn.TrItemRefs == null) continue;
 
@@ -398,7 +398,7 @@ namespace ORTS.TrackViewer.Drawing
                 {
                     PlatformLocations[platform.ItemName] = new WorldLocation(trackItem.TileX, trackItem.TileZ, trackItem.X, trackItem.Y, trackItem.Z);
                     StationLocations[platform.Station] = PlatformLocations[platform.ItemName];
-                }     
+                }
             }
         }
         #endregion
@@ -414,10 +414,10 @@ namespace ORTS.TrackViewer.Drawing
             // determine the min and max values of the tiles that we actually need to draw
             // in some cases (e.g. during initialization) the drawing area itself is really outside the track database,
             // so we have to account for that.
-            int actualTileXLeft  = Math.Max(Math.Min(drawArea.LocationUpperLeft.TileX , MaxTileX), MinTileX);
+            int actualTileXLeft = Math.Max(Math.Min(drawArea.LocationUpperLeft.TileX, MaxTileX), MinTileX);
             int actualTileXRight = Math.Min(Math.Max(drawArea.LocationLowerRight.TileX, MinTileX), MaxTileX);
-            int actualTileZBot   = Math.Max(Math.Min(drawArea.LocationLowerRight.TileZ, MaxTileZ), MinTileZ);
-            int actualTileZTop   = Math.Min(Math.Max(drawArea.LocationUpperLeft.TileZ , MinTileZ), MaxTileZ);
+            int actualTileZBot = Math.Max(Math.Min(drawArea.LocationLowerRight.TileZ, MaxTileZ), MinTileZ);
+            int actualTileZTop = Math.Min(Math.Max(drawArea.LocationUpperLeft.TileZ, MinTileZ), MaxTileZ);
 
             SetTileIndexes(actualTileXLeft, actualTileXRight, actualTileZBot, actualTileZTop);
         }
@@ -451,9 +451,9 @@ namespace ORTS.TrackViewer.Drawing
             SetTileIndexes(MinTileX, MaxTileX, MinTileZ, MaxTileZ);
             availableRailVectorNodeIndexes = new List<TrackNode>[tileXIndexStop + 1][];
             availableRoadVectorNodeIndexes = new List<TrackNode>[tileXIndexStop + 1][];
-            availablePointNodeIndexes      = new List<TrackNode>[tileXIndexStop + 1][];
-            availableRailItemIndexes       = new List<DrawableTrackItem>   [tileXIndexStop + 1][];
-            availableRoadItemIndexes       = new List<DrawableTrackItem>   [tileXIndexStop + 1][];
+            availablePointNodeIndexes = new List<TrackNode>[tileXIndexStop + 1][];
+            availableRailItemIndexes = new List<DrawableTrackItem>[tileXIndexStop + 1][];
+            availableRoadItemIndexes = new List<DrawableTrackItem>[tileXIndexStop + 1][];
             InitIndexedLists(availableRailVectorNodeIndexes);
             InitIndexedLists(availableRoadVectorNodeIndexes);
             InitIndexedLists(availablePointNodeIndexes);
@@ -477,7 +477,8 @@ namespace ORTS.TrackViewer.Drawing
                         TrVectorSection tvs = tn.TrVectorNode.TrVectorSections[tvsi];
                         if (tvs == null) continue;
                         List<WorldLocation> locationList = FindLocationList(tni, tvsi, true);
-                        foreach (WorldLocation location in locationList) {
+                        foreach (WorldLocation location in locationList)
+                        {
                             AddLocationToAvailableList(location, availableRailVectorNodeIndexes, tn);
                         }
                     }
@@ -532,7 +533,7 @@ namespace ORTS.TrackViewer.Drawing
                     AddLocationToAvailableList(drawableTrackItem.WorldLocation, availableRoadItemIndexes, drawableTrackItem);
                 }
             }
- 
+
             // remove double entries
             MakeUniqueLists(availableRailVectorNodeIndexes);
             MakeUniqueLists(availableRoadVectorNodeIndexes);
@@ -588,7 +589,7 @@ namespace ORTS.TrackViewer.Drawing
                 {
                     arrayOfLists[xindex][zindex] = arrayOfLists[xindex][zindex].Distinct().ToList();
                 }
-            }    
+            }
         }
 
         /// <summary>
@@ -605,7 +606,7 @@ namespace ORTS.TrackViewer.Drawing
 
             TrackNode tn = useRailTracks ? trackDB.TrackNodes[trackNodeIndex] : roadTrackDB.TrackNodes[trackNodeIndex];
             if (tn == null) return resultList;
-            
+
             TrVectorSection tvs = tn.TrVectorNode.TrVectorSections[trackVectorSectionIndex];
             if (tvs == null) return resultList;
 
@@ -613,7 +614,7 @@ namespace ORTS.TrackViewer.Drawing
             if (trackSection == null) return resultList;
 
             float trackSectionLength = DrawTrackDB.GetLength(trackSection);
-            
+
             // We want to make sure all tiles that a track crosses are noted.
             // To do this, we make a box around the track (straight or curved), and for all locations of that box
             // we calculate the min and max values of the tileX and tileZ. We then return a list of 4 worldlocations
@@ -621,7 +622,7 @@ namespace ORTS.TrackViewer.Drawing
             // The assumption here is that no single track section crosses a while tile of 2014 meters
             List<WorldLocation> boxList = new List<WorldLocation>();
             WorldLocation beginLocation = FindLocationInSection(tvs, trackSection, 0);
-            WorldLocation endLocation   = FindLocationInSection(tvs, trackSection, trackSectionLength);
+            WorldLocation endLocation = FindLocationInSection(tvs, trackSection, trackSectionLength);
             boxList.Add(beginLocation);
             boxList.Add(endLocation);
             if (trackSection.SectionCurve != null)
@@ -629,12 +630,12 @@ namespace ORTS.TrackViewer.Drawing
                 // For curved, here, the box has a width. It will be a rectangle containing begin and end node on one side.
                 // On the other side it will touch the middle point of the curve/arc. 
                 // The box will then contain the full curve as long as the curve is not more than 180 degrees
-                WorldLocation midLocation = FindLocationInSection(tvs, trackSection, trackSectionLength/2);
+                WorldLocation midLocation = FindLocationInSection(tvs, trackSection, trackSectionLength / 2);
 
                 // (deltaX, deltaZ) is a vector from begin to end.
                 float deltaX = (endLocation.Location.X - endLocation.Location.X);
                 float deltaZ = (endLocation.Location.Z - endLocation.Location.Z);
-                deltaX += 2048 * (endLocation.TileX - endLocation.TileX); 
+                deltaX += 2048 * (endLocation.TileX - endLocation.TileX);
                 deltaZ += 2048 * (endLocation.TileZ - endLocation.TileZ);
 
                 WorldLocation begin2Location = new WorldLocation(midLocation);
@@ -877,7 +878,7 @@ namespace ORTS.TrackViewer.Drawing
                 }
             }
         }
-        
+
         /// <summary>
         /// Draw a specific junction node.
         /// </summary>
@@ -911,7 +912,7 @@ namespace ORTS.TrackViewer.Drawing
         /// <param name="drawArea">Area to draw the items on</param>
         public void DrawTrackItems(DrawArea drawArea)
         {
-            
+
             for (int xindex = tileXIndexStart; xindex <= tileXIndexStop; xindex++)
             {
                 for (int zindex = tileZIndexStart; zindex <= tileZIndexStop; zindex++)
@@ -925,7 +926,7 @@ namespace ORTS.TrackViewer.Drawing
                     }
                 }
             }
-       }
+        }
 
         /// <summary>
         /// Draw the various road track items, mainly car spawners but also level crossings (again).
@@ -936,7 +937,7 @@ namespace ORTS.TrackViewer.Drawing
             ClosestTrackItem.Reset(); // dirtily assumes this is called before normal track items
             // we only want the carspawners here
             if (!Properties.Settings.Default.showCarSpawners && !Properties.Settings.Default.showRoadCrossings) return;
-            
+
             for (int xindex = tileXIndexStart; xindex <= tileXIndexStop; xindex++)
             {
                 for (int zindex = tileZIndexStart; zindex <= tileZIndexStop; zindex++)
@@ -966,13 +967,13 @@ namespace ORTS.TrackViewer.Drawing
             if (tn == null) return WorldLocation.None;
 
             IsHighlightOverridden = true;
-            if (tn.TrJunctionNode != null )
+            if (tn.TrJunctionNode != null)
             {
                 searchJunctionOrEnd = new CloseToMouseJunctionOrEnd(tn, "junction");
                 return UidLocation(tn.UiD);
             }
 
-            if (tn.TrEndNode )
+            if (tn.TrEndNode)
             {
                 searchJunctionOrEnd = new CloseToMouseJunctionOrEnd(tn, "endnode");
                 return UidLocation(tn.UiD);
@@ -1000,7 +1001,7 @@ namespace ORTS.TrackViewer.Drawing
             if (tn == null) return WorldLocation.None;
 
             IsHighlightOverridden = true;
-            
+
             if (tn.TrEndNode)
             {
                 searchJunctionOrEnd = new CloseToMouseJunctionOrEnd(tn, "endnode");
@@ -1013,7 +1014,7 @@ namespace ORTS.TrackViewer.Drawing
             TrackNode nodeAhead = roadTrackDB.TrackNodes[tn.TrPins[1].Link];
             return TrackLocation(tn, nodeBehind, nodeAhead);
         }
- 
+
         /// <summary>
         /// Find the item with the given index. And if it exists, prepare for highlighting it
         /// </summary>
@@ -1217,9 +1218,9 @@ namespace ORTS.TrackViewer.Drawing
         {
             try
             {
-                TrackNode tn = useRailTracks ?              
-                    trackDB.TrackNodes[trackNodeIndex]: roadTrackDB.TrackNodes[trackNodeIndex];
-                
+                TrackNode tn = useRailTracks ?
+                    trackDB.TrackNodes[trackNodeIndex] : roadTrackDB.TrackNodes[trackNodeIndex];
+
                 TrVectorSection tvs = tn.TrVectorNode.TrVectorSections[trackVectorSectionIndex];
 
                 TrackSection trackSection = tsectionDat.TrackSections.Get(tvs.SectionIndex);

--- a/Source/Contrib/TrackViewer/Drawing/DrawWorldTiles.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawWorldTiles.cs
@@ -40,7 +40,7 @@ namespace ORTS.TrackViewer.Drawing
         // for each index=TileX, a list containing start and stop tileZ's
         // in many cases each list will contain only two elements. But in the case of holes, it might be more.
         private Dictionary<int, List<int>> worldTileRanges;
-        
+
         /// <summary>
         /// Default constructor
         /// </summary>
@@ -53,7 +53,7 @@ namespace ORTS.TrackViewer.Drawing
         /// From the names of these file we determine the tile location, and store these locations for later drawing
         /// </summary>
         /// <param name="routePath"></param>
-        public void SetRoute(string routePath) 
+        public void SetRoute(string routePath)
         {
             worldTileRanges = new Dictionary<int, List<int>>();
             Dictionary<int, List<int>> worldTiles = new Dictionary<int, List<int>>();
@@ -80,7 +80,7 @@ namespace ORTS.TrackViewer.Drawing
             //now make ranges out of it. For each available TileX a range is given by a minimum and maximum value of 
             //TileZ such that all tiles from the minimum till/including the maximum are available
             //multiple ranges can occur for a single tileX.
-            
+
             foreach (int TileX in worldTiles.Keys)
             {
                 worldTileRanges[TileX] = new List<int>();
@@ -112,7 +112,7 @@ namespace ORTS.TrackViewer.Drawing
                 for (int i = 0; i < worldTileRanges[TileX].Count; i += 2)
                 {
                     int TileZstart = worldTileRanges[TileX][i];
-                    int TileZstop = worldTileRanges[TileX][i+1];
+                    int TileZstop = worldTileRanges[TileX][i + 1];
                     WorldLocation bot = new WorldLocation(TileX, TileZstart, 0, 0, -1024);
                     WorldLocation top = new WorldLocation(TileX, TileZstop, 0, 0, 1024);
                     drawArea.DrawLineAlways(2048, DrawColors.colorsNormal.Tile, bot, top);

--- a/Source/Contrib/TrackViewer/Drawing/DrawableTrackItem.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawableTrackItem.cs
@@ -59,17 +59,17 @@ namespace ORTS.TrackViewer.Drawing
         /// <returns>A drawable trackitem, with proper subclass</returns>
         public static DrawableTrackItem CreateDrawableTrItem(TrItem originalTrItem)
         {
-            if (originalTrItem is SignalItem)     { return new DrawableSignalItem(originalTrItem); }
-            if (originalTrItem is PlatformItem)   { return new DrawablePlatformItem(originalTrItem); }
-            if (originalTrItem is SidingItem)     { return new DrawableSidingItem(originalTrItem); }
-            if (originalTrItem is SpeedPostItem)  { return new DrawableSpeedPostItem(originalTrItem); }
-            if (originalTrItem is HazzardItem)    { return new DrawableHazardItem(originalTrItem); }
-            if (originalTrItem is PickupItem)     { return new DrawablePickupItem(originalTrItem); }
-            if (originalTrItem is LevelCrItem)    { return new DrawableLevelCrItem(originalTrItem); }
-            if (originalTrItem is SoundRegionItem){ return new DrawableSoundRegionItem(originalTrItem); }
-            if (originalTrItem is RoadLevelCrItem){ return new DrawableRoadLevelCrItem(originalTrItem); }
+            if (originalTrItem is SignalItem) { return new DrawableSignalItem(originalTrItem); }
+            if (originalTrItem is PlatformItem) { return new DrawablePlatformItem(originalTrItem); }
+            if (originalTrItem is SidingItem) { return new DrawableSidingItem(originalTrItem); }
+            if (originalTrItem is SpeedPostItem) { return new DrawableSpeedPostItem(originalTrItem); }
+            if (originalTrItem is HazzardItem) { return new DrawableHazardItem(originalTrItem); }
+            if (originalTrItem is PickupItem) { return new DrawablePickupItem(originalTrItem); }
+            if (originalTrItem is LevelCrItem) { return new DrawableLevelCrItem(originalTrItem); }
+            if (originalTrItem is SoundRegionItem) { return new DrawableSoundRegionItem(originalTrItem); }
+            if (originalTrItem is RoadLevelCrItem) { return new DrawableRoadLevelCrItem(originalTrItem); }
             if (originalTrItem is CarSpawnerItem) { return new DrawableCarSpawnerItem(originalTrItem); }
-            if (originalTrItem is CrossoverItem)  { return new DrawableCrossoverItem(originalTrItem); }
+            if (originalTrItem is CrossoverItem) { return new DrawableCrossoverItem(originalTrItem); }
             return new DrawableEmptyItem(originalTrItem);
         }
 
@@ -134,9 +134,9 @@ namespace ORTS.TrackViewer.Drawing
                 this.angle = signalTraveller.RotY;
 
                 // Shift signal a little bit to be able to distinguish backfacing from normal facing
-                Microsoft.Xna.Framework.Vector3 shiftedLocation = this.WorldLocation.Location + 
-                    0.0001f * new Microsoft.Xna.Framework.Vector3((float) Math.Cos(this.angle), 0f, -(float) Math.Sin(this.angle));
-                this.WorldLocation = new WorldLocation(this.WorldLocation.TileX, this.WorldLocation.TileZ, shiftedLocation );
+                Microsoft.Xna.Framework.Vector3 shiftedLocation = this.WorldLocation.Location +
+                    0.0001f * new Microsoft.Xna.Framework.Vector3((float)Math.Cos(this.angle), 0f, -(float)Math.Sin(this.angle));
+                this.WorldLocation = new WorldLocation(this.WorldLocation.TileX, this.WorldLocation.TileZ, shiftedLocation);
             }
             catch { }
         }
@@ -166,7 +166,7 @@ namespace ORTS.TrackViewer.Drawing
         /// <param name="drawAlways">Do we need to draw anyway, independent of settings?</param>
         internal override bool Draw(DrawArea drawArea, ColorScheme colors, bool drawAlways)
         {
-            if (   drawAlways 
+            if (drawAlways
                 || Properties.Settings.Default.showAllSignals
                 || (Properties.Settings.Default.showSignals && isNormal)
                 )
@@ -337,13 +337,13 @@ namespace ORTS.TrackViewer.Drawing
                 drawArea.DrawExpandingString(this.WorldLocation, this.itemName);
                 returnValue = true;
             }
-            if (Properties.Settings.Default.showStationNames || 
-                (drawAlways && !Properties.Settings.Default.showPlatformNames) )
+            if (Properties.Settings.Default.showStationNames ||
+                (drawAlways && !Properties.Settings.Default.showPlatformNames))
             {   // if drawAlways and no station nor platform name requested, then also show station
                 drawArea.DrawExpandingString(this.WorldLocation, this.stationName);
                 returnValue = true;
             }
-            
+
             return returnValue;
         }
     }

--- a/Source/Contrib/TrackViewer/Drawing/Labels/DrawLabels.cs
+++ b/Source/Contrib/TrackViewer/Drawing/Labels/DrawLabels.cs
@@ -88,7 +88,7 @@ namespace ORTS.TrackViewer.Drawing.Labels
                     DrawLabel(label);
                 }
                 float distanceSquared = CloseToMouse.GetGroundDistanceSquared(label.WorldLocation, drawArea.MouseLocation);
-                if (distanceSquared < closestDistanceSquared )
+                if (distanceSquared < closestDistanceSquared)
                 {
                     closestDistanceSquared = distanceSquared;
                     closestToMouseLabel = label;
@@ -107,7 +107,7 @@ namespace ORTS.TrackViewer.Drawing.Labels
         /// <param name="label">The lable to draw</param>
         private void DrawLabel(StorableLabel label)
         {
-            drawArea.DrawExpandingString(label.WorldLocation, label.LabelText, 0, -fontHeight/2);
+            drawArea.DrawExpandingString(label.WorldLocation, label.LabelText, 0, -fontHeight / 2);
         }
 
         #endregion
@@ -120,7 +120,7 @@ namespace ORTS.TrackViewer.Drawing.Labels
         /// <param name="mouseY">Current Y-location of the mouse to determine popu location</param>
         internal void AddLabel(int mouseX, int mouseY)
         {
-            var labelInputPopup = new EditLabel("<label>", mouseX, mouseY, 
+            var labelInputPopup = new EditLabel("<label>", mouseX, mouseY,
                 (newLabelText) => labels.Add(drawArea.MouseLocation, newLabelText),
                 allowDelete: false);
             TrackViewer.Localize(labelInputPopup);
@@ -194,7 +194,8 @@ namespace ORTS.TrackViewer.Drawing.Labels
         /// Ask the user for a filename to be used for saving
         /// </summary>
         /// <returns>Either the filename or empty when cancelled by the user</returns>
-        private string GetSaveFileName() {
+        private string GetSaveFileName()
+        {
             var dialog = new Microsoft.Win32.SaveFileDialog
             {
                 OverwritePrompt = true,
@@ -240,7 +241,8 @@ namespace ORTS.TrackViewer.Drawing.Labels
         /// Ask the user for a filename to be used for loading
         /// </summary>
         /// <returns>Either the filename or empty when cancelled by the user</returns>
-        private string GetLoadFileName() {
+        private string GetLoadFileName()
+        {
             var dialog = new Microsoft.Win32.OpenFileDialog
             {
                 FileName = "labels.json",
@@ -266,7 +268,7 @@ namespace ORTS.TrackViewer.Drawing.Labels
                 MessageBox.Show(TrackViewer.catalog.GetString("The .json file could not be read properly."));
                 return;
             }
-            
+
             bool itemsWereRemoved = labelsNew.Sanitize();
             int itemsLeft = labelsNew.Labels.Count();
             string message = string.Empty;
@@ -320,8 +322,8 @@ namespace ORTS.TrackViewer.Drawing.Labels
             //The new location is then 'original' + 'current' - 'start'.
             draggingStartLocation.NormalizeTo(drawArea.MouseLocation.TileX, drawArea.MouseLocation.TileZ);
             WorldLocation shiftedLocation = new WorldLocation(
-                draggingLabelToReplace.WorldLocation.TileX      + drawArea.MouseLocation.TileX      - draggingStartLocation.TileX,
-                draggingLabelToReplace.WorldLocation.TileZ      + drawArea.MouseLocation.TileZ      - draggingStartLocation.TileZ,
+                draggingLabelToReplace.WorldLocation.TileX + drawArea.MouseLocation.TileX - draggingStartLocation.TileX,
+                draggingLabelToReplace.WorldLocation.TileZ + drawArea.MouseLocation.TileZ - draggingStartLocation.TileZ,
                 draggingLabelToReplace.WorldLocation.Location.X + drawArea.MouseLocation.Location.X - draggingStartLocation.Location.X,
                 0,
                 draggingLabelToReplace.WorldLocation.Location.Z + drawArea.MouseLocation.Location.Z - draggingStartLocation.Location.Z

--- a/Source/Contrib/TrackViewer/Drawing/Labels/EditLabel.xaml.cs
+++ b/Source/Contrib/TrackViewer/Drawing/Labels/EditLabel.xaml.cs
@@ -70,7 +70,7 @@ namespace ORTS.TrackViewer.Drawing.Labels
         {
             this.Close();
         }
-        
+
         /// <summary>
         /// Delete the label
         /// </summary>
@@ -81,7 +81,7 @@ namespace ORTS.TrackViewer.Drawing.Labels
             this.Close();
             callback(null);
         }
-        
+
         /// <summary>
         /// Handle an enter/return press on the textbox. If return is pressed, just do the same as the save button.
         /// </summary>

--- a/Source/Contrib/TrackViewer/Drawing/Labels/StorableLabels.cs
+++ b/Source/Contrib/TrackViewer/Drawing/Labels/StorableLabels.cs
@@ -63,7 +63,8 @@ namespace ORTS.TrackViewer.Drawing.Labels
         internal void Replace(StorableLabel oldLabel, StorableLabel newLabel)
         {
             int index = _labels.IndexOf(oldLabel);
-            if (index != -1) {
+            if (index != -1)
+            {
                 _labels[index] = newLabel;
             }
         }
@@ -111,7 +112,7 @@ namespace ORTS.TrackViewer.Drawing.Labels
         /// </summary>
         /// <param name="location">The location in MSTS coordinates of the label</param>
         /// <param name="text">The text of the label</param>
-        public StorableLabel(WorldLocation location, string text )
+        public StorableLabel(WorldLocation location, string text)
         {
             LabelText = text;
             WorldLocation = location;

--- a/Source/Contrib/TrackViewer/Drawing/ShadowDrawArea.cs
+++ b/Source/Contrib/TrackViewer/Drawing/ShadowDrawArea.cs
@@ -68,7 +68,7 @@ namespace ORTS.TrackViewer.Drawing
     ///         Also in the Game.Draw, but before spriteBatch.begin:    yourShadowDrawArea.DrawShadowTextures(DrawSomething, background color);
     ///
     ///</summary>
-    public class ShadowDrawArea: DrawArea, IDisposable
+    public class ShadowDrawArea : DrawArea, IDisposable
     {
         #region private Fields
         int blockW; // Width  of single block in pixels
@@ -80,7 +80,7 @@ namespace ORTS.TrackViewer.Drawing
         double shadowOffsetZ;   // lower-left location (in real world coordinates) of the combined texture
 
         // fields related to when and what we are re-drawing
-        bool needToRedraw      = true;
+        bool needToRedraw = true;
         bool needToRedrawLater = true;
         bool[] needToDrawRectangle; // Array of booleans describing which of the rectangles still need to be redrawn
         int nextRectangleToDraw; // integer from 0 to Nblocks-1, describing which of the subblocks will be drawn
@@ -113,8 +113,8 @@ namespace ORTS.TrackViewer.Drawing
         /// <summary>
         /// Constructor. Just calling the base constructor
         /// </summary>
-        public ShadowDrawArea(DrawScaleRuler drawScaleRuler) 
-            :base(drawScaleRuler)
+        public ShadowDrawArea(DrawScaleRuler drawScaleRuler)
+            : base(drawScaleRuler)
         {
             shadowDrawArea = new ShadowDrawArea();
         }
@@ -125,7 +125,7 @@ namespace ORTS.TrackViewer.Drawing
         /// Therefore, it is a shadowDrawArea, but we will not use any of its additional functionality.
         /// Hence also private
         /// </summary>
-        ShadowDrawArea(): base(null){}
+        ShadowDrawArea() : base(null) { }
 
         /// <summary>
         /// Sets the screen size on which we can draw (in pixels). 
@@ -174,7 +174,7 @@ namespace ORTS.TrackViewer.Drawing
         private void SetRendertargetSizes()
         {
             if (graphicsDevice == null) { return; }
-            
+
             blockW = (AreaW * Nsampling + Ninner - 1) / Ninner; // in case areaW*Nsampling is not a multiple of Ninner this
             blockH = (AreaH * Nsampling + Ninner - 1) / Ninner; // makes sure block size at least covers all of area, to prevent constant redrawing
 
@@ -201,7 +201,7 @@ namespace ORTS.TrackViewer.Drawing
                 {
                     shadowMapsSingle[i].Dispose();
                 }
-                shadowRenderTargetSingle[i] = new RenderTarget2D(graphicsDevice, 1 * blockW, 1 * blockH, 1, SurfaceFormat.Color, 
+                shadowRenderTargetSingle[i] = new RenderTarget2D(graphicsDevice, 1 * blockW, 1 * blockH, 1, SurfaceFormat.Color,
                         graphicsDevice.DepthStencilBuffer.MultiSampleType, graphicsDevice.DepthStencilBuffer.MultiSampleQuality);
                 shadowMapsSingle[i] = new Texture2D(graphicsDevice, 1, 1);
             }
@@ -227,7 +227,7 @@ namespace ORTS.TrackViewer.Drawing
                 orderIndex++;
             }
 
-            for (int iRing = Nrings-1; iRing >= 0; iRing--)   // work from the inside out.
+            for (int iRing = Nrings - 1; iRing >= 0; iRing--)   // work from the inside out.
             {
                 int Nside = Nouter - 1 - 2 * iRing;  // The amount of blocks - 1 in a side, for the given ring. Alwasy Nouter - 1 for last ring!
                 //left side
@@ -343,19 +343,19 @@ namespace ORTS.TrackViewer.Drawing
             double ShiftLimitInBlocks = (Nborder > 1) ? Nborder - 1 : 0.5;
             double shiftLimitX = ShiftLimitInBlocks * blockW / shadowScale;
             double shiftLimitZ = ShiftLimitInBlocks * blockH / shadowScale;
-            if (OffsetX              < shadowOffsetX               + shiftLimitX) { ShiftBlocks(ShiftDirection.Right); }
-            if (OffsetZ              < shadowOffsetZ               + shiftLimitZ) { ShiftBlocks(ShiftDirection.Up); }
+            if (OffsetX < shadowOffsetX + shiftLimitX) { ShiftBlocks(ShiftDirection.Right); }
+            if (OffsetZ < shadowOffsetZ + shiftLimitZ) { ShiftBlocks(ShiftDirection.Up); }
             if (OffsetX + insetRealW > shadowOffsetX + shadowRealW - shiftLimitX) { ShiftBlocks(ShiftDirection.Left); }
             if (OffsetZ + insetRealH > shadowOffsetZ + shadowRealH - shiftLimitZ) { ShiftBlocks(ShiftDirection.Down); }
-            
-                //double ringW = Nborder * blockW / shadowScale;
-                //double ringH = Nborder * blockH / shadowScale;
-                ////we will redraw later in case we are close, we do not want to do this too much though
-                //if (offsetX < shadowOffsetX + 0.2 * ringW) { needToRedrawLater = true; }
-                //if (offsetZ < shadowOffsetZ + 0.2 * ringH) { needToRedrawLater = true; }
-                //if (offsetX + insetRealW > shadowOffsetX + shadowRealW - 0.2 * ringW) { needToRedrawLater = true; }
-                //if (offsetZ + insetRealH > shadowOffsetZ + shadowRealH - 0.2 * ringW) { needToRedrawLater = true; }
-            
+
+            //double ringW = Nborder * blockW / shadowScale;
+            //double ringH = Nborder * blockH / shadowScale;
+            ////we will redraw later in case we are close, we do not want to do this too much though
+            //if (offsetX < shadowOffsetX + 0.2 * ringW) { needToRedrawLater = true; }
+            //if (offsetZ < shadowOffsetZ + 0.2 * ringH) { needToRedrawLater = true; }
+            //if (offsetX + insetRealW > shadowOffsetX + shadowRealW - 0.2 * ringW) { needToRedrawLater = true; }
+            //if (offsetZ + insetRealH > shadowOffsetZ + shadowRealH - 0.2 * ringW) { needToRedrawLater = true; }
+
         }
 
         /// <summary>
@@ -377,20 +377,22 @@ namespace ORTS.TrackViewer.Drawing
         private void SetNextRectangleToDraw(bool recheck)
         {
             if (recheck) { nextRectangleToDraw = -1; }
-            do {
-                nextRectangleToDraw ++;
+            do
+            {
+                nextRectangleToDraw++;
             } while (nextRectangleToDraw < Nsubblocks && !needToDrawRectangle[nextRectangleToDraw]);
         }
 
-        enum ShiftDirection {Left, Right, Up, Down};
+        enum ShiftDirection { Left, Right, Up, Down };
 
         /// <summary>
         /// Instead of redrawing a lot of subblocks, we will just move most of the blocks by one block to any direction
         /// and only mark a single column or row for redrawing.
         /// </summary>
         /// <param name="direction">The direction to shift</param>
-        private void ShiftBlocks(ShiftDirection direction) {
-                 
+        private void ShiftBlocks(ShiftDirection direction)
+        {
+
             switch (direction)
             {
                 case ShiftDirection.Right:
@@ -429,7 +431,7 @@ namespace ORTS.TrackViewer.Drawing
         /// The real world location is so far left, that we can discard the right-most column of blocks and add a new column on the left
         /// </summary>
         private void ShiftSubBlocksRight()
-        {    
+        {
             for (int row = 0; row < Nouter; row++)
             {
                 RenderTarget2D tempTarget = shadowRenderTargetSingle[orderFromLocation[Nouter - 1][row]];
@@ -441,7 +443,7 @@ namespace ORTS.TrackViewer.Drawing
                 shadowRenderTargetSingle[orderFromLocation[0][row]] = tempTarget;
                 needToDrawRectangle[orderFromLocation[0][row]] = true;
             }
-       }
+        }
 
         /// <summary>
         /// The real world location is so far right, that we can discard the right-most column of blocks and add a new column on the right
@@ -546,10 +548,11 @@ namespace ORTS.TrackViewer.Drawing
 
                 needToDrawRectangle[nextRectangleToDraw] = false;
             }
-            catch {
+            catch
+            {
                 graphicsDevice.SetRenderTarget(0, null); // return control to main render target
             }
-            graphicsDevice.SetRenderTarget(0, null); 
+            graphicsDevice.SetRenderTarget(0, null);
         }
 
         /// <summary>
@@ -569,13 +572,14 @@ namespace ORTS.TrackViewer.Drawing
                 for (int i = 0; i < Nsubblocks; i++)
                 {
                     Vector2 position = new Vector2(xOrder[i] * blockW, (Nouter - 1 - zOrder[i]) * blockH);
-                    spriteBatch.Draw(shadowMapsSingle[i], position, null, Color.White, 0, Vector2.Zero, Vector2.One, SpriteEffects.None, 0);            
+                    spriteBatch.Draw(shadowMapsSingle[i], position, null, Color.White, 0, Vector2.Zero, Vector2.One, SpriteEffects.None, 0);
                 }
                 spriteBatch.End();
                 graphicsDevice.SetRenderTarget(0, null);
                 shadowMapCombined = shadowRenderTargetCombined.GetTexture();
             }
-            catch {
+            catch
+            {
                 graphicsDevice.SetRenderTarget(0, null); // return control to main render target
             }
         }
@@ -607,12 +611,12 @@ namespace ORTS.TrackViewer.Drawing
             float scaleRatio = (float)(Scale / shadowScale);
             Vector2 scaleAsVector = new Vector2(scaleRatio);
             Microsoft.Xna.Framework.Rectangle? sourceRectangle = new Microsoft.Xna.Framework.Rectangle(
-                Convert.ToInt32(                  shadowScale * (                OffsetX - shadowOffsetX)),
+                Convert.ToInt32(shadowScale * (OffsetX - shadowOffsetX)),
                 Convert.ToInt32(blockH * Nouter - shadowScale * (AreaH / Scale + OffsetZ - shadowOffsetZ)),
                 Convert.ToInt32(AreaW * shadowScale / Scale),
                 Convert.ToInt32(AreaH * shadowScale / Scale));
 
-  
+
             Vector2 position = new Vector2(AreaOffsetX, AreaOffsetY);
             Vector2 origin = Vector2.Zero;
 

--- a/Source/Contrib/TrackViewer/Editing/AutoConnectTools.cs
+++ b/Source/Contrib/TrackViewer/Editing/AutoConnectTools.cs
@@ -22,7 +22,7 @@ using System.Text;
 
 namespace ORTS.TrackViewer.Editing
 {
-    
+
     /// <summary>
     /// Class to define common methods related to autoconnecting a path. Autoconnecting means really searching
     /// for a possible connection between two nodes, and creating the path if the user wants to.
@@ -77,7 +77,7 @@ namespace ORTS.TrackViewer.Editing
         {
             DisAllowedJunctionIndexes.Add(junctionIndex);
         }
-  
+
         /// <summary>
         /// Try to find a connection between two given nodes. Depth-first search via main track at junctions.
         /// Also reversing the start or reconnectNode is tried, in case one of these nodes has a non-defined orientation 
@@ -106,7 +106,7 @@ namespace ORTS.TrackViewer.Editing
             // We try to find a connection between two non-broken nodes.
             // We store the connection as a stack of linking tvns (track-node-vector-indexes)
             // The connection will only contain junctions (apart from maybe start and end=reconnect nodes)
-            
+
             autoConnectFromNode = new ConnectableNode(fromNode, true, true);
             autoConnectToNodeOptions = new ReconnectNodeOptions(true);
             autoConnectToNodeOptions.AddNode(toNode, false); // only one option here
@@ -203,9 +203,9 @@ namespace ORTS.TrackViewer.Editing
                 autoConnectFromNode = swap;
             }
 
-            
+
             TrainpathNode currentNode = autoConnectFromNode.OriginalNode;
-            
+
             if ((currentNode is TrainpathVectorNode) && !sameTrackConnect)
             {   // in case the first node is a vector node (and not a direct connect), go to its junction first
                 currentNode = modificationTools.AddAdditionalNode(currentNode, isMainPath);
@@ -323,7 +323,7 @@ namespace ORTS.TrackViewer.Editing
             bool foundConnection = autoConnectToNodeOptions.FoundConnectionSameTrack(autoConnectFromNode, firstTvnIndex);
             return foundConnection;
         }
-            
+
         /// <summary>
         /// Try to find a connection. Depth-first search via main track at junctions. Stores the found connection in a list of 
         /// TrackNodeVectorIndexes (tvn's). No reversing of the nodes will be allowed. 
@@ -336,9 +336,10 @@ namespace ORTS.TrackViewer.Editing
         {
             linkingTvns.Clear();
             sameTrackConnect = false;
-            
+
             int firstJunctionIndex = autoConnectFromNode.ConnectingJunctionIndex;
-            if (DisAllowedJunctionIndexes.Contains(firstJunctionIndex)) {
+            if (DisAllowedJunctionIndexes.Contains(firstJunctionIndex))
+            {
                 return false;
             }
 
@@ -424,7 +425,7 @@ namespace ORTS.TrackViewer.Editing
 
             return succeeded;
         }
-        
+
         /// <summary>
         /// Can a node in a path be reversed without breaking something?
         /// </summary>
@@ -461,7 +462,7 @@ namespace ORTS.TrackViewer.Editing
 
             return incomingAllowsReversal && outgoingAllowsReversal;
         }
-        
+
         #endregion
 
         #region debug methods
@@ -481,10 +482,10 @@ namespace ORTS.TrackViewer.Editing
     /// This allows the Start node to be changed (e.g. regarding exact location on track, or perhaps moved to another
     /// track), and still be able to find reconnections.
     /// </summary>
-    public class ContinuousAutoConnecting:AutoConnectTools
+    public class ContinuousAutoConnecting : AutoConnectTools
     {
         /// <summary>The Start/From node needs to be reversed to be able to make the connection</summary>
-        public bool NeedsReverse { get { return this.FromNodeNeedsReverse;} }
+        public bool NeedsReverse { get { return this.FromNodeNeedsReverse; } }
         /// <summary>The connection is made forward along the path from the Start/From node</summary>
         private bool isForward;
 
@@ -505,7 +506,7 @@ namespace ORTS.TrackViewer.Editing
         {
             isForward = isConnectingForward;
             List<TrainpathNode> reconnectNodes = this.FindReconnectNodeCandidates(startNode, isConnectingForward, true);
-            
+
             autoConnectToNodeOptions = new ReconnectNodeOptions(isConnectingForward);
             int count = 0;
             foreach (TrainpathNode node in reconnectNodes)

--- a/Source/Contrib/TrackViewer/Editing/AutoFixAllPaths.xaml.cs
+++ b/Source/Contrib/TrackViewer/Editing/AutoFixAllPaths.xaml.cs
@@ -36,12 +36,12 @@ namespace ORTS.TrackViewer.Editing
         DrawTrackDB drawTrackDB;
 
         Dictionary<string, List<string>> pathsThatAre = new Dictionary<string, List<string>>
-            {
-                ["UnmodifiedFine"] = new List<string>(),
-                ["UnmodifiedBroken"] = new List<string>(),
-                ["ModifiedFine"] = new List<string>(),
-                ["ModifiedBroken"] = new List<string>(),
-            };
+        {
+            ["UnmodifiedFine"] = new List<string>(),
+            ["UnmodifiedBroken"] = new List<string>(),
+            ["ModifiedFine"] = new List<string>(),
+            ["ModifiedBroken"] = new List<string>(),
+        };
         List<PathEditor> modifiedPaths;
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace ORTS.TrackViewer.Editing
         /// </summary>
         /// <param name="Paths">The list of paths that are availabel and that need to be checked and possibly fixed</param>
         /// <param name="callback">Callback that will be called showing the current processing that is being done</param>
-        public void FixallAndShowResults(Collection<Path> Paths, Action<string> callback )
+        public void FixallAndShowResults(Collection<Path> Paths, Action<string> callback)
         {
             _Fixall(Paths, callback);
             _ShowResults();
@@ -188,7 +188,7 @@ namespace ORTS.TrackViewer.Editing
             if (String.IsNullOrEmpty(fullFilePath)) return;
 
             System.IO.StreamWriter file = new System.IO.StreamWriter(fullFilePath, false, System.Text.Encoding.Unicode);
-            string[] statusses = { "ModifiedBroken", "ModifiedFine", "UnmodifiedBroken", "UnmodifiedFine"};
+            string[] statusses = { "ModifiedBroken", "ModifiedFine", "UnmodifiedBroken", "UnmodifiedFine" };
             foreach (string status in statusses)
             {
                 file.WriteLine("");

--- a/Source/Contrib/TrackViewer/Editing/Charts/DrawPathChart.cs
+++ b/Source/Contrib/TrackViewer/Editing/Charts/DrawPathChart.cs
@@ -43,7 +43,7 @@ namespace ORTS.TrackViewer.Editing.Charts
     {
         /// <summary>Does the chart window have focus (actived) or not</summary>
         public bool IsActived { get { return this.chartWindow.IsActivated; } }
-        
+
         // Injection dependencies
         private PathEditor pathEditor;
         private ORTS.TrackViewer.Drawing.RouteData routeData;
@@ -163,14 +163,14 @@ namespace ORTS.TrackViewer.Editing.Charts
             chartWindow.Draw();
             chartWindow.SetTitle(pathEditor.CurrentTrainPath.PathName);
         }
-        
+
         /// <summary>
         /// Zoom the chart window
         /// </summary>
         /// <param name="zoomSteps">The number of zoom steps (negative for zooming in)</param>
         public void Zoom(int zoomSteps)
         {
-            this.chartWindow.ZoomChange(Math.Exp(-0.1*zoomSteps));
+            this.chartWindow.ZoomChange(Math.Exp(-0.1 * zoomSteps));
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace ORTS.TrackViewer.Editing.Charts
             textBlock.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity)); // find out how tall it wants to be
             Canvas.SetLeft(textBlock, leftX);
             Canvas.SetTop(textBlock, centerY - textBlock.DesiredSize.Height / 2); // So no it should be centered vertically
-            
+
             drawingCanvas.Children.Add(textBlock);
         }
 
@@ -459,8 +459,8 @@ namespace ORTS.TrackViewer.Editing.Charts
                 Foreground = new SolidColorBrush(color)
             };
             textBlock.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity)); // find out how tall it wants to be
-            Canvas.SetLeft(textBlock, centerX - textBlock.DesiredSize.Height/2);
-            Canvas.SetTop(textBlock, bottomY); 
+            Canvas.SetLeft(textBlock, centerX - textBlock.DesiredSize.Height / 2);
+            Canvas.SetTop(textBlock, bottomY);
             textBlock.RenderTransform = new RotateTransform(-90);
 
             drawingCanvas.Children.Add(textBlock);
@@ -482,8 +482,8 @@ namespace ORTS.TrackViewer.Editing.Charts
                 Height = imageSize,
                 Fill = new ImageBrush(BitmapImageManager.Instance.GetImage(imageName))
             };
-            Canvas.SetLeft(rect, centerX-imageSize/2);
-            Canvas.SetTop(rect, centerY-imageSize/2);
+            Canvas.SetLeft(rect, centerX - imageSize / 2);
+            Canvas.SetTop(rect, centerY - imageSize / 2);
             drawingCanvas.Children.Add(rect);
         }
         #endregion
@@ -501,7 +501,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         /// Determine the scaling needed: store the minimum and maximum of the x and y values, both for the whole set of data as for the set of data visible after zooming
         /// </summary>
         /// <param name="getField">The method to get a value (normally a field) of a PathChartPoint, that is then used for drawing</param>
-        protected void DetermineScaling(Func<PathChartPoint,float> getField)
+        protected void DetermineScaling(Func<PathChartPoint, float> getField)
         {
             this.minX = this.pathData.PointWithMinima.DistanceAlongPath;
             this.maxX = this.pathData.PointWithMaxima.DistanceAlongPath;
@@ -659,7 +659,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         /// <param name="height">The height for this label</param>
         private void DrawHeightLabel(Canvas drawingCanvas, decimal height)
         {
-            string textToDraw = String.Format("{0}{1}", height/niceScale.Scale, niceScale.Unit);
+            string textToDraw = String.Format("{0}{1}", height / niceScale.Scale, niceScale.Unit);
             DrawText(drawingCanvas, 5, ScaledY((double)height), textToDraw, Colors.Black);
         }
 
@@ -684,7 +684,7 @@ namespace ORTS.TrackViewer.Editing.Charts
 
                 if (lastTextToDraw != newTextToDraw)
                 {
-                    DrawTextVertical(drawingCanvas, (lastX+newX)/2, ScaledY(this.minY), lastTextToDraw, Colors.Black);
+                    DrawTextVertical(drawingCanvas, (lastX + newX) / 2, ScaledY(this.minY), lastTextToDraw, Colors.Black);
                     lastX = newX;
                     lastTextToDraw = newTextToDraw;
                 }
@@ -699,11 +699,11 @@ namespace ORTS.TrackViewer.Editing.Charts
 
         private void ShowSpecialNodes(Canvas drawingCanvas)
         {
-            foreach (KeyValuePair<TrainpathNode,double> item in this.pathData.DistanceAlongPath)
+            foreach (KeyValuePair<TrainpathNode, double> item in this.pathData.DistanceAlongPath)
             {
                 if (item.Key.NodeType == TrainpathNodeType.Reverse)
                 {
-                    
+
                     DrawImage(drawingCanvas, ScaledX(item.Value), ScaledY(item.Key.Location.Location.Y), "pathReverse");
                 }
                 if (item.Key.NodeType == TrainpathNodeType.Stop)
@@ -727,7 +727,7 @@ namespace ORTS.TrackViewer.Editing.Charts
     /// The chart that shows the grade of the path (in percentages)
     /// Also prints the text of the x-location
     /// </summary>
-    public class GradeChart: SubChart
+    public class GradeChart : SubChart
     {
         /// <summary>
         /// Constructor
@@ -744,7 +744,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         {
             DetermineScaling(p => p.GradePercent);
             CleanScaling();
-            
+
             DrawHorizontalGridLines(drawingCanvas, legendCanvas);
 
             DrawDataPolyLine(drawingCanvas, p => p.GradePercent, true);
@@ -803,7 +803,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                 maxY = Math.Ceiling(maxY);
             }
         }
-  }
+    }
     #endregion
 
     #region CurvatureChart
@@ -834,14 +834,14 @@ namespace ORTS.TrackViewer.Editing.Charts
 
         private void DrawDegreesTurned(Canvas drawingCanvas)
         {
-            double pixelsPerKm = 1000*this.canvasWidth / (this.zoomedMaxX - this.zoomedMinX);
+            double pixelsPerKm = 1000 * this.canvasWidth / (this.zoomedMaxX - this.zoomedMinX);
             if (pixelsPerKm < 100)
             {   // do not draw if we do not have enoug pixels
                 return;
             }
 
             bool InCurve = false;
-            double accumulatedCurveRad=0;
+            double accumulatedCurveRad = 0;
             double distanceAlongPathAtStart = 0;
             char degree = (char)176;
             foreach (PathChartPoint sourcePoint in this.pathData.PathChartPoints)
@@ -855,7 +855,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                     if (InCurve)
                     {   // end of a curve
 
-                        string textToDraw = String.Format("{0:F0}{1}", 180*accumulatedCurveRad/Math.PI, degree);
+                        string textToDraw = String.Format("{0:F0}{1}", 180 * accumulatedCurveRad / Math.PI, degree);
                         DrawTextCentered(drawingCanvas, ScaledX((sourcePoint.DistanceAlongPath + distanceAlongPathAtStart) / 2), 30, textToDraw, Colors.Red);
                     }
                     InCurve = false;
@@ -882,7 +882,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         /// <param name="pathPoint">The single point for which to determine the deviation from 0</param>
         private float CurvatureDeviation(PathChartPoint pathPoint)
         {
-            float deviation =  10 * Math.Sign(pathPoint.Curvature);
+            float deviation = 10 * Math.Sign(pathPoint.Curvature);
             //deviation = pathPoint.Curvature;
             return deviation;
         }
@@ -937,7 +937,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                 DrawText(drawingCanvas, ScaledX((double)niceValue), 5, textToDraw, Colors.Black);
             }
         }
-  
+
     }
     #endregion
 
@@ -1092,7 +1092,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         /// <param name="unit">The string to use as unit</param>
         /// <param name="minNumberOfTicks">optional: The minimum number of nice ticks</param>
         /// <param name="strict">When set, the nice values will never exceed the given ranges</param>
-        public NiceScaling(double valueMin, double valueMax, double scale, string unit, int minNumberOfTicks=4, bool strict=false)
+        public NiceScaling(double valueMin, double valueMax, double scale, string unit, int minNumberOfTicks = 4, bool strict = false)
         {
             if (valueMin == valueMax)
             {
@@ -1117,9 +1117,9 @@ namespace ORTS.TrackViewer.Editing.Charts
 
 
             this.Unit = unit;
-            double valueScaledMin = valueMin/scale;
-            double valueScaledMax = valueMax/scale;
-            double subDivisionMax = (valueScaledMax - valueScaledMin)/minNumberOfTicks;
+            double valueScaledMin = valueMin / scale;
+            double valueScaledMax = valueMax / scale;
+            double subDivisionMax = (valueScaledMax - valueScaledMin) / minNumberOfTicks;
             double sub10log = Math.Floor(Math.Log10(subDivisionMax));
 
             double power10 = Math.Pow(10.0, sub10log);
@@ -1137,10 +1137,11 @@ namespace ORTS.TrackViewer.Editing.Charts
             {
                 valueScaledStart += valueScaledStep;
             }
-            
+
             List<decimal> values = new List<decimal>();
             decimal valueScaled = valueScaledStart;
-            while (valueScaled < (decimal)valueScaledMax) {
+            while (valueScaled < (decimal)valueScaledMax)
+            {
                 values.Add(valueScaled * this.Scale);
                 valueScaled += valueScaledStep;
             }
@@ -1148,7 +1149,7 @@ namespace ORTS.TrackViewer.Editing.Charts
 
             NiceValues = values.ToArray();
             ValueMin = valueScaledStart * this.Scale;
-            ValueMax = valueScaled      * this.Scale;
+            ValueMax = valueScaled * this.Scale;
         }
     }
     #endregion

--- a/Source/Contrib/TrackViewer/Editing/Charts/PathChartData.cs
+++ b/Source/Contrib/TrackViewer/Editing/Charts/PathChartData.cs
@@ -49,7 +49,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         public IDictionary<TrainpathNode, double> DistanceAlongPath;
         /// <summary>Is there actually a path loaded with one or more points</summary>
         [JsonIgnore]
-        public bool HasPath { get { return PathChartPoints != null && PathChartPoints.Count() > 0;} }
+        public bool HasPath { get { return PathChartPoints != null && PathChartPoints.Count() > 0; } }
 
         [JsonProperty("PathName")]
         private string PathName { get; set; }
@@ -116,7 +116,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                     lastDistance += relativePoint.DistanceAlongNextSection;
                     AddPoint(localPathChartPoints, absolutePoint);
                 }
-                
+
                 node = node.NextMainNode;
             }
 
@@ -164,8 +164,8 @@ namespace ORTS.TrackViewer.Editing.Charts
         /// </summary>
         private void StoreAllMinMax()
         {
-            this.PointWithMaxima = new PathChartPoint(new PathChartPoint(this.MaxHeightM, this.MaxCurvature, this.MaxGradePercent/100, 0), this.MaxDistanceAlongPath);
-            this.PointWithMinima = new PathChartPoint(new PathChartPoint(this.MinHeightM, this.MinCurvature, this.MinGradePercent/100, 0), this.MinDistanceAlongPath);
+            this.PointWithMaxima = new PathChartPoint(new PathChartPoint(this.MaxHeightM, this.MaxCurvature, this.MaxGradePercent / 100, 0), this.MaxDistanceAlongPath);
+            this.PointWithMinima = new PathChartPoint(new PathChartPoint(this.MinHeightM, this.MinCurvature, this.MinGradePercent / 100, 0), this.MinDistanceAlongPath);
         }
         #endregion
 
@@ -216,7 +216,7 @@ namespace ORTS.TrackViewer.Editing.Charts
             float sectionOffsetStop;
 
             DetermineSectionDetails(thisNode, nextNode, tn, out isForward, out tvsiStart, out sectionOffsetStart);
-            DetermineSectionDetails(nextNode, thisNode, tn, out isReverse, out tvsiStop,  out sectionOffsetStop);
+            DetermineSectionDetails(nextNode, thisNode, tn, out isReverse, out tvsiStop, out sectionOffsetStop);
 
             float height;
             if (isForward)
@@ -228,7 +228,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                     height = vectorNode.TrVectorSections[tvsi].Y;
                     AddPointAndTrackItems(newPoints, vectorNode, trackItemsInTracknode, isForward, height, tvsi, 0, sectionOffsetNext);
 
-                    sectionOffsetNext = SectionLengthAlongTrack(tn, tvsi-1);
+                    sectionOffsetNext = SectionLengthAlongTrack(tn, tvsi - 1);
                 }
 
                 //Also works in case this is the only point we are adding
@@ -242,7 +242,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                 for (int tvsi = tvsiStop; tvsi < tvsiStart; tvsi++)
                 {
                     // The height needs to come from the end of the section, so the where the next section starts. And we only know the height at the start.
-                    height = vectorNode.TrVectorSections[tvsi+1].Y;
+                    height = vectorNode.TrVectorSections[tvsi + 1].Y;
                     AddPointAndTrackItems(newPoints, vectorNode, trackItemsInTracknode, isForward, height, tvsi, sectionOffsetNext, SectionLengthAlongTrack(tn, tvsi));
 
                     sectionOffsetNext = 0;
@@ -353,7 +353,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                     }
                 }
             }
-            
+
             return curvature;
         }
 
@@ -391,7 +391,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                 sectionOffsetStart = currentNodeAsVector.TrackSectionOffset;
             }
         }
-        
+
         /// <summary>
         /// Determine the length of the section along the track.
         /// </summary>
@@ -443,7 +443,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         /// <returns></returns>
         private int DetermineTrackVectorSection(TrainpathNode node, int tvn)
         { // It would be nice if we could separate this into different classes for vector and junction, but this would mean creating three additional classes for only a few methods
-            TrainpathVectorNode nodeAsVector =  node as TrainpathVectorNode;
+            TrainpathVectorNode nodeAsVector = node as TrainpathVectorNode;
             if (nodeAsVector != null)
             {
                 return nodeAsVector.TrackVectorSectionIndex;
@@ -451,10 +451,12 @@ namespace ORTS.TrackViewer.Editing.Charts
             else
             {
                 TrainpathJunctionNode currentNodeAsJunction = node as TrainpathJunctionNode;
-                if (currentNodeAsJunction.JunctionIndex == trackDB.TrackNodes[node.NextMainTvnIndex].JunctionIndexAtStart()) {
+                if (currentNodeAsJunction.JunctionIndex == trackDB.TrackNodes[node.NextMainTvnIndex].JunctionIndexAtStart())
+                {
                     return 0;
                 }
-                else{
+                else
+                {
                     return trackDB.TrackNodes[node.NextMainTvnIndex].TrVectorNode.TrVectorSections.Count() - 1;
                 }
             }
@@ -499,7 +501,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         /// <param name="node">The node describing where the location of the point is</param>
         public PathChartPoint(TrainpathNode node)
         {
-            HeightM = node.Location.Location.Y; 
+            HeightM = node.Location.Location.Y;
             DistanceAlongPath = 0;
             Curvature = 0;
             GradePercent = 0;
@@ -522,7 +524,7 @@ namespace ORTS.TrackViewer.Editing.Charts
             HeightM = height;
             DistanceAlongPath = 0;
             Curvature = curvature;
-            GradePercent = grade*100;
+            GradePercent = grade * 100;
             DistanceAlongNextSection = distanceAlongSection;
             TrackItemText = itemText;
             TrackItemType = type;
@@ -629,7 +631,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                 {
                     var travellerAtItem = new Traveller(tsectionDat, trackDB.TrackNodes, tn,
                         trItem.TileX, trItem.TileZ, trItem.X, trItem.Z, Traveller.TravellerDirection.Forward);
-                    
+
                     if (travellerAtItem != null)
                     {
                         tracknodeItems.Add(new ChartableTrackItem(trItem, travellerAtItem));
@@ -679,7 +681,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         public float TrackVectorSectionOffset;
         /// <summary>The type of item</summary>
         public ChartableTrackItemType ItemType;
-        
+
         /// <summary>
         /// Constructor
         /// </summary>

--- a/Source/Contrib/TrackViewer/Editing/Charts/PathChartWindow.xaml.cs
+++ b/Source/Contrib/TrackViewer/Editing/Charts/PathChartWindow.xaml.cs
@@ -33,7 +33,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         public PathChartWindow()
         {
             InitializeComponent();
-            
+
             chartCanvasses = new Dictionary<string, Canvas> {
                 {"height", HeightCanvas},
                 {"grade", GradeCanvas},
@@ -76,7 +76,8 @@ namespace ORTS.TrackViewer.Editing.Charts
             {
                 ISubChart subChart;
                 subCharts.TryGetValue(chartName, out subChart);
-                if (subChart != null) {
+                if (subChart != null)
+                {
                     subChart.Draw(zoomRatioStart, zoomRatioStop, chartCanvasses[chartName], legendCanvasses[chartName]);
                 }
             }
@@ -144,7 +145,7 @@ namespace ORTS.TrackViewer.Editing.Charts
         }
 
         private bool mouseIsMoving = false;
-        private double realXatMouse=0;
+        private double realXatMouse = 0;
         private void Window_MouseDown(object sender, MouseButtonEventArgs e)
         {
             if (e.LeftButton != MouseButtonState.Pressed)

--- a/Source/Contrib/TrackViewer/Editing/ConnectableNode.cs
+++ b/Source/Contrib/TrackViewer/Editing/ConnectableNode.cs
@@ -88,7 +88,7 @@ namespace ORTS.TrackViewer.Editing
         {
 
             int tvnIndex = OriginalNodeAsVector.TvnIndex;
-            if ( (IsFrom && IsConnectingForward) || (!IsFrom && !IsConnectingForward))
+            if ((IsFrom && IsConnectingForward) || (!IsFrom && !IsConnectingForward))
             {
                 // the first junction node of the reconnect path is after the vector node.
                 this.ConnectingJunctionIndex = OriginalNodeAsVector.GetNextJunctionIndex(tvnIndex);
@@ -115,7 +115,8 @@ namespace ORTS.TrackViewer.Editing
             DetermineJunction();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return "Connectable " + OriginalNode.ToString();
         }
     }
@@ -199,14 +200,15 @@ namespace ORTS.TrackViewer.Editing
             }
 
             ConnectableNode candidate = connectableNodeOptions[0];
-            
-            if (ExistsConnectionSameTrack(fromNode, candidate, firstTvnIndex)) {
+
+            if (ExistsConnectionSameTrack(fromNode, candidate, firstTvnIndex))
+            {
                 ActualReconnectNode = candidate;
                 return true;
             }
 
             return false;
-        
+
         }
 
         /// <summary>
@@ -244,7 +246,7 @@ namespace ORTS.TrackViewer.Editing
             {
                 if (fromAsVector.ForwardOriented == fromAsVector.IsEarlierOnTrackThan(toAsVector)) return false;
             }
-            
+
             return true;
         }
 

--- a/Source/Contrib/TrackViewer/Editing/DrawEditorAction.cs
+++ b/Source/Contrib/TrackViewer/Editing/DrawEditorAction.cs
@@ -36,7 +36,7 @@ namespace ORTS.TrackViewer.Editing
             lowerLeft = new Vector2(xLowerLeft, yLowerLeft);
         }
 
-    
+
         /// <summary>
         /// Draw (print) the values of longitude and latitude
         /// </summary>
@@ -44,7 +44,7 @@ namespace ORTS.TrackViewer.Editing
         public void Draw(PathEditor editor)
         {
             if (editor == null) { return; }
-            if (!Properties.Settings.Default.showEditorAction) { return;}
+            if (!Properties.Settings.Default.showEditorAction) { return; }
             BasicShapes.DrawString(lowerLeft, DrawColors.colorsNormal.Text, editor.CurrentActionDescription);
         }
     }

--- a/Source/Contrib/TrackViewer/Editing/DrawPATfile.cs
+++ b/Source/Contrib/TrackViewer/Editing/DrawPATfile.cs
@@ -45,7 +45,7 @@ namespace ORTS.TrackViewer.Editing
 
         /// <summary>Number of nodes that will be drawn. Start with a few</summary>
         private int numberToDraw = int.MaxValue / 2; // large, but not close to overflow
-        
+
         /// <summary>Index of the last main node that has been drawn</summary>
         private int currentMainNodeIndex;
 
@@ -60,7 +60,7 @@ namespace ORTS.TrackViewer.Editing
         /// Constructor
         /// </summary>
         /// <param name="path">Contains the information (mainly filepath) needed for loading the .pat file</param>
-        public DrawPATfile (ORTS.Menu.Path path)
+        public DrawPATfile(ORTS.Menu.Path path)
         {
             FileName = path.FilePath.Split('\\').Last();
             patFile = new PathFile(path.FilePath);
@@ -72,7 +72,7 @@ namespace ORTS.TrackViewer.Editing
         /// <param name="drawArea">Area to draw upon</param>
         public void Draw(DrawArea drawArea)
         {
-            
+
             //draw actual path
             currentMainNodeIndex = 0; // starting point
             int currentSidingNodeIndex = -1; // we start without siding path
@@ -98,11 +98,11 @@ namespace ORTS.TrackViewer.Editing
 
                 TrPathNode curMainNode = patFile.TrPathNodes[currentMainNodeIndex];
                 WorldLocation curMainLoc = GetPdpLocation(patFile.TrackPDPs[(int)curMainNode.fromPDP]);
-                
+
                 // from this main line point to the next siding node.
                 // If there is a next siding node, we also reset the currentSidingNodeIndex
                 // but probably it is not allowed to have siding
-                int nextSidingNodeIndex = (int)curMainNode.nextSidingNode;             
+                int nextSidingNodeIndex = (int)curMainNode.nextSidingNode;
                 if (nextSidingNodeIndex >= 0)
                 {
                     // draw the start of a siding path
@@ -114,7 +114,7 @@ namespace ORTS.TrackViewer.Editing
                 }
 
                 // From this main line point to the next
-                int nextMainNodeIndex = (int)curMainNode.nextMainNode; 
+                int nextMainNodeIndex = (int)curMainNode.nextMainNode;
                 if (nextMainNodeIndex >= 0)
                 {
                     TrPathNode nextNode = patFile.TrPathNodes[nextMainNodeIndex];
@@ -124,7 +124,7 @@ namespace ORTS.TrackViewer.Editing
                     currentMainNodeIndex = nextMainNodeIndex;
                 }
             }
- 
+
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace ORTS.TrackViewer.Editing
         /// </summary>
         public void ExtendPath()
         {
-            int maxNumber = patFile.TrPathNodes.Count-1;
+            int maxNumber = patFile.TrPathNodes.Count - 1;
             if (++numberToDraw > maxNumber) numberToDraw = maxNumber;
         }
 

--- a/Source/Contrib/TrackViewer/Editing/DrawPath.cs
+++ b/Source/Contrib/TrackViewer/Editing/DrawPath.cs
@@ -55,7 +55,7 @@ namespace ORTS.TrackViewer.Editing
         /// <summary>
         /// Constructor
         /// </summary>
-        public DrawPath (TrackDB trackDB, TrackSectionsFile tsectionDat)
+        public DrawPath(TrackDB trackDB, TrackSectionsFile tsectionDat)
         {
             this.trackDB = trackDB;
             this.tsectionDat = tsectionDat;
@@ -74,7 +74,7 @@ namespace ORTS.TrackViewer.Editing
             DrawnPathData dummyData = new DrawnPathData();
             Draw(drawArea, firstNode, null, int.MaxValue, dummyData);
         }
- 
+
         /// <summary>
         /// Draw the actual path coded in the PATfile (for a number of nodes that can be extended or reduced)
         /// </summary>
@@ -84,15 +84,15 @@ namespace ORTS.TrackViewer.Editing
         /// <param name="numberToDraw">The requested number of nodes to draw</param>
         /// <param name="drawnPathData">Data structure that we will fill with information about the path we have drawn</param>
         /// <returns>the number of nodes actually drawn (not taking into account nodes on a siding)</returns>
-        public int Draw(DrawArea drawArea, 
+        public int Draw(DrawArea drawArea,
                          TrainpathNode firstNode,
                          TrainpathNode firstNodeOfTail,
-                         int numberToDraw, 
+                         int numberToDraw,
                          DrawnPathData drawnPathData)
         {
             //List of all nodes that need to be drawn.
             List<TrainpathNode> drawnNodes = new List<TrainpathNode>();
- 
+
             // start of path
             TrainpathNode currentSidingNode = null; // we start without siding path
             CurrentMainNode = firstNode;
@@ -102,19 +102,19 @@ namespace ORTS.TrackViewer.Editing
                 DrawTail(drawArea, ColorSchemeMain, null, firstNodeOfTail);
                 return 0;
             }
-         
+
             drawnNodes.Add(CurrentMainNode);
             drawnPathData.AddNode(CurrentMainNode);
 
             // We want to draw only a certain number of nodes. And if there is a siding, for the siding
             // we also want to draw the same number of nodes from where it splits from the main track
-            TrainpathNode LastVectorStart= null;
+            TrainpathNode LastVectorStart = null;
             TrainpathNode LastVectorEnd = null;
             int LastVectorTvn = 0;
             int numberDrawn = 1;
             while (numberDrawn < numberToDraw)
             {
-                
+
                 // If we have a current siding track, we draw it 
                 if (currentSidingNode != null)
                 {
@@ -137,14 +137,14 @@ namespace ORTS.TrackViewer.Editing
                             sidingNodesToDraw = 0;
                         }
                         currentSidingNode = nextNodeOnSiding;
-                        
+
                     }
                 }
- 
+
                 // Draw the start of a siding path, so from this main line point to the next siding node.
                 // If there is a next siding node, we also reset the currentSidingNode
                 // but probably it is not allowed to have siding on a siding
-                TrainpathNode nextSidingNode = CurrentMainNode.NextSidingNode;             
+                TrainpathNode nextSidingNode = CurrentMainNode.NextSidingNode;
                 if (nextSidingNode != null)
                 {
                     DrawPathOnVectorNode(drawArea, ColorSchemeSiding, CurrentMainNode, nextSidingNode, CurrentMainNode.NextSidingTvnIndex);
@@ -183,7 +183,8 @@ namespace ORTS.TrackViewer.Editing
 
             //Draw all the nodes themselves
             TrainpathNode lastNode = null;
-            foreach (TrainpathNode node in drawnNodes) {
+            foreach (TrainpathNode node in drawnNodes)
+            {
                 DrawNodeItself(drawArea, node, false);
                 lastNode = node;
             }
@@ -199,7 +200,7 @@ namespace ORTS.TrackViewer.Editing
             return numberDrawn;
         }
 
-        
+
 
         /// <summary>
         /// Draw the current path node texture, showing what kind of node it is
@@ -214,7 +215,7 @@ namespace ORTS.TrackViewer.Editing
             int maxPixelSize = 24;
             float angle = trainpathNode.TrackAngle;
 
-            Color colorMain = isLastNode ? this.ColorSchemeLast.TrackStraight : ColorSchemeMain.TrackStraight  ;
+            Color colorMain = isLastNode ? this.ColorSchemeLast.TrackStraight : ColorSchemeMain.TrackStraight;
             Color colorSiding = this.ColorSchemeSiding.TrackStraight;
             Color colorBroken = this.ColorSchemeMain.BrokenNode;
 
@@ -239,7 +240,7 @@ namespace ORTS.TrackViewer.Editing
                     break;
                 default:
                     bool isSidingNode = (trainpathNode.NextMainNode == null) &&
-                        ( (trainpathNode.NextSidingNode != null) || trainpathNode.IsBroken);  // The IsBroken condition should indicate a dangling siding node
+                        ((trainpathNode.NextSidingNode != null) || trainpathNode.IsBroken);  // The IsBroken condition should indicate a dangling siding node
                     Color normalColor = (isSidingNode) ? colorSiding : colorMain;
                     drawArea.DrawTexture(trainpathNode.Location, "pathNormal", pathPointSize, minPixelSize, maxPixelSize, normalColor, angle);
                     break;
@@ -250,7 +251,7 @@ namespace ORTS.TrackViewer.Editing
                 drawArea.DrawTexture(trainpathNode.Location, "crossedRing", pathPointSize, minPixelSize, maxPixelSize, colorBroken);
             }
             //drawArea.DrawExpandingString(trainpathNode.Location, trainpathNode.NodeType.ToString()); //debug only
-            
+
         }
 
         /// <summary>
@@ -277,7 +278,7 @@ namespace ORTS.TrackViewer.Editing
 
             //Default situation (and most occuring) is to draw the complete vector node 
             int tvsiStart = 0;
-            int tvsiStop = tn.TrVectorNode.TrVectorSections.Length-1;
+            int tvsiStop = tn.TrVectorNode.TrVectorSections.Length - 1;
             float sectionOffsetStart = 0;
             float sectionOffsetStop = -1;
             if (currentNode is TrainpathJunctionNode)
@@ -393,13 +394,13 @@ namespace ORTS.TrackViewer.Editing
             if (trackSection == null) return;
 
             WorldLocation thisLocation = new WorldLocation(tvs.TileX, tvs.TileZ, tvs.X, 0, tvs.Z);
-            
+
             if (trackSection.SectionCurve != null)
             {   //curved section
                 float radius = trackSection.SectionCurve.Radius;
                 int sign = (trackSection.SectionCurve.Angle < 0) ? -1 : 1;
-                float angleLength = (stopOffset < 0) ? trackSection.SectionCurve.Angle : sign*MathHelper.ToDegrees(stopOffset/radius);
-                float angleStart = sign*MathHelper.ToDegrees(startOffset / radius);
+                float angleLength = (stopOffset < 0) ? trackSection.SectionCurve.Angle : sign * MathHelper.ToDegrees(stopOffset / radius);
+                float angleStart = sign * MathHelper.ToDegrees(startOffset / radius);
                 angleLength -= angleStart;
 
                 drawArea.DrawArc(trackSection.SectionSize.Width, colors.TrackCurved, thisLocation,
@@ -423,7 +424,7 @@ namespace ORTS.TrackViewer.Editing
         /// <param name="nextNode">node to draw to</param>
         private static void DrawPathBrokenNode(DrawArea drawArea, ColorScheme colors, TrainpathNode currentNode, TrainpathNode nextNode)
         {
-            drawArea.DrawLine(1f, colors.BrokenPath , currentNode.Location, nextNode.Location);
+            drawArea.DrawLine(1f, colors.BrokenPath, currentNode.Location, nextNode.Location);
         }
 
         /// <summary>
@@ -456,7 +457,7 @@ namespace ORTS.TrackViewer.Editing
         /// List of main-track nodes that were actually drawn and can therefore be selected for editing
         /// </summary>     
         public Collection<TrainpathNode> DrawnNodes { get; private set; }
-        
+
         /// <summary>
         /// Keys are tracknode indexes, value is a list of (main) track node (in pairs) that are both
         /// on the tracknode and the path between them has been drawn 

--- a/Source/Contrib/TrackViewer/Editing/EditorActions.cs
+++ b/Source/Contrib/TrackViewer/Editing/EditorActions.cs
@@ -50,7 +50,7 @@ namespace ORTS.TrackViewer.Editing
         protected TrainpathNode ActiveNode { get; private set; }
         /// <summary>The currently active location on a track node on which the action of (some) subclasses will act</summary>
         protected TrainpathVectorNode ActiveTrackLocation { get; private set; }
-        
+
         /// <summary>x-location of the mouse</summary>
         protected int MouseX { get; set; }
         /// <summary>y-location of the mouse</summary>
@@ -94,7 +94,7 @@ namespace ORTS.TrackViewer.Editing
 
             ModificationTools = new ModificationTools();
         }
-        
+
         /// <summary>
         /// Set the state of the item in the menu (depending on whether the action can be executed or not.
         /// </summary>
@@ -169,7 +169,7 @@ namespace ORTS.TrackViewer.Editing
         }
     }
     #endregion
-    
+
     #region AddStart
     /// <summary>
     /// Subclass to implement the action: Add Start Node 
@@ -197,7 +197,7 @@ namespace ORTS.TrackViewer.Editing
         }
 
         /// <summary>Returns the net amount of main nodes added.</summary>
-       protected override int NetMainNodesAdded()
+        protected override int NetMainNodesAdded()
         {
             return ModificationTools.NetNodesAdded + 1; // first node is not counted automatically
         }
@@ -427,7 +427,7 @@ namespace ORTS.TrackViewer.Editing
         /// <param name="nodeToEdit">(Wait) node for which you want to edit the metadata.</param>
         protected void EditWaitMetaData(TrainpathVectorNode nodeToEdit)
         {
-            if (nodeToEdit.WaitTimeS == 0 )
+            if (nodeToEdit.WaitTimeS == 0)
             {
                 nodeToEdit.WaitTimeS = 602; // some initial value: 10 minutes, 2 seconds
             }
@@ -556,7 +556,7 @@ namespace ORTS.TrackViewer.Editing
         protected bool CanTakeOtherExit(bool addPassingPath)
         {
             TrainpathJunctionNode activeNodeAsJunction = ActiveNode as TrainpathJunctionNode;
-            
+
             return
                 CanTakeOtherExitBasic(activeNodeAsJunction) &&
                 CanReconnectOtherExit(activeNodeAsJunction, addPassingPath);
@@ -601,7 +601,7 @@ namespace ORTS.TrackViewer.Editing
             else
             {
                 // if there is no siding path, we can just reconnect either a new main or a siding path:
-                if (!ActiveNode.HasSidingPath) return true; 
+                if (!ActiveNode.HasSidingPath) return true;
                 // We already have a siding path, so we cannot add another
                 if (addPassingPath) return false;
 
@@ -663,7 +663,7 @@ namespace ORTS.TrackViewer.Editing
             int junctionsToCheck = maxNumberNodesToCheckForReconnect;
             while (junctionsToCheck > 0)
             {
-                int nextJunctionIndex = TrackExtensions.GetNextJunctionIndex(junctionIndex, TvnIndex); 
+                int nextJunctionIndex = TrackExtensions.GetNextJunctionIndex(junctionIndex, TvnIndex);
                 foreach (TrainpathJunctionNode reconnectNode in reconnectNodes)
                 {
                     if (reconnectNode.JunctionIndex == nextJunctionIndex)
@@ -690,7 +690,7 @@ namespace ORTS.TrackViewer.Editing
             }
             return null;
         }
-      
+
     }
     #endregion
 
@@ -715,7 +715,7 @@ namespace ORTS.TrackViewer.Editing
         protected override void ExecuteAction()
         {
             TrainpathJunctionNode activeNodeAsJunction = ActiveNode as TrainpathJunctionNode;
-            
+
             if (ReconnectNode == null)
             {   //really take other exit and discard rest of path
                 activeNodeAsJunction.NextMainTvnIndex = NewTvnIndex;
@@ -799,7 +799,7 @@ namespace ORTS.TrackViewer.Editing
             if (!CanTakeOtherExitBasic(activeNodeAsJunction)) return false;
             if (ActiveNode.HasSidingPath) return false;
             if (activeNodeAsJunction.IsSimpleSidingStart()) return false;
-            
+
             //The idea was that if a normal passing path is possible, then there is no need for a complex passing path
             //However, if you want to connect not to the default recnnect node, we do need this
             //if (CanReconnectOtherExit(activeNodeAsJunction, true)) return false;
@@ -847,7 +847,7 @@ namespace ORTS.TrackViewer.Editing
         }
     }
     #endregion
-    
+
     #region RemovePassingPath
     /// <summary>
     /// Subclass to implement the action: Remove as passing path
@@ -870,12 +870,12 @@ namespace ORTS.TrackViewer.Editing
             TrainpathNode mainNode = ActiveNode;
             mainNode.NodeType = TrainpathNodeType.Other; // this was SidingStart
             mainNode.NextSidingNode = null;
-            
+
             if (!mainNode.HasSidingPath)
             {   // only a broken stub created by StartPassingPath
                 return;
             }
-            
+
             //make sure the main path does no longer show it has a siding path.
             while (mainNode.NodeType != TrainpathNodeType.SidingEnd)
             {
@@ -958,8 +958,8 @@ namespace ORTS.TrackViewer.Editing
             if (ActiveNode.NodeType == TrainpathNodeType.Start) return false;
             if (ActiveNode.NextMainNode == null) return false;
             if (ActiveNode.IsBroken) return false;
-            if (ActiveNode.NodeType == TrainpathNodeType.SidingEnd) return false; 
-            
+            if (ActiveNode.NodeType == TrainpathNodeType.SidingEnd) return false;
+
             if (ActiveNode.HasSidingPath)
             {
                 // a siding start itself should still be fine.
@@ -967,7 +967,7 @@ namespace ORTS.TrackViewer.Editing
             }
             return true;
 
-          
+
         }
 
         /// <summary>Execute the action. This assumes that the action can be executed</summary>
@@ -979,12 +979,12 @@ namespace ORTS.TrackViewer.Editing
 
             TrainpathNode lastEditableNode = ActiveNode.PrevNode;
             ActiveNode.PrevNode = null;
-            
+
             lastEditableNode.NextMainNode = null;
         }
     }
     #endregion
-  
+
     #region AutoFixBrokenNodes
     /// <summary>
     /// Subclass to implement the action: Auto-fix broken nodes
@@ -1193,7 +1193,8 @@ namespace ORTS.TrackViewer.Editing
         /// This action can only be done if there is a passing path stub, that is, a start of a passing path
         /// that contains only a single siding node that is broken and not reconnected.
         /// </summary>
-        void FindPassingPathStub() {
+        void FindPassingPathStub()
+        {
             sidingStartNode = null;
             autoConnectTools.ResetDisallowedJunctions();
 
@@ -1202,7 +1203,7 @@ namespace ORTS.TrackViewer.Editing
             while (mainNode != null)
             {
                 TrainpathJunctionNode mainNodeAsJunction = mainNode as TrainpathJunctionNode;
-                    
+
                 if (mainNodeAsJunction != null)
                 {
                     if (mainNode.NodeType == TrainpathNodeType.SidingStart)
@@ -1240,7 +1241,7 @@ namespace ORTS.TrackViewer.Editing
             TrainpathNode sidingEnd = ActiveNode;
 
             sidingStartNode.NextSidingNode.SetNonBroken();
-            
+
             sidingStartNode.NodeType = TrainpathNodeType.SidingStart;
             sidingEnd.NodeType = TrainpathNodeType.SidingEnd;
 
@@ -1282,13 +1283,14 @@ namespace ORTS.TrackViewer.Editing
         protected override bool CanExecuteAction()
         {
             if (Trainpath.FirstNode == null) return false;
-            if (ActiveNode.IsBroken) return false; 
+            if (ActiveNode.IsBroken) return false;
             if (ActiveNode.NextMainNode != null) return false;
             if (ActiveNode.NextSidingNode == null) return false;
             if (ActiveNode.NextSidingNode.NodeType == TrainpathNodeType.SidingEnd) return false; // not enough room to take other exit.
 
             TrainpathJunctionNode activeNodeAsJunction = (ActiveNode as TrainpathJunctionNode);
-            if ((activeNodeAsJunction == null) || (!activeNodeAsJunction.IsFacingPoint) ) {
+            if ((activeNodeAsJunction == null) || (!activeNodeAsJunction.IsFacingPoint))
+            {
                 return false;
             }
 
@@ -1297,7 +1299,7 @@ namespace ORTS.TrackViewer.Editing
 
             if (!FindDisAllowedJunctionIndexes()) return false;
             int newNextTvnIndex = activeNodeAsJunction.OtherExitTvnIndex();
-            return autoConnectTools.FindConnection(ActiveNode,sidingEndNode, newNextTvnIndex);
+            return autoConnectTools.FindConnection(ActiveNode, sidingEndNode, newNextTvnIndex);
         }
 
         /// <summary>
@@ -1386,7 +1388,7 @@ namespace ORTS.TrackViewer.Editing
     public abstract class EditorActionMouseDrag : EditorAction
     {
         /// <summary>Constructor</summary>
-        protected EditorActionMouseDrag(string header, string pngFileName) : base(header, pngFileName) {}
+        protected EditorActionMouseDrag(string header, string pngFileName) : base(header, pngFileName) { }
 
         /// <summary>
         /// Dragging has commenced. Perform initialization actions
@@ -1455,7 +1457,7 @@ namespace ORTS.TrackViewer.Editing
 
     }
     #endregion
-  
+
     #region MouseDragVectorNode
     /// <summary>
     /// Subclass to implement the actions related to mouse dragging.
@@ -1477,7 +1479,7 @@ namespace ORTS.TrackViewer.Editing
             if (ActiveNode.IsBroken) return false;
             nodeBeingDragged = ActiveNode as TrainpathVectorNode;
             if (nodeBeingDragged == null) return false;
-            
+
             switch (ActiveNode.NodeType)
             {
                 case TrainpathNodeType.Start:
@@ -1485,10 +1487,10 @@ namespace ORTS.TrackViewer.Editing
                 case TrainpathNodeType.Stop:
                 case TrainpathNodeType.Reverse:
                     return true;
-                default: 
+                default:
                     return false;
             }
-            
+
         }
 
         /// <summary>Execute the action. This assumes that the action can be executed</summary>
@@ -1502,15 +1504,15 @@ namespace ORTS.TrackViewer.Editing
         /// Note that undo/redo is already taken care of.
         /// </summary>
         protected override void InitDragging()
-        {          
+        {
             switch (ActiveNode.NodeType)
             {
-                case TrainpathNodeType.Start:   FindDraggingLimitsStart(); break;
-                case TrainpathNodeType.End:     FindDraggingLimitsEnd(); break;
-                case TrainpathNodeType.Stop:    FindDraggingLimitsStop(); break;
+                case TrainpathNodeType.Start: FindDraggingLimitsStart(); break;
+                case TrainpathNodeType.End: FindDraggingLimitsEnd(); break;
+                case TrainpathNodeType.Stop: FindDraggingLimitsStop(); break;
                 case TrainpathNodeType.Reverse: FindDraggingLimitsReverse(); break;
                 default: break;
-            }   
+            }
         }
 
         /// <summary>
@@ -1519,13 +1521,13 @@ namespace ORTS.TrackViewer.Editing
         protected override bool SucceededDragging()
         {
 
-            if ( (nodeBeingDragged.TvnIndex == ActiveTrackLocation.TvnIndex)
+            if ((nodeBeingDragged.TvnIndex == ActiveTrackLocation.TvnIndex)
               && (ActiveTrackLocation.Location != WorldLocation.None)
               && (ActiveTrackLocation.IsBetween(dragLimitNode1, dragLimitNode2)))
             {
-                nodeBeingDragged.Location                = ActiveTrackLocation.Location;
+                nodeBeingDragged.Location = ActiveTrackLocation.Location;
                 nodeBeingDragged.TrackVectorSectionIndex = ActiveTrackLocation.TrackVectorSectionIndex;
-                nodeBeingDragged.TrackSectionOffset      = ActiveTrackLocation.TrackSectionOffset;
+                nodeBeingDragged.TrackSectionOffset = ActiveTrackLocation.TrackSectionOffset;
 
                 return true;
             }
@@ -1547,7 +1549,7 @@ namespace ORTS.TrackViewer.Editing
                 dragLimitNode2 = nodeBeingDragged.NextMainNode;
             }
         }
-        
+
         void FindDraggingLimitsEnd()
         {
             dragLimitNode1 = nodeBeingDragged.PrevNode;
@@ -1564,7 +1566,7 @@ namespace ORTS.TrackViewer.Editing
             {   // we now need to find which of the next and previous nodes is closest to the reverse point
                 TrainpathVectorNode prevVectorNode = nodeBeingDragged.PrevNode as TrainpathVectorNode;
                 TrainpathVectorNode nextVectorNode = nodeBeingDragged.NextMainNode as TrainpathVectorNode;
-                    
+
                 if (prevVectorNode == null)
                 {   // prev is a junction node. Then either the next node is a vector node, or it is the same junction. Just take it
                     dragLimitNode1 = nodeBeingDragged.NextMainNode;
@@ -1575,7 +1577,8 @@ namespace ORTS.TrackViewer.Editing
                 }
                 else
                 {   // both are vector nodes.
-                    if (prevVectorNode.IsBetween(nextVectorNode,nodeBeingDragged)) {
+                    if (prevVectorNode.IsBetween(nextVectorNode, nodeBeingDragged))
+                    {
                         dragLimitNode1 = nodeBeingDragged.PrevNode;
                     }
                     else
@@ -1629,7 +1632,7 @@ namespace ORTS.TrackViewer.Editing
         private ContinuousAutoConnecting autoConnectReverse;
         private TrainpathVectorNode nodeBeingDragged;               // link to a possibly possibly temporary node that is being dragged.
         private int netNodesDeleted;
-        
+
         //private DebugWindow debugWindow;
         /// <summary>Constructor</summary>
         public EditorActionMouseDragAutoConnect()
@@ -1830,7 +1833,7 @@ namespace ORTS.TrackViewer.Editing
 
             if (connectionIsGood)
             {
-                PrepareNodeCountUpdate(autoConnectReverse.ReconnectTrainpathNode, nodeBeingDragged, 0);                
+                PrepareNodeCountUpdate(autoConnectReverse.ReconnectTrainpathNode, nodeBeingDragged, 0);
                 autoConnectReverse.CreateFoundConnection(ModificationTools, true); // note: reverse is not yet done, compare 'normal connection'
             }
 
@@ -1877,7 +1880,7 @@ namespace ORTS.TrackViewer.Editing
         // * Passing paths.
     }
     #endregion
-  
+
     #region NonInteractiveActions
     /// <summary>
     /// Subclass to implement the 'action': add Missing ambiguity nodes. This is not an interactive action, but still and edit to the path.
@@ -1894,7 +1897,7 @@ namespace ORTS.TrackViewer.Editing
         }
 
         /// <summary>Execute the action. This assumes that the action can be executed</summary>
-        protected override void ExecuteAction() {}
+        protected override void ExecuteAction() { }
 
         /// <summary>
         /// Add additional main nodes (to the end of the current path)

--- a/Source/Contrib/TrackViewer/Editing/ModificationTools.cs
+++ b/Source/Contrib/TrackViewer/Editing/ModificationTools.cs
@@ -34,7 +34,7 @@ namespace ORTS.TrackViewer.Editing
         #region node counting
         /// <summary>Keeps cound of the net amount of nodes that have been added</summary>
         public int NetNodesAdded { get; private set; }
-        
+
         /// <summary>
         /// Reset the amount of nodes added
         /// </summary>
@@ -142,7 +142,7 @@ namespace ORTS.TrackViewer.Editing
             newNode.SetFacingPoint();
             newNode.DetermineOrientation(lastNode, nextTvnIndex);
 
-            NetNodesAdded ++ ;
+            NetNodesAdded++;
             return newNode;
         }
 
@@ -174,7 +174,7 @@ namespace ORTS.TrackViewer.Editing
                 lastNode.NextSidingNode = newNode;
             }
 
-            NetNodesAdded ++;
+            NetNodesAdded++;
             return newNode;
         }
 
@@ -306,10 +306,10 @@ namespace ORTS.TrackViewer.Editing
         {
             //Check if we need to add an disambiguity node
             TrainpathJunctionNode currentNodeAsJunction = currentNode as TrainpathJunctionNode;
-            if (   (currentNodeAsJunction != null) 
+            if ((currentNodeAsJunction != null)
                 && (currentNode.NextMainNode != null)
                 && (currentNode.NextMainNode is TrainpathJunctionNode)
-                && (currentNodeAsJunction.IsSimpleSidingStart()) 
+                && (currentNodeAsJunction.IsSimpleSidingStart())
                 )
             {
                 TrainpathVectorNode halfwayNode = CreateHalfWayNode(currentNodeAsJunction, currentNodeAsJunction.NextMainTvnIndex);
@@ -385,7 +385,7 @@ namespace ORTS.TrackViewer.Editing
 
             //in case the first node of the second path is a vector, make sure that its next tvn index is copied
             if (firstNodeSecondPathAsVector != null)
-            {   
+            {
                 if (isMainPath)
                 {
                     lastNodeFirstPath.NextMainTvnIndex = firstNodeSecondPathAsVector.TvnIndex;

--- a/Source/Contrib/TrackViewer/Editing/PathEditor.cs
+++ b/Source/Contrib/TrackViewer/Editing/PathEditor.cs
@@ -56,8 +56,9 @@ namespace ORTS.TrackViewer.Editing
         /// <summary>The current path that we are editing</summary>
         public Trainpath CurrentTrainPath { get; private set; }
         /// <summary>Editing is active or not</summary>
-        public bool EditingIsActive { 
-            get {return _editingIsActive;}
+        public bool EditingIsActive
+        {
+            get { return _editingIsActive; }
             set { _editingIsActive = value; OnActiveOrPathChanged(); }
         }
 
@@ -88,7 +89,7 @@ namespace ORTS.TrackViewer.Editing
         DrawTrackDB drawTrackDB; // We need to know what has been drawn, especially to get track closest to mouse
         TrackDB trackDB;
         TrackSectionsFile tsectionDat;
-        
+
         DrawPath drawPath;      // drawing of the path itself
 
         TrainpathNode activeNode;           // active Node (if present) for which actions can be performed
@@ -102,7 +103,7 @@ namespace ORTS.TrackViewer.Editing
         Separator separatorActiveTrack;
         Separator separatorBroken;
 
-        const int practicalInfinityInt = int.MaxValue/2; // large, but not close to overflow
+        const int practicalInfinityInt = int.MaxValue / 2; // large, but not close to overflow
         int numberToDraw = practicalInfinityInt; // number of nodes to draw, start with all
         int maxNodesToAdd;  // if at end of path, how many nodes do we allow to be added
 
@@ -164,7 +165,7 @@ namespace ORTS.TrackViewer.Editing
         /// <param name="routeData">The route information that contains track data base and track section data</param>
         /// <param name="drawTrackDB">The drawn tracks to know about where the mouse is</param>/// <param name="pathsDirectory">The directory where paths will be stored</param>
         public PathEditor(RouteData routeData, DrawTrackDB drawTrackDB, string pathsDirectory)
-            :this(routeData, drawTrackDB)
+            : this(routeData, drawTrackDB)
         {
             CurrentTrainPath = new Trainpath(trackDB, tsectionDat);
             FileName = CurrentTrainPath.PathId + ".pat";
@@ -180,7 +181,7 @@ namespace ORTS.TrackViewer.Editing
         /// <param name="drawTrackDB">The drawn tracks to know about where the mouse is</param>
         /// <param name="path">Path to the .pat file</param>
         public PathEditor(RouteData routeData, DrawTrackDB drawTrackDB, ORTS.Menu.Path path)
-            :this(routeData, drawTrackDB)
+            : this(routeData, drawTrackDB)
         {
             FileName = path.FilePath.Split('\\').Last();
             CurrentTrainPath = new Trainpath(trackDB, tsectionDat, path.FilePath);
@@ -274,7 +275,8 @@ namespace ORTS.TrackViewer.Editing
         /// <summary>
         /// Create the context menu from previously defined items.
         /// </summary>
-        private void CreateContextMenu() {
+        private void CreateContextMenu()
+        {
 
             contextMenu = new ContextMenu();
             separatorActiveNode = new Separator();
@@ -292,7 +294,7 @@ namespace ORTS.TrackViewer.Editing
                 contextMenu.Items.Add(action.ActionMenuItem);
             }
             contextMenu.Items.Add(separatorActiveNode);
-            
+
 
             foreach (EditorAction action in editorActionsActiveTrack)
             {
@@ -305,7 +307,7 @@ namespace ORTS.TrackViewer.Editing
                 contextMenu.Items.Add(action.ActionMenuItem);
             }
             contextMenu.Items.Add(separatorBroken);
-            
+
             foreach (EditorAction action in editorActionsOthers)
             {
                 contextMenu.Items.Add(action.ActionMenuItem);
@@ -313,7 +315,7 @@ namespace ORTS.TrackViewer.Editing
 
             contextMenu.Closed += new RoutedEventHandler(ContextMenu_Closed);
         }
-       
+
         /// <summary>
         /// Popup the context menu at the given location. Also disable updates related to mouse movement while menu is open.
         /// </summary>
@@ -357,7 +359,7 @@ namespace ORTS.TrackViewer.Editing
                 someOtherActionIsPossible = someOtherActionIsPossible || actionCanBeExecuted;
             }
 
-            noActionPossibleMenuItem.Visibility = 
+            noActionPossibleMenuItem.Visibility =
                 (someNodeActionIsPossible || someTrackActionIsPossible || someOtherActionIsPossible)
                 ? Visibility.Collapsed : Visibility.Visible;
 
@@ -512,8 +514,8 @@ namespace ORTS.TrackViewer.Editing
         public void Draw(DrawArea drawArea)
         {
             DrawnPathData drawnPathData = new DrawnPathData();
-            
-            int numberDrawn = drawPath.Draw(drawArea, CurrentTrainPath.FirstNode, CurrentTrainPath.FirstNodeOfTail, numberToDraw, 
+
+            int numberDrawn = drawPath.Draw(drawArea, CurrentTrainPath.FirstNode, CurrentTrainPath.FirstNodeOfTail, numberToDraw,
                 drawnPathData);
 
             if (numberDrawn < numberToDraw)
@@ -611,7 +613,7 @@ namespace ORTS.TrackViewer.Editing
             activeTrackLocation.TrackSectionOffset = distance;
             activeTrackLocation.Location = location;
 
-            if ( (CurrentTrainPath.FirstNode != null) && (activeMouseDragAction == null) ) 
+            if ((CurrentTrainPath.FirstNode != null) && (activeMouseDragAction == null))
             {   //Only in case this is not the first path.
                 TrainpathNode prevNode = FindPrevNodeOfActiveTrack(drawnPathData, tni_int);
                 if (prevNode == null || prevNode.HasSidingPath)
@@ -756,13 +758,15 @@ namespace ORTS.TrackViewer.Editing
             // We have a current path and a new path.
             // First check if the new path is usable
             TrainpathNode newStart = newPath.FirstNode;
-            if (newPath.FirstNode == null || newPath.FirstNode.NextMainNode == null) {
+            if (newPath.FirstNode == null || newPath.FirstNode.NextMainNode == null)
+            {
                 MessageBox.Show(TrackViewer.catalog.GetString("The selected path contains no or only 1 node. The current path was not extended."));
                 return;
             }
 
             TrainpathNode lastNode = CurrentTrainPath.FirstNode;
-            while (lastNode.NextMainNode != null) {
+            while (lastNode.NextMainNode != null)
+            {
                 lastNode = lastNode.NextMainNode;
             }
             if (CurrentTrainPath.HasEnd)
@@ -834,7 +838,7 @@ namespace ORTS.TrackViewer.Editing
         /// <param name="popupY">The screen y-location of where the edit metadata popup needs to be placed</param>
         public void ReversePath(int popupX, int popupY)
         {
-            if (! CanReverse()) return;
+            if (!CanReverse()) return;
             CurrentTrainPath.StoreCurrentPath();
             CurrentTrainPath.ReversePath();
             EditMetaData(popupX, popupY);
@@ -889,7 +893,8 @@ namespace ORTS.TrackViewer.Editing
                     actionFixInvalid.DoAction();
                     brokenNodes = CurrentTrainPath.GetBrokenNodes();
                 }
-                else {
+                else
+                {
                     fixSucceeded = false;
                     nodeToTry++;
                 }

--- a/Source/Contrib/TrackViewer/Editing/PathMetadataDialog.xaml.cs
+++ b/Source/Contrib/TrackViewer/Editing/PathMetadataDialog.xaml.cs
@@ -29,10 +29,10 @@ namespace ORTS.TrackViewer.Editing
             InitializeComponent();
             this.Left = 100;
             this.Top = 10;
-            pathID.Text    = metadata[0];
-            pathName.Text  = metadata[1];
+            pathID.Text = metadata[0];
+            pathName.Text = metadata[1];
             pathStart.Text = metadata[2];
-            pathEnd.Text   = metadata[3];
+            pathEnd.Text = metadata[3];
             pathIsPlayerPath.IsChecked = isPlayerPath;
             pathID.Focus();
             pathID.SelectAll();

--- a/Source/Contrib/TrackViewer/Editing/SavePatFile.cs
+++ b/Source/Contrib/TrackViewer/Editing/SavePatFile.cs
@@ -90,15 +90,15 @@ namespace ORTS.TrackViewer.Editing
             List<string> cancelReasons = new List<string>();
             if (!trainpath.HasEnd) cancelReasons.Add(TrackViewer.catalog.GetString("* The path does not have a well-defined end-point"));
             //if (trainpath.IsBroken) cancelReasons.Add(TrackViewer.catalog.GetString("* The path has broken nodes or links"));
-            if (trainpath.FirstNodeOfTail!=null) cancelReasons.Add(TrackViewer.catalog.GetString("* The path has a stored and not-yet reconnected tail"));
-            
+            if (trainpath.FirstNodeOfTail != null) cancelReasons.Add(TrackViewer.catalog.GetString("* The path has a stored and not-yet reconnected tail"));
+
             if (cancelReasons.Count == 0) return false;
 
             string message = TrackViewer.catalog.GetString("The current path is not finished:") + "\n";
             message += String.Join("\n", cancelReasons.ToArray());
             message += "\n" + TrackViewer.catalog.GetString("Do you want to continue?");
 
-            DialogResult dialogResult = MessageBox.Show(message, 
+            DialogResult dialogResult = MessageBox.Show(message,
                         TrackViewer.catalog.GetString("Trackviewer Path Editor"), MessageBoxButtons.OKCancel, MessageBoxIcon.Question);
             return (dialogResult == DialogResult.Cancel);
 
@@ -143,7 +143,7 @@ namespace ORTS.TrackViewer.Editing
         {
             trackPDPs = new List<string>();
             trpathnodes = new List<string>();
-            pdpOfJunction = new Dictionary<int,int>();
+            pdpOfJunction = new Dictionary<int, int>();
 
             uint nextMainIndex = 1;
             TrainpathNode currentMainNode = trainpath.FirstNode;
@@ -154,7 +154,7 @@ namespace ORTS.TrackViewer.Editing
                 if (currentMainNode.NextSidingNode == null)
                 {
                     AddNode(currentMainNode, nextMainIndex, nonext);
-                }              
+                }
                 else
                 {
                     // This is a siding start.
@@ -183,7 +183,7 @@ namespace ORTS.TrackViewer.Editing
                         extraMainNodes++;
                         tempMainNode = tempMainNode.NextMainNode; // It should exist, if not path editor itself is broken.
                     }
-                    
+
 
                     if (extraSidingNodes == 0)
                     {
@@ -200,14 +200,14 @@ namespace ORTS.TrackViewer.Editing
                         currentSidingNode = currentMainNode.NextSidingNode;
                         while (currentSidingNode.NextSidingNode.NextSidingNode != null)
                         {
-                            nextSidingIndex++; 
+                            nextSidingIndex++;
                             AddNode(currentSidingNode, nonext, nextSidingIndex);
                             currentSidingNode = currentSidingNode.NextSidingNode;
                         }
 
                         // Write the final siding node, linking to main path again.
                         AddNode(currentSidingNode, nonext, nextMainIndex + extraMainNodes);
-                        
+
                     }
                 }
                 nextMainIndex++;
@@ -229,7 +229,7 @@ namespace ORTS.TrackViewer.Editing
             int pdpIndex;
             string trackPDPstart = String.Format(System.Globalization.CultureInfo.InvariantCulture,
                 "\tTrackPDP ( {0,6:D} {1,6:D} {2,9} {3,9:F3} {4,9:F3}",
-                node.Location.TileX, node.Location.TileZ, 
+                node.Location.TileX, node.Location.TileZ,
                 node.Location.Location.X.ToString("F3", System.Globalization.CultureInfo.CreateSpecificCulture("en-US")),
                 node.Location.Location.Y.ToString("F3", System.Globalization.CultureInfo.CreateSpecificCulture("en-US")),
                 node.Location.Location.Z.ToString("F3", System.Globalization.CultureInfo.CreateSpecificCulture("en-US")));
@@ -264,7 +264,7 @@ namespace ORTS.TrackViewer.Editing
                         "{0} {1} {2} )", trackPDPstart, 1, 1));
                 }
             }
-            
+
             trpathnodes.Add(String.Format(System.Globalization.CultureInfo.InvariantCulture,
                 "\t\tTrPathNode ( {0} {1} {2} {3} )",
                     node.FlagsToString(), nextMainIndex, nextSidingIndex, pdpIndex));
@@ -290,18 +290,19 @@ namespace ORTS.TrackViewer.Editing
             file.WriteLine(")");
             file.WriteLine("TrackPath (");
             file.WriteLine("\tTrPathName ( \"" + trainpath.PathId + "\" )");
-         
+
             // How to format hex? "{0:X8}" is not working for me. Neither is {0:X08}.
             // Fortunately, {0:X} will use 8 characters anyway. Maybe because it knows the length from the number of bits in the number
             string flagsString = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:X}", trainpath.PathFlags);
-            file.WriteLine("\tTrPathFlags ( " + flagsString + " )"); 
-            
+            file.WriteLine("\tTrPathFlags ( " + flagsString + " )");
+
             file.WriteLine("\tName ( \"" + trainpath.PathName + "\" )");
-            file.WriteLine("\tTrPathStart ( \""  + trainpath.PathStart + "\" )");
+            file.WriteLine("\tTrPathStart ( \"" + trainpath.PathStart + "\" )");
             file.WriteLine("\tTrPathEnd ( \"" + trainpath.PathEnd + "\" )");
-            file.Write    ("\tTrPathNodes ( ");
+            file.Write("\tTrPathNodes ( ");
             file.WriteLine(trpathnodes.Count());
-            foreach (string line in trpathnodes) {
+            foreach (string line in trpathnodes)
+            {
                 file.WriteLine(line);
             }
             file.WriteLine("\t)");

--- a/Source/Contrib/TrackViewer/Editing/TrackExtensions.cs
+++ b/Source/Contrib/TrackViewer/Editing/TrackExtensions.cs
@@ -49,7 +49,7 @@ namespace ORTS.TrackViewer.Editing
         {
             trackNodes = trackNodesIn;
             tsectionDat = tsectionDatIn;
-            
+
             mainRouteIndex = new uint[trackNodes.Length];
             sidingRouteIndex = new uint[trackNodes.Length];
             for (int tni = 0; tni < trackNodes.Length; tni++)
@@ -67,7 +67,7 @@ namespace ORTS.TrackViewer.Editing
                 }
                 catch (System.IO.InvalidDataException exception)
                 {
-                    exception.ToString(); 
+                    exception.ToString();
                 }
 
                 mainRouteIndex[tni] = tn.Inpins + mainRoute;
@@ -96,7 +96,7 @@ namespace ORTS.TrackViewer.Editing
 
         /// <summary>Return the tracknode corresponding the given index</summary>
         public static TrackNode TrackNode(int tvnIndex) { return trackNodes[tvnIndex]; }
-       
+
         /// <summary>
         /// Get the index of the junction node at the other side of the linking track vector node.
         /// This uses only the track database, no trainpath nodes.
@@ -134,7 +134,8 @@ namespace ORTS.TrackViewer.Editing
             if (junctionIndex <= 0) return 0; // something wrong in database
 
             TrackNode junctionTrackNode = trackNodes[junctionIndex];
-            if (junctionTrackNode == null) {
+            if (junctionTrackNode == null)
+            {
                 return 0;
             }
 
@@ -148,7 +149,7 @@ namespace ORTS.TrackViewer.Editing
             }
             return junctionTrackNode.TrailingTvn();
         }
-        
+
     }
 
 }

--- a/Source/Contrib/TrackViewer/Editing/Trainpath.cs
+++ b/Source/Contrib/TrackViewer/Editing/Trainpath.cs
@@ -219,7 +219,7 @@ namespace ORTS.TrackViewer.Editing
             if (patFile.End == null) { return true; }
             if (patFile.TrackPDPs.Count == 0) { return true; }
             if (patFile.TrPathNodes.Count == 0) { return true; }
-            
+
             return false;
         }
 
@@ -602,7 +602,7 @@ namespace ORTS.TrackViewer.Editing
             }
 
             return RemoveDoubles(stationNames);
-            
+
         }
 
         private List<string> StationNamesBetweenNodes(TrainpathNode firstNode, TrainpathNode secondNode)
@@ -621,7 +621,7 @@ namespace ORTS.TrackViewer.Editing
                 TrItem trItem = trackDB.TrItemTable[trackItemIndex];
                 if (trItem.ItemType == TrItem.trItemType.trPLATFORM)
                 {
-                    var traveller = new Traveller(tsectionDat, trackDB.TrackNodes, tn, 
+                    var traveller = new Traveller(tsectionDat, trackDB.TrackNodes, tn,
                         trItem.TileX, trItem.TileZ, trItem.X, trItem.Z, Traveller.TravellerDirection.Forward);
                     if (traveller != null)
                     {
@@ -632,7 +632,7 @@ namespace ORTS.TrackViewer.Editing
                             stationNames.Add(platform.Station);
                         }
                     }
-            
+
                 }
             }
 
@@ -703,14 +703,14 @@ namespace ORTS.TrackViewer.Editing
             //all intermediate nodes
             for (int i = 1; i < lastIndex; i++)
             {
-                mainNodes[i].NextMainNode = mainNodes[i+1];
-                mainNodes[i].NextMainTvnIndex = mainNodes[i+1].NextMainTvnIndex;  // note main TVN index was in reverse direction
+                mainNodes[i].NextMainNode = mainNodes[i + 1];
+                mainNodes[i].NextMainTvnIndex = mainNodes[i + 1].NextMainTvnIndex;  // note main TVN index was in reverse direction
                 mainNodes[i].PrevNode = mainNodes[i - 1];
                 if (mainNodes[i].NodeType != TrainpathNodeType.Reverse)
                 {   // reverse nodes have input and output swapped, but they are not changed themselves!
                     mainNodes[i].ReverseOrientation();
                 }
-                
+
                 if (mainNodes[i].NodeType == TrainpathNodeType.SidingStart)
                 {
                     ReverseSidingPath(mainNodes[i]);
@@ -747,10 +747,10 @@ namespace ORTS.TrackViewer.Editing
             sidingNodes[0].NextSidingTvnIndex = sidingNodes[1].NextSidingTvnIndex;
             sidingNodes[0].NodeType = TrainpathNodeType.SidingStart;
             // no reversing because this node is reversed as part of main path.
-            
+
             // making new connections for all intermediate nodes, and reversing them as well
             // Note order is important.
-            for (int i = 1 ; i < lastIndex ; i++)
+            for (int i = 1; i < lastIndex; i++)
             {
                 sidingNodes[i].NextSidingNode = sidingNodes[i + 1];
                 sidingNodes[i].NextSidingTvnIndex = sidingNodes[i + 1].NextSidingTvnIndex; // this was oriented in the other direction!

--- a/Source/Contrib/TrackViewer/Editing/TrainpathNode.cs
+++ b/Source/Contrib/TrackViewer/Editing/TrainpathNode.cs
@@ -53,7 +53,8 @@ namespace ORTS.TrackViewer.Editing
     /// <summary>
     /// Enumerate the various types of nodes that are available
     /// </summary>
-    public enum TrainpathNodeType { 
+    public enum TrainpathNodeType
+    {
         /// <summary>Node is the start node </summary>
         Start,
         /// <summary>Node is the end node (and not just the last node) </summary>
@@ -110,7 +111,7 @@ namespace ORTS.TrackViewer.Editing
         /// <summary> True if the node is broken because off-track and therefore not drawable</summary>
         public bool IsBrokenOffTrack { get { return (brokenStatus == NodeStatus.NotOnJunction) || (brokenStatus == NodeStatus.NotOnTrack); } }
         private NodeStatus brokenStatus;
-        
+
         // From simple linking:
         /// <summary>Next path node on main path</summary>
         public TrainpathNode NextMainNode { get; set; }
@@ -123,7 +124,7 @@ namespace ORTS.TrackViewer.Editing
         /// This does include siding start, but Siding end is the first node that has no siding path anymore.
         /// </summary>
         public bool HasSidingPath { get; set; }
-        
+
         //To find these, both the current node and the next node need to be known.
         /// <summary>Index of main vector node leaving this path node</summary>
         public int NextMainTvnIndex { get; set; }
@@ -144,14 +145,16 @@ namespace ORTS.TrackViewer.Editing
         /// <returns>A sub-class object properly initialized</returns>
         public static TrainpathNode CreatePathNode(TrPathNode tpn, TrackPDP pdp, TrackDB trackDB, TrackSectionsFile tsectionDat)
         {
-            if (pdp.IsJunction) {
+            if (pdp.IsJunction)
+            {
                 // we do not use tpn: this means we do not interpret the flags
                 return new TrainpathJunctionNode(pdp, trackDB, tsectionDat);
             }
-            else {
+            else
+            {
                 return new TrainpathVectorNode(tpn, pdp, trackDB, tsectionDat);
             }
-            
+
         }
 
         /// <summary>
@@ -171,7 +174,7 @@ namespace ORTS.TrackViewer.Editing
         /// constructor, in case node is not created from PAT file.
         /// </summary>
         protected TrainpathNode(TrainpathNode otherNode)
-            :this(otherNode.TrackDB, otherNode.TsectionDat)
+            : this(otherNode.TrackDB, otherNode.TsectionDat)
         {
         }
 
@@ -181,7 +184,7 @@ namespace ORTS.TrackViewer.Editing
         /// The trainpath constructor will initialize the rest.
         /// </summary>
         protected TrainpathNode(TrackPDP pdp, TrackDB trackDB, TrackSectionsFile tsectionDat)
-            :this(trackDB, tsectionDat)
+            : this(trackDB, tsectionDat)
         {
             Location = new WorldLocation(pdp.TileX, pdp.TileZ, pdp.X, pdp.Y, pdp.Z);
             if (pdp.IsInvalid) // not a valid point
@@ -279,7 +282,7 @@ namespace ORTS.TrackViewer.Editing
             }
 
         }
-        
+
 
         /// <summary>
         /// String output for shorter debug information
@@ -293,7 +296,7 @@ namespace ORTS.TrackViewer.Editing
         {
             return String.Format(System.Globalization.CultureInfo.CurrentCulture, "({0}-{1}-{2}){3}",
                 (this.PrevNode == null) ? "-" : this.PrevNode.ToString(),
-                this.ToString(), 
+                this.ToString(),
                 (this.NextMainNode == null) ? "-" : this.NextMainNode.ToString(),
                 (this.NextSidingNode == null) ? String.Empty : this.NextSidingNode.ToString());
         }
@@ -318,7 +321,7 @@ namespace ORTS.TrackViewer.Editing
         public int SidingTvn { get { return TrackDB.TrackNodes[JunctionIndex].SidingTvn(); } }
         /// <summary>Return the vector node index of the trailing path leaving this junction</summary>
         public int TrailingTvn { get { return TrackDB.TrackNodes[JunctionIndex].TrailingTvn(); } }
-       
+
 
         /// <summary>The maximum distance a junction node is allowed from its closest junction before it is said to be broken</summary>
         const float maxDistanceAway = 2.5f;
@@ -328,7 +331,7 @@ namespace ORTS.TrackViewer.Editing
         /// </summary>
         /// <param name="otherNode">Just another node that already has trackDB and tsectionDB set</param>
         public TrainpathJunctionNode(TrainpathNode otherNode)
-            :base(otherNode)
+            : base(otherNode)
         {
         }
 
@@ -338,7 +341,7 @@ namespace ORTS.TrackViewer.Editing
         /// <param name="pdp">Corresponding PDP in the .patfile</param>
         /// <param name="trackDB"></param>
         /// <param name="tsectionDat"></param>
-        public TrainpathJunctionNode(TrackPDP pdp, TrackDB trackDB, TrackSectionsFile tsectionDat) 
+        public TrainpathJunctionNode(TrackPDP pdp, TrackDB trackDB, TrackSectionsFile tsectionDat)
             : base(pdp, trackDB, tsectionDat)
         {
             JunctionIndex = FindJunctionOrEndIndex(true);
@@ -387,7 +390,7 @@ namespace ORTS.TrackViewer.Editing
                 }
 
             }
-            bool broken = (bestDistance2 > maxDistanceAway*maxDistanceAway);
+            bool broken = (bestDistance2 > maxDistanceAway * maxDistanceAway);
             if (broken)
             {
                 SetBroken(NodeStatus.NotOnJunction);
@@ -404,7 +407,7 @@ namespace ORTS.TrackViewer.Editing
             TrackNode tn = TrackDB.TrackNodes[JunctionIndex];
             if (tn == null) return;  // Leave IsFacingPoint to what it is.
             if (tn.TrJunctionNode == null) return;  // Leave IsFacingPoint to what it is.
-                
+
             //First try using the next main index
             if (NextMainNode != null && NextMainTvnIndex >= 0)
             {
@@ -589,7 +592,7 @@ namespace ORTS.TrackViewer.Editing
         public int OtherExitTvnIndex()
         {
             // selecting whether to do this on main or siding is simple: if there is no next main, has to be siding
-            int CurrentNextTvnIndex = (NextMainTvnIndex > 0 ) ? NextMainTvnIndex : NextSidingTvnIndex;
+            int CurrentNextTvnIndex = (NextMainTvnIndex > 0) ? NextMainTvnIndex : NextSidingTvnIndex;
             if (CurrentNextTvnIndex == MainTvn)
             {
                 return SidingTvn;
@@ -613,8 +616,8 @@ namespace ORTS.TrackViewer.Editing
         /// </summary>
         public override string ToString()
         {
-            return String.Format(System.Globalization.CultureInfo.CurrentCulture, 
-                "Junction {0}={1} ({2})", this.JunctionIndex, this.NodeType.ToString(), 
+            return String.Format(System.Globalization.CultureInfo.CurrentCulture,
+                "Junction {0}={1} ({2})", this.JunctionIndex, this.NodeType.ToString(),
                 this.IsFacingPoint ? "Facing" : "Trailing"
                 );
         }
@@ -649,7 +652,7 @@ namespace ORTS.TrackViewer.Editing
         public float TrackSectionOffset { get; set; }
         /// <summary>number of seconds to wait after stopping at this node.
         /// For openrails advanced shunting it can mean something else (3HHMM, 4NNSS, 5???? formats)</summary>
-        public int WaitTimeS { get; set; } 
+        public int WaitTimeS { get; set; }
 
         private bool _forwardOriented = true;
         /// <summary>is the path oriented forward  or not (with respect of orientation of track itself</summary>
@@ -665,7 +668,7 @@ namespace ORTS.TrackViewer.Editing
         /// <param name="trackDB"></param>
         /// <param name="tsectionDat"></param>
         public TrainpathVectorNode(TrackDB trackDB, TrackSectionsFile tsectionDat)
-            :base(trackDB, tsectionDat)
+            : base(trackDB, tsectionDat)
         {
             TvnIndex = 0;
         }
@@ -675,7 +678,7 @@ namespace ORTS.TrackViewer.Editing
         /// </summary>
         /// <param name="otherNode">Just another node that already has trackDB and tsectionDB set</param>
         public TrainpathVectorNode(TrainpathNode otherNode)
-            :base(otherNode)
+            : base(otherNode)
         {
             TvnIndex = 0;
         }
@@ -686,7 +689,7 @@ namespace ORTS.TrackViewer.Editing
         /// <param name="otherNode">just another node to have access to trackDB and tsectiondat</param>
         /// <param name="traveller">The traveller that contains the exact location and distance on track to initialize the node</param>
         public TrainpathVectorNode(TrainpathNode otherNode, Traveller traveller)
-            :base(otherNode)
+            : base(otherNode)
         {
             CopyDataFromTraveller(traveller);
             Location = traveller.WorldLocation; // Not part of CopyDataFromTraveller
@@ -698,7 +701,7 @@ namespace ORTS.TrackViewer.Editing
         /// </summary>
         /// <param name="nodeCandidate"></param>
         public TrainpathVectorNode(TrainpathVectorNode nodeCandidate)
-            :base(nodeCandidate)
+            : base(nodeCandidate)
         {
             TvnIndex = nodeCandidate.TvnIndex;
             TrackVectorSectionIndex = nodeCandidate.TrackVectorSectionIndex;
@@ -797,7 +800,7 @@ namespace ORTS.TrackViewer.Editing
                 return this.TvnIndex;
             }
 
-            TrainpathJunctionNode nextAsJunctionNode = nextNode as TrainpathJunctionNode;          
+            TrainpathJunctionNode nextAsJunctionNode = nextNode as TrainpathJunctionNode;
             if ((nextAsJunctionNode != null) && nextAsJunctionNode.ConnectsToTrack(TvnIndex))
             {   // vector node to junction node, junction must connect to tvnIndex
                 return this.TvnIndex;
@@ -829,7 +832,7 @@ namespace ORTS.TrackViewer.Editing
                 ReverseOrientation();
             }
         }
-        
+
         /// <summary>
         /// Reverse the orientation of the node
         /// </summary>
@@ -857,7 +860,7 @@ namespace ORTS.TrackViewer.Editing
                   || ((TrackVectorSectionIndex == otherVectorNode.TrackVectorSectionIndex)
                             && (TrackSectionOffset < otherVectorNode.TrackSectionOffset));
 
-        }        
+        }
 
         /// <summary>
         /// Is the current node between the two other nodes or not.
@@ -914,7 +917,7 @@ namespace ORTS.TrackViewer.Editing
         {
             int AAAA = 0;
             int BBBB = 0;
-            
+
             switch (NodeType)
             {
                 case TrainpathNodeType.Start:
@@ -931,7 +934,7 @@ namespace ORTS.TrackViewer.Editing
                 default:
                     BBBB = 4; //intermediate point;
                     break;
-                    
+
             }
             return string.Format(System.Globalization.CultureInfo.InvariantCulture,
                 "{0:x4}{1:x4}", AAAA, BBBB);
@@ -960,7 +963,7 @@ namespace ORTS.TrackViewer.Editing
             TrackNode linkingTrackNode = TrackDB.TrackNodes[linkingTrackNodeIndex];
             bool towardsNodeIsForwardOriented =
                 (this.NodeType == TrainpathNodeType.Reverse)
-                ? !ForwardOriented 
+                ? !ForwardOriented
                 : ForwardOriented;
             return towardsNodeIsForwardOriented
                 ? linkingTrackNode.JunctionIndexAtStart()

--- a/Source/Contrib/TrackViewer/Editing/WaitPointDialog.xaml.cs
+++ b/Source/Contrib/TrackViewer/Editing/WaitPointDialog.xaml.cs
@@ -56,7 +56,7 @@ namespace ORTS.TrackViewer.Editing
             waitTimeMinutes.Text = "1";
             waitTimeSeconds.Text = "1";
             blowHornSeconds.Text = "1";
-            
+
             if (currentWaitTimeS >= 30000 && currentWaitTimeS < 40000)
             {
                 // Absolute time to wait until. 
@@ -106,7 +106,7 @@ namespace ORTS.TrackViewer.Editing
         ///<summary>Return the selected wait time in seconds</summary>
         public int GetWaitTime()
         {
-            
+
             if (selectUntil.IsChecked == true)
             {
                 // coding is 3HHMM
@@ -159,13 +159,14 @@ namespace ORTS.TrackViewer.Editing
 
         int GetIntOrZero(string inputText)
         {
-            int returnValue; 
+            int returnValue;
             try
             {
                 returnValue = Convert.ToInt32(inputText, System.Globalization.CultureInfo.CurrentCulture);
             }
-            catch {
-                returnValue=0;
+            catch
+            {
+                returnValue = 0;
             }
             return returnValue;
         }
@@ -270,6 +271,6 @@ namespace ORTS.TrackViewer.Editing
             }
             UpdateWaitTime();
         }
- 
+
     }
 }

--- a/Source/Contrib/TrackViewer/Program.cs
+++ b/Source/Contrib/TrackViewer/Program.cs
@@ -52,7 +52,7 @@ namespace ORTS.TrackViewer
                                     "This error may be due to bad data or a bug. ",
                                     Application.ProductName, errorSummary),
                                     Application.ProductName, MessageBoxButtons.OKCancel, MessageBoxIcon.Error);
-                            
+
                     }
                     trackViewer.Exit();
                 }

--- a/Source/Contrib/TrackViewer/TrackViewer.cs
+++ b/Source/Contrib/TrackViewer/TrackViewer.cs
@@ -213,7 +213,7 @@ namespace ORTS.TrackViewer
                 {
                     Properties.Settings.Default.installDirectory = MSTS.MSTSPath.Base();
                 }
-                catch {}
+                catch { }
             }
             InstallFolder = new Folder("default", Properties.Settings.Default.installDirectory);
 
@@ -244,7 +244,7 @@ namespace ORTS.TrackViewer
 
             //Some on-screen features depend on the actual font-height
             int halfHeight = (int)(fontManager.DefaultFont.Height / 2);
-            drawScaleRuler.SetLocationAndSize(halfHeight, ScreenH - statusbarHeight - halfHeight, 2*halfHeight);
+            drawScaleRuler.SetLocationAndSize(halfHeight, ScreenH - statusbarHeight - halfHeight, 2 * halfHeight);
             drawLongitudeLatitude = new DrawLongitudeLatitude(halfHeight, menuHeight);
             drawEditorAction = new DrawEditorAction(halfHeight, menuHeight + 2 * halfHeight);
         }
@@ -367,18 +367,18 @@ namespace ORTS.TrackViewer
 
             if (DrawPATfile != null && Properties.Settings.Default.showPATfile)
             {
-                if (TVUserInput.IsPressed(TVUserCommands.ExtendPath))     DrawPATfile.ExtendPath();
+                if (TVUserInput.IsPressed(TVUserCommands.ExtendPath)) DrawPATfile.ExtendPath();
                 if (TVUserInput.IsPressed(TVUserCommands.ExtendPathFull)) DrawPATfile.ExtendPathFull();
-                if (TVUserInput.IsPressed(TVUserCommands.ReducePath))     DrawPATfile.ReducePath();
+                if (TVUserInput.IsPressed(TVUserCommands.ReducePath)) DrawPATfile.ReducePath();
                 if (TVUserInput.IsPressed(TVUserCommands.ReducePathFull)) DrawPATfile.ReducePathFull();
                 if (TVUserInput.IsDown(TVUserCommands.ShiftToPathLocation)) DrawArea.ShiftToLocation(DrawPATfile.CurrentLocation);
             }
 
             if (PathEditor != null && Properties.Settings.Default.showTrainpath)
             {
-                if (TVUserInput.IsPressed(TVUserCommands.ExtendPath))     PathEditor.ExtendPath();
+                if (TVUserInput.IsPressed(TVUserCommands.ExtendPath)) PathEditor.ExtendPath();
                 if (TVUserInput.IsPressed(TVUserCommands.ExtendPathFull)) PathEditor.ExtendPathFull();
-                if (TVUserInput.IsPressed(TVUserCommands.ReducePath))     PathEditor.ReducePath();
+                if (TVUserInput.IsPressed(TVUserCommands.ReducePath)) PathEditor.ReducePath();
                 if (TVUserInput.IsPressed(TVUserCommands.ReducePathFull)) PathEditor.ReducePathFull();
                 if (TVUserInput.IsDown(TVUserCommands.ShiftToPathLocation)) DrawArea.ShiftToLocation(PathEditor.CurrentLocation);
 
@@ -389,7 +389,7 @@ namespace ORTS.TrackViewer
             }
 
             var mouseLocationAbsoluteX = Window.ClientBounds.Left + TVUserInput.MouseLocationX;
-            var mouseLocationAbsoluteY = Window.ClientBounds.Top  + TVUserInput.MouseLocationY;
+            var mouseLocationAbsoluteY = Window.ClientBounds.Top + TVUserInput.MouseLocationY;
             if (PathEditor != null && PathEditor.EditingIsActive)
             {
                 if (TVUserInput.IsMouseRightButtonPressed())
@@ -570,7 +570,7 @@ namespace ORTS.TrackViewer
                 drawAreaInset.DrawBorder(Color.Black);
             }
 
-            if (DrawMultiplePaths != null ) DrawMultiplePaths.Draw(DrawArea);
+            if (DrawMultiplePaths != null) DrawMultiplePaths.Draw(DrawArea);
             if (DrawPATfile != null && Properties.Settings.Default.showPATfile) DrawPATfile.Draw(DrawArea);
             if (PathEditor != null && Properties.Settings.Default.showTrainpath) PathEditor.Draw(DrawArea);
             drawEditorAction.Draw(PathEditor);
@@ -622,7 +622,8 @@ namespace ORTS.TrackViewer
         public void Quit()
         {
             string message = String.Empty;
-            if (PathEditor!=null && PathEditor.HasModifiedPath)  {
+            if (PathEditor != null && PathEditor.HasModifiedPath)
+            {
                 message = catalog.GetString("The path you are working on has un-saved changes.\n");
             }
             message += catalog.GetString("Do you really want to Quit?");
@@ -740,7 +741,8 @@ namespace ORTS.TrackViewer
             }
 
             string installFolder = System.IO.Directory.GetParent(System.IO.Directory.GetParent(routeFolder).ToString()).ToString();
-            if (!SetSelectedInstallFolder(installFolder)) {
+            if (!SetSelectedInstallFolder(installFolder))
+            {
                 MessageBox.Show(string.Format(catalog.GetString("Route cannot be loaded.\nWhile trying to open {0} the folder {1} was inferred as (MSTS or similar) install folder but does not contain expected files"), givenPathOrFile, installFolder));
                 return;
             }

--- a/Source/Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs
+++ b/Source/Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs
@@ -169,7 +169,8 @@ namespace ORTS.TrackViewer.UserInterface
         void UpdateMenuSettings()
         {
             menuShowPATfile.IsEnabled = !menuEnableEditing.IsChecked;
-            if (!menuShowPATfile.IsEnabled) {
+            if (!menuShowPATfile.IsEnabled)
+            {
                 menuShowPATfile.IsChecked = false;
             }
             if (!menuShowSignals.IsChecked)
@@ -412,7 +413,7 @@ namespace ORTS.TrackViewer.UserInterface
         /// </summary>
         public void PopulateStations()
         {
-            
+
             if (trackViewer.DrawTrackDB == null) return;
             if (trackViewer.DrawTrackDB.StationLocations == null) return;
             List<string> stations = trackViewer.DrawTrackDB.StationLocations.Keys.OrderBy(a => a.ToString()).ToList();
@@ -420,7 +421,7 @@ namespace ORTS.TrackViewer.UserInterface
             menuStationCombobox.ItemsSource = stations;
             menuStationCombobox.SelectedItem = menuStationCombobox.Items.GetItemAt(0).ToString();
         }
-        
+
         /// <summary>
         /// Update the menu to make sure all the platforms are listed
         /// </summary>
@@ -484,7 +485,7 @@ namespace ORTS.TrackViewer.UserInterface
             if (menuStationCombobox.Items.Count > 0)
             {
                 menuStationCombobox.SelectedItem = menuStationCombobox.Items.GetItemAt(0).ToString();
-            } 
+            }
             if (menuPlatformCombobox.Items.Count > 0)
             {
                 menuPlatformCombobox.SelectedItem = menuPlatformCombobox.Items.GetItemAt(0).ToString();
@@ -757,7 +758,7 @@ namespace ORTS.TrackViewer.UserInterface
             }
             UpdateMenuSettings();
         }
-        
+
         /// <summary>
         /// Toggle whether the speedlimits are shown
         /// </summary>
@@ -1084,7 +1085,7 @@ namespace ORTS.TrackViewer.UserInterface
         public void PopulateLanguages()
         {
             comboBoxLanguage.ItemsSource = trackViewer.LanguageManager.Languages;
-            comboBoxLanguage.SelectedValue = LanguageManager.CurrentLanguageCode; 
+            comboBoxLanguage.SelectedValue = LanguageManager.CurrentLanguageCode;
         }
 
         private void ComboBoxLanguage_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -1195,7 +1196,7 @@ namespace ORTS.TrackViewer.UserInterface
     /// <summary>
     /// Dictionary that supports saving to stored user settings.
     /// </summary>
-    class SaveableSettingsDictionary : Dictionary<string,string>
+    class SaveableSettingsDictionary : Dictionary<string, string>
     {
         /// <summary>
         /// Constructor. Also loads the values from stored settings.
@@ -1244,7 +1245,7 @@ namespace ORTS.TrackViewer.UserInterface
         private static StringCollection ToStringCollection(Dictionary<string, string> dictionary)
         {
             StringCollection result = new StringCollection();
-            foreach (KeyValuePair<string,string> kvp in dictionary)
+            foreach (KeyValuePair<string, string> kvp in dictionary)
             {
                 result.Add(kvp.Key);
                 result.Add(kvp.Value);

--- a/Source/Contrib/TrackViewer/UserInterface/OtherPathsWindow.xaml.cs
+++ b/Source/Contrib/TrackViewer/UserInterface/OtherPathsWindow.xaml.cs
@@ -85,7 +85,7 @@ namespace ORTS.TrackViewer.UserInterface
                     if (backgroundColor == null)
                     {
                         checkBox.IsChecked = false;
-                        checkBox.Foreground = new SolidColorBrush(Color.FromArgb(255,0,0,0));
+                        checkBox.Foreground = new SolidColorBrush(Color.FromArgb(255, 0, 0, 0));
                     }
                     else
                     {

--- a/Source/Contrib/TrackViewer/UserInterface/SearchControl.xaml.cs
+++ b/Source/Contrib/TrackViewer/UserInterface/SearchControl.xaml.cs
@@ -37,7 +37,8 @@ namespace ORTS.TrackViewer.UserInterface
     /// <summary>
     /// The kind of items that can be searched from the search control
     /// </summary>
-    public enum SearchableItem {
+    public enum SearchableItem
+    {
         /// <summary>Search for (rail) track node</summary>
         TrackNode,
         /// <summary>Search for (rail) track item</summary>

--- a/Source/Contrib/TrackViewer/UserInterface/StatusBarControl.xaml.cs
+++ b/Source/Contrib/TrackViewer/UserInterface/StatusBarControl.xaml.cs
@@ -58,7 +58,7 @@ namespace ORTS.TrackViewer.UserInterface
         {
             InitializeComponent();
 
-            StatusbarHeight = (int) tvStatusbar.Height;
+            StatusbarHeight = (int)tvStatusbar.Height;
 
             //ElementHost object helps us to connect a WPF User Control.
             elementHost = new ElementHost
@@ -79,7 +79,7 @@ namespace ORTS.TrackViewer.UserInterface
         /// <param name="yBottom">Y-value in screen pixels at the bottom of the statusbar</param>
         public void SetScreenSize(int width, int height, int yBottom)
         {
-            elementHost.Location = new System.Drawing.Point(0, yBottom-height);
+            elementHost.Location = new System.Drawing.Point(0, yBottom - height);
             elementHost.Size = new System.Drawing.Size(width, height);
         }
 
@@ -241,16 +241,16 @@ namespace ORTS.TrackViewer.UserInterface
                 {
                     //gather some info on path status
                     List<string> statusItems = new List<string>();
-                    
+
                     if (trackViewer.PathEditor.HasEndingPath) statusItems.Add("good end");
                     if (trackViewer.PathEditor.HasBrokenPath) statusItems.Add("broken");
                     if (trackViewer.PathEditor.HasModifiedPath) statusItems.Add("modified");
                     if (trackViewer.PathEditor.HasStoredTail) statusItems.Add("stored tail");
-                    
+
                     string pathStatus = String.Join(", ", statusItems.ToArray());
-                    
+
                     ORTS.TrackViewer.Editing.TrainpathNode curNode = trackViewer.PathEditor.CurrentNode;
-                    
+
                     statusAdditional.Text += string.Format(System.Globalization.CultureInfo.CurrentCulture,
                         " {0} ({4}): TVNs=[{1} {2}] (type={3})",
                         trackViewer.PathEditor.FileName, curNode.NextMainTvnIndex, curNode.NextSidingTvnIndex,
@@ -268,7 +268,7 @@ namespace ORTS.TrackViewer.UserInterface
                             " (wait-time={0}s)",
                             curVectorNode.WaitTimeS);
                     }
-            
+
                 }
                 else
                 {

--- a/Source/Contrib/TrackViewer/UserInterface/TVInputSettings.cs
+++ b/Source/Contrib/TrackViewer/UserInterface/TVInputSettings.cs
@@ -166,7 +166,7 @@ namespace ORTS.TrackViewer.UserInterface
         /// Array of commands that have been defined and for which a key-combination can and should be defined below
         /// </summary>
         public static UserCommandInput[] Commands = new UserCommandInput[Enum.GetNames(typeof(TVUserCommands)).Length];
-        
+
         //static readonly string[] KeyboardLayout = new[] {
         //    "[01 ]   [3B ][3C ][3D ][3E ]   [3F ][40 ][41 ][42 ]   [43 ][44 ][57 ][58 ]   [37 ][46 ][11D]",
         //    "                                                                                            ",
@@ -183,20 +183,20 @@ namespace ORTS.TrackViewer.UserInterface
         public static void SetDefaults()
         {
             Commands[(int)TVUserCommands.ReloadRoute] = new ORTS.Settings.UserCommandKeyInput(0x13, ORTS.Settings.KeyModifiers.Control);
-            Commands[(int)TVUserCommands.ZoomIn]     = new ORTS.Settings.UserCommandKeyInput(0x0D);
-            Commands[(int)TVUserCommands.ZoomOut]    = new ORTS.Settings.UserCommandKeyInput(0x0C);
+            Commands[(int)TVUserCommands.ZoomIn] = new ORTS.Settings.UserCommandKeyInput(0x0D);
+            Commands[(int)TVUserCommands.ZoomOut] = new ORTS.Settings.UserCommandKeyInput(0x0C);
             Commands[(int)TVUserCommands.ZoomInSlow] = new ORTS.Settings.UserCommandKeyInput(0x0D, ORTS.Settings.KeyModifiers.Shift);
-            Commands[(int)TVUserCommands.ZoomOutSlow]= new ORTS.Settings.UserCommandKeyInput(0x0C, ORTS.Settings.KeyModifiers.Shift);
-            Commands[(int)TVUserCommands.ZoomReset]  = new ORTS.Settings.UserCommandKeyInput(0x13);
+            Commands[(int)TVUserCommands.ZoomOutSlow] = new ORTS.Settings.UserCommandKeyInput(0x0C, ORTS.Settings.KeyModifiers.Shift);
+            Commands[(int)TVUserCommands.ZoomReset] = new ORTS.Settings.UserCommandKeyInput(0x13);
             Commands[(int)TVUserCommands.ZoomToTile] = new ORTS.Settings.UserCommandKeyInput(0x2C);
-            Commands[(int)TVUserCommands.ShiftLeft]  = new ORTS.Settings.UserCommandKeyInput(0x4B);
+            Commands[(int)TVUserCommands.ShiftLeft] = new ORTS.Settings.UserCommandKeyInput(0x4B);
             Commands[(int)TVUserCommands.ShiftRight] = new ORTS.Settings.UserCommandKeyInput(0x4D);
-            Commands[(int)TVUserCommands.ShiftUp]    = new ORTS.Settings.UserCommandKeyInput(0x48);
-            Commands[(int)TVUserCommands.ShiftDown]  = new ORTS.Settings.UserCommandKeyInput(0x50);
+            Commands[(int)TVUserCommands.ShiftUp] = new ORTS.Settings.UserCommandKeyInput(0x48);
+            Commands[(int)TVUserCommands.ShiftDown] = new ORTS.Settings.UserCommandKeyInput(0x50);
             Commands[(int)TVUserCommands.ShiftToPathLocation] = new ORTS.Settings.UserCommandKeyInput(0x2E);
             Commands[(int)TVUserCommands.ShiftToMouseLocation] = new ORTS.Settings.UserCommandKeyInput(0x2E, ORTS.Settings.KeyModifiers.Shift);
             Commands[(int)TVUserCommands.ToggleZoomAroundMouse] = new ORTS.Settings.UserCommandKeyInput(0x32);
-            
+
             Commands[(int)TVUserCommands.ToggleShowSpeedLimits] = new ORTS.Settings.UserCommandKeyInput(0x3F);
             Commands[(int)TVUserCommands.ToggleShowMilePosts] = new ORTS.Settings.UserCommandKeyInput(0x3F, ORTS.Settings.KeyModifiers.Shift);
             Commands[(int)TVUserCommands.ToggleShowTerrain] = new ORTS.Settings.UserCommandKeyInput(0x40);
@@ -219,9 +219,9 @@ namespace ORTS.TrackViewer.UserInterface
             Commands[(int)TVUserCommands.PlaceEndPoint] = new ORTS.Settings.UserCommandKeyInput(0x12);
             Commands[(int)TVUserCommands.PlaceWaitPoint] = new ORTS.Settings.UserCommandKeyInput(0x11);
 
-            Commands[(int)TVUserCommands.AddLabel]   = new ORTS.Settings.UserCommandKeyInput(0x26);
-            Commands[(int)TVUserCommands.Quit]       = new ORTS.Settings.UserCommandKeyInput(0x10);
-            Commands[(int)TVUserCommands.Debug]      = new ORTS.Settings.UserCommandKeyInput(0x34);
+            Commands[(int)TVUserCommands.AddLabel] = new ORTS.Settings.UserCommandKeyInput(0x26);
+            Commands[(int)TVUserCommands.Quit] = new ORTS.Settings.UserCommandKeyInput(0x10);
+            Commands[(int)TVUserCommands.Debug] = new ORTS.Settings.UserCommandKeyInput(0x34);
             Commands[(int)TVUserCommands.DebugDumpKeymap] = new ORTS.Settings.UserCommandKeyInput(0x3B, ORTS.Settings.KeyModifiers.Alt);
 
             Commands[(int)TVUserCommands.MouseZoomSlow] = new UserCommandModifierInput(Settings.KeyModifiers.Shift);

--- a/Source/Contrib/TrackViewer/UserInterface/TVUserInput.cs
+++ b/Source/Contrib/TrackViewer/UserInterface/TVUserInput.cs
@@ -86,7 +86,7 @@ namespace ORTS.TrackViewer.UserInterface
                 || LastMouseState.ScrollWheelValue != MouseState.ScrollWheelValue)
             {
                 Changed = true;
-             
+
             }
 #if DEBUG_RAW_INPUT
             for (Keys key = 0; key <= Keys.OemClear; key++)

--- a/Source/Menu/ImportExportSaveForm.cs
+++ b/Source/Menu/ImportExportSaveForm.cs
@@ -46,7 +46,7 @@ namespace ORTS
             Font = SystemFonts.MessageBoxFont;
 
             Save = save;
-			if (!Directory.Exists(UserSettings.SavePackFolder)) Directory.CreateDirectory(UserSettings.SavePackFolder);
+            if (!Directory.Exists(UserSettings.SavePackFolder)) Directory.CreateDirectory(UserSettings.SavePackFolder);
             UpdateFileList(null);
             bExport.Enabled = !(Save == null);
             ofdImportSave.Filter = Application.ProductName + catalog.GetString("Save Packs") + " (*." + SavePackFileExtension + ")|*." + SavePackFileExtension + "|" + catalog.GetString("All files") + " (*.*)|*";
@@ -56,10 +56,10 @@ namespace ORTS
         private void bImportSave_Click_1(object sender, EventArgs e)
         {
             // Show the dialog and get result.
-			ofdImportSave.InitialDirectory = UserSettings.SavePackFolder;
+            ofdImportSave.InitialDirectory = UserSettings.SavePackFolder;
             if (ofdImportSave.ShowDialog() == DialogResult.OK)
             {
-				ExtractFilesFromZip(ofdImportSave.FileName, UserSettings.UserDataFolder);
+                ExtractFilesFromZip(ofdImportSave.FileName, UserSettings.UserDataFolder);
                 UpdateFileList(catalog.GetStringFmt("Save Pack '{0}' imported successfully.", Path.GetFileNameWithoutExtension(ofdImportSave.FileName)));
             }
         }
@@ -72,9 +72,9 @@ namespace ORTS
             // For Zip, see http://weblogs.asp.net/jgalloway/archive/2007/10/25/creating-zip-archives-in-net-without-an-external-library-like-sharpziplib.aspx
 
             // Copy files to new package in folder save_packs
-			var fullFilePath = Path.Combine(UserSettings.UserDataFolder, Save.File);
+            var fullFilePath = Path.Combine(UserSettings.UserDataFolder, Save.File);
             var toFile = Path.GetFileNameWithoutExtension(Save.File) + "." + SavePackFileExtension;
-			var fullZipFilePath = Path.Combine(UserSettings.SavePackFolder, toFile);
+            var fullZipFilePath = Path.Combine(UserSettings.SavePackFolder, toFile);
             foreach (var fileName in new[] {
                 fullFilePath,
                 Path.ChangeExtension(fullFilePath, "png"),
@@ -92,11 +92,11 @@ namespace ORTS
             var objPSI = new System.Diagnostics.ProcessStartInfo();
             var winDir = Environment.GetEnvironmentVariable("windir");
             objPSI.FileName = winDir + @"\explorer.exe";
-			objPSI.Arguments = "\"" + UserSettings.SavePackFolder + "\""; // Opens the Save Packs folder
+            objPSI.Arguments = "\"" + UserSettings.SavePackFolder + "\""; // Opens the Save Packs folder
             if (Save != null)
             {
                 var toFile = Path.GetFileNameWithoutExtension(Save.File) + "." + SavePackFileExtension;
-				var fullZipFilePath = Path.Combine(UserSettings.SavePackFolder, toFile);
+                var fullZipFilePath = Path.Combine(UserSettings.SavePackFolder, toFile);
                 if (File.Exists(fullZipFilePath))
                 {
                     objPSI.Arguments = "/select,\"" + fullZipFilePath + "\""; // Opens the Save Packs folder and selects the exported SavePack
@@ -108,7 +108,7 @@ namespace ORTS
 
         void UpdateFileList(string message)
         {
-			var files = Directory.GetFiles(UserSettings.SavePackFolder, "*." + SavePackFileExtension);
+            var files = Directory.GetFiles(UserSettings.SavePackFolder, "*." + SavePackFileExtension);
             textBoxSavePacks.Text = String.IsNullOrEmpty(message) ? "" : message + "\r\n";
             textBoxSavePacks.Text += catalog.GetPluralStringFmt("Save Pack folder contains {0} save pack:", "Save Pack folder contains {0} save packs:", files.Length);
             foreach (var s in files)

--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -84,7 +84,7 @@ namespace ORTS
                 return programNormal;
             }
         }
-        
+
         // Base items
         public Folder SelectedFolder { get { return (Folder)comboBoxFolder.SelectedItem; } }
         public Route SelectedRoute { get { return (Route)comboBoxRoute.SelectedItem; } }
@@ -216,7 +216,8 @@ namespace ORTS
                             Process.Start("cmd", "/k \"" + toolPath + "\"");
                         else
                             Process.Start(toolPath);
-                    }) { Tag = executable });
+                    })
+                    { Tag = executable });
                 }
                 // Add all the tools in alphabetical order.
                 contextMenuStripTools.Items.AddRange((from tool in tools
@@ -241,7 +242,8 @@ namespace ORTS
                             {
                                 var docPath = (sender2 as ToolStripItem).Tag as string;
                                 Process.Start(docPath);
-                             }) { Tag = entry });
+                            })
+                            { Tag = entry });
                         }
                         contextMenuStripDocuments.Items.AddRange((from tool in docs
                                                                   orderby tool.Text
@@ -593,7 +595,7 @@ namespace ORTS
             OpenResumeForm(true);
         }
 
-        void OpenResumeForm (bool multiplayer)
+        void OpenResumeForm(bool multiplayer)
         {
             if (radioButtonModeTimetable.Checked)
             {
@@ -632,7 +634,7 @@ namespace ORTS
         {
             if (CheckUserName(textBoxMPUser.Text) == false) return;
             SaveOptions();
-            SelectedAction = radioButtonMPClient.Checked? UserAction.MultiplayerClient : UserAction.MultiplayerServer;
+            SelectedAction = radioButtonMPClient.Checked ? UserAction.MultiplayerClient : UserAction.MultiplayerServer;
             DialogResult = DialogResult.OK;
         }
 

--- a/Source/Menu/Options.cs
+++ b/Source/Menu/Options.cs
@@ -180,7 +180,7 @@ namespace ORTS
             // Simulation tab
             checkUseAdvancedAdhesion.Checked = Settings.UseAdvancedAdhesion;
             labelAdhesionMovingAverageFilterSize.Enabled = checkUseAdvancedAdhesion.Checked;
-            numericAdhesionMovingAverageFilterSize.Enabled = checkUseAdvancedAdhesion.Checked; 
+            numericAdhesionMovingAverageFilterSize.Enabled = checkUseAdvancedAdhesion.Checked;
             numericAdhesionMovingAverageFilterSize.Value = Settings.AdhesionMovingAverageFilterSize;
             checkBreakCouplers.Checked = Settings.BreakCouplers;
             checkCurveResistanceDependent.Checked = Settings.CurveResistanceDependent;
@@ -226,7 +226,7 @@ namespace ORTS
             checkDataLogTrainSpeed.Checked = Settings.DataLogTrainSpeed;
             labelDataLogTSInterval.Enabled = checkDataLogTrainSpeed.Checked;
             numericDataLogTSInterval.Enabled = checkDataLogTrainSpeed.Checked;
-            checkListDataLogTSContents.Enabled = checkDataLogTrainSpeed.Checked;  
+            checkListDataLogTSContents.Enabled = checkDataLogTrainSpeed.Checked;
             numericDataLogTSInterval.Value = Settings.DataLogTSInterval;
             checkListDataLogTSContents.Items.AddRange(new object[] {
                 catalog.GetString("Time"),
@@ -704,21 +704,21 @@ namespace ORTS
         private void checkAlerter_CheckedChanged(object sender, EventArgs e)
         {
             //Disable checkAlerterExternal when checkAlerter is not checked
-            if (checkAlerter.Checked )
+            if (checkAlerter.Checked)
             {
-                checkAlerterExternal.Enabled = true; 
+                checkAlerterExternal.Enabled = true;
             }
             else
             {
                 checkAlerterExternal.Enabled = false;
-                checkAlerterExternal.Checked = false; 
+                checkAlerterExternal.Checked = false;
             }
         }
 
         private void checkDistantMountains_Click(object sender, EventArgs e)
         {
-           labelDistantMountainsViewingDistance.Enabled = checkDistantMountains.Checked;
-           numericDistantMountainsViewingDistance.Enabled = checkDistantMountains.Checked;
+            labelDistantMountainsViewingDistance.Enabled = checkDistantMountains.Checked;
+            numericDistantMountainsViewingDistance.Enabled = checkDistantMountains.Checked;
         }
 
         private void checkUseAdvancedAdhesion_Click(object sender, EventArgs e)

--- a/Source/Menu/ResumeForm.cs
+++ b/Source/Menu/ResumeForm.cs
@@ -76,7 +76,7 @@ namespace ORTS
         List<Save> Saves = new List<Save>();
         Task<List<Save>> SaveLoader;
 
-        public class Save 
+        public class Save
         {
             public string File { get; private set; }
             public string PathName { get; private set; }
@@ -182,7 +182,7 @@ namespace ORTS
 
             if (SelectedAction == MainForm.UserAction.SinglePlayerTimetableGame)
             {
-                Text =String.Format("{0} - {1} - {2}", Text, route.Name, Path.GetFileNameWithoutExtension(Timetable.fileName));
+                Text = String.Format("{0} - {1} - {2}", Text, route.Name, Path.GetFileNameWithoutExtension(Timetable.fileName));
                 pathNameDataGridViewTextBoxColumn.Visible = true;
             }
             else
@@ -248,7 +248,7 @@ namespace ORTS
                             if (save.RouteName == Route.Name)
                             {
                                 if (!save.IsMultiplayer ^ Multiplayer)
-                                saves.Add(save);
+                                    saves.Add(save);
                             }
                             else    // In case you receive a SavePack where the activity is recognised but the route has been renamed.
                                     // Checks the route is not in your list of routes.
@@ -311,7 +311,7 @@ namespace ORTS
 
             if (save.Valid != false) // I.e. true or null. Check is for safety as buttons should be disabled if Save is invalid.
             {
-                if( Found(save) )
+                if (Found(save))
                 {
                     if (save.Valid == null)
                         if (!AcceptUseOfNonvalidSave(save))
@@ -454,11 +454,11 @@ namespace ORTS
                     var save = new Save(saveFile, build, Settings.YoungestFailedToRestore);
                     if (save.Valid == false)
                     {
-                        foreach (var fileName in new[] { 
-                            save.File, 
-                            Path.ChangeExtension(save.File, "png"), 
+                        foreach (var fileName in new[] {
+                            save.File,
+                            Path.ChangeExtension(save.File, "png"),
                             Path.ChangeExtension(save.File, "txt"),
-                            Path.ChangeExtension(save.File, "replay") 
+                            Path.ChangeExtension(save.File, "replay")
                             }
                         )
                         {
@@ -481,17 +481,17 @@ namespace ORTS
             SelectedAction = MainForm.UserAction.SingleplayerReplaySave;
             InitiateReplay(true);
         }
-        
+
         private void buttonReplayFromPreviousSave_Click(object sender, EventArgs e)
         {
             SelectedAction = MainForm.UserAction.SingleplayerReplaySaveFromSave;
             InitiateReplay(false);
         }
-        
+
         private void InitiateReplay(bool fromStart)
         {
             var save = saveBindingSource.Current as Save;
-            if (Found(save) )
+            if (Found(save))
             {
                 if (fromStart && (save.Valid == null))
                     if (!AcceptUseOfNonvalidSave(save))
@@ -553,36 +553,36 @@ namespace ORTS
                     var rewriteNeeded = false;
                     // savedArgs[0] contains Activity or Path filepath
                     var filePath = savedArgs[0];
-                    if( !System.IO.File.Exists(filePath) )
+                    if (!System.IO.File.Exists(filePath))
                     {
                         // Show the dialog and get result.
                         openFileDialog1.InitialDirectory = MSTSPath.Base();
                         openFileDialog1.FileName = Path.GetFileName(filePath);
                         openFileDialog1.Title = @"Find location for file " + filePath;
-                        if( openFileDialog1.ShowDialog() != DialogResult.OK )
+                        if (openFileDialog1.ShowDialog() != DialogResult.OK)
                             return false;
                         rewriteNeeded = true;
                         savedArgs[0] = openFileDialog1.FileName;
                     }
-                    if( savedArgs.Length > 1 )  // Explore, not Activity
+                    if (savedArgs.Length > 1)  // Explore, not Activity
                     {
                         // savedArgs[1] contains Consist filepath
                         filePath = savedArgs[1];
-                        if( !System.IO.File.Exists(filePath) )
+                        if (!System.IO.File.Exists(filePath))
                         {
                             // Show the dialog and get result.
                             openFileDialog1.InitialDirectory = MSTSPath.Base();
                             openFileDialog1.FileName = Path.GetFileName(filePath);
                             openFileDialog1.Title = @"Find location for file " + filePath;
-                            if( openFileDialog1.ShowDialog() != DialogResult.OK )
+                            if (openFileDialog1.ShowDialog() != DialogResult.OK)
                                 return false;
                             rewriteNeeded = true;
                             savedArgs[1] = openFileDialog1.FileName;
                         }
                     }
-                    if( rewriteNeeded )
+                    if (rewriteNeeded)
                     {
-                        using( BinaryWriter outf = new BinaryWriter(new FileStream(save.File + ".tmp", FileMode.Create, FileAccess.Write)) )
+                        using (BinaryWriter outf = new BinaryWriter(new FileStream(save.File + ".tmp", FileMode.Create, FileAccess.Write)))
                         {
                             // copy the start of the file
                             outf.Write(version);
@@ -597,17 +597,17 @@ namespace ORTS
                             outf.Write(initialTileZ);
                             outf.Write(savedArgs.Length);
                             // copy the pars which may have changed
-                            for( var i = 0; i < savedArgs.Length; i++ )
+                            for (var i = 0; i < savedArgs.Length; i++)
                                 outf.Write(savedArgs[i]);
                             // copy the rest of the file
-                            while( inf.BaseStream.Position < inf.BaseStream.Length )
+                            while (inf.BaseStream.Position < inf.BaseStream.Length)
                             {
                                 outf.Write(inf.ReadByte());
                             }
                         }
                         inf.Close();
                         File.Replace(save.File + ".tmp", save.File, null);
-                    } 
+                    }
                     else
                     {
                         inf.Close();

--- a/Source/Menu/TestingForm.cs
+++ b/Source/Menu/TestingForm.cs
@@ -64,8 +64,8 @@ namespace ORTS
 
         readonly MainForm MainForm;
         readonly UserSettings Settings;
-		readonly string SummaryFilePath = Path.Combine(UserSettings.UserDataFolder, "TestingSummary.csv");
-		readonly string LogFilePath = Path.Combine(UserSettings.UserDataFolder, "TestingLog.txt");
+        readonly string SummaryFilePath = Path.Combine(UserSettings.UserDataFolder, "TestingSummary.csv");
+        readonly string LogFilePath = Path.Combine(UserSettings.UserDataFolder, "TestingLog.txt");
 
         public TestingForm(MainForm mainForm, UserSettings settings)
         {

--- a/Source/ORTS.Common/Conversions.cs
+++ b/Source/ORTS.Common/Conversions.cs
@@ -63,27 +63,28 @@ namespace ORTS.Common
     /// <summary>
     /// Distance conversions from and to metres
     /// </summary>
-    public static class Me {   // Not M to avoid conflict with MSTSMath.M, but note that MSTSMath.M will be gone in future.
+    public static class Me
+    {   // Not M to avoid conflict with MSTSMath.M, but note that MSTSMath.M will be gone in future.
         /// <summary>Convert (statute or land) miles to metres</summary>
-        public static float FromMi(float miles)  { return miles  * 1609.344f; }
+        public static float FromMi(float miles) { return miles * 1609.344f; }
         /// <summary>Convert metres to (statute or land) miles</summary>
-        public static float ToMi(float metres)   { return metres * (1.0f / 1609.344f); }
+        public static float ToMi(float metres) { return metres * (1.0f / 1609.344f); }
         /// <summary>Convert kilometres to metres</summary>
         public static float FromKiloM(float miles) { return miles * 1000f; }
         /// <summary>Convert metres to kilometres</summary>
         public static float ToKiloM(float metres) { return metres * (1.0f / 1000f); }
         /// <summary>Convert yards to metres</summary>
-        public static float FromYd(float yards)  { return yards  * 0.9144f; }
+        public static float FromYd(float yards) { return yards * 0.9144f; }
         /// <summary>Convert metres to yards</summary>
-        public static float ToYd(float metres)   { return metres * (1.0f / 0.9144f); }
+        public static float ToYd(float metres) { return metres * (1.0f / 0.9144f); }
         /// <summary>Convert feet to metres</summary>
-        public static float FromFt(float feet)   { return feet   * 0.3048f; }
+        public static float FromFt(float feet) { return feet * 0.3048f; }
         /// <summary>Convert metres to feet</summary>
-        public static float ToFt(float metres)   { return metres *(1.0f/ 0.3048f); }
+        public static float ToFt(float metres) { return metres * (1.0f / 0.3048f); }
         /// <summary>Convert inches to metres</summary>
         public static float FromIn(float inches) { return inches * 0.0254f; }
         /// <summary>Convert metres to inches</summary>
-        public static float ToIn(float metres)   { return metres * (1.0f / 0.0254f); }
+        public static float ToIn(float metres) { return metres * (1.0f / 0.0254f); }
 
         /// <summary>
         /// Convert from metres into kilometres or miles, depending on the flag isMetric
@@ -112,11 +113,11 @@ namespace ORTS.Common
     public static class Me2
     {
         /// <summary>Convert from feet squared to metres squared</summary>
-        public static float FromFt2(float feet2) { return feet2   * 0.092903f; }
+        public static float FromFt2(float feet2) { return feet2 * 0.092903f; }
         /// <summary>Convert from metres squared to feet squared</summary>
         public static float ToFt2(float metres2) { return metres2 * (1.0f / 0.092903f); }
         /// <summary>Convert from inches squared to metres squared</summary>
-        public static float FromIn2(float feet2) { return feet2   * (1.0f / 1550.0031f); }
+        public static float FromIn2(float feet2) { return feet2 * (1.0f / 1550.0031f); }
         /// <summary>Convert from metres squared to inches squared</summary>
         public static float ToIn2(float metres2) { return metres2 * 1550.0031f; }
     }
@@ -127,13 +128,13 @@ namespace ORTS.Common
     public static class Me3
     {
         /// <summary>Convert from cubic feet to cubic metres</summary>
-        public static float FromFt3(float feet3) { return feet3   * (1.0f / 35.3146665722f); }
+        public static float FromFt3(float feet3) { return feet3 * (1.0f / 35.3146665722f); }
         /// <summary>Convert from cubic metres to cubic feet</summary>
         public static float ToFt3(float metres3) { return metres3 * 35.3146665722f; }
         /// <summary>Convert from cubic inches to cubic metres</summary>
         public static float FromIn3(float inches3) { return inches3 * (1.0f / 61023.7441f); }
         /// <summary>Convert from cubic metres to cubic inches</summary>
-        public static float ToIn3(float metres3)   { return metres3 * 61023.7441f; }
+        public static float ToIn3(float metres3) { return metres3 * 61023.7441f; }
     }
 
     /// <summary>
@@ -142,13 +143,13 @@ namespace ORTS.Common
 	public static class MpS
     {
         /// <summary>Convert miles/hour to metres/second</summary>
-        public static float FromMpH(float milesPerHour)     { return milesPerHour   * (1.0f / 2.23693629f); }
+        public static float FromMpH(float milesPerHour) { return milesPerHour * (1.0f / 2.23693629f); }
         /// <summary>Convert metres/second to miles/hour</summary>
-        public static float ToMpH(float metrePerSecond)     { return metrePerSecond * 2.23693629f; }
+        public static float ToMpH(float metrePerSecond) { return metrePerSecond * 2.23693629f; }
         /// <summary>Convert kilometre/hour to metres/second</summary>
         public static float FromKpH(float kilometrePerHour) { return kilometrePerHour * (1.0f / 3.600f); }
         /// <summary>Convert metres/second to kilometres/hour</summary>
-        public static float ToKpH(float metrePerSecond)     { return metrePerSecond   * 3.600f; }
+        public static float ToKpH(float metrePerSecond) { return metrePerSecond * 3.600f; }
 
         /// <summary>
         /// Convert from metres/second to kilometres/hour or miles/hour, depending on value of isMetric
@@ -177,19 +178,19 @@ namespace ORTS.Common
     public static class Kg
     {
         /// <summary>Convert from pounds (lb) to kilograms</summary>
-        public static float FromLb(float lb)     { return lb * (1.0f / 2.20462f); }
+        public static float FromLb(float lb) { return lb * (1.0f / 2.20462f); }
         /// <summary>Convert from kilograms to pounds (lb)</summary>
-        public static float ToLb(float kg)       { return kg * 2.20462f; }
+        public static float ToLb(float kg) { return kg * 2.20462f; }
         /// <summary>Convert from US Tons to kilograms</summary>
         public static float FromTUS(float tonsUS) { return tonsUS * 907.1847f; }
         /// <summary>Convert from kilograms to US Tons</summary>
-        public static float ToTUS(float kg)       { return kg     * (1.0f / 907.1847f); }
+        public static float ToTUS(float kg) { return kg * (1.0f / 907.1847f); }
         /// <summary>Convert from UK Tons to kilograms</summary>
         public static float FromTUK(float tonsUK) { return tonsUK * 1016.047f; }
         /// <summary>Convert from kilograms to UK Tons</summary>
-        public static float ToTUK(float kg)       { return kg     * (1.0f / 1016.047f); }
+        public static float ToTUK(float kg) { return kg * (1.0f / 1016.047f); }
         /// <summary>Convert from kilogram to metric tonnes</summary>
-        public static float ToTonne(float kg)      { return kg    * (1.0f / 1000.0f); }
+        public static float ToTonne(float kg) { return kg * (1.0f / 1000.0f); }
         /// <summary>Convert from metrix tonnes to kilogram</summary>
         public static float FromTonne(float tonne) { return tonne * 1000.0f; }
     }
@@ -200,7 +201,7 @@ namespace ORTS.Common
     public static class N
     {
         /// <summary>Convert from pound-force to Newtons</summary>
-        public static float FromLbf(float lbf)  { return lbf    * (1.0f / 0.224808943871f); }
+        public static float FromLbf(float lbf) { return lbf * (1.0f / 0.224808943871f); }
         /// <summary>Convert from Newtons to Pound-force</summary>
         public static float ToLbf(float newton) { return newton * 0.224808943871f; }
     }
@@ -211,7 +212,7 @@ namespace ORTS.Common
     public static class KgpS
     {
         /// <summary>Convert from pound/hour to kilograms/second</summary>
-        public static float FromLbpH(float poundsPerHour)    { return poundsPerHour      * (1.0f / 7936.64144f); }
+        public static float FromLbpH(float poundsPerHour) { return poundsPerHour * (1.0f / 7936.64144f); }
         /// <summary>Convert from kilograms/second to pounds/hour</summary>
         public static float ToLbpH(float kilogramsPerSecond) { return kilogramsPerSecond * 7936.64144f; }
     }
@@ -224,11 +225,11 @@ namespace ORTS.Common
         /// <summary>Convert from kiloWatts to Watts</summary>
         public static float FromKW(float kiloWatts) { return kiloWatts * 1000f; }
         /// <summary>Convert from Watts to kileWatts</summary>
-        public static float ToKW(float watts)       { return watts     * (1.0f / 1000f); }
+        public static float ToKW(float watts) { return watts * (1.0f / 1000f); }
         /// <summary>Convert from HorsePower to Watts</summary>
         public static float FromHp(float horsePowers) { return horsePowers * 745.699872f; }
         /// <summary>Convert from Watts to HorsePower</summary>
-        public static float ToHp(float watts)         { return watts       * (1.0f / 745.699872f); }
+        public static float ToHp(float watts) { return watts * (1.0f / 745.699872f); }
         /// <summary>Convert from BoilerHorsePower to Watts</summary>
         public static float FromBhp(float horsePowers) { return horsePowers * 9809.5f; }
         /// <summary>Convert from Watts to BoilerHorsePower</summary>
@@ -236,7 +237,7 @@ namespace ORTS.Common
         /// <summary>Convert from British Thermal Unit (BTU) per second to watts</summary>
         public static float FromBTUpS(float btuPerSecond) { return btuPerSecond * 1055.05585f; }
         /// <summary>Convert from Watts to British Thermal Unit (BTU) per second</summary>
-        public static float ToBTUpS(float watts)          { return watts        * (1.0f / 1055.05585f); }
+        public static float ToBTUpS(float watts) { return watts * (1.0f / 1055.05585f); }
     }
 
     /// <summary>
@@ -681,7 +682,7 @@ namespace ORTS.Common
             }
             else
             {
-                return String.Format(CultureInfo.CurrentCulture,"{0:F0} {1}", Kg.ToLb(massKg), lb);
+                return String.Format(CultureInfo.CurrentCulture, "{0:F0} {1}", Kg.ToLb(massKg), lb);
             }
         }
 

--- a/Source/ORTS.Common/Coordinates.cs
+++ b/Source/ORTS.Common/Coordinates.cs
@@ -324,5 +324,5 @@ namespace ORTS.Common
         {
             return TileX.GetHashCode() ^ TileZ.GetHashCode() ^ Location.GetHashCode();
         }
-	}
+    }
 }

--- a/Source/ORTS.Common/DataLogger.cs
+++ b/Source/ORTS.Common/DataLogger.cs
@@ -56,8 +56,8 @@ namespace ORTS.Common
         public void End()
         {
             Cache.AppendLine();
-			if (Cache.Length >= CacheSize)
-				Flush();
+            if (Cache.Length >= CacheSize)
+                Flush();
             FirstItem = true;
         }
 

--- a/Source/ORTS.Common/Filter.cs
+++ b/Source/ORTS.Common/Filter.cs
@@ -136,9 +136,9 @@ namespace ORTS.Common
             {
                 case FilterTypes.Butterworth:
                     ComputeButterworth(
-                        Order                   = order,
-                        CutoffFrequencyRadpS    = cutoffFrequency,
-                        SamplingPeriod_s        = samplingPeriod);
+                        Order = order,
+                        CutoffFrequencyRadpS = cutoffFrequency,
+                        SamplingPeriod_s = samplingPeriod);
                     break;
                 default:
                     throw new NotImplementedException("Other filter types are not implemented yet.");
@@ -167,7 +167,7 @@ namespace ORTS.Common
         {
             set
             {
-                if(NCoef <= 0)
+                if (NCoef <= 0)
                     NCoef = value.Count - 1;
                 x = new ArrayList();
                 y = new ArrayList();
@@ -197,7 +197,7 @@ namespace ORTS.Common
         {
             set
             {
-                if(NCoef <= 0)
+                if (NCoef <= 0)
                     NCoef = value.Count - 1;
                 x = new ArrayList();
                 y = new ArrayList();
@@ -265,10 +265,10 @@ namespace ORTS.Common
 
         public enum FilterTypes
         {
-            Exponential     = 0,
-            Chebychev       = 1,
-            Butterworth     = 2,
-            Bessel          = 3
+            Exponential = 0,
+            Chebychev = 1,
+            Butterworth = 2,
+            Bessel = 3
         }
 
         public FilterTypes FilterType { set; get; }
@@ -308,7 +308,7 @@ namespace ORTS.Common
             if (samplingPeriod <= 0.0f)
                 return 0.0f;
 
-            switch(FilterType)
+            switch (FilterType)
             {
                 case FilterTypes.Butterworth:
                     if ((1 / (samplingPeriod) < RadToHz(cuttoffFreqRadpS)))
@@ -355,7 +355,7 @@ namespace ORTS.Common
         /// <param name="initValue">Initial value</param>
         public void Reset(float initValue)
         {
-            for (float t = 0; t < (10.0f*cuttoffFreqRadpS); t += 0.1f)
+            for (float t = 0; t < (10.0f * cuttoffFreqRadpS); t += 0.1f)
             {
                 Filter(initValue, 0.1f);
             }
@@ -437,7 +437,7 @@ namespace ORTS.Common
                     break;
                 default:
                     throw new NotImplementedException("Filter order higher than 1 is not supported yet");
-                    
+
             }
         }
 
@@ -480,9 +480,11 @@ namespace ORTS.Common
         Queue<float> Buffer;
 
         int size;
-        public int Size { get { if (Buffer != null) return Buffer.Count; else return 0; } 
-                          set { if(value > 0) size = value; else size = 1; Initialize(); }
-                        }
+        public int Size
+        {
+            get { if (Buffer != null) return Buffer.Count; else return 0; }
+            set { if (value > 0) size = value; else size = 1; Initialize(); }
+        }
 
         public void Initialize(float value)
         {

--- a/Source/ORTS.Common/FxCopAttributes.cs
+++ b/Source/ORTS.Common/FxCopAttributes.cs
@@ -22,43 +22,43 @@ using System.Text;
 
 namespace ORTS.Common
 {
-	/// <summary>
-	/// Explicitly sets the name of the thread on which the target will run.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-	public sealed class ThreadNameAttribute : Attribute
-	{
-		readonly string threadName;
+    /// <summary>
+    /// Explicitly sets the name of the thread on which the target will run.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+    public sealed class ThreadNameAttribute : Attribute
+    {
+        readonly string threadName;
 
-		// This is a positional argument
-		public ThreadNameAttribute(string threadName)
-		{
-			this.threadName = threadName;
-		}
+        // This is a positional argument
+        public ThreadNameAttribute(string threadName)
+        {
+            this.threadName = threadName;
+        }
 
-		public string ThreadName
-		{
-			get { return threadName; }
-		}
-	}
+        public string ThreadName
+        {
+            get { return threadName; }
+        }
+    }
 
-	/// <summary>
-	/// Defines a thread on which the target is allowed to run; multiple threads may be allowed for a single target.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+    /// <summary>
+    /// Defines a thread on which the target is allowed to run; multiple threads may be allowed for a single target.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
     public sealed class CallOnThreadAttribute : Attribute
-	{
-		readonly string threadName;
+    {
+        readonly string threadName;
 
-		// This is a positional argument
-		public CallOnThreadAttribute(string threadName)
-		{
-			this.threadName = threadName;
-		}
+        // This is a positional argument
+        public CallOnThreadAttribute(string threadName)
+        {
+            this.threadName = threadName;
+        }
 
-		public string ThreadName
-		{
-			get { return threadName; }
-		}
-	}
+        public string ThreadName
+        {
+            get { return threadName; }
+        }
+    }
 }

--- a/Source/ORTS.Common/SettingsBase.cs
+++ b/Source/ORTS.Common/SettingsBase.cs
@@ -26,19 +26,19 @@ namespace ORTS.Common
     /// Base class for supporting settings (either from user, commandline, default, ...)
     /// </summary>
 	public abstract class SettingsBase
-	{
+    {
         /// <summary>
         /// Enumeration of the various sources for settings
         /// </summary>
 		protected enum Source
-		{
+        {
             /// <summary>Setting is a default setting</summary>
 			Default,
             /// <summary>Setting comes from the command line</summary>
             CommandLine,
             /// <summary>Setting comes from user (so stored between runs)</summary>
             User,
-		}
+        }
 
         /// <summary>The store of the settings</summary>
         protected SettingsStore SettingStore { get; private set; }
@@ -50,9 +50,9 @@ namespace ORTS.Common
         /// </summary>
         /// <param name="settings">The store for the settings</param>
 		protected SettingsBase(SettingsStore settings)
-		{
-			SettingStore = settings;
-		}
+        {
+            SettingStore = settings;
+        }
 
         /// <summary>
         /// Get the default value of a setting
@@ -101,21 +101,21 @@ namespace ORTS.Common
         /// </summary>
         /// <param name="options">???</param>
 		protected void Load(IEnumerable<string> options)
-		{
-			// This special command-line option prevents the registry values from being used.
-			var allowUserSettings = !options.Contains("skip-user-settings", StringComparer.OrdinalIgnoreCase);
+        {
+            // This special command-line option prevents the registry values from being used.
+            var allowUserSettings = !options.Contains("skip-user-settings", StringComparer.OrdinalIgnoreCase);
 
-			// Pull apart the command-line options so we can find them by setting name.
-			var optionsDictionary = new Dictionary<string, string>();
-			foreach (var option in options)
-			{
-				var k = option.Split(new[] { '=', ':' }, 2)[0].ToLowerInvariant();
-				var v = option.Contains('=') || option.Contains(':') ? option.Split(new[] { '=', ':' }, 2)[1].ToLowerInvariant() : "yes";
-				optionsDictionary[k] = v;
-			}
+            // Pull apart the command-line options so we can find them by setting name.
+            var optionsDictionary = new Dictionary<string, string>();
+            foreach (var option in options)
+            {
+                var k = option.Split(new[] { '=', ':' }, 2)[0].ToLowerInvariant();
+                var v = option.Contains('=') || option.Contains(':') ? option.Split(new[] { '=', ':' }, 2)[1].ToLowerInvariant() : "yes";
+                optionsDictionary[k] = v;
+            }
 
-			Load(allowUserSettings, optionsDictionary);
-		}
+            Load(allowUserSettings, optionsDictionary);
+        }
 
         /// <summary>
         /// Load a single value from the store, once type of the setting is known
@@ -125,54 +125,54 @@ namespace ORTS.Common
         /// <param name="name">name of the setting</param>
         /// <param name="type">type of the setting</param>
 		protected void Load(bool allowUserSettings, Dictionary<string, string> optionsDictionary, string name, Type type)
-		{
-			// Get the default value.
-			var defValue = GetDefaultValue(name);
+        {
+            // Get the default value.
+            var defValue = GetDefaultValue(name);
 
-			// Read in the user setting, if it exists.
-			var userValue = allowUserSettings ? SettingStore.GetUserValue(name, type) : null;
+            // Read in the user setting, if it exists.
+            var userValue = allowUserSettings ? SettingStore.GetUserValue(name, type) : null;
 
-			// Read in the command-line option, if it exists into optValue.
-			var propertyNameLower = name.ToLowerInvariant();
-			var optValue = optionsDictionary.ContainsKey(propertyNameLower) ? (object)optionsDictionary[propertyNameLower] : null;
+            // Read in the command-line option, if it exists into optValue.
+            var propertyNameLower = name.ToLowerInvariant();
+            var optValue = optionsDictionary.ContainsKey(propertyNameLower) ? (object)optionsDictionary[propertyNameLower] : null;
 
             // Parse command-line options...
 
-			if ((optValue != null) && (type == typeof(bool)))
+            if ((optValue != null) && (type == typeof(bool)))
                 // Option for boolean types so true/yes/on/1 are all true; everything else is false.
                 optValue = new[] { "true", "yes", "on", "1" }.Contains(optValue);
 
-			else if ((optValue != null) && (type == typeof(int)))
+            else if ((optValue != null) && (type == typeof(int)))
                 // Option for int types.
                 optValue = int.Parse((string)optValue);
 
-			else if ((optValue != null) && (type == typeof(string[])))
+            else if ((optValue != null) && (type == typeof(string[])))
                 // Option for string[] types.
                 optValue = ((string)optValue).Split(',').Select(s => s.Trim()).ToArray();
 
-			else if ((optValue != null) && (type == typeof(int[])))
+            else if ((optValue != null) && (type == typeof(int[])))
                 // Option for int[] types.
                 optValue = ((string)optValue).Split(',').Select(s => int.Parse(s.Trim())).ToArray();
 
-			// We now have defValue, regValue, optValue containing the default, persisted and override values
-			// for the setting. regValue and optValue are null if they are not found/specified.
-			var value = optValue != null ? optValue : userValue != null ? userValue : defValue;
-			try
-			{
-				// int[] values must have the same number of items as default value.
-				if ((type == typeof(int[])) && (value != null) && ((int[])value).Length != ((int[])defValue).Length)
-					throw new ArgumentException();
+            // We now have defValue, regValue, optValue containing the default, persisted and override values
+            // for the setting. regValue and optValue are null if they are not found/specified.
+            var value = optValue != null ? optValue : userValue != null ? userValue : defValue;
+            try
+            {
+                // int[] values must have the same number of items as default value.
+                if ((type == typeof(int[])) && (value != null) && ((int[])value).Length != ((int[])defValue).Length)
+                    throw new ArgumentException();
 
-				SetValue(name, value);
-				Sources.Add(name, value.Equals(defValue) ? Source.Default : optValue != null ? Source.CommandLine : userValue != null ? Source.User : Source.Default);
-			}
-			catch (ArgumentException)
-			{
-				Trace.TraceWarning("Unable to load {0} value from type {1}", name, value.GetType().FullName);
-				value = defValue;
-				Sources.Add(name, Source.Default);
-			}
-		}
+                SetValue(name, value);
+                Sources.Add(name, value.Equals(defValue) ? Source.Default : optValue != null ? Source.CommandLine : userValue != null ? Source.User : Source.Default);
+            }
+            catch (ArgumentException)
+            {
+                Trace.TraceWarning("Unable to load {0} value from type {1}", name, value.GetType().FullName);
+                value = defValue;
+                Sources.Add(name, Source.Default);
+            }
+        }
 
         /// <summary>
         /// Save a setting to the store, if name and especially type are known
@@ -180,24 +180,24 @@ namespace ORTS.Common
         /// <param name="name">name of the setting</param>
         /// <param name="type">type of the setting</param>
 		protected void Save(string name, Type type)
-		{
-			var defValue = GetDefaultValue(name);
-			var value = GetValue(name);
+        {
+            var defValue = GetDefaultValue(name);
+            var value = GetValue(name);
 
-			if (defValue.Equals(value)
-				|| (type == typeof(string[]) && String.Join(",", (string[])defValue) == String.Join(",", (string[])value))
-				|| (type == typeof(int[]) && String.Join(",", ((int[])defValue).Select(v => v.ToString()).ToArray()) == String.Join(",", ((int[])value).Select(v => v.ToString()).ToArray())))
-			{
-				SettingStore.DeleteUserValue(name);
-			}
-			else if (type == typeof(string))
-			{
-				SettingStore.SetUserValue(name, (string)value);
-			}
-			else if (type == typeof(int))
-			{
-				SettingStore.SetUserValue(name, (int)value);
-			}
+            if (defValue.Equals(value)
+                || (type == typeof(string[]) && String.Join(",", (string[])defValue) == String.Join(",", (string[])value))
+                || (type == typeof(int[]) && String.Join(",", ((int[])defValue).Select(v => v.ToString()).ToArray()) == String.Join(",", ((int[])value).Select(v => v.ToString()).ToArray())))
+            {
+                SettingStore.DeleteUserValue(name);
+            }
+            else if (type == typeof(string))
+            {
+                SettingStore.SetUserValue(name, (string)value);
+            }
+            else if (type == typeof(int))
+            {
+                SettingStore.SetUserValue(name, (int)value);
+            }
             else if (type == typeof(bool))
             {
                 SettingStore.SetUserValue(name, (bool)value);
@@ -211,14 +211,14 @@ namespace ORTS.Common
                 SettingStore.SetUserValue(name, (TimeSpan)value);
             }
             else if (type == typeof(string[]))
-			{
-				SettingStore.SetUserValue(name, (string[])value);
-			}
-			else if (type == typeof(int[]))
-			{
-				SettingStore.SetUserValue(name, (int[])value);
-			}
-		}
+            {
+                SettingStore.SetUserValue(name, (string[])value);
+            }
+            else if (type == typeof(int[]))
+            {
+                SettingStore.SetUserValue(name, (int[])value);
+            }
+        }
 
         /// <summary>
         /// Reset a single setting to its default
@@ -229,5 +229,5 @@ namespace ORTS.Common
             SetValue(name, GetDefaultValue(name));
             SettingStore.DeleteUserValue(name);
         }
-	}
+    }
 }

--- a/Source/ORTS.Common/SettingsStore.cs
+++ b/Source/ORTS.Common/SettingsStore.cs
@@ -27,11 +27,11 @@ using Microsoft.Win32;
 
 namespace ORTS.Common
 {
-	/// <summary>
-	/// Base class for all means of persisting settings from the user/game.
-	/// </summary>
-	public abstract class SettingsStore
-	{
+    /// <summary>
+    /// Base class for all means of persisting settings from the user/game.
+    /// </summary>
+    public abstract class SettingsStore
+    {
         /// <summary>Name of a 'section', to distinguish various part within a underlying store</summary>
         protected string Section { get; private set; }
 
@@ -40,9 +40,9 @@ namespace ORTS.Common
         /// </summary>
         /// <param name="section">Name of the 'section', to distinguish various part within a underlying store</param>
 		protected SettingsStore(string section)
-		{
-			Section = section;
-		}
+        {
+            Section = section;
+        }
 
         /// <summary>
         /// Assert that the type expected from the settings store is an allowed type.
@@ -137,29 +137,29 @@ namespace ORTS.Common
         /// <param name="section">Name to distinguish between various 'section's used in underlying store.</param>
         /// <returns>The created SettingsStore</returns>
 		public static SettingsStore GetSettingStore(string filePath, string registryKey, string section)
-		{
-			if (!String.IsNullOrEmpty(filePath) && File.Exists(filePath))
-				return new SettingsStoreLocalIni(filePath, section);
-			if (!String.IsNullOrEmpty(registryKey))
-				return new SettingsStoreRegistry(registryKey, section);
-			throw new ArgumentException("Neither 'filePath' nor 'registryKey' arguments are valid.");
-		}
-	}
+        {
+            if (!String.IsNullOrEmpty(filePath) && File.Exists(filePath))
+                return new SettingsStoreLocalIni(filePath, section);
+            if (!String.IsNullOrEmpty(registryKey))
+                return new SettingsStoreRegistry(registryKey, section);
+            throw new ArgumentException("Neither 'filePath' nor 'registryKey' arguments are valid.");
+        }
+    }
 
-	/// <summary>
+    /// <summary>
     /// Registry implementation of <see cref="SettingsStore"/>.
-	/// </summary>
-	public sealed class SettingsStoreRegistry : SettingsStore
-	{
-		readonly string RegistryKey;
-		readonly RegistryKey Key;
+    /// </summary>
+    public sealed class SettingsStoreRegistry : SettingsStore
+    {
+        readonly string RegistryKey;
+        readonly RegistryKey Key;
 
-		internal SettingsStoreRegistry(string registryKey, string section)
-			: base(section)
-		{
-			RegistryKey = String.IsNullOrEmpty(section) ? registryKey : registryKey + @"\" + section;
-			Key = Registry.CurrentUser.CreateSubKey(RegistryKey);
-		}
+        internal SettingsStoreRegistry(string registryKey, string section)
+            : base(section)
+        {
+            RegistryKey = String.IsNullOrEmpty(section) ? registryKey : registryKey + @"\" + section;
+            Key = Registry.CurrentUser.CreateSubKey(RegistryKey);
+        }
 
         /// <summary>
         /// Return an array of all setting-names that are in the store
@@ -267,9 +267,9 @@ namespace ORTS.Common
         /// <param name="name">name of the setting</param>
         /// <param name="value">value of the setting</param>
         public override void SetUserValue(string name, int[] value)
-		{
-			Key.SetValue(name, String.Join(",", ((int[])value).Select(v => v.ToString()).ToArray()), RegistryValueKind.String);
-		}
+        {
+            Key.SetValue(name, String.Join(",", ((int[])value).Select(v => v.ToString()).ToArray()), RegistryValueKind.String);
+        }
 
         /// <summary>
         /// Set a value of a user setting
@@ -286,25 +286,25 @@ namespace ORTS.Common
         /// </summary>
         /// <param name="name">name of the setting</param>
         public override void DeleteUserValue(string name)
-		{
-			Key.DeleteValue(name, false);
-		}
-	}
+        {
+            Key.DeleteValue(name, false);
+        }
+    }
 
-	/// <summary>
+    /// <summary>
     /// INI file implementation of <see cref="SettingsStore"/>.
-	/// </summary>
-	public sealed class SettingsStoreLocalIni : SettingsStore
-	{
-		const string DefaultSection = "ORTS";
+    /// </summary>
+    public sealed class SettingsStoreLocalIni : SettingsStore
+    {
+        const string DefaultSection = "ORTS";
 
-		readonly string FilePath;
+        readonly string FilePath;
 
-		internal SettingsStoreLocalIni(string filePath, string section)
-			: base(String.IsNullOrEmpty(section) ? DefaultSection : section)
-		{
-			FilePath = filePath;
-		}
+        internal SettingsStoreLocalIni(string filePath, string section)
+            : base(String.IsNullOrEmpty(section) ? DefaultSection : section)
+        {
+            FilePath = filePath;
+        }
 
         /// <summary>
         /// Returns an array of all sections within the store, including the one used by this instance.
@@ -426,9 +426,9 @@ namespace ORTS.Common
         /// <param name="name">name of the setting</param>
         /// <param name="value">value of the setting</param>
         public override void SetUserValue(string name, bool value)
-		{
-			NativeMethods.WritePrivateProfileString(Section, name, "bool:" + (value ? "true" : "false"), FilePath);
-		}
+        {
+            NativeMethods.WritePrivateProfileString(Section, name, "bool:" + (value ? "true" : "false"), FilePath);
+        }
 
         /// <summary>
         /// Set a value of a user setting
@@ -466,9 +466,9 @@ namespace ORTS.Common
         /// <param name="name">name of the setting</param>
         /// <param name="value">value of the setting</param>
         public override void SetUserValue(string name, string value)
-		{
-			NativeMethods.WritePrivateProfileString(Section, name, "string:" + Uri.EscapeDataString(value), FilePath);
-		}
+        {
+            NativeMethods.WritePrivateProfileString(Section, name, "string:" + Uri.EscapeDataString(value), FilePath);
+        }
 
         /// <summary>
         /// Set a value of a user setting
@@ -476,9 +476,9 @@ namespace ORTS.Common
         /// <param name="name">name of the setting</param>
         /// <param name="value">value of the setting</param>
         public override void SetUserValue(string name, int[] value)
-		{
-			NativeMethods.WritePrivateProfileString(Section, name, "int[]:" + String.Join(",", ((int[])value).Select(v => Uri.EscapeDataString(v.ToString(CultureInfo.InvariantCulture))).ToArray()), FilePath);
-		}
+        {
+            NativeMethods.WritePrivateProfileString(Section, name, "int[]:" + String.Join(",", ((int[])value).Select(v => Uri.EscapeDataString(v.ToString(CultureInfo.InvariantCulture))).ToArray()), FilePath);
+        }
 
         /// <summary>
         /// Set a value of a user setting
@@ -486,26 +486,26 @@ namespace ORTS.Common
         /// <param name="name">name of the setting</param>
         /// <param name="value">value of the setting</param>
         public override void SetUserValue(string name, string[] value)
-		{
-			NativeMethods.WritePrivateProfileString(Section, name, "string[]:" + String.Join(",", value.Select(v => Uri.EscapeDataString(v)).ToArray()), FilePath);
-		}
+        {
+            NativeMethods.WritePrivateProfileString(Section, name, "string[]:" + String.Join(",", value.Select(v => Uri.EscapeDataString(v)).ToArray()), FilePath);
+        }
 
         /// <summary>
         /// Remove a user setting from the store
         /// </summary>
         /// <param name="name">name of the setting</param>
         public override void DeleteUserValue(string name)
-		{
-			NativeMethods.WritePrivateProfileString(Section, name, null, FilePath);
-		}
-	}
+        {
+            NativeMethods.WritePrivateProfileString(Section, name, null, FilePath);
+        }
+    }
 
     // TODO: This class and its methods should be internal visibility.
     /// <summary>
     /// Native methods for interacting with INI files.
     /// </summary>
 	public static class NativeMethods
-	{
+    {
         /// <summary>
         /// Retrieves all the keys and values for the specified section of an initialization file.
         /// </summary>

--- a/Source/ORTS.Content/MSTSPath.cs
+++ b/Source/ORTS.Content/MSTSPath.cs
@@ -44,20 +44,20 @@ namespace MSTS
          */
         {
 
-			if (DefaultLocation == null)
-			{
-				DefaultLocation = "c:\\program files\\microsoft games\\train simulator";
+            if (DefaultLocation == null)
+            {
+                DefaultLocation = "c:\\program files\\microsoft games\\train simulator";
 
-				RegistryKey RK = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Microsoft Games\Train Simulator\1.0");
-				if (RK == null)
-					RK = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Wow6432Node\Microsoft\Microsoft Games\Train Simulator\1.0");
-				if (RK != null)
-					DefaultLocation = (string)RK.GetValue("Path", DefaultLocation);
+                RegistryKey RK = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Microsoft Games\Train Simulator\1.0");
+                if (RK == null)
+                    RK = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Wow6432Node\Microsoft\Microsoft Games\Train Simulator\1.0");
+                if (RK != null)
+                    DefaultLocation = (string)RK.GetValue("Path", DefaultLocation);
 
-				// Verify installation at this location
-				if (!Directory.Exists(DefaultLocation))
-					throw new FileNotFoundException("MSTS directory '" + DefaultLocation + "' does not exist.", DefaultLocation);
-			}
+                // Verify installation at this location
+                if (!Directory.Exists(DefaultLocation))
+                    throw new FileNotFoundException("MSTS directory '" + DefaultLocation + "' does not exist.", DefaultLocation);
+            }
 
             return DefaultLocation;
         }  //

--- a/Source/ORTS.IO/BufferedInMemoryStream.cs
+++ b/Source/ORTS.IO/BufferedInMemoryStream.cs
@@ -20,109 +20,127 @@ using System.IO;
 
 namespace ORTS.IO
 {
-	/// <summary>
-	/// A <see cref="Stream"/> which buffers both reads and writes in memory (as a <see cref="MemoryStream"/>).
-	/// </summary>
-	/// <remarks>
-	/// <para>Treat this stream like any other; <see cref="Read"/>, <see cref="Write"/>, <see cref="Seek"/> all work normally (or close enough) in most
-	/// cases. There are some specific exceptions, which shouldn't be a problem normally, outlined below.</para>
-	/// <para>When reading, if the underlying stream does not report a length itself, the value reported by <see cref="Length"/> represents the amount
-	/// buffered. The <see cref="BufferedInMemoryStream"/> attempts to keep the <see cref="Length"/> beyond the current seek location at all times.</para>
-	/// <para>when reading, <see cref="Seek"/> will operate normally but only within the data already buffered; attempts to seek beyond this will raise
-	/// an exception. There is no way to force a certain amount of data to be buffered.</para>
-	/// <para>When writing, <see cref="Flush"/> is a no-op and <see cref="SetLength"/> is not implemented. None of the <see cref="Stream"/> methods and
-	/// properties will cause data to be written to the underlying stream.</para>
-	/// <para>When writing, to cause all buffered data to be written to the underlying stream, call <see cref="RealFlush"/>. This non-standard behavior
-	/// is due to unfortunate existing code which calls <see cref="Flush"/> after writing to a <see cref="Stream"/>, which would otherwise cause us a
-	/// problem with write-once underlying streams (which we're specifically trying to support here).</para>
-	/// </remarks>
-	public class BufferedInMemoryStream : Stream
-	{
-		MemoryStream Memory;
-		Stream Base;
-		long WritePosition;
-		const int ChunkSize = 1024;
+    /// <summary>
+    /// A <see cref="Stream"/> which buffers both reads and writes in memory (as a <see cref="MemoryStream"/>).
+    /// </summary>
+    /// <remarks>
+    /// <para>Treat this stream like any other; <see cref="Read"/>, <see cref="Write"/>, <see cref="Seek"/> all work normally (or close enough) in most
+    /// cases. There are some specific exceptions, which shouldn't be a problem normally, outlined below.</para>
+    /// <para>When reading, if the underlying stream does not report a length itself, the value reported by <see cref="Length"/> represents the amount
+    /// buffered. The <see cref="BufferedInMemoryStream"/> attempts to keep the <see cref="Length"/> beyond the current seek location at all times.</para>
+    /// <para>when reading, <see cref="Seek"/> will operate normally but only within the data already buffered; attempts to seek beyond this will raise
+    /// an exception. There is no way to force a certain amount of data to be buffered.</para>
+    /// <para>When writing, <see cref="Flush"/> is a no-op and <see cref="SetLength"/> is not implemented. None of the <see cref="Stream"/> methods and
+    /// properties will cause data to be written to the underlying stream.</para>
+    /// <para>When writing, to cause all buffered data to be written to the underlying stream, call <see cref="RealFlush"/>. This non-standard behavior
+    /// is due to unfortunate existing code which calls <see cref="Flush"/> after writing to a <see cref="Stream"/>, which would otherwise cause us a
+    /// problem with write-once underlying streams (which we're specifically trying to support here).</para>
+    /// </remarks>
+    public class BufferedInMemoryStream : Stream
+    {
+        MemoryStream Memory;
+        Stream Base;
+        long WritePosition;
+        const int ChunkSize = 1024;
 
-		public BufferedInMemoryStream(Stream stream) {
-			Memory = new MemoryStream();
-			Base = stream;
-		}
+        public BufferedInMemoryStream(Stream stream)
+        {
+            Memory = new MemoryStream();
+            Base = stream;
+        }
 
-		public override void Close() {
-			base.Close();
-			Base.Close();
-		}
+        public override void Close()
+        {
+            base.Close();
+            Base.Close();
+        }
 
-		void ReadChunk(int chunk) {
-			var buffer = new byte[chunk];
-			var bytes = Base.Read(buffer, 0, chunk);
-			var oldPosition = Memory.Position;
-			Memory.Seek(0, SeekOrigin.End);
-			Memory.Write(buffer, 0, bytes);
-			Memory.Seek(oldPosition, SeekOrigin.Begin);
-		}
+        void ReadChunk(int chunk)
+        {
+            var buffer = new byte[chunk];
+            var bytes = Base.Read(buffer, 0, chunk);
+            var oldPosition = Memory.Position;
+            Memory.Seek(0, SeekOrigin.End);
+            Memory.Write(buffer, 0, bytes);
+            Memory.Seek(oldPosition, SeekOrigin.Begin);
+        }
 
-		public override bool CanRead {
-			get { return true;  }
-		}
+        public override bool CanRead
+        {
+            get { return true; }
+        }
 
-		public override bool CanSeek {
-			get { return true; }
-		}
+        public override bool CanSeek
+        {
+            get { return true; }
+        }
 
-		public override bool CanWrite {
-			get { return Base.CanWrite; }
-		}
+        public override bool CanWrite
+        {
+            get { return Base.CanWrite; }
+        }
 
-		public override void Flush() {
-		}
+        public override void Flush()
+        {
+        }
 
-		public void RealFlush() {
-			if (Memory.Position > WritePosition) {
-				var currentPosition = Memory.Position;
-				Memory.Seek(WritePosition, SeekOrigin.Begin);
-				var buffer = new byte[currentPosition - WritePosition];
-				Memory.Read(buffer, 0, buffer.Length);
-				Base.Write(buffer, 0, buffer.Length);
-				WritePosition = currentPosition;
-				Memory.Position = currentPosition;
-			}
+        public void RealFlush()
+        {
+            if (Memory.Position > WritePosition)
+            {
+                var currentPosition = Memory.Position;
+                Memory.Seek(WritePosition, SeekOrigin.Begin);
+                var buffer = new byte[currentPosition - WritePosition];
+                Memory.Read(buffer, 0, buffer.Length);
+                Base.Write(buffer, 0, buffer.Length);
+                WritePosition = currentPosition;
+                Memory.Position = currentPosition;
+            }
 
-			Base.Flush();
-		}
+            Base.Flush();
+        }
 
-		public override long Length {
-			get {
-				if (Base.CanSeek) return Base.Length;
-				if (Base.CanRead && (Memory.Position + ChunkSize >= Memory.Length)) ReadChunk(ChunkSize);
-				return Memory.Length;
-			}
-		}
+        public override long Length
+        {
+            get
+            {
+                if (Base.CanSeek) return Base.Length;
+                if (Base.CanRead && (Memory.Position + ChunkSize >= Memory.Length)) ReadChunk(ChunkSize);
+                return Memory.Length;
+            }
+        }
 
-		public override long Position {
-			get {
-				return Memory.Position;
-			}
-			set {
-				Memory.Position = value;
-			}
-		}
+        public override long Position
+        {
+            get
+            {
+                return Memory.Position;
+            }
+            set
+            {
+                Memory.Position = value;
+            }
+        }
 
-		public override int Read(byte[] buffer, int offset, int count) {
-			if (Memory.Position + count > Memory.Length) ReadChunk(count);
-			return Memory.Read(buffer, offset, count);
-		}
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (Memory.Position + count > Memory.Length) ReadChunk(count);
+            return Memory.Read(buffer, offset, count);
+        }
 
-		public override long Seek(long offset, SeekOrigin origin) {
-			return Memory.Seek(offset, origin);
-		}
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return Memory.Seek(offset, origin);
+        }
 
-		public override void SetLength(long value) {
-			throw new NotImplementedException();
-		}
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
 
-		public override void Write(byte[] buffer, int offset, int count) {
-			Memory.Write(buffer, offset, count);
-		}
-	}
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            Memory.Write(buffer, offset, count);
+        }
+    }
 }

--- a/Source/ORTS.IO/ByteEncoding.cs
+++ b/Source/ORTS.IO/ByteEncoding.cs
@@ -19,86 +19,95 @@ using System.Text;
 
 namespace ORTS.IO
 {
-	/// <summary>
-	/// A basic encoding which maps bytes 0-255 to Unicode characters 0-255.
-	/// </summary>
-	public class ByteEncoding : Encoding
-	{
-		public static Encoding Encoding = new ByteEncoding();
+    /// <summary>
+    /// A basic encoding which maps bytes 0-255 to Unicode characters 0-255.
+    /// </summary>
+    public class ByteEncoding : Encoding
+    {
+        public static Encoding Encoding = new ByteEncoding();
 
-		public ByteEncoding() {
-		}
+        public ByteEncoding()
+        {
+        }
 
-		/// <summary>
-		/// Calculates the number of bytes produced by encoding a set of characters from the specified character array.
-		/// </summary>
-		/// <param name="chars">The character array containing the set of characters to encode.</param>
-		/// <param name="index">The index of the first character to encode.</param>
-		/// <param name="count">The number of characters to encode.</param>
-		/// <returns>The number of bytes produced by encoding the specified characters.</returns>
-		public override int GetByteCount(char[] chars, int index, int count) {
-			return count;
-		}
+        /// <summary>
+        /// Calculates the number of bytes produced by encoding a set of characters from the specified character array.
+        /// </summary>
+        /// <param name="chars">The character array containing the set of characters to encode.</param>
+        /// <param name="index">The index of the first character to encode.</param>
+        /// <param name="count">The number of characters to encode.</param>
+        /// <returns>The number of bytes produced by encoding the specified characters.</returns>
+        public override int GetByteCount(char[] chars, int index, int count)
+        {
+            return count;
+        }
 
-		/// <summary>
-		/// Encodes a set of characters from the specified character array into the specified byte array.
-		/// </summary>
-		/// <param name="chars">The character array containing the set of characters to encode.</param>
-		/// <param name="charIndex">The index of the first character to encode.</param>
-		/// <param name="charCount">The number of characters to encode.</param>
-		/// <param name="bytes">The byte array to contain the resulting sequence of bytes.</param>
-		/// <param name="byteIndex">The index at which to start writing the resulting sequence of bytes.</param>
-		/// <returns>The actual number of bytes written into <paramref name="bytes"/>.</returns>
-		public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) {
-			for (var i = 0; i < charCount; i++) {
-				bytes[i + byteIndex] = (byte)chars[i + charIndex];
-			}
-			return charCount;
-		}
+        /// <summary>
+        /// Encodes a set of characters from the specified character array into the specified byte array.
+        /// </summary>
+        /// <param name="chars">The character array containing the set of characters to encode.</param>
+        /// <param name="charIndex">The index of the first character to encode.</param>
+        /// <param name="charCount">The number of characters to encode.</param>
+        /// <param name="bytes">The byte array to contain the resulting sequence of bytes.</param>
+        /// <param name="byteIndex">The index at which to start writing the resulting sequence of bytes.</param>
+        /// <returns>The actual number of bytes written into <paramref name="bytes"/>.</returns>
+        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+        {
+            for (var i = 0; i < charCount; i++)
+            {
+                bytes[i + byteIndex] = (byte)chars[i + charIndex];
+            }
+            return charCount;
+        }
 
-		/// <summary>
-		/// Calculates the number of characters produced by decoding a sequence of bytes from the specified byte array.
-		/// </summary>
-		/// <param name="bytes">The byte array containing the sequence of bytes to decode.</param>
-		/// <param name="index">The index of the first byte to decode.</param>
-		/// <param name="count">The number of bytes to decode.</param>
-		/// <returns>The number of characters produced by decoding the specified sequence of bytes.</returns>
-		public override int GetCharCount(byte[] bytes, int index, int count) {
-			return count;
-		}
+        /// <summary>
+        /// Calculates the number of characters produced by decoding a sequence of bytes from the specified byte array.
+        /// </summary>
+        /// <param name="bytes">The byte array containing the sequence of bytes to decode.</param>
+        /// <param name="index">The index of the first byte to decode.</param>
+        /// <param name="count">The number of bytes to decode.</param>
+        /// <returns>The number of characters produced by decoding the specified sequence of bytes.</returns>
+        public override int GetCharCount(byte[] bytes, int index, int count)
+        {
+            return count;
+        }
 
-		/// <summary>
-		/// Decodes a sequence of bytes from the specified byte array into the specified character array.
-		/// </summary>
-		/// <param name="bytes">The byte array containing the sequence of bytes to decode.</param>
-		/// <param name="byteIndex">The index of the first byte to decode.</param>
-		/// <param name="byteCount">The number of bytes to decode.</param>
-		/// <param name="chars">The character array to contain the resulting set of characters.</param>
-		/// <param name="charIndex">The index at which to start writing the resulting set of characters.</param>
-		/// <returns>The actual number of characters written into <paramref name="chars"/>.</returns>
-		public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) {
-			for (var i = 0; i < byteCount; i++) {
-				chars[i + charIndex] = (char)bytes[i + byteIndex];
-			}
-			return byteCount;
-		}
+        /// <summary>
+        /// Decodes a sequence of bytes from the specified byte array into the specified character array.
+        /// </summary>
+        /// <param name="bytes">The byte array containing the sequence of bytes to decode.</param>
+        /// <param name="byteIndex">The index of the first byte to decode.</param>
+        /// <param name="byteCount">The number of bytes to decode.</param>
+        /// <param name="chars">The character array to contain the resulting set of characters.</param>
+        /// <param name="charIndex">The index at which to start writing the resulting set of characters.</param>
+        /// <returns>The actual number of characters written into <paramref name="chars"/>.</returns>
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+        {
+            for (var i = 0; i < byteCount; i++)
+            {
+                chars[i + charIndex] = (char)bytes[i + byteIndex];
+            }
+            return byteCount;
+        }
 
-		/// <summary>
-		/// Calculates the maximum number of bytes produced by encoding the specified number of characters.
-		/// </summary>
-		/// <param name="charCount">The number of characters to encode.</param>
-		/// <returns>The maximum number of bytes produced by encoding the specified number of characters.</returns>
-		public override int GetMaxByteCount(int charCount) {
-			return charCount;
-		}
+        /// <summary>
+        /// Calculates the maximum number of bytes produced by encoding the specified number of characters.
+        /// </summary>
+        /// <param name="charCount">The number of characters to encode.</param>
+        /// <returns>The maximum number of bytes produced by encoding the specified number of characters.</returns>
+        public override int GetMaxByteCount(int charCount)
+        {
+            return charCount;
+        }
 
-		/// <summary>
-		/// Calculates the maximum number of characters produced by decoding the specified number of bytes.
-		/// </summary>
-		/// <param name="byteCount">The number of bytes to decode.</param>
-		/// <returns>The maximum number of characters produced by decoding the specified number of bytes.</returns>
-		public override int GetMaxCharCount(int byteCount) {
-			return byteCount;
-		}
-	}
+        /// <summary>
+        /// Calculates the maximum number of characters produced by decoding the specified number of bytes.
+        /// </summary>
+        /// <param name="byteCount">The number of bytes to decode.</param>
+        /// <returns>The maximum number of characters produced by decoding the specified number of bytes.</returns>
+        public override int GetMaxCharCount(int byteCount)
+        {
+            return byteCount;
+        }
+    }
 }

--- a/Source/ORTS.Menu/Paths.cs
+++ b/Source/ORTS.Menu/Paths.cs
@@ -145,7 +145,8 @@ namespace ORTS.Menu
             {
                 path = new Path(file);
             }
-            catch {
+            catch
+            {
                 path = null;
             }
 

--- a/Source/ORTS.Menu/Routes.cs
+++ b/Source/ORTS.Menu/Routes.cs
@@ -36,10 +36,10 @@ namespace ORTS.Menu
         {
             if (Directory.Exists(path))
             {
-				var trkFilePath = MSTSPath.GetTRKFileName(path);
+                var trkFilePath = MSTSPath.GetTRKFileName(path);
                 try
                 {
-					var trkFile = new RouteFile(trkFilePath);
+                    var trkFile = new RouteFile(trkFilePath);
                     Name = trkFile.Tr_RouteFile.Name.Trim();
                     RouteID = trkFile.Tr_RouteFile.RouteID;
                     Description = trkFile.Tr_RouteFile.Description.Trim();

--- a/Source/ORTS.Settings/InputSettings.cs
+++ b/Source/ORTS.Settings/InputSettings.cs
@@ -304,7 +304,7 @@ namespace ORTS.Settings
             Commands[(int)UserCommand.CameraBrowseBackwards] = new UserCommandKeyInput(0x4F, KeyModifiers.Shift | KeyModifiers.Alt);
             Commands[(int)UserCommand.CameraBrowseForwards] = new UserCommandKeyInput(0x47, KeyModifiers.Shift | KeyModifiers.Alt);
             Commands[(int)UserCommand.CameraCab] = new UserCommandKeyInput(0x02);
-			Commands[(int)UserCommand.CameraThreeDimensionalCab] = new UserCommandKeyInput(0x02, KeyModifiers.Alt);
+            Commands[(int)UserCommand.CameraThreeDimensionalCab] = new UserCommandKeyInput(0x02, KeyModifiers.Alt);
             Commands[(int)UserCommand.CameraCarFirst] = new UserCommandKeyInput(0x47, KeyModifiers.Alt);
             Commands[(int)UserCommand.CameraCarLast] = new UserCommandKeyInput(0x4F, KeyModifiers.Alt);
             Commands[(int)UserCommand.CameraCarNext] = new UserCommandKeyInput(0x49, KeyModifiers.Alt);

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -218,8 +218,8 @@ namespace ORTS.Settings
         public bool DataLogMisc { get; set; }
         [Default(false)]
         public bool DataLogSteamPerformance { get; set; }
-        
-        
+
+
         // Evaluation settings:
         [Default(false)]
         public bool DataLogTrainSpeed { get; set; }

--- a/Source/ORTS.Updater/UpdateManager.cs
+++ b/Source/ORTS.Updater/UpdateManager.cs
@@ -550,7 +550,7 @@ namespace ORTS.Updater
             var commonName = subjectLines.FirstOrDefault(line => line.StartsWith("CN="));
             var country = subjectLines.FirstOrDefault(line => line.StartsWith("C="));
             return certificate.Verify() + "\n" + commonName + "\n" + country;
-         }
+        }
 
         static List<X509Certificate2> GetCertificatesFromFile(string filename)
         {

--- a/Source/Orts.Formats.Msts/AceFile.cs
+++ b/Source/Orts.Formats.Msts/AceFile.cs
@@ -104,9 +104,9 @@ namespace Orts.Formats.Msts
                 texture = new Texture2D(graphicsDevice, width, height, 1, TextureUsage.None, textureFormat);
             else
                 if (imageCount > 1)
-                    texture = new Texture2D(graphicsDevice, width, height, imageCount, TextureUsage.None, textureFormat);
-                else
-                    texture = new Texture2D(graphicsDevice, width, height, 0, TextureUsage.AutoGenerateMipMap, textureFormat);
+                texture = new Texture2D(graphicsDevice, width, height, imageCount, TextureUsage.None, textureFormat);
+            else
+                texture = new Texture2D(graphicsDevice, width, height, 0, TextureUsage.AutoGenerateMipMap, textureFormat);
 
             // Read in the color channels; each one defines a size (in bits) and type (reg, green, blue, mask, alpha).
             var channels = new List<SimisAceChannel>();

--- a/Source/Orts.Formats.Msts/ActivityFile.cs
+++ b/Source/Orts.Formats.Msts/ActivityFile.cs
@@ -54,17 +54,17 @@
 //         *)
 
 //        RouteID = "RouteID", "(", Text, ")" ;  (* file name *)
-			
+
 //        Name = "Name", "(", Text, ")" ;
-			
+
 //        Description = "Description", "(", Text, ")" ;
 
 //        Briefing = "Briefing", "(", ParagraphText, ")" ;
-			
+
 //            ParagraphText = Text, *( "+", Text ) ;
-			
+
 //        CompleteActivity = "CompleteActivity", "(", Integer, ")" ;	(* 1 for true (to be checked) *)
-			
+
 //        Type = "Type", "(", Integer, ")" ;	(* 0 (default) for ??? (to be checked) *)
 
 //        Mode = "Mode", "(", Integer, ")" ;	(* 2 (default) for ??? (to be checked) *)
@@ -84,25 +84,25 @@
 //        Difficulty = "Difficulty", "(", Integer, ")" ;	(* Easy=0 (default), Medium, Hard *)
 
 //        Animals = "Animals", "(", Integer, ")" ;	(* 0-100 for % (default is 100) *)
-			
+
 //        Workers = "Workers", "(", Integer, ")" ;	(* 0-100 for % (default is 0) *)
-			
+
 //        FuelWater = "FuelWater", "(", Integer, ")";	(* 0-100 for % (default is 100) *)
-			
+
 //        FuelCoal = "FuelCoal", "(", Integer, ")";	(* 0-100 for % (default is 100) *)
-			
+
 //        FuelDiesel = "FuelDiesel", "(", Integer, ")";	(* 0-100 for % (default is 100) *)
 
 //    Tr_Activity_File = "Tr_Activity_File", 
 //        "(", *[ Player_Service_Definition | NextServiceUID | NextActivityObjectUID
 //        | Traffic_Definition | Events | ActivityObjects | ActivityFailedSignals | PlatformNumPassengersWaiting | ActivityRestrictedSpeedZones ] ")" ;
-		
+
 //        Player_Service_Definition = "Player_Service_Definition",	(* Text is linked to PathID somehow. *)
 //            "(", Text, [ Player_Traffic_Definition | UiD | *Player_Service_Item ], ")" ;    (* Code suggests just one Player_Traffic_Definition *)
-			
+
 //                Player_Traffic_Definition = "Player_Traffic_Definition", 
 //                    "(", Integer, *( Player_Traffic_Item ), ")" ;
-					
+
 //                    Player_Traffic_Item =	(* Note lack of separator between Player_Traffic_Items. 
 //                                               For simplicity, parser creates a new object whenever PlatformStartID is parsed. *)
 //                        *[ "ArrivalTime", "(", Integer, ")"
@@ -110,7 +110,7 @@
 //                         | "SkipCount", "(", Integer, ")"
 //                         | "DistanceDownPath", "(", Float, ")" ],
 //                        "PlatformStartID", "(", Integer, ")" ;
-				
+
 //                UiD = "UiD", "(", Integer, ")" ;
 
 //                Player_Service_Item =	(* Note lack of separator between Player_Service_Items *)
@@ -119,13 +119,13 @@
 //                     | "SkipCount", "(", Integer, ")"
 //                     | "DistanceDownPath", "(", Float, ")" ],
 //                    "PlatformStartID", "(", Integer, ")" ;
-				
+
 //        NextServiceUID = "NextServiceUID", "(", Integer, ")" ;
 
 //        NextActivityObjectUID = "NextActivityObjectUID", "(", Integer, ")" ;
-			
+
 //        Traffic_Definition = "Traffic_Definition", "(", Text, *Service_Definition, ")" ;
-			
+
 //            Service_Definition = "Service_Definition",
 //                "(", Text, Integer, UiD, *Player_Service_Item, ")" ;  (* Integer is time in seconds *)
 
@@ -135,34 +135,34 @@
 //            EventCategoryLocation = "EventCategoryLocation", 
 //                "(", *[ EventTypeLocation | ID | Activation_Level | Outcomes
 //                | Name | Location | TriggerOnStop ], ")" ;  (* ID and Name defined above *)	
-				
+
 //                EventTypeLocation = "EventTypeLocation", "(", ")" ;
-				
+
 //                ID = "ID", "(", Integer, ")" ;
-				
+
 //                Activation_Level = "Activation_Level", "(", Integer, ")" ;
-					
+
 //                Outcomes = "Outcomes",
 //                    "(", *[ ActivitySuccess | ActivityFail | ActivateEvent | RestoreActLevel | DecActLevel | IncActLevel | DisplayMessage ], ")" ;
-				
+
 //                    ActivitySuccess = "ActivitySuccess", "(", ")" ;   (* No text parameter *)
-						
+
 //                    ActivityFail = "ActivityFail", "(", Text, ")" ;
-						
+
 //                    ActivateEvent = "ActivateEvent", "(", Integer, ")" ;
 
 //                    RestoreActLevel = "RestoreActLevel", "(", Integer, ")" ;
 
 //                    DecActLevel = "DecActLevel", "(", Integer, ")" ;
-						
+
 //                    IncActLevel = "IncActLevel", "(", Integer, ")" ;  (* Some MSTS samples have more than a single IncActLevel *)
-						
+
 //                    DisplayMessage = "DisplayMessage", "(", Text, ")" ;
-						
+
 //                Location = "Location", "(", 5*Integer, ")" ;
-					
+
 //                TriggerOnStop = "TriggerOnStop", "(", Integer, ")" ;  (* 0 for ?? *)
-					
+
 //                TextToDisplayOnCompletionIfTriggered = "TextToDisplayOnCompletionIfTriggered", "(", ParagraphText, ")" ;
 
 //                TextToDisplayOnCompletionIfNotTriggered = "TextToDisplayOnCompletionIfNotTriggered", "(", ParagraphText, ")" ;
@@ -180,41 +180,41 @@
 //                    EventTypeAllStops = "EventTypeAllStops", "(", ")" ;
 
 //                    EventTypeAssembleTrain = "EventTypeAssembleTrain", "(", ")" ;
-					
+
 //                    EventTypeAssembleTrainAtLocation = "EventTypeAssembleTrainAtLocation", "(", ")" ;
-					
+
 //                    EventTypeDropOffWagonsAtLocation = "EventTypeDropOffWagonsAtLocation", "(", ")" ;
-					
+
 //                    EventTypePickUpPassengers = "EventTypePickUpPassengers", "(", ")" ;
 
 //                    EventTypePickUpWagons = "EventTypePickUpWagons", "(", ")" ;
-					
+
 //                    EventTypeReachSpeed = "EventTypeReachSpeed", "(", ")" ;
 
 //                Reversable_Event = [ "Reversable_Event" | "Reversible_Event" ],  (* Reversable is not listed at www.learnersdictionary.com *) 
 //                    "(", ")" ;
-					
+
 //                SidingItem =  "(", Integer, ")" ;
 
 //                Wagon_List = "Wagon_List", "(", *WagonListItem, ")" ;
-					
+
 //                    WagonListItem = (* Description omitted from PickUpWagons and sometimes from DropOffWagonsAtLocation *)
 //                        UiD, SidingItem, [ "Description", "(", Text, ")" ] ;  (" MSTS uses SidingItem inside the Wagon_List and also at the same level *)
-						
+
 //                StationStop = 
-				
+
 //                Speed = "(", Integer, ")" ;
-					
+
 //            EventCategoryTime = "EventCategoryTime", "(",  (* single instance of each alternative *)
 //                [ EventTypeTime | ID | Activation_Level | Outcomes | TextToDisplayOnCompletionIfTriggered 
 //                | TextToDisplayOnCompletionIfNotTriggered | Name | Time ], ")" ;  (* Outcomes may have empty parameters *)
-				
+
 //                EventTypeTime = "EventTypeTime", "(", ")" ;
 
 //                Time = "Time", "(", Integer, ")" ;
-					
+
 //        ActivityObjects	= "ActivityObjects", "(", *ActivityObject, ")" ;
-			
+
 //            ActivityObject = "ActivityObject", 
 //                "(", *[ ObjectType | Train_Config | Direction | ID | Tile ], ")" ;  (* ID defined above *)
 
@@ -225,13 +225,13 @@
 
 //                    TrainCfg = "TrainCfg", 
 //                        "(", [ Name | Serial | MaxVelocity | NextWagonUID | Durability | Wagon | Engine ], ")" ;
-						
+
 //                        Serial = "Serial", "(", Integer, ")" ;
-						
+
 //                        MaxVelocity = "MaxVelocity", "(", 2*Float, ")" ;
-						
+
 //                        NextWagonUID = "NextWagonUID", "(", Integer, ")" ;
-						
+
 //                        Durability = "Durability", "(", Float, ")" ;
 
 //                        Wagon = "Wagon", 
@@ -240,29 +240,29 @@
 //                            WagonData = "WagonData", "(", 2*Text, ")" ;
 
 //                        Engine = "Engine", "(", *[ UiD | EngineData ], ")" ;  (* UiD defined above *)
-						
+
 //                            EngineData = "EngineData", 
 //                                "(", 2*Text, ")" ;
-							
+
 //                Direction = "Direction", "(", Integer, ")" ;  (* 0 for ??, 1 for ?? *)
 
 //                Tile = "Tile", "(", 2*Integer, 2*Float, ")" ;
-		
+
 //        ActivityFailedSignals = "ActivityFailedSignals", "(", *ActivityFailedSignal, ")" ;
-		
+
 //            ActivityFailedSignal = "ActivityFailedSignal", "(", Integer, ")" ;
-		
+
 //        PlatformNumPassengersWaiting = "PlatformNumPassengersWaiting", "(", *PlatformData, ")" ;
-		
+
 //            PlatformData = "PlatformData", "(", 2*Integer, ")" ;
-		
+
 //        ActivityRestrictedSpeedZones = "ActivityRestrictedSpeedZones", "(", *ActivityRestrictedSpeedZone, ")" ;
-			
+
 //            ActivityRestrictedSpeedZone = "ActivityRestrictedSpeedZone",
 //                "(", StartPosition, EndPosition, ")" ;
 
 //                StartPosition = "StartPosition, "(", 4*Integer, ")" ;
-				
+
 //                EndPosition = "EndPosition", "(", 4*Integer, ")" ;
 
 
@@ -279,7 +279,8 @@ namespace Orts.Formats.Msts
     public enum SeasonType { Spring = 0, Summer, Autumn, Winter }
     public enum WeatherType { Clear = 0, Snow, Rain }
     public enum Difficulty { Easy = 0, Medium, Hard }
-    public enum EventType {
+    public enum EventType
+    {
         AllStops = 0, AssembleTrain, AssembleTrainAtLocation, DropOffWagonsAtLocation, PickUpPassengers,
         PickUpWagons, ReachSpeed
     }
@@ -294,19 +295,24 @@ namespace Orts.Formats.Msts
     /// Parse and *.act file.
     /// Naming for classes matches the terms in the *.act file.
     /// </summary>
-    public class ActivityFile {
+    public class ActivityFile
+    {
         public Tr_Activity Tr_Activity;
 
-        public ActivityFile(string filenamewithpath) {
+        public ActivityFile(string filenamewithpath)
+        {
             Read(filenamewithpath, false);
         }
 
-        public ActivityFile(string filenamewithpath, bool headerOnly) {
+        public ActivityFile(string filenamewithpath, bool headerOnly)
+        {
             Read(filenamewithpath, headerOnly);
         }
 
-        public void Read(string filenamewithpath, bool headerOnly) {
-            using (STFReader stf = new STFReader(filenamewithpath, false)) {
+        public void Read(string filenamewithpath, bool headerOnly)
+        {
+            using (STFReader stf = new STFReader(filenamewithpath, false))
+            {
                 stf.ParseFile(() => headerOnly && (Tr_Activity != null) && (Tr_Activity.Tr_Activity_Header != null), new STFReader.TokenProcessor[] {
                     new STFReader.TokenProcessor("tr_activity", ()=>{ Tr_Activity = new Tr_Activity(stf, headerOnly); }),
                 });
@@ -335,12 +341,14 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class Tr_Activity {
+    public class Tr_Activity
+    {
         public int Serial = 1;
         public Tr_Activity_Header Tr_Activity_Header;
         public Tr_Activity_File Tr_Activity_File;
 
-        public Tr_Activity(STFReader stf, bool headerOnly) {
+        public Tr_Activity(STFReader stf, bool headerOnly)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(() => headerOnly && (Tr_Activity_Header != null), new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("tr_activity_file", ()=>{ Tr_Activity_File = new Tr_Activity_File(stf); }),
@@ -371,7 +379,8 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class Tr_Activity_Header {
+    public class Tr_Activity_Header
+    {
         public string RouteID;
         public string Name;					// AE Display Name
         public string Description = " ";
@@ -392,7 +401,8 @@ namespace Orts.Formats.Msts
         public int FuelCoal = 100;		// percent
         public int FuelDiesel = 100;	// percent
 
-        public Tr_Activity_Header(STFReader stf) {
+        public Tr_Activity_Header(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("routeid", ()=>{ RouteID = stf.ReadStringBlock(null); }),
@@ -406,7 +416,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("season", ()=>{ Season = (SeasonType)stf.ReadIntBlock(null); }),
                 new STFReader.TokenProcessor("weather", ()=>{ Weather = (WeatherType)stf.ReadIntBlock(null); }),
                 new STFReader.TokenProcessor("pathid", ()=>{ PathID = stf.ReadStringBlock(null); }),
-                new STFReader.TokenProcessor("startingspeed", ()=>{ StartingSpeed = (int)stf.ReadFloatBlock(STFReader.UNITS.Speed, (float)StartingSpeed); }),                
+                new STFReader.TokenProcessor("startingspeed", ()=>{ StartingSpeed = (int)stf.ReadFloatBlock(STFReader.UNITS.Speed, (float)StartingSpeed); }),
                 new STFReader.TokenProcessor("duration", ()=>{ Duration = new Duration(stf); }),
                 new STFReader.TokenProcessor("difficulty", ()=>{ Difficulty = (Difficulty)stf.ReadIntBlock(null); }),
                 new STFReader.TokenProcessor("animals", ()=>{ Animals = stf.ReadIntBlock(Animals); }),
@@ -423,18 +433,21 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class StartTime {
+    public class StartTime
+    {
         public int Hour;
         public int Minute;
         public int Second;
 
-        public StartTime(int h, int m, int s) {
+        public StartTime(int h, int m, int s)
+        {
             Hour = h;
             Minute = m;
             Second = s;
         }
 
-        public StartTime(STFReader stf) {
+        public StartTime(STFReader stf)
+        {
             stf.MustMatch("(");
             Hour = stf.ReadInt(null);
             Minute = stf.ReadInt(null);
@@ -442,22 +455,26 @@ namespace Orts.Formats.Msts
             stf.MustMatch(")");
         }
 
-        public String FormattedStartTime() {
+        public String FormattedStartTime()
+        {
             return Hour.ToString("00") + ":" + Minute.ToString("00") + ":" + Second.ToString("00");
         }
     }
 
-    public class Duration {
+    public class Duration
+    {
         int Hour;
         int Minute;
         int Second;
 
-        public Duration(int h, int m) {
+        public Duration(int h, int m)
+        {
             Hour = h;
             Minute = m;
         }
 
-        public Duration(STFReader stf) {
+        public Duration(STFReader stf)
+        {
             stf.MustMatch("(");
             Hour = stf.ReadInt(null);
             Minute = stf.ReadInt(null);
@@ -466,10 +483,10 @@ namespace Orts.Formats.Msts
 
         public int ActivityDuration()
         {
-            return Hour* 3600 + Minute* 60 + Second; // Convert time to seconds
+            return Hour * 3600 + Minute * 60 + Second; // Convert time to seconds
         }
 
-    public String FormattedDurationTime()
+        public String FormattedDurationTime()
         {
             return Hour.ToString("00") + ":" + Minute.ToString("00");
         }
@@ -481,7 +498,8 @@ namespace Orts.Formats.Msts
 
     }
 
-    public class Tr_Activity_File {
+    public class Tr_Activity_File
+    {
         public Player_Service_Definition Player_Service_Definition;
         public int NextServiceUID = 1;
         public int NextActivityObjectUID = 32786;
@@ -494,7 +512,8 @@ namespace Orts.Formats.Msts
         public int ORTSAIHornAtCrossings = -1;
 
 
-        public Tr_Activity_File(STFReader stf) {
+        public Tr_Activity_File(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("player_service_definition",()=>{ Player_Service_Definition = new Player_Service_Definition(stf); }),
@@ -536,11 +555,13 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class Player_Service_Definition {
+    public class Player_Service_Definition
+    {
         public string Name;
         public Player_Traffic_Definition Player_Traffic_Definition;
 
-        public Player_Service_Definition(STFReader stf) {
+        public Player_Service_Definition(STFReader stf)
+        {
             stf.MustMatch("(");
             Name = stf.ReadString();
             stf.ParseBlock(new STFReader.TokenProcessor[] {
@@ -555,11 +576,13 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class Player_Traffic_Definition {
+    public class Player_Traffic_Definition
+    {
         public int Time;
         public List<Player_Traffic_Item> Player_Traffic_List = new List<Player_Traffic_Item>();
 
-        public Player_Traffic_Definition(STFReader stf) {
+        public Player_Traffic_Definition(STFReader stf)
+        {
             DateTime baseDT = new DateTime();
             DateTime arrivalTime = new DateTime();
             DateTime departTime = new DateTime();
@@ -575,7 +598,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("departtime", ()=>{ departTime = baseDT.AddSeconds(stf.ReadFloatBlock(STFReader.UNITS.Time, null)); }),
                 new STFReader.TokenProcessor("skipcount", ()=>{ skipCount = stf.ReadIntBlock(null); }),
                 new STFReader.TokenProcessor("distancedownpath", ()=>{ distanceDownPath = stf.ReadFloatBlock(STFReader.UNITS.Distance, null); }),
-                new STFReader.TokenProcessor("platformstartid", ()=>{ platformStartID = stf.ReadIntBlock(null); 
+                new STFReader.TokenProcessor("platformstartid", ()=>{ platformStartID = stf.ReadIntBlock(null);
                     Player_Traffic_List.Add(new Player_Traffic_Item(arrivalTime, departTime, skipCount, distanceDownPath, platformStartID)); }),
             });
         }
@@ -586,13 +609,15 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class Player_Traffic_Item {
+    public class Player_Traffic_Item
+    {
         public DateTime ArrivalTime;
         public DateTime DepartTime;
         public float DistanceDownPath;
         public int PlatformStartID;
 
-        public Player_Traffic_Item(DateTime arrivalTime, DateTime departTime, int skipCount, float distanceDownPath, int platformStartID) {
+        public Player_Traffic_Item(DateTime arrivalTime, DateTime departTime, int skipCount, float distanceDownPath, int platformStartID)
+        {
             ArrivalTime = arrivalTime;
             DepartTime = departTime;
             DistanceDownPath = distanceDownPath;
@@ -600,7 +625,8 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class Service_Definition {
+    public class Service_Definition
+    {
         public string Name;
         public int Time;
         public int UiD;
@@ -610,7 +636,8 @@ namespace Orts.Formats.Msts
         float distanceDownPath = new float();
         int platformStartID;
 
-        public Service_Definition(STFReader stf) {
+        public Service_Definition(STFReader stf)
+        {
             stf.MustMatch("(");
             Name = stf.ReadString();
             Time = (int)stf.ReadFloat(STFReader.UNITS.Time, null);
@@ -622,7 +649,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("efficiency", ()=>{ efficiency = stf.ReadFloatBlock(STFReader.UNITS.Any, null); }),
                 new STFReader.TokenProcessor("skipcount", ()=>{ skipCount = stf.ReadIntBlock(null); }),
                 new STFReader.TokenProcessor("distancedownpath", ()=>{ distanceDownPath = stf.ReadFloatBlock(STFReader.UNITS.Distance, null); }),
-                new STFReader.TokenProcessor("platformstartid", ()=>{ platformStartID = stf.ReadIntBlock(null); 
+                new STFReader.TokenProcessor("platformstartid", ()=>{ platformStartID = stf.ReadIntBlock(null);
                     ServiceList.Add(new Service_Item(efficiency, skipCount, distanceDownPath, platformStartID)); }),
             });
         }
@@ -649,7 +676,7 @@ namespace Orts.Formats.Msts
         /// <\summary>
         /// 
 
-        public Service_Definition ()
+        public Service_Definition()
         { }
 
         //================================================================================================//
@@ -664,9 +691,9 @@ namespace Orts.Formats.Msts
             {
                 outf.Write(-1);
             }
-            else          
+            else
             {
-                outf.Write (ServiceList.Count);
+                outf.Write(ServiceList.Count);
                 foreach (Service_Item thisServiceItem in ServiceList)
                 {
                     outf.Write(thisServiceItem.Efficiency);
@@ -674,7 +701,7 @@ namespace Orts.Formats.Msts
                 }
             }
         }
-     }
+    }
 
     public class Service_Item
     {
@@ -683,7 +710,8 @@ namespace Orts.Formats.Msts
         public float DistanceDownPath = new float();
         public int PlatformStartID;
 
-        public Service_Item(float efficiency, int skipCount, float distanceDownPath, int platformStartID) {
+        public Service_Item(float efficiency, int skipCount, float distanceDownPath, int platformStartID)
+        {
             Efficiency = efficiency;
             SkipCount = skipCount;
             DistanceDownPath = distanceDownPath;
@@ -694,12 +722,14 @@ namespace Orts.Formats.Msts
     /// <summary>
     /// Parses Service_Definition objects and saves them in ServiceDefinitionList.
     /// </summary>
-    public class Traffic_Definition {
+    public class Traffic_Definition
+    {
         public string Name;
         public TrafficFile TrafficFile;
         public List<Service_Definition> ServiceDefinitionList = new List<Service_Definition>();
 
-        public Traffic_Definition(STFReader stf) {
+        public Traffic_Definition(STFReader stf)
+        {
             stf.MustMatch("(");
             Name = stf.ReadString();
             stf.ParseBlock(new STFReader.TokenProcessor[] {
@@ -714,10 +744,12 @@ namespace Orts.Formats.Msts
     /// <summary>
     /// Parses Event objects and saves them in EventList.
     /// </summary>
-    public class Events {
+    public class Events
+    {
         public List<Event> EventList = new List<Event>();
 
-        public Events(STFReader stf) {
+        public Events(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("eventcategorylocation", ()=>{ EventList.Add(new EventCategoryLocation(stf)); }),
@@ -726,7 +758,7 @@ namespace Orts.Formats.Msts
             });
         }
 
-        public void InsertORSpecificData (STFReader stf)
+        public void InsertORSpecificData(STFReader stf)
         {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
@@ -760,7 +792,7 @@ namespace Orts.Formats.Msts
                     wrongEventID = !TestMatch(Category, origEvent);
                     if (!wrongEventID)
                     {
-                       origEvent.AddOrModifyEvent(stf, Path.GetDirectoryName(stf.FileName));
+                        origEvent.AddOrModifyEvent(stf, Path.GetDirectoryName(stf.FileName));
                     }
                     else
                     {
@@ -797,7 +829,8 @@ namespace Orts.Formats.Msts
     /// <summary>
     /// The 3 types of event are inherited from the abstract Event class.
     /// </summary>
-    public abstract class Event {
+    public abstract class Event
+    {
         public int ID;
         public string Name;
         public int Activation_Level;
@@ -812,11 +845,12 @@ namespace Orts.Formats.Msts
         public string TrainService = "";
         public int TrainStartingTime = -1;
 
-        public virtual void AddOrModifyEvent (STFReader stf, string fileName)
+        public virtual void AddOrModifyEvent(STFReader stf, string fileName)
         { }
     }
 
-    public class EventCategoryLocation : Event {
+    public class EventCategoryLocation : Event
+    {
         public bool TriggerOnStop;  // Value assumed if property not found.
         public int TileX;
         public int TileZ;
@@ -824,17 +858,18 @@ namespace Orts.Formats.Msts
         public float Z;
         public float RadiusM;
 
-        public EventCategoryLocation(STFReader stf) {
+        public EventCategoryLocation(STFReader stf)
+        {
             stf.MustMatch("(");
             AddOrModifyEvent(stf, stf.FileName);
-                }
+        }
 
-        public override void AddOrModifyEvent (STFReader stf, string fileName)
+        public override void AddOrModifyEvent(STFReader stf, string fileName)
         {
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("eventtypelocation", ()=>{ stf.MustMatch("("); stf.MustMatch(")"); }),
                 new STFReader.TokenProcessor("id", ()=>{ ID = stf.ReadIntBlock(null); }),
-                new STFReader.TokenProcessor("ortstriggeringtrain", ()=>{ ParseTrain(stf); }), 
+                new STFReader.TokenProcessor("ortstriggeringtrain", ()=>{ ParseTrain(stf); }),
                 new STFReader.TokenProcessor("activation_level", ()=>{ Activation_Level = stf.ReadIntBlock(null); }),
                 new STFReader.TokenProcessor("outcomes", ()=>
                 {
@@ -890,14 +925,16 @@ namespace Orts.Formats.Msts
     /// Parses all types of action events.
     /// Save type of action event in Type. MSTS syntax isn't fully hierarchical, so using inheritance here instead of Type would be awkward. 
     /// </summary>
-    public class EventCategoryAction : Event {
+    public class EventCategoryAction : Event
+    {
         public EventType Type;
         public WagonList WagonList;
         public Nullable<uint> SidingId;  // May be specified inside the Wagon_List instead. Nullable as can't use -1 to indicate not set.
         public float SpeedMpS;
         //private const float MilespHourToMeterpSecond = 0.44704f;
 
-        public EventCategoryAction(STFReader stf) {
+        public EventCategoryAction(STFReader stf)
+        {
             stf.MustMatch("(");
             AddOrModifyEvent(stf, stf.FileName);
         }
@@ -952,19 +989,21 @@ namespace Orts.Formats.Msts
     }
 
 
-    public class WagonList {
+    public class WagonList
+    {
         public List<WorkOrderWagon> WorkOrderWagonList = new List<WorkOrderWagon>();
         Nullable<uint> uID;        // Nullable as can't use -1 to indicate not set.  
         Nullable<uint> sidingId;   // May be specified outside the Wagon_List instead.
         string description = "";   // Value assumed if property not found.
 
-        public WagonList(STFReader stf, EventType eventType) {
+        public WagonList(STFReader stf, EventType eventType)
+        {
             stf.MustMatch("(");
             // "Drop Off" Wagon_List sometimes lacks a Description attribute, so we create the wagon _before_ description
             // is parsed. Bad practice, but not very dangerous as each Description usually repeats the same data.
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("uid", ()=>{ uID = stf.ReadUIntBlock(null); }),
-                new STFReader.TokenProcessor("sidingitem", ()=>{ sidingId = stf.ReadUIntBlock(null); 
+                new STFReader.TokenProcessor("sidingitem", ()=>{ sidingId = stf.ReadUIntBlock(null);
                     WorkOrderWagonList.Add(new WorkOrderWagon(uID.Value, sidingId.Value, description));}),
                 new STFReader.TokenProcessor("description", ()=>{ description = stf.ReadStringBlock(""); }),
             });
@@ -975,22 +1014,26 @@ namespace Orts.Formats.Msts
     /// Parses a wagon from the WagonList.
     /// Do not confuse with older class Wagon below, which parses TrainCfg from the *.con file.
     /// </summary>
-    public class WorkOrderWagon {
+    public class WorkOrderWagon
+    {
         public Nullable<uint> UID;        // Nullable as can't use -1 to indicate not set.  
         public Nullable<uint> SidingId;   // May be specified outside the Wagon_List.
         public string Description = "";   // Value assumed if property not found.
 
-        public WorkOrderWagon(uint uId, uint sidingId, string description) {
+        public WorkOrderWagon(uint uId, uint sidingId, string description)
+        {
             UID = uId;
             SidingId = sidingId;
             Description = description;
         }
     }
 
-    public class EventCategoryTime : Event {  // E.g. Hisatsu route and Short Passenger Run shrtpass.act
+    public class EventCategoryTime : Event
+    {  // E.g. Hisatsu route and Short Passenger Run shrtpass.act
         public int Time;
 
-        public EventCategoryTime(STFReader stf) {
+        public EventCategoryTime(STFReader stf)
+        {
             stf.MustMatch("(");
             AddOrModifyEvent(stf, stf.FileName);
         }
@@ -1033,7 +1076,8 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class Outcomes {
+    public class Outcomes
+    {
         public bool ActivitySuccess;
         public string ActivityFail;
         // MSTS Activity Editor limits model to 4 outcomes of any type. We use lists so there is no restriction.
@@ -1042,17 +1086,18 @@ namespace Orts.Formats.Msts
         public List<int> DecActLevelList = new List<int>();
         public List<int> IncActLevelList = new List<int>();
         public string DisplayMessage;
- //       public string WaitingTrainToRestart;
+        //       public string WaitingTrainToRestart;
         public RestartWaitingTrain RestartWaitingTrain;
         public ORTSWeatherChange ORTSWeatherChange;
         public ActivitySound ActivitySound;
 
-        public Outcomes(STFReader stf, string fileName) {
+        public Outcomes(STFReader stf, string fileName)
+        {
             CreateOrModifyOutcomes(stf, fileName);
         }
 
         public void CreateOrModifyOutcomes(STFReader stf, string fileName)
-        { 
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("activitysuccess", ()=>{ stf.MustMatch("("); stf.MustMatch(")"); ActivitySuccess = true; }),
@@ -1078,7 +1123,7 @@ namespace Orts.Formats.Msts
         public int DelayToRestart;
         public int MatchingWPDelay;
 
-        public RestartWaitingTrain (STFReader stf)
+        public RestartWaitingTrain(STFReader stf)
         {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
@@ -1115,10 +1160,10 @@ namespace Orts.Formats.Msts
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("ortsovercast", ()=>
                 {
-                    stf.MustMatch("(");                    
+                    stf.MustMatch("(");
                     ORTSOvercast = stf.ReadFloat(0, -1);
                     ORTSOvercastTransitionTimeS = stf.ReadInt(-1);
-                    stf.MustMatch(")");                
+                    stf.MustMatch(")");
                 }),
                 new STFReader.TokenProcessor("ortsfog", ()=>
                 {
@@ -1192,7 +1237,8 @@ namespace Orts.Formats.Msts
     /// <summary>
     /// Parses ActivityObject objects and saves them in ActivityObjectList.
     /// </summary>
-    public class ActivityObjects {
+    public class ActivityObjects
+    {
         public List<ActivityObject> ActivityObjectList = new List<ActivityObject>();
 
         //public new ActivityObject this[int i]
@@ -1201,7 +1247,8 @@ namespace Orts.Formats.Msts
         //    set { base[i] = value; }
         //}
 
-        public ActivityObjects(STFReader stf) {
+        public ActivityObjects(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("activityobject", ()=>{ ActivityObjectList.Add(new ActivityObject(stf)); }),
@@ -1209,7 +1256,8 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class ActivityObject {
+    public class ActivityObject
+    {
         public Train_Config Train_Config;
         public int Direction;
         public int ID;
@@ -1218,7 +1266,8 @@ namespace Orts.Formats.Msts
         public float X;
         public float Z;
 
-        public ActivityObject(STFReader stf) {
+        public ActivityObject(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("objecttype", ()=>{ stf.MustMatch("("); stf.MustMatch("WagonsList"); stf.MustMatch(")"); }),
@@ -1237,10 +1286,12 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class Train_Config {
+    public class Train_Config
+    {
         public TrainCfg TrainCfg;
 
-        public Train_Config(STFReader stf) {
+        public Train_Config(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("traincfg", ()=>{ TrainCfg = new TrainCfg(stf); }),
@@ -1249,11 +1300,13 @@ namespace Orts.Formats.Msts
     }
 
 
-    public class MaxVelocity {
+    public class MaxVelocity
+    {
         public float A;
         public float B = 0.001f;
 
-        public MaxVelocity(STFReader stf) {
+        public MaxVelocity(STFReader stf)
+        {
             stf.MustMatch("(");
             A = stf.ReadFloat(STFReader.UNITS.Speed, null);
             B = stf.ReadFloat(STFReader.UNITS.Speed, null);
@@ -1261,7 +1314,8 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class TrainCfg {
+    public class TrainCfg
+    {
         public string Name = "Loose consist.";
         int Serial = 1;
         public MaxVelocity MaxVelocity;
@@ -1270,7 +1324,8 @@ namespace Orts.Formats.Msts
 
         public List<Wagon> WagonList = new List<Wagon>();
 
-        public TrainCfg(STFReader stf) {
+        public TrainCfg(STFReader stf)
+        {
             stf.MustMatch("(");
             Name = stf.ReadString();
             stf.ParseBlock(new STFReader.TokenProcessor[] {
@@ -1285,14 +1340,16 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class Wagon {
+    public class Wagon
+    {
         public string Folder;
         public string Name;
         public int UiD;
         public bool IsEngine;
         public bool Flip;
 
-        public Wagon(STFReader stf) {
+        public Wagon(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("uid", ()=>{ UiD = stf.ReadIntBlock(null); }),
@@ -1302,10 +1359,13 @@ namespace Orts.Formats.Msts
             });
         }
 
-        public string GetName(uint uId, List<Wagon> wagonList) {
-            foreach (var item in wagonList) {
+        public string GetName(uint uId, List<Wagon> wagonList)
+        {
+            foreach (var item in wagonList)
+            {
                 var wagon = item as Wagon;
-                if (wagon.UiD == uId) {
+                if (wagon.UiD == uId)
+                {
                     return wagon.Name;
                 }
             }
@@ -1313,10 +1373,12 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class PlatformNumPassengersWaiting {  // For use, see file EUROPE1\ACTIVITIES\aftstorm.act
+    public class PlatformNumPassengersWaiting
+    {  // For use, see file EUROPE1\ACTIVITIES\aftstorm.act
         public List<PlatformData> PlatformDataList = new List<PlatformData>();
 
-        public PlatformNumPassengersWaiting(STFReader stf) {
+        public PlatformNumPassengersWaiting(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("platformdata", ()=>{ PlatformDataList.Add(new PlatformData(stf)); }),
@@ -1324,16 +1386,19 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class PlatformData { // e.g. "PlatformData ( 41 20 )" 
+    public class PlatformData
+    { // e.g. "PlatformData ( 41 20 )" 
         public int Id;
         public int PassengerCount;
 
-        public PlatformData(int id, int passengerCount) {
+        public PlatformData(int id, int passengerCount)
+        {
             Id = id;
             PassengerCount = passengerCount;
         }
 
-        public PlatformData(STFReader stf) {
+        public PlatformData(STFReader stf)
+        {
             stf.MustMatch("(");
             Id = stf.ReadInt(null);
             PassengerCount = stf.ReadInt(null);
@@ -1341,9 +1406,11 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class ActivityFailedSignals { // e.g. ActivityFailedSignals ( ActivityFailedSignal ( 50 ) )
+    public class ActivityFailedSignals
+    { // e.g. ActivityFailedSignals ( ActivityFailedSignal ( 50 ) )
         public List<int> FailedSignalList = new List<int>();
-        public ActivityFailedSignals(STFReader stf) {
+        public ActivityFailedSignals(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("activityfailedsignal", ()=>{ FailedSignalList.Add(stf.ReadIntBlock(null)); }),
@@ -1351,10 +1418,12 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class ActivityRestrictedSpeedZones {  // For use, see file EUROPE1\ACTIVITIES\aftstorm.act
+    public class ActivityRestrictedSpeedZones
+    {  // For use, see file EUROPE1\ACTIVITIES\aftstorm.act
         public List<ActivityRestrictedSpeedZone> ActivityRestrictedSpeedZoneList = new List<ActivityRestrictedSpeedZone>();
 
-        public ActivityRestrictedSpeedZones(STFReader stf) {
+        public ActivityRestrictedSpeedZones(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("activityrestrictedspeedzone", ()=>{ ActivityRestrictedSpeedZoneList.Add(new ActivityRestrictedSpeedZone(stf)); }),
@@ -1362,11 +1431,13 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class ActivityRestrictedSpeedZone {
+    public class ActivityRestrictedSpeedZone
+    {
         public Position StartPosition;
         public Position EndPosition;
 
-        public ActivityRestrictedSpeedZone(STFReader stf) {
+        public ActivityRestrictedSpeedZone(STFReader stf)
+        {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("startposition", ()=>{ StartPosition = new Position(stf); }),
@@ -1375,21 +1446,24 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class Position {
+    public class Position
+    {
         public int TileX;
         public int TileZ;
         public float X;
         public float Z;
         public float Y;
 
-        public Position(int tileX, int tileZ, int x, int z) {
+        public Position(int tileX, int tileZ, int x, int z)
+        {
             TileX = tileX;
             TileZ = tileZ;
             X = x;
             Z = z;
         }
 
-        public Position(STFReader stf) {
+        public Position(STFReader stf)
+        {
             stf.MustMatch("(");
             TileX = stf.ReadInt(null);
             TileZ = stf.ReadInt(null);

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -27,9 +27,9 @@ using Orts.Parsers.Msts;
 namespace Orts.Formats.Msts
 {
 
-	// TODO - this is an incomplete parse of the cvf file.
-	public class CabViewFile
-	{
+    // TODO - this is an incomplete parse of the cvf file.
+    public class CabViewFile
+    {
         public List<Vector3> Locations = new List<Vector3>();   // Head locations for front, left and right views
         public List<Vector3> Directions = new List<Vector3>();  // Head directions for each view
         public List<string> TwoDViews = new List<string>();     // 2D CAB Views - by GeorgeS
@@ -38,7 +38,7 @@ namespace Orts.Formats.Msts
         public CabViewControls CabViewControls;                 // Controls in CAB - by GeorgeS
 
         public CabViewFile(string filePath, string basePath)
-		{
+        {
             using (STFReader stf = new STFReader(filePath, false))
                 stf.ParseFile(new STFReader.TokenProcessor[] {
                     new STFReader.TokenProcessor("tr_cabviewfile", ()=>{ stf.MustMatch("("); stf.ParseBlock(new STFReader.TokenProcessor[] {
@@ -64,9 +64,9 @@ namespace Orts.Formats.Msts
                         new STFReader.TokenProcessor("cabviewcontrols", ()=>{ CabViewControls = new CabViewControls(stf, basePath); }),
                     });}),
                 });
-		}
+        }
 
-	} // class CVFFile
+    } // class CVFFile
 
     public enum CABViewControlTypes
     {
@@ -191,8 +191,8 @@ namespace Orts.Formats.Msts
         NOT_SPRUNG,
         WHILE_PRESSED,
         PRESSED,
-        ONOFF, 
-        _24HOUR, 
+        ONOFF,
+        _24HOUR,
         _12HOUR
     }
 
@@ -208,7 +208,7 @@ namespace Orts.Formats.Msts
         KILOVOLTS,
 
         KM_PER_HOUR,
-        MILES_PER_HOUR, 
+        MILES_PER_HOUR,
         METRESµSECµSEC,
         METRES_SEC_SEC,
         KMµHOURµHOUR,
@@ -220,7 +220,7 @@ namespace Orts.Formats.Msts
         MILES_HOUR_MIN,
         MILES_HOUR_HOUR,
 
-        NEWTONS, 
+        NEWTONS,
         KILO_NEWTONS,
         KILO_LBS,
         METRES_PER_SEC,
@@ -247,14 +247,14 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("tristate", ()=>{ Add(new CVCDiscrete(stf, basepath)); }),
                 new STFReader.TokenProcessor("multistate", ()=>{ Add(new CVCDiscrete(stf, basepath)); }),
                 new STFReader.TokenProcessor("multistatedisplay", ()=>{ Add(new CVCMultiStateDisplay(stf, basepath)); }),
-                new STFReader.TokenProcessor("cabsignaldisplay", ()=>{ Add(new CVCSignal(stf, basepath)); }), 
-                new STFReader.TokenProcessor("digital", ()=>{ Add(new CVCDigital(stf, basepath)); }), 
+                new STFReader.TokenProcessor("cabsignaldisplay", ()=>{ Add(new CVCSignal(stf, basepath)); }),
+                new STFReader.TokenProcessor("digital", ()=>{ Add(new CVCDigital(stf, basepath)); }),
                 new STFReader.TokenProcessor("combinedcontrol", ()=>{ Add(new CVCDiscrete(stf, basepath)); }),
                 new STFReader.TokenProcessor("firebox", ()=>{ Add(new CVCFirebox(stf, basepath)); }),
                 new STFReader.TokenProcessor("dialclock", ()=>{ ProcessDialClock(stf, basepath);  }),
                 new STFReader.TokenProcessor("digitalclock", ()=>{ Add(new CVCDigitalClock(stf, basepath)); })
             });
-            
+
             //TODO Uncomment when parsed all type
             /*
             if (count != this.Count) STFException.ReportWarning(inf, "CabViewControl count mismatch");
@@ -297,7 +297,7 @@ namespace Orts.Formats.Msts
             {
                 ControlType = (CABViewControlTypes)Enum.Parse(typeof(CABViewControlTypes), stf.ReadString());
             }
-            catch(ArgumentException)
+            catch (ArgumentException)
             {
                 stf.StepBackOneItem();
                 STFException.TraceInformation(stf, "Skipped unknown ControlType " + stf.ReadString());
@@ -340,7 +340,7 @@ namespace Orts.Formats.Msts
             {
                 string sStyle = stf.ReadString();
                 int checkNumeric = 0;
-                if(int.TryParse(sStyle.Substring(0, 1), out checkNumeric) == true)
+                if (int.TryParse(sStyle.Substring(0, 1), out checkNumeric) == true)
                 {
                     sStyle = sStyle.Insert(0, "_");
                 }
@@ -373,7 +373,7 @@ namespace Orts.Formats.Msts
             stf.SkipRestOfBlock();
         }
         // Used by subclasses CVCGauge and CVCDigital
-        protected virtual color ParseControlColor( STFReader stf )
+        protected virtual color ParseControlColor(STFReader stf)
         {
             stf.MustMatch("(");
             color colour = new color { A = 1, R = stf.ReadInt(0) / 255f, G = stf.ReadInt(0) / 255f, B = stf.ReadInt(0) / 255f };
@@ -474,7 +474,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("zeropos", ()=>{ ZeroPos = stf.ReadIntBlock(null); }),
                 new STFReader.TokenProcessor("orientation", ()=>{ Orientation = stf.ReadIntBlock(null); }),
                 new STFReader.TokenProcessor("dirincrease", ()=>{ Direction = stf.ReadIntBlock(null); }),
-                new STFReader.TokenProcessor("area", ()=>{ 
+                new STFReader.TokenProcessor("area", ()=>{
                     stf.MustMatch("(");
                     int x = stf.ReadInt(null);
                     int y = stf.ReadInt(null);
@@ -483,27 +483,27 @@ namespace Orts.Formats.Msts
                     Area = new Rectangle(x, y, width, height);
                     stf.SkipRestOfBlock();
                 }),
-                new STFReader.TokenProcessor("positivecolour", ()=>{ 
+                new STFReader.TokenProcessor("positivecolour", ()=>{
                     stf.MustMatch("(");
                     NumPositiveColors = stf.ReadInt(0);
                     if((stf.EndOfBlock() == false))
                     {
                        List <color> Colorset = new List<color>();
                        stf.ParseBlock(new STFReader.TokenProcessor[] {
-                            new STFReader.TokenProcessor("controlcolour", ()=>{ Colorset.Add(ParseControlColor(stf));}), 
+                            new STFReader.TokenProcessor("controlcolour", ()=>{ Colorset.Add(ParseControlColor(stf));}),
                             new STFReader.TokenProcessor("switchval", () => { PositiveSwitchVal = ParseSwitchVal(stf); }) });
                     PositiveColor = Colorset [0];
                     if ((NumPositiveColors >= 2) && (Colorset.Count >= 2 ))SecondPositiveColor = Colorset [1];
                     }
                    }),
-               new STFReader.TokenProcessor("negativecolour", ()=>{ 
+               new STFReader.TokenProcessor("negativecolour", ()=>{
                     stf.MustMatch("(");
                     NumNegativeColors = stf.ReadInt(0);
                     if ((stf.EndOfBlock() == false))
                     {
                         List<color> Colorset = new List<color>();
                         stf.ParseBlock(new STFReader.TokenProcessor[] {
-                            new STFReader.TokenProcessor("controlcolour", ()=>{ Colorset.Add(ParseControlColor(stf));}), 
+                            new STFReader.TokenProcessor("controlcolour", ()=>{ Colorset.Add(ParseControlColor(stf));}),
                             new STFReader.TokenProcessor("switchval", () => { NegativeSwitchVal = ParseSwitchVal(stf); }) });
                         NegativeColor = Colorset[0];
                         if ((NumNegativeColors >= 2) && (Colorset.Count >= 2)) SecondNegativeColor = Colorset[1];
@@ -526,7 +526,7 @@ namespace Orts.Formats.Msts
     {
         public string FireACEFile;
 
-        public CVCFirebox(STFReader stf, string basepath) 
+        public CVCFirebox(STFReader stf, string basepath)
         {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
@@ -588,7 +588,7 @@ namespace Orts.Formats.Msts
             FontSize = 8;
             FontStyle = 0;
             FontFamily = "Lucida Sans";
-            
+
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("type", ()=>{ ParseType(stf); }),
@@ -598,30 +598,30 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("style", ()=>{ ParseStyle(stf); }),
                 new STFReader.TokenProcessor("units", ()=>{ ParseUnits(stf); }),
                 new STFReader.TokenProcessor("leadingzeros", ()=>{ ParseLeadingZeros(stf); }),
-                new STFReader.TokenProcessor("accuracy", ()=>{ ParseAccuracy(stf); }), 
-                new STFReader.TokenProcessor("accuracyswitch", ()=>{ ParseAccuracySwitch(stf); }), 
+                new STFReader.TokenProcessor("accuracy", ()=>{ ParseAccuracy(stf); }),
+                new STFReader.TokenProcessor("accuracyswitch", ()=>{ ParseAccuracySwitch(stf); }),
                 new STFReader.TokenProcessor("justification", ()=>{ ParseJustification(stf); }),
-                new STFReader.TokenProcessor("positivecolour", ()=>{ 
+                new STFReader.TokenProcessor("positivecolour", ()=>{
                     stf.MustMatch("(");
                     NumPositiveColors = stf.ReadInt(0);
                     if((stf.EndOfBlock() == false))
                     {
                        List <color> Colorset = new List<color>();
                        stf.ParseBlock(new STFReader.TokenProcessor[] {
-                            new STFReader.TokenProcessor("controlcolour", ()=>{ Colorset.Add(ParseControlColor(stf));}), 
+                            new STFReader.TokenProcessor("controlcolour", ()=>{ Colorset.Add(ParseControlColor(stf));}),
                             new STFReader.TokenProcessor("switchval", () => { PositiveSwitchVal = ParseSwitchVal(stf); }) });
                     PositiveColor = Colorset [0];
                     if ((NumPositiveColors >= 2) && (Colorset.Count >= 2 ))SecondPositiveColor = Colorset [1];
                     }
                    }),
-               new STFReader.TokenProcessor("negativecolour", ()=>{ 
+               new STFReader.TokenProcessor("negativecolour", ()=>{
                     stf.MustMatch("(");
                     NumNegativeColors = stf.ReadInt(0);
                     if ((stf.EndOfBlock() == false))
                     {
                         List<color> Colorset = new List<color>();
                         stf.ParseBlock(new STFReader.TokenProcessor[] {
-                            new STFReader.TokenProcessor("controlcolour", ()=>{ Colorset.Add(ParseControlColor(stf));}), 
+                            new STFReader.TokenProcessor("controlcolour", ()=>{ Colorset.Add(ParseControlColor(stf));}),
                             new STFReader.TokenProcessor("switchval", () => { NegativeSwitchVal = ParseSwitchVal(stf); }) });
                         NegativeColor = Colorset[0];
                         if ((NumNegativeColors >= 2) && (Colorset.Count >= 2)) SecondNegativeColor = Colorset[1];
@@ -676,7 +676,7 @@ namespace Orts.Formats.Msts
             var fontFamily = stf.ReadString();
             if (fontFamily != null) FontFamily = fontFamily;
             stf.SkipRestOfBlock();
-         }
+        }
     }
 
     public class CVCDigitalClock : CVCDigital
@@ -692,13 +692,13 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("type", ()=>{ ParseType(stf); }),
                 new STFReader.TokenProcessor("position", ()=>{ ParsePosition(stf);  }),
                 new STFReader.TokenProcessor("style", ()=>{ ParseStyle(stf); }),
-                new STFReader.TokenProcessor("accuracy", ()=>{ ParseAccuracy(stf); }), 
+                new STFReader.TokenProcessor("accuracy", ()=>{ ParseAccuracy(stf); }),
                 new STFReader.TokenProcessor("controlcolour", ()=>{ PositiveColor = ParseControlColor(stf); }),
                 new STFReader.TokenProcessor("ortsfont", ()=>{ParseFont(stf); })
             });
         }
 
-        
+
     }
     #endregion
 
@@ -714,7 +714,7 @@ namespace Orts.Formats.Msts
         public int Orientation;
         public int Direction;
 
-        public List<double> Values 
+        public List<double> Values
         {
             get
             {
@@ -733,7 +733,7 @@ namespace Orts.Formats.Msts
 
         public CVCDiscrete(STFReader stf, string basepath)
         {
-//            try
+            //            try
             {
                 stf.MustMatch("(");
                 stf.ParseBlock(new STFReader.TokenProcessor[] {
@@ -794,7 +794,7 @@ namespace Orts.Formats.Msts
                             positionsRead++;
 
                         if (minPosition < 0)
-                        { 
+                        {
                             for (int iPos = 0; iPos <= Positions.Count - 1; iPos++)
                             {
                                 Positions[iPos] -= minPosition;
@@ -812,8 +812,8 @@ namespace Orts.Formats.Msts
                         // Check if eligible for filling
 
                         if (Positions.Count > 1 && Positions[0] != 0) canFill = false;
-                        else 
-                        { 
+                        else
+                        {
                             for (var iPos = 1; iPos <= Positions.Count - 1; iPos++)
                             {
                                 if (Positions[iPos] > Positions[iPos-1]) continue;
@@ -850,7 +850,7 @@ namespace Orts.Formats.Msts
                             // Avoid later repositioning, put every value to its Position
                             // But before resize Values if needed
                             if (numValues != numPositions)
-                            { 
+                            {
                                 while (Values.Count <= Positions[_ValuesRead])
                                 {
                                     Values.Add(0);
@@ -874,7 +874,7 @@ namespace Orts.Formats.Msts
                 //     The twostate, tristate, signal displays are not in these
                 // Need check the Values collection for validity
                 if (_ValuesRead > 0 || ControlStyle == CABViewControlStyles.SPRUNG || ControlStyle == CABViewControlStyles.NOT_SPRUNG ||
-                    FramesCount  > 0 || (FramesX > 0 && FramesY > 0 ))
+                    FramesCount > 0 || (FramesX > 0 && FramesY > 0))
                 {
                     // Check max number of Frames
                     if (FramesCount == 0)
@@ -897,7 +897,7 @@ namespace Orts.Formats.Msts
 
                     // Only shuffle data in following cases
 
-                    if (Values.Count != Positions.Count || (Values.Count < FramesCount & canFill)|| ( Values.Count > 0 && Values[0] == Values[Values.Count - 1] && Values[0] == 0))
+                    if (Values.Count != Positions.Count || (Values.Count < FramesCount & canFill) || (Values.Count > 0 && Values[0] == Values[Values.Count - 1] && Values[0] == 0))
                     {
 
                         // Fixup Positions and Values collections first
@@ -913,19 +913,19 @@ namespace Orts.Formats.Msts
                             //This if clause covers among others following cases:
                             // Case 1 (e.g. engine brake lever of Dash 9):
                             //NumFrames ( 22 11 2 )
-			                //NumPositions ( 1 0 )
-			                //NumValues ( 1 0 )
-			                //Orientation ( 1 )
-			                //DirIncrease ( 1 )
-			                //ScaleRange ( 0 1 )
+                            //NumPositions ( 1 0 )
+                            //NumValues ( 1 0 )
+                            //Orientation ( 1 )
+                            //DirIncrease ( 1 )
+                            //ScaleRange ( 0 1 )
                             //
                             // Case 2 (e.g. throttle lever of Acela):
-			                //NumFrames ( 25 5 5 )
-			                //NumPositions ( 0 )
-			                //NumValues ( 0 )
-			                //Orientation ( 1 )
-			                //DirIncrease ( 1 )
-			                //ScaleRange ( 0 1 )
+                            //NumFrames ( 25 5 5 )
+                            //NumPositions ( 0 )
+                            //NumValues ( 0 )
+                            //Orientation ( 1 )
+                            //DirIncrease ( 1 )
+                            //ScaleRange ( 0 1 )
                             //
                             // Clear existing
                             Positions.Clear();
@@ -948,29 +948,29 @@ namespace Orts.Formats.Msts
                         {
                             //This if clause covers among others following cases:
                             // Case 1 (e.g. engine brake lever of gp38):
-			                //NumFrames ( 18 2 9 )
-			                //NumPositions ( 2 0 1 )
-			                //NumValues ( 2 0 0.3 )
-			                //Orientation ( 0 )
-			                //DirIncrease ( 0 )
-			                //ScaleRange ( 0 1 )
+                            //NumFrames ( 18 2 9 )
+                            //NumPositions ( 2 0 1 )
+                            //NumValues ( 2 0 0.3 )
+                            //Orientation ( 0 )
+                            //DirIncrease ( 0 )
+                            //ScaleRange ( 0 1 )
                             Positions.Add(FramesCount);
                             // Fill empty Values
                             for (int i = Values.Count; i < FramesCount; i++)
                                 Values.Add(Values[1]);
-                            Values.Add(MaxValue);                            
+                            Values.Add(MaxValue);
                         }
 
                         else
                         {
                             //This if clause covers among others following cases:
                             // Case 1 (e.g. train brake lever of Acela): 
-			                //NumFrames ( 12 4 3 )
-			                //NumPositions ( 5 0 1 9 10 11 )
-			                //NumValues ( 5 0 0.2 0.85 0.9 0.95 )
-			                //Orientation ( 1 )
-			                //DirIncrease ( 1 )
-			                //ScaleRange ( 0 1 )
+                            //NumFrames ( 12 4 3 )
+                            //NumPositions ( 5 0 1 9 10 11 )
+                            //NumValues ( 5 0 0.2 0.85 0.9 0.95 )
+                            //Orientation ( 1 )
+                            //DirIncrease ( 1 )
+                            //ScaleRange ( 0 1 )
                             //
                             // Fill empty Values
                             int iValues = 1;
@@ -1028,19 +1028,19 @@ namespace Orts.Formats.Msts
                 if (ControlType == CABViewControlTypes.PANTOGRAPH || ControlType == CABViewControlTypes.PANTOGRAPH2 ||
                     ControlType == CABViewControlTypes.ORTS_PANTOGRAPH3 || ControlType == CABViewControlTypes.ORTS_PANTOGRAPH4)
                     ControlStyle = CABViewControlStyles.ONOFF;
-                if (ControlType == CABViewControlTypes.HORN || ControlType == CABViewControlTypes.SANDERS || ControlType == CABViewControlTypes.BELL 
+                if (ControlType == CABViewControlTypes.HORN || ControlType == CABViewControlTypes.SANDERS || ControlType == CABViewControlTypes.BELL
                     || ControlType == CABViewControlTypes.RESET)
                     ControlStyle = CABViewControlStyles.WHILE_PRESSED;
                 if (ControlType == CABViewControlTypes.DIRECTION && Orientation == 0)
                     Direction = 1 - Direction;
             }
-//            catch (Exception error)
-//            {
-//                if (error is STFException) // Parsing error, so pass it on
-//                    throw;
-//                else                       // Unexpected error, so provide a hint
-//                    throw new STFException(stf, "Problem with NumPositions/NumValues/NumFrames/ScaleRange");
-//            } // End of Need check the Values collection for validity
+            //            catch (Exception error)
+            //            {
+            //                if (error is STFException) // Parsing error, so pass it on
+            //                    throw;
+            //                else                       // Unexpected error, so provide a hint
+            //                    throw new STFException(stf, "Problem with NumPositions/NumValues/NumFrames/ScaleRange");
+            //            } // End of Need check the Values collection for validity
         } // End of Constructor
     }
     #endregion
@@ -1048,9 +1048,9 @@ namespace Orts.Formats.Msts
     #region Multistate Display Controls
     public class CVCMultiStateDisplay : CVCWithFrames
     {
-         public List<double> MSStyles = new List<double>();
+        public List<double> MSStyles = new List<double>();
 
-           public CVCMultiStateDisplay(STFReader stf, string basepath)
+        public CVCMultiStateDisplay(STFReader stf, string basepath)
         {
 
             stf.MustMatch("(");
@@ -1067,7 +1067,7 @@ namespace Orts.Formats.Msts
                     FramesX = stf.ReadInt(null);
                     FramesY = stf.ReadInt(null);
                     stf.ParseBlock(new STFReader.TokenProcessor[] {
-                        new STFReader.TokenProcessor("state", ()=>{ 
+                        new STFReader.TokenProcessor("state", ()=>{
                             stf.MustMatch("(");
                             stf.ParseBlock( new STFReader.TokenProcessor[] {
                                 new STFReader.TokenProcessor("style", ()=>{ MSStyles.Add(ParseNumStyle(stf));

--- a/Source/Orts.Formats.Msts/CameraConfigurationFile.cs
+++ b/Source/Orts.Formats.Msts/CameraConfigurationFile.cs
@@ -69,12 +69,12 @@ namespace Orts.Formats.Msts
         public string CamControl;
         public Vector3 CameraOffset = new Vector3();
         public Vector3 Direction = new Vector3();
-	    public float Fov = 55f;
-	    public float ZClip =0.1f;
-	    public int WagonNum =-1;
+        public float Fov = 55f;
+        public float ZClip = 0.1f;
+        public int WagonNum = -1;
         public Vector3 ObjectOffset = new Vector3();
         public Vector3 RotationLimit = new Vector3();
-	    public string Description ="";
+        public string Description = "";
 
     }
 

--- a/Source/Orts.Formats.Msts/CarSpawnerFile.cs
+++ b/Source/Orts.Formats.Msts/CarSpawnerFile.cs
@@ -93,17 +93,17 @@ namespace Orts.Formats.Msts
             dist = stf.ReadFloat(STFReader.UNITS.Distance, null);
             stf.SkipRestOfBlock();
         }
-    } 
+    }
 
-	public class CarSpawnerFile
-	{
-		public CarSpawnerFile(string filePath, string shapePath, List<CarSpawnerList> carSpawnerLists)
-		{
-			using (STFReader stf = new STFReader(filePath, false))
-			{
+    public class CarSpawnerFile
+    {
+        public CarSpawnerFile(string filePath, string shapePath, List<CarSpawnerList> carSpawnerLists)
+        {
+            using (STFReader stf = new STFReader(filePath, false))
+            {
                 var carSpawnerBlock = new CarSpawnerBlock(stf, shapePath, carSpawnerLists, "Default");
-			}
-		}
-	}
+            }
+        }
+    }
 }
 

--- a/Source/Orts.Formats.Msts/EnvironmentFile.cs
+++ b/Source/Orts.Formats.Msts/EnvironmentFile.cs
@@ -75,7 +75,7 @@ namespace Orts.Formats.Msts
             int skylayers = stf.ReadInt(null);
             SkyLayers = new List<ENVFileSkyLayer>(skylayers);
 
-            stf.ParseBlock(new STFReader.TokenProcessor[] 
+            stf.ParseBlock(new STFReader.TokenProcessor[]
             {
                 new STFReader.TokenProcessor("world_sky_layer", ()=>{ if(skylayers-- > 0) SkyLayers.Add(new ENVFileSkyLayer(stf)); })});
 
@@ -86,8 +86,8 @@ namespace Orts.Formats.Msts
             int skysatellite = stf.ReadInt(null);
             SkySatellite = new List<ENVFileSkySatellite>(skysatellite);
 
-            stf.ParseBlock(new STFReader.TokenProcessor[] 
-        {                
+            stf.ParseBlock(new STFReader.TokenProcessor[]
+        {
             new STFReader.TokenProcessor("world_sky_satellite", () => { if (skysatellite-- > 0) SkySatellite.Add(new ENVFileSkySatellite(stf)); })});
         }
 
@@ -117,7 +117,7 @@ namespace Orts.Formats.Msts
     public class ENVFileSkyLayer
     {
         public string Fadein_Begin_Time;
-        public string Fadein_End_Time; 
+        public string Fadein_End_Time;
         public string TextureName;
         public string TextureMode;
         public float TileX;
@@ -127,13 +127,13 @@ namespace Orts.Formats.Msts
         public ENVFileSkyLayer(STFReader stf)
         {
             stf.MustMatch("(");
-                stf.ParseBlock(new STFReader.TokenProcessor[] {
+            stf.ParseBlock(new STFReader.TokenProcessor[] {
                         new STFReader.TokenProcessor("world_sky_layer_fadein", ()=>{ stf.MustMatch("("); Fadein_Begin_Time = stf.ReadString(); Fadein_End_Time = stf.ReadString(); stf.SkipRestOfBlock();}),
                         new STFReader.TokenProcessor("world_anim_shader", ()=>{ stf.MustMatch("("); stf.ParseBlock(new STFReader.TokenProcessor[] {
                             new STFReader.TokenProcessor("world_anim_shader_frames", ()=>{ stf.MustMatch("("); stf.ParseBlock(new STFReader.TokenProcessor[] {
                                 new STFReader.TokenProcessor("world_anim_shader_frame", ()=>{ stf.MustMatch("("); stf.ParseBlock(new STFReader.TokenProcessor[] {
                                     new STFReader.TokenProcessor("world_anim_shader_frame_uvtiles", ()=>{ stf.MustMatch("("); TileX = stf.ReadFloat(STFReader.UNITS.Any, 1.0f); TileY = stf.ReadFloat(STFReader.UNITS.Any, 1.0f); stf.ParseBlock(new STFReader.TokenProcessor[] {
-                                    });}),  
+                                    });}),
                                 });}),
                             });}),
                             new STFReader.TokenProcessor("world_shader", ()=>{ stf.MustMatch("("); TextureMode = stf.ReadString(); stf.ParseBlock(new STFReader.TokenProcessor[] {

--- a/Source/Orts.Formats.Msts/HazardFile.cs
+++ b/Source/Orts.Formats.Msts/HazardFile.cs
@@ -24,36 +24,36 @@ using Orts.Parsers.Msts;
 
 namespace Orts.Formats.Msts
 {
-	public class HazardFile
-	{
-		public HazardFile(string filename)
-		{
-			try
-			{
-				using (STFReader stf = new STFReader(filename, false))
-				{
-					stf.ParseFile(new STFReader.TokenProcessor[] {
+    public class HazardFile
+    {
+        public HazardFile(string filename)
+        {
+            try
+            {
+                using (STFReader stf = new STFReader(filename, false))
+                {
+                    stf.ParseFile(new STFReader.TokenProcessor[] {
                         new STFReader.TokenProcessor("tr_worldfile", ()=>{ Tr_HazardFile = new Tr_HazardFile(stf); }),
                     });
-					//TODO This should be changed to STFException.TraceError() with defaults values created
-					if (Tr_HazardFile == null) throw new STFException(stf, "Missing Tr_WorldFile");
-				}
-			}
-			finally
-			{
-			}
-		}
-		public Tr_HazardFile Tr_HazardFile;
-	}
+                    //TODO This should be changed to STFException.TraceError() with defaults values created
+                    if (Tr_HazardFile == null) throw new STFException(stf, "Missing Tr_WorldFile");
+                }
+            }
+            finally
+            {
+            }
+        }
+        public Tr_HazardFile Tr_HazardFile;
+    }
 
 
 
-	public class Tr_HazardFile
-	{
-		public Tr_HazardFile(STFReader stf)
-		{
-			stf.MustMatch("(");
-			stf.ParseBlock(new STFReader.TokenProcessor[] {
+    public class Tr_HazardFile
+    {
+        public Tr_HazardFile(STFReader stf)
+        {
+            stf.MustMatch("(");
+            stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("filename", ()=>{ FileName = stf.ReadStringBlock(null); }),
                 new STFReader.TokenProcessor("workers", ()=>{ Workers = stf.ReadStringBlock(null); }),
                 new STFReader.TokenProcessor("distance", ()=>{ Distance = stf.ReadFloatBlock(STFReader.UNITS.None, 10); }),
@@ -64,19 +64,19 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("surprise_key_right", ()=>{ Surprise_Key_Right = stf.ReadVector2Block(STFReader.UNITS.None, Surprise_Key_Right); }),
                 new STFReader.TokenProcessor("success_scarper_key", ()=>{ Success_Scarper_Key = stf.ReadVector2Block(STFReader.UNITS.None, Success_Scarper_Key); }),
            });
-			//TODO This should be changed to STFException.TraceError() with defaults values created
-			if (FileName == null) throw new STFException(stf, "Missing FileName");
-		}
+            //TODO This should be changed to STFException.TraceError() with defaults values created
+            if (FileName == null) throw new STFException(stf, "Missing FileName");
+        }
 
-		public string FileName; // ie OdakyuSE - used for MKR,RDB,REF,RIT,TDB,TIT
-		public string Workers;
-		public float Distance;
-		public float Speed;
-		public Vector2 Idle_Key = new Vector2();
-		public Vector2 Idle_Key2 = new Vector2();
-		public Vector2 Surprise_Key_Left = new Vector2();
-		public Vector2 Surprise_Key_Right = new Vector2();
-		public Vector2 Success_Scarper_Key = new Vector2();
+        public string FileName; // ie OdakyuSE - used for MKR,RDB,REF,RIT,TDB,TIT
+        public string Workers;
+        public float Distance;
+        public float Speed;
+        public Vector2 Idle_Key = new Vector2();
+        public Vector2 Idle_Key2 = new Vector2();
+        public Vector2 Surprise_Key_Left = new Vector2();
+        public Vector2 Surprise_Key_Right = new Vector2();
+        public Vector2 Success_Scarper_Key = new Vector2();
 
-	}
+    }
 }

--- a/Source/Orts.Formats.Msts/PathFile.cs
+++ b/Source/Orts.Formats.Msts/PathFile.cs
@@ -39,47 +39,47 @@ namespace Orts.Formats.Msts
     [Flags]
     public enum PathFlags
     {
-        NotPlayerPath = 0x20,  
+        NotPlayerPath = 0x20,
     }
 
-	/// <summary>
-	/// Paths for both player train as well as AI trains.
+    /// <summary>
+    /// Paths for both player train as well as AI trains.
     /// This class reads and stores the MSTS .pat file. Because of the format of the .pat file 
     /// it is easier to have an intermediate format that just contains the data of the .pat file
     /// and create the wanted data scructure from that.
     /// It is the intention that it is only used for
     ///     * ORTS main menu
     ///     * postprocessing by TrainPath.
-	/// </summary>
-// Typical simple .PATfile (the example helps to understand the code below)
-/*
-    SIMISA@@@@@@@@@@JINX0P0t______
+    /// </summary>
+    // Typical simple .PATfile (the example helps to understand the code below)
+    /*
+        SIMISA@@@@@@@@@@JINX0P0t______
 
-Serial ( 1 )
-TrackPDPs (
-	TrackPDP ( -12557 14761 -6.1249 1173.74 72.5884 2 0 )
-	TrackPDP ( -12557 14761 -204.363 1173.74 976.083 2 0 )
-	TrackPDP ( -12557 14762 -287.228 1173.74 -971.75 2 0 )
-	TrackPDP ( -12558 14763 278.107 1155.51 -941.416 2 0 )
-	TrackPDP ( -12557 14761 -49.6355 1173.74 -164.577 1 1 )
-	TrackPDP ( -12558 14763 245.63 1139.65 -387.96 1 1 )
-)
-TrackPath (
-	TrPathName ( EsxPincal )
-	Name ( "Essex - Pinnacle" )
-	TrPathStart ( Essex )
-	TrPathEnd ( Pinnacle )
-	TrPathNodes ( 6
-		TrPathNode ( 00000000 1 4294967295 4 )
-		TrPathNode ( 00000000 2 4294967295 0 )
-		TrPathNode ( 00000000 3 4294967295 1 )
-		TrPathNode ( 00000000 4 4294967295 2 )
-		TrPathNode ( 00000000 5 4294967295 3 )
-		TrPathNode ( 00000000 4294967295 4294967295 5 )
-	)
+    Serial ( 1 )
+    TrackPDPs (
+        TrackPDP ( -12557 14761 -6.1249 1173.74 72.5884 2 0 )
+        TrackPDP ( -12557 14761 -204.363 1173.74 976.083 2 0 )
+        TrackPDP ( -12557 14762 -287.228 1173.74 -971.75 2 0 )
+        TrackPDP ( -12558 14763 278.107 1155.51 -941.416 2 0 )
+        TrackPDP ( -12557 14761 -49.6355 1173.74 -164.577 1 1 )
+        TrackPDP ( -12558 14763 245.63 1139.65 -387.96 1 1 )
+    )
+    TrackPath (
+        TrPathName ( EsxPincal )
+        Name ( "Essex - Pinnacle" )
+        TrPathStart ( Essex )
+        TrPathEnd ( Pinnacle )
+        TrPathNodes ( 6
+            TrPathNode ( 00000000 1 4294967295 4 )
+            TrPathNode ( 00000000 2 4294967295 0 )
+            TrPathNode ( 00000000 3 4294967295 1 )
+            TrPathNode ( 00000000 4 4294967295 2 )
+            TrPathNode ( 00000000 5 4294967295 3 )
+            TrPathNode ( 00000000 4294967295 4294967295 5 )
+        )
 
-)
-*/
+    )
+    */
     // TrackPDP format is : TrackPDP ( tileX tileZ x y z flag1 flag2)
     //      Precise meaning of flag1 and flag2 is unknown. 
     //          2 0 seems to be junction
@@ -112,8 +112,8 @@ TrackPath (
     //      2 0         8       (e.g. Shiatsu, not clear why). It does not seem to be 'other exit'
     //  
 
-    
-	public class PathFile
+
+    public class PathFile
     {
         #region Fields
 
@@ -162,11 +162,11 @@ TrackPath (
                         new STFReader.TokenProcessor("trackpdp", ()=>{ trackPDPs.Add(new TrackPDP(stf)); }),
                     });}),
                     new STFReader.TokenProcessor("trackpath", ()=>{ stf.MustMatch("("); stf.ParseBlock(new STFReader.TokenProcessor[] {
-						new STFReader.TokenProcessor("trpathname", ()=>{ PathID = stf.ReadStringBlock(null); }),
+                        new STFReader.TokenProcessor("trpathname", ()=>{ PathID = stf.ReadStringBlock(null); }),
                         new STFReader.TokenProcessor("name", ()=>{ Name = stf.ReadStringBlock(null); }),
-						new STFReader.TokenProcessor("trpathflags", ()=>{ Flags = (PathFlags)stf.ReadHexBlock(null); }),
-						new STFReader.TokenProcessor("trpathstart", ()=>{ Start = stf.ReadStringBlock(null); }),
-						new STFReader.TokenProcessor("trpathend", ()=>{ End = stf.ReadStringBlock(null); }),
+                        new STFReader.TokenProcessor("trpathflags", ()=>{ Flags = (PathFlags)stf.ReadHexBlock(null); }),
+                        new STFReader.TokenProcessor("trpathstart", ()=>{ Start = stf.ReadStringBlock(null); }),
+                        new STFReader.TokenProcessor("trpathend", ()=>{ End = stf.ReadStringBlock(null); }),
                         new STFReader.TokenProcessor("trpathnodes", ()=>{
                             stf.MustMatch("(");
                             var count = stf.ReadInt(null);
@@ -194,15 +194,15 @@ TrackPath (
         {
             return this.Name;
         }
-	}
+    }
 
     // for explanation of TrackPDP, see class PATfile
-	public class TrackPDP
-	{
+    public class TrackPDP
+    {
         //We are not using WorldLocation to keep MSTS file parsing independent of other parts of the code
         public int TileX;
         public int TileZ;
-        public float X,Y,Z;
+        public float X, Y, Z;
         public int junctionFlag, invalidFlag;
 
         #region Properties
@@ -212,7 +212,7 @@ TrackPath (
         #endregion
 
         public TrackPDP(STFReader stf)
-		{
+        {
             stf.MustMatch("(");
             TileX = stf.ReadInt(null);
             TileZ = stf.ReadInt(null);
@@ -234,16 +234,16 @@ TrackPath (
             junctionFlag = 0;
             invalidFlag = 0;
         }
-	}
+    }
 
     // for an explanation, see class PATfile 
     public class TrPathNode
     {
-        public uint pathFlags,nextMainNode,nextSidingNode,fromPDP;
-        
+        public uint pathFlags, nextMainNode, nextSidingNode, fromPDP;
+
         // Note, pathFlags is a complicated beast, which is not fully understood, see AIPath.cs
 
-        public bool HasNextMainNode   { get { return (nextMainNode   != 0xffffffff); } }
+        public bool HasNextMainNode { get { return (nextMainNode != 0xffffffff); } }
         public bool HasNextSidingNode { get { return (nextSidingNode != 0xffffffff); } }
 
         public TrPathNode(STFReader stf)
@@ -256,7 +256,7 @@ TrackPath (
             stf.SkipRestOfBlock();
         }
 
-        public TrPathNode (uint flags, uint nextNode, uint nextSiding, uint pdp)
+        public TrPathNode(uint flags, uint nextNode, uint nextSiding, uint pdp)
         {
             pathFlags = flags;
             nextMainNode = nextNode;

--- a/Source/Orts.Formats.Msts/RoadDatabaseFile.cs
+++ b/Source/Orts.Formats.Msts/RoadDatabaseFile.cs
@@ -23,14 +23,14 @@ using Orts.Parsers.Msts;
 
 namespace Orts.Formats.Msts
 {
-	/// <summary>
-	/// RDBFile is a representation of the .rdb file, that contains the road data base.
+    /// <summary>
+    /// RDBFile is a representation of the .rdb file, that contains the road data base.
     /// The database contains the same kind of objects as TDBFile, apart from a few road-specific items.
-	/// </summary>
+    /// </summary>
     [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", Justification = "Keeping identifier consistent to use in MSTS")]
     [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Disposable only used in using statement, known FcCop bug")]
     public class RoadDatabaseFile
-	{
+    {
         /// <summary>
         /// Contains the Database with all the road tracks.
         /// Warning, the first RoadTrackDB entry is always null.
@@ -42,19 +42,19 @@ namespace Orts.Formats.Msts
         /// </summary>
         /// <param name="filenamewithpath">Full file name of the .rdb file</param>
 		public RoadDatabaseFile(string filenamewithpath)
-		{
-			using (STFReader stf = new STFReader(filenamewithpath, false))
-				stf.ParseFile(new STFReader.TokenProcessor[] {
+        {
+            using (STFReader stf = new STFReader(filenamewithpath, false))
+                stf.ParseFile(new STFReader.TokenProcessor[] {
                     new STFReader.TokenProcessor("trackdb", ()=>{ RoadTrackDB = new RoadTrackDB(stf); }),
                 });
-		}
-	}
+        }
+    }
 
     /// <summary>
     /// This class represents the Road Track Database. This is pretty similar to the (rail) Track Database. So for more details see there
     /// </summary>
 	public class RoadTrackDB
-	{
+    {
         /// <summary>
         /// Array of all TrackNodes in the road database
         /// Warning, the first TrackNode is always null.
@@ -96,14 +96,14 @@ namespace Orts.Formats.Msts
                 }),
             });
         }
-	}
+    }
 
     /// <summary>
     /// Represents a Level crossing Item on the road (i.e. where cars must stop when a train is passing).
     /// </summary>
     [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", Justification = "Keeping identifier consistent to use in MSTS")]
     public class RoadLevelCrItem : TrItem
-	{
+    {
         /// <summary>Direction along track: 0 or 1 depending on which way signal is facing</summary>
         public uint Direction { get; set; }
         /// <summary>index to Sigal Object Table</summary>
@@ -116,38 +116,38 @@ namespace Orts.Formats.Msts
         /// <param name="idx">The index of this TrItem in the list of TrItems</param>
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", Justification = "Keeping identifier consistent to use in MSTS")]
         public RoadLevelCrItem(STFReader stf, int idx)
-		{
+        {
             SigObj = -1;
-			ItemType = trItemType.trXING;
-			stf.MustMatch("(");
-			stf.ParseBlock(new STFReader.TokenProcessor[] {
+            ItemType = trItemType.trXING;
+            stf.MustMatch("(");
+            stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("tritemid", ()=>{ ParseTrItemID(stf, idx); }),
                 new STFReader.TokenProcessor("tritemrdata", ()=>{ TrItemRData(stf); }),
                 new STFReader.TokenProcessor("tritemsdata", ()=>{ TrItemSData(stf); }),
                 new STFReader.TokenProcessor("tritempdata", ()=>{ TrItemPData(stf); })
             });
-		}
-	}
+        }
+    }
 
     /// <summary>
     /// Represent a Car Spawner: the place where cars start to appear or disappear again
     /// </summary>
 	public class CarSpawnerItem : TrItem
-	{
+    {
         /// <summary>
         /// Default constructor used during file parsing.
         /// </summary>
         /// <param name="stf">The STFreader containing the file stream</param>
         /// <param name="idx">The index of this TrItem in the list of TrItems</param>
 		public CarSpawnerItem(STFReader stf, int idx)
-		{
-			ItemType = trItemType.trCARSPAWNER;
-			stf.MustMatch("(");
-			stf.ParseBlock(new STFReader.TokenProcessor[] {
+        {
+            ItemType = trItemType.trCARSPAWNER;
+            stf.MustMatch("(");
+            stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("tritemid", ()=>{ ParseTrItemID(stf, idx); }),
                 new STFReader.TokenProcessor("tritemrdata", ()=>{ TrItemRData(stf); }),
                 new STFReader.TokenProcessor("tritemsdata", ()=>{ TrItemSData(stf); })
             });
-		}
-	}
+        }
+    }
 }

--- a/Source/Orts.Formats.Msts/RouteFile.cs
+++ b/Source/Orts.Formats.Msts/RouteFile.cs
@@ -87,9 +87,9 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("routestart", ()=>{ if (RouteStart == null) RouteStart = new RouteStart(stf); }),
                 new STFReader.TokenProcessor("environment", ()=>{ Environment = new TRKEnvironment(stf); }),
                 new STFReader.TokenProcessor("milepostunitskilometers", ()=>{ MilepostUnitsMetric = true; }),
-				new STFReader.TokenProcessor("electrified", ()=>{ Electrified = stf.ReadBoolBlock(false); }),
+                new STFReader.TokenProcessor("electrified", ()=>{ Electrified = stf.ReadBoolBlock(false); }),
                 new STFReader.TokenProcessor("overheadwireheight", ()=>{ OverheadWireHeight = stf.ReadFloatBlock(STFReader.UNITS.Distance, 6.0f);}),
- 				new STFReader.TokenProcessor("speedlimit", ()=>{ SpeedLimit = stf.ReadFloatBlock(STFReader.UNITS.Speed, 500.0f); }),
+                 new STFReader.TokenProcessor("speedlimit", ()=>{ SpeedLimit = stf.ReadFloatBlock(STFReader.UNITS.Speed, 500.0f); }),
                 new STFReader.TokenProcessor("defaultcrossingsms", ()=>{ DefaultCrossingSMS = stf.ReadStringBlock(null); }),
                 new STFReader.TokenProcessor("defaultcoaltowersms", ()=>{ DefaultCoalTowerSMS = stf.ReadStringBlock(null); }),
                 new STFReader.TokenProcessor("defaultdieseltowersms", ()=>{ DefaultDieselTowerSMS = stf.ReadStringBlock(null); }),
@@ -141,22 +141,22 @@ namespace Orts.Formats.Msts
         public TRKEnvironment Environment;
         public bool MilepostUnitsMetric;
         public double MaxLineVoltage;
-		public bool Electrified = true;
-		public double OverheadWireHeight = 6.0;
-		public double SpeedLimit = 500.0f; //global speed limit m/s.
+        public bool Electrified = true;
+        public double OverheadWireHeight = 6.0;
+        public double SpeedLimit = 500.0f; //global speed limit m/s.
         public string DefaultCrossingSMS;
         public string DefaultCoalTowerSMS;
         public string DefaultDieselTowerSMS;
         public string DefaultWaterTowerSMS;
         public string DefaultSignalSMS;
-		public float TempRestrictedSpeed = -1f;
+        public float TempRestrictedSpeed = -1f;
         public Interpolator SuperElevationHgtpRadiusM; // Superelevation of tracks
 
         // Values for calculating Tunnel Resistance - will override default values.
-        public float SingleTunnelAreaM2; 
+        public float SingleTunnelAreaM2;
         public float SingleTunnelPerimeterM;
         public float DoubleTunnelAreaM2;
-        public float DoubleTunnelPerimeterM; 
+        public float DoubleTunnelPerimeterM;
 
         public float ForestClearDistance = 0;
         public bool RemoveForestTreesFromRoads = false;
@@ -173,7 +173,7 @@ namespace Orts.Formats.Msts
         public float TriphaseWidth;
 
         public string DefaultTurntableSMS;
-        public bool ? OpenDoorsInAITrains; // true if option active
+        public bool? OpenDoorsInAITrains; // true if option active
 
         public int SwitchSMSNumber = -1; // defines the number of the switch SMS files in file ttypedat
         public int CurveSMSNumber = -1; // defines the number of the curve SMS files in file ttype.dat
@@ -203,12 +203,12 @@ namespace Orts.Formats.Msts
         public TRKEnvironment(STFReader stf)
         {
             stf.MustMatch("(");
-            for( int i = 0; i < 12; ++i )
+            for (int i = 0; i < 12; ++i)
             {
                 var envfilekey = stf.ReadString();
                 var envfile = stf.ReadStringBlock(null);
                 ENVFileNames.Add(envfilekey, envfile);
-//                Trace.TraceInformation("Environments array key {0} equals file name {1}", envfilekey, envfile);
+                //                Trace.TraceInformation("Environments array key {0} equals file name {1}", envfilekey, envfile);
             }
             stf.SkipRestOfBlock();
         }
@@ -219,7 +219,7 @@ namespace Orts.Formats.Msts
             //return ENVFileNames[index];
             var envfilekey = seasonType.ToString() + weatherType.ToString();
             var envfile = ENVFileNames[envfilekey];
-//            Trace.TraceInformation("Selected Environment file is {1}", envfilekey, envfile);
+            //            Trace.TraceInformation("Selected Environment file is {1}", envfilekey, envfile);
             return envfile;
         }
     }

--- a/Source/Orts.Formats.Msts/ServiceFile.cs
+++ b/Source/Orts.Formats.Msts/ServiceFile.cs
@@ -22,27 +22,27 @@ using Orts.Parsers.Msts;
 
 namespace Orts.Formats.Msts
 {
-	/// <summary>
-	/// Work with Service Files
-	/// </summary>
-	public class ServiceFile
-	{
-		public int Serial;
-		public string Name;
-		public string Train_Config;   // name of the consist file, no extension
-		public string PathID;  // name of the path file, no extension
-		public float MaxWheelAcceleration;
-		public float Efficiency;
-		public string TimeTableItem;
+    /// <summary>
+    /// Work with Service Files
+    /// </summary>
+    public class ServiceFile
+    {
+        public int Serial;
+        public string Name;
+        public string Train_Config;   // name of the consist file, no extension
+        public string PathID;  // name of the path file, no extension
+        public float MaxWheelAcceleration;
+        public float Efficiency;
+        public string TimeTableItem;
         public TimeTable TimeTable;
 
-		/// <summary>
-		/// Open a service file, 
-		/// filePath includes full path and extension
-		/// </summary>
-		/// <param name="filePath"></param>
-		public ServiceFile( string filePath )
-		{
+        /// <summary>
+        /// Open a service file, 
+        /// filePath includes full path and extension
+        /// </summary>
+        /// <param name="filePath"></param>
+        public ServiceFile(string filePath)
+        {
             using (STFReader stf = new STFReader(filePath, false))
                 stf.ParseFile(new STFReader.TokenProcessor[] {
                     new STFReader.TokenProcessor("service_definition", ()=> { stf.MustMatch("("); stf.ParseBlock(new STFReader.TokenProcessor[] {
@@ -63,13 +63,13 @@ namespace Orts.Formats.Msts
             Efficiency = 0.9f;
             TimeTable = new TimeTable();
         }
-	} // SRVFile
+    } // SRVFile
 
     public class TimeTable
     {
         public float InitialSpeed;
- 
-        public TimeTable (STFReader stf)
+
+        public TimeTable(STFReader stf)
         {
             stf.MustMatch("(");
             stf.ParseBlock(new STFReader.TokenProcessor[] {

--- a/Source/Orts.Formats.Msts/SignalConfigurationFile.cs
+++ b/Source/Orts.Formats.Msts/SignalConfigurationFile.cs
@@ -392,7 +392,7 @@ namespace Orts.Formats.Msts
             Name = stf.ReadString().ToLowerInvariant();
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("colour", ()=>{
-				    stf.MustMatch("(");
+                    stf.MustMatch("(");
                     a = (byte)stf.ReadUInt(null);
                     r = (byte)stf.ReadUInt(null);
                     g = (byte)stf.ReadUInt(null);
@@ -516,7 +516,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("signalnumclearahead", ()=>{ numClearAhead = numClearAhead >= -1 ? numClearAhead : stf.ReadIntBlock(null); numdefs++;}),
                 new STFReader.TokenProcessor("semaphoreinfo", ()=>{ SemaphoreInfo = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsdayglow", ()=>{ DayGlow = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
-                new STFReader.TokenProcessor("ortsnightglow", ()=>{ NightGlow = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),                
+                new STFReader.TokenProcessor("ortsnightglow", ()=>{ NightGlow = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsdaylight", ()=>{ DayLight = stf.ReadBoolBlock(true); }),
                 new STFReader.TokenProcessor("ortsnormalsubtype", ()=>{ ORTSNormalSubtype = ReadORTSNormalSubtype(stf, ORTSNormalSubtypes); }),
                 new STFReader.TokenProcessor("sigflashduration", ()=>{
@@ -949,7 +949,7 @@ namespace Orts.Formats.Msts
         /// <summary>Set to true if SignalFlags ASAP option specified, meaning train needs to go to speed As Soon As Possible</summary>
         public bool Asap { get; private set; }
         /// <summary>Set to true if SignalFlags RESET option specified (ORTS only)</summary>
-        public bool Reset; 
+        public bool Reset;
         /// <summary>Set to true if no speed reduction is required for RESTRICTED or STOP_AND_PROCEED aspects (ORTS only) </summary>
         public bool NoSpeedReduction;
 
@@ -1008,7 +1008,7 @@ namespace Orts.Formats.Msts
     /// <summary>
     /// Describes a signal object shape and the set of signal heads and other sub-objects that are present on this.
     /// </summary>
-    
+
     public class ApproachControlLimits
     {
         public float? ApproachControlPositionM = null;
@@ -1090,7 +1090,7 @@ namespace Orts.Formats.Msts
             /// </summary>
             public static IList<string> SignalSubTypes =
                     new[] {"DECOR","SIGNAL_HEAD","DUMMY1","DUMMY2",
-				"NUMBER_PLATE","GRADIENT_PLATE","USER1","USER2","USER3","USER4"};
+                "NUMBER_PLATE","GRADIENT_PLATE","USER1","USER2","USER3","USER4"};
             // made public for access from SIGSCR processing
             // Altered to match definition in MSTS
 

--- a/Source/Orts.Formats.Msts/SoundManagmentFile.cs
+++ b/Source/Orts.Formats.Msts/SoundManagmentFile.cs
@@ -53,16 +53,16 @@ namespace Orts.Formats.Msts
         }
     }
 
-	/// <summary>
-	/// Represents the hiearchical structure of the SMS File
-	/// </summary>
-	public class SoundManagmentFile
-	{
-		public Tr_SMS Tr_SMS;
+    /// <summary>
+    /// Represents the hiearchical structure of the SMS File
+    /// </summary>
+    public class SoundManagmentFile
+    {
+        public Tr_SMS Tr_SMS;
 
-		public SoundManagmentFile( string filePath )
-		{
-            ReadFile(filePath);  
+        public SoundManagmentFile(string filePath)
+        {
+            ReadFile(filePath);
         }
 
         private void ReadFile(string filePath)
@@ -73,12 +73,12 @@ namespace Orts.Formats.Msts
                 });
         }
 
-	} // class SMSFile
+    } // class SMSFile
 
     public class Tr_SMS
     {
         public List<ScalabiltyGroup> ScalabiltyGroups = new List<ScalabiltyGroup>();
-        
+
         public Tr_SMS(STFReader stf)
         {
             stf.MustMatch("(");
@@ -139,14 +139,14 @@ namespace Orts.Formats.Msts
 
     }
 
-    public class Deactivation: Activation
+    public class Deactivation : Activation
     {
-        public Deactivation(STFReader stf): base(stf)
+        public Deactivation(STFReader stf) : base(stf)
         {
         }
 
         // for precompiled sound sources for activity sound
-        public Deactivation(): base()
+        public Deactivation() : base()
         { }
     }
 
@@ -230,10 +230,10 @@ namespace Orts.Formats.Msts
                     {
                         CurvePoints[i].X = stf.ReadFloat(STFReader.UNITS.None, null);
                         if (Control == Controls.DistanceControlled)
-						{
-							if (CurvePoints[i].X >= 0) CurvePoints[i].X *= CurvePoints[i].X;
-							else CurvePoints[i].X *= -CurvePoints[i].X;
-						}
+                        {
+                            if (CurvePoints[i].X >= 0) CurvePoints[i].X *= CurvePoints[i].X;
+                            else CurvePoints[i].X *= -CurvePoints[i].X;
+                        }
                         CurvePoints[i].Y = stf.ReadFloat(STFReader.UNITS.None, null);
                     }
                     stf.SkipRestOfBlock();
@@ -242,7 +242,7 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class FrequencyCurve: VolumeCurve
+    public class FrequencyCurve : VolumeCurve
     {
         public FrequencyCurve(STFReader stf)
             : base(stf)
@@ -280,13 +280,13 @@ namespace Orts.Formats.Msts
         {
             switch (lowertoken)
             {
-                case "playoneshot": 
+                case "playoneshot":
                 case "startloop":
-                case "releaselooprelease": 
+                case "releaselooprelease":
                 case "startlooprelease":
-                case "releaseloopreleasewithjump": 
-                case "disabletrigger": 
-                case "enabletrigger": 
+                case "releaseloopreleasewithjump":
+                case "disabletrigger":
+                case "enabletrigger":
                 case "setstreamvolume":
                     ++playcommandcount;
                     if (playcommandcount > 1)
@@ -300,11 +300,11 @@ namespace Orts.Formats.Msts
             {
                 case "playoneshot": SoundCommand = new PlayOneShot(f); break;
                 case "startloop": SoundCommand = new StartLoop(f); break;
-                case "releaselooprelease":  SoundCommand = new ReleaseLoopRelease(f); break; 
-                case "startlooprelease":  SoundCommand = new StartLoopRelease( f ); break; 
-                case "releaseloopreleasewithjump": SoundCommand = new ReleaseLoopReleaseWithJump( f ); break; 
-                case "disabletrigger": SoundCommand = new DisableTrigger( f); break; 
-                case "enabletrigger": SoundCommand = new EnableTrigger( f); break;
+                case "releaselooprelease": SoundCommand = new ReleaseLoopRelease(f); break;
+                case "startlooprelease": SoundCommand = new StartLoopRelease(f); break;
+                case "releaseloopreleasewithjump": SoundCommand = new ReleaseLoopReleaseWithJump(f); break;
+                case "disabletrigger": SoundCommand = new DisableTrigger(f); break;
+                case "enabletrigger": SoundCommand = new EnableTrigger(f); break;
                 case "setstreamvolume": SoundCommand = new SetStreamVolume(f); break;
                 case "(": f.SkipRestOfBlock(); break;
             }
@@ -338,8 +338,10 @@ namespace Orts.Formats.Msts
 
     public class Variable_Trigger : Trigger
     {
-        public enum Events { Speed_Inc_Past, Speed_Dec_Past, Distance_Inc_Past, Distance_Dec_Past,
-        Variable1_Inc_Past, Variable1_Dec_Past, Variable2_Inc_Past, Variable2_Dec_Past, Variable3_Inc_Past, Variable3_Dec_Past, BrakeCyl_Inc_Past, BrakeCyl_Dec_Past, CurveForce_Inc_Past, CurveForce_Dec_Past
+        public enum Events
+        {
+            Speed_Inc_Past, Speed_Dec_Past, Distance_Inc_Past, Distance_Dec_Past,
+            Variable1_Inc_Past, Variable1_Dec_Past, Variable2_Inc_Past, Variable2_Dec_Past, Variable3_Inc_Past, Variable3_Dec_Past, BrakeCyl_Inc_Past, BrakeCyl_Dec_Past, CurveForce_Inc_Past, CurveForce_Dec_Past
         };
 
         public Events Event;
@@ -381,7 +383,7 @@ namespace Orts.Formats.Msts
                 case "curveforce_dec_past": Event = Events.CurveForce_Dec_Past; break;
             }
 
-           
+
 
             while (!f.EndOfBlock())
                 ParsePlayCommand(f, f.ReadString().ToLower());
@@ -488,7 +490,7 @@ namespace Orts.Formats.Msts
         }
     }
 
-    public class SoundPlayCommand: SoundCommand
+    public class SoundPlayCommand : SoundCommand
     {
         public string[] Files;
         public SelectionMethods SelectionMethod = SelectionMethods.SequentialSelection;
@@ -496,7 +498,7 @@ namespace Orts.Formats.Msts
 
     public class PlayOneShot : SoundPlayCommand
     {
-        
+
         public PlayOneShot(STFReader f)
         {
             f.MustMatch("(");
@@ -538,7 +540,7 @@ namespace Orts.Formats.Msts
 
     public class StartLoop : PlayOneShot
     {
-        public StartLoop( STFReader f ): base(f)
+        public StartLoop(STFReader f) : base(f)
         {
         }
     }

--- a/Source/Orts.Formats.Msts/SpeedpostDatFile.cs
+++ b/Source/Orts.Formats.Msts/SpeedpostDatFile.cs
@@ -27,15 +27,15 @@ using Orts.Parsers.Msts;
 namespace Orts.Formats.Msts
 {
 
-	public class SpeedpostDatFile
-	{
-		public string [] TempSpeedShapeNames = new string[3];
+    public class SpeedpostDatFile
+    {
+        public string[] TempSpeedShapeNames = new string[3];
 
-		public SpeedpostDatFile(string filePath, string shapePath)
-		{
-			using (STFReader stf = new STFReader(filePath, false))
-			{
-				stf.ParseBlock(new STFReader.TokenProcessor[] {
+        public SpeedpostDatFile(string filePath, string shapePath)
+        {
+            using (STFReader stf = new STFReader(filePath, false))
+            {
+                stf.ParseBlock(new STFReader.TokenProcessor[] {
                     new STFReader.TokenProcessor("speed_warning_sign_shape", ()=>
                          {
                             var dataItem = stf.ReadStringBlock(null);
@@ -76,8 +76,8 @@ namespace Orts.Formats.Msts
                          }
                          ),
                 });
-			}
-		}
+            }
+        }
 
     } // class SpeedpostDatFile
 }

--- a/Source/Orts.Formats.Msts/TrackDatabaseFile.cs
+++ b/Source/Orts.Formats.Msts/TrackDatabaseFile.cs
@@ -44,7 +44,7 @@ namespace Orts.Formats.Msts
         /// </summary>
         /// <param name="filenamewithpath">Full file name of the .rdb file</param>
         public TrackDatabaseFile(string filenamewithpath)
-        {        
+        {
             using (STFReader stf = new STFReader(filenamewithpath, false))
                 stf.ParseFile(new STFReader.TokenProcessor[] {
                     new STFReader.TokenProcessor("trackdb", ()=>{ TrackDB = new TrackDB(stf); }),
@@ -132,7 +132,7 @@ namespace Orts.Formats.Msts
                 }),
             });
         }
-        
+
         /// <summary>
         /// Find the index of the TrackNode
         /// </summary>
@@ -179,7 +179,7 @@ namespace Orts.Formats.Msts
             for (int i = 0; i < newTrItems.Length; i++)
             {
                 int newId = i + TrItemTable.Length;
-                newTrItems[i].TrItemId = (uint) newId;
+                newTrItems[i].TrItemId = (uint)newId;
                 newTrItemTable[newId] = newTrItems[i];
             }
 
@@ -206,7 +206,7 @@ namespace Orts.Formats.Msts
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", Justification = "Keeping identifier consistent to use in MSTS")]
         public TrVectorNode TrVectorNode { get; set; }
-        
+
         /// <summary>
         /// True when this TrackNode has nothing else connected to it (that is, it is
         /// a buffer end or an unfinished track) and trains cannot proceed beyond here.
@@ -332,7 +332,7 @@ namespace Orts.Formats.Msts
         /// <summary>
         /// Default (empty) constructor 
         /// </summary>
-        public TrPin() {}
+        public TrPin() { }
 
         /// <summary>
         /// Create a shallow copy of the current TrPin
@@ -401,7 +401,7 @@ namespace Orts.Formats.Msts
             AZ = stf.ReadFloat(STFReader.UNITS.None, null);
             stf.SkipRestOfBlock();
         }
-        
+
         /// <summary>
         /// Constructor from a vector section
         /// </summary>
@@ -433,7 +433,7 @@ namespace Orts.Formats.Msts
         /// The route of a switch that is currently in use.
         /// </summary>
         public int SelectedRoute { get; set; }
-        
+
         /// <summary>
         /// Reference to the parent trackNode
         /// </summary>
@@ -499,7 +499,7 @@ namespace Orts.Formats.Msts
                 TrackShape trackShape = tsectionDat.TrackShapes.Get(ShapeIndex);
                 SectionIdx[] SectionIdxs = trackShape.SectionIdxs;
 
-                for (int index = 0; index <= SectionIdxs.Length-1 ; index++)
+                for (int index = 0; index <= SectionIdxs.Length - 1; index++)
                 {
                     if (index == trackShape.MainRoute) continue;
                     uint[] sections = SectionIdxs[index].TrackSections;
@@ -730,7 +730,7 @@ namespace Orts.Formats.Msts
         /// Describes the various types of Track Items
         /// </summary>
         public enum trItemType
-        {   
+        {
             /// <summary>empty item</summary>
             trEMPTY, // the first, so translates to '0', so this is the default.
             /// <summary>A place where two tracks cross over each other</summary>
@@ -807,7 +807,7 @@ namespace Orts.Formats.Msts
             Debug.Assert(idx == TrItemId, "Index Mismatch");
             stf.SkipRestOfBlock();
         }
-        
+
         /// <summary>
         /// Reads the Rdata from filestream
         /// </summary>
@@ -1038,7 +1038,7 @@ namespace Orts.Formats.Msts
             SigObj = -1;
             ItemType = trItemType.trSPEEDPOST;
             stf.MustMatch("(");
-			stf.ParseBlock(new STFReader.TokenProcessor[] {
+            stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("tritemid", ()=>{ ParseTrItemID(stf, idx); }),
                 new STFReader.TokenProcessor("tritemrdata", ()=>{ TrItemRData(stf); }),
                 new STFReader.TokenProcessor("tritemsdata", ()=>{ TrItemSData(stf); }),
@@ -1047,44 +1047,44 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("speedposttritemdata", ()=>{
                     stf.MustMatch("(");
                     Flags = stf.ReadUInt(null);
-					if ((Flags & 1) != 0) IsWarning = true;
-					if ((Flags & (1 << 1)) != 0) IsLimit = true;
-					if (!IsWarning && !IsLimit) {
-						IsMilePost = true;
-					}
-					else {
-						if (IsWarning && IsLimit)
-						{
-							IsWarning = false;
-							IsResume = true;
-						}
+                    if ((Flags & 1) != 0) IsWarning = true;
+                    if ((Flags & (1 << 1)) != 0) IsLimit = true;
+                    if (!IsWarning && !IsLimit) {
+                        IsMilePost = true;
+                    }
+                    else {
+                        if (IsWarning && IsLimit)
+                        {
+                            IsWarning = false;
+                            IsResume = true;
+                        }
 
-						if ((Flags & (1 << 5)) != 0) IsPassenger = true;
-						if ((Flags & (1 << 6)) != 0) IsFreight = true;
-						if ((Flags & (1 << 7)) != 0) IsFreight = IsPassenger = true;
-						if ((Flags & (1 << 8)) != 0) IsMPH = true;
-						if ((Flags & (1 << 4)) != 0) {
-							ShowNumber = true;
-							if ((Flags & (1 << 9)) != 0) ShowDot = true;
-						}
-					}
+                        if ((Flags & (1 << 5)) != 0) IsPassenger = true;
+                        if ((Flags & (1 << 6)) != 0) IsFreight = true;
+                        if ((Flags & (1 << 7)) != 0) IsFreight = IsPassenger = true;
+                        if ((Flags & (1 << 8)) != 0) IsMPH = true;
+                        if ((Flags & (1 << 4)) != 0) {
+                            ShowNumber = true;
+                            if ((Flags & (1 << 9)) != 0) ShowDot = true;
+                        }
+                    }
 
 
                     //  The number of parameters depends on the flags seeting
                     //  To do: Check flags seetings and parse accordingly.
 		            if (!IsResume)
-		            {
+                    {
                         //SpeedInd = stf.ReadFloat(STFReader.UNITS.None, null);
                         if (IsMilePost && ((Flags & (1 << 9)) == 0)) SpeedInd = (float)Math.Truncate(stf.ReadDouble(null));
                         else SpeedInd = stf.ReadFloat(STFReader.UNITS.None, null);
-		            }
+                    }
 
-    		        if (ShowNumber)
-		            {
-			            DisplayNumber = stf.ReadInt(null);
-		            }
-                    
-			        Angle = MathHelper.WrapAngle(stf.ReadFloat(STFReader.UNITS.None, null));
+                    if (ShowNumber)
+                    {
+                        DisplayNumber = stf.ReadInt(null);
+                    }
+
+                    Angle = MathHelper.WrapAngle(stf.ReadFloat(STFReader.UNITS.None, null));
 
                     stf.SkipRestOfBlock();
                 }),
@@ -1097,7 +1097,7 @@ namespace Orts.Formats.Msts
     }
 
     public class TempSpeedPostItem : SpeedPostItem
-    {      
+    {
         /// <summary>
         /// Constructor for creating a speedpost from activity speed restriction zone
         /// </summary>
@@ -1107,7 +1107,7 @@ namespace Orts.Formats.Msts
         /// 
         public WorldPosition WorldPosition;
 
-        public TempSpeedPostItem(Tr_RouteFile routeFile, Position position,  bool isStart, WorldPosition worldPosition, bool isWarning)
+        public TempSpeedPostItem(Tr_RouteFile routeFile, Position position, bool isStart, WorldPosition worldPosition, bool isWarning)
         {
             // TrItemId needs to be set later
             ItemType = trItemType.trSPEEDPOST;
@@ -1125,7 +1125,7 @@ namespace Orts.Formats.Msts
             if (routeFile.MilepostUnitsMetric == true)
             {
                 this.IsMPH = false;
-                SpeedInd = (int)(ORTS.Common.MpS.ToKpH(routeFile.TempRestrictedSpeed) + 0.1f); 
+                SpeedInd = (int)(ORTS.Common.MpS.ToKpH(routeFile.TempRestrictedSpeed) + 0.1f);
             }
             else
             {
@@ -1212,7 +1212,7 @@ namespace Orts.Formats.Msts
     /// <summary>
     /// Representa a level Crossing item (so track crossing road)
     /// </summary>
-    [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", Justification="Keeping identifier consistent to use in MSTS")]
+    [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", Justification = "Keeping identifier consistent to use in MSTS")]
     public class LevelCrItem : TrItem
     {
         /// <summary>
@@ -1269,7 +1269,7 @@ namespace Orts.Formats.Msts
             });
         }
     }
-    
+
     /// <summary>
     /// Represents either start or end of a platform (a place where trains can stop).
     /// </summary>

--- a/Source/Orts.Formats.Msts/TrackSectionsFile.cs
+++ b/Source/Orts.Formats.Msts/TrackSectionsFile.cs
@@ -25,100 +25,100 @@ using Orts.Parsers.Msts;
 
 namespace Orts.Formats.Msts
 {
-	// GLOBAL TSECTION DAT
+    // GLOBAL TSECTION DAT
 
-	public class SectionCurve
-	{
-		public SectionCurve()
-		{
-			Radius = 0;
-			Angle = 0;
-		}
-		public SectionCurve(STFReader stf)
-		{
-			stf.MustMatch("(");
+    public class SectionCurve
+    {
+        public SectionCurve()
+        {
+            Radius = 0;
+            Angle = 0;
+        }
+        public SectionCurve(STFReader stf)
+        {
+            stf.MustMatch("(");
             Radius = stf.ReadFloat(STFReader.UNITS.Distance, null);
             Angle = stf.ReadFloat(STFReader.UNITS.None, null);
             stf.SkipRestOfBlock();
-		}
-		public float Radius;	// meters
-		public float Angle;	// degrees
-	}
+        }
+        public float Radius;    // meters
+        public float Angle; // degrees
+    }
 
-	public class SectionSize
-	{
-		public SectionSize()
-		{
-			Width = 1.5F;
-			Length = 0;
-		}
-		public SectionSize(STFReader stf)
-		{
-			stf.MustMatch("(");
+    public class SectionSize
+    {
+        public SectionSize()
+        {
+            Width = 1.5F;
+            Length = 0;
+        }
+        public SectionSize(STFReader stf)
+        {
+            stf.MustMatch("(");
             Width = stf.ReadFloat(STFReader.UNITS.Distance, null);
             Length = stf.ReadFloat(STFReader.UNITS.Distance, null);
             stf.SkipRestOfBlock();
-		}
-		public float Width;
-		public float Length;
-	}
-	
-	public class TrackSection
-	{
-		public TrackSection()
-		{
-		}
-		
-		public TrackSection(STFReader stf)
-		{
-			stf.MustMatch("(");
+        }
+        public float Width;
+        public float Length;
+    }
+
+    public class TrackSection
+    {
+        public TrackSection()
+        {
+        }
+
+        public TrackSection(STFReader stf)
+        {
+            stf.MustMatch("(");
             SectionIndex = stf.ReadUInt(null);
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("sectionsize", ()=>{ SectionSize = new SectionSize(stf); }),
                 new STFReader.TokenProcessor("sectioncurve", ()=>{ SectionCurve = new SectionCurve(stf); }),
             });
-			//if( SectionSize == null )
-			//	throw( new STFError( stf, "Missing SectionSize" ) );
-			//  note- default TSECTION.DAT does have some missing sections
-		}
-		public uint SectionIndex;
-		public SectionSize SectionSize;
-		public SectionCurve SectionCurve;
-	}
-	
-	public class RouteTrackSection: TrackSection
-	{
-		public RouteTrackSection(STFReader stf)
-		{
-			stf.MustMatch("(");
-			stf.MustMatch( "SectionCurve" );
-			stf.SkipBlock();
+            //if( SectionSize == null )
+            //	throw( new STFError( stf, "Missing SectionSize" ) );
+            //  note- default TSECTION.DAT does have some missing sections
+        }
+        public uint SectionIndex;
+        public SectionSize SectionSize;
+        public SectionCurve SectionCurve;
+    }
+
+    public class RouteTrackSection : TrackSection
+    {
+        public RouteTrackSection(STFReader stf)
+        {
+            stf.MustMatch("(");
+            stf.MustMatch("SectionCurve");
+            stf.SkipBlock();
             SectionIndex = stf.ReadUInt(null);
-			SectionSize = new SectionSize();
+            SectionSize = new SectionSize();
             float a = stf.ReadFloat(STFReader.UNITS.Distance, null);
             float b = stf.ReadFloat(STFReader.UNITS.None, null);
-			if( b == 0 )
-				// Its straight
-			{
-				SectionSize.Length = a;
-			}
-			else
-				// its curved
-			{
-				SectionCurve = new SectionCurve();
-				SectionCurve.Radius = b;
+            if (b == 0)
+            // Its straight
+            {
+                SectionSize.Length = a;
+            }
+            else
+            // its curved
+            {
+                SectionCurve = new SectionCurve();
+                SectionCurve.Radius = b;
                 SectionCurve.Angle = (float)MathHelper.ToDegrees(a);
-			}
-			stf.SkipRestOfBlock();
-		}
-	}
+            }
+            stf.SkipRestOfBlock();
+        }
+    }
 
-	public class TrackSections: Dictionary<uint, TrackSection>
-	{
-		public TrackSections(STFReader stf)
-		{
+    public class TrackSections : Dictionary<uint, TrackSection>
+    {
+        public TrackSections(STFReader stf)
+        {
             AddRouteStandardTrackSections(stf);
-		}
+        }
 
         public void AddRouteStandardTrackSections(STFReader stf)
         {
@@ -129,14 +129,14 @@ namespace Orts.Formats.Msts
             });
         }
 
-		public void AddRouteTrackSections(STFReader stf)
-		{
-			stf.MustMatch("(");
+        public void AddRouteTrackSections(STFReader stf)
+        {
+            stf.MustMatch("(");
             MaxSectionIndex = stf.ReadUInt(null);
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("tracksection", ()=>{ AddSection(stf, new RouteTrackSection(stf)); }),
             });
-		}
+        }
 
         void AddSection(STFReader stf, TrackSection section)
         {
@@ -147,57 +147,57 @@ namespace Orts.Formats.Msts
 
         public static int MissingTrackSectionWarnings;
 
-		public TrackSection Get( uint targetSectionIndex )
-		{
+        public TrackSection Get(uint targetSectionIndex)
+        {
             TrackSection ts;
             if (TryGetValue(targetSectionIndex, out ts))
                 return ts;
-			if (MissingTrackSectionWarnings++ < 5)
-				Trace.TraceWarning("Skipped track section {0} not in global or dynamic TSECTION.DAT", targetSectionIndex);
+            if (MissingTrackSectionWarnings++ < 5)
+                Trace.TraceWarning("Skipped track section {0} not in global or dynamic TSECTION.DAT", targetSectionIndex);
             return null;
-		}
-		public uint MaxSectionIndex;
-	}
+        }
+        public uint MaxSectionIndex;
+    }
 
-	public class SectionIdx
-	{
-		public SectionIdx(STFReader stf)
-		{
-			stf.MustMatch("(");
+    public class SectionIdx
+    {
+        public SectionIdx(STFReader stf)
+        {
+            stf.MustMatch("(");
             NoSections = stf.ReadUInt(null);
             X = stf.ReadDouble(null);
             Y = stf.ReadDouble(null);
             Z = stf.ReadDouble(null);
             A = stf.ReadDouble(null);
-			TrackSections = new uint[NoSections]; 
-			for( int i = 0; i < NoSections; ++i )  
-			{
-       			string token = stf.ReadString();
-                if( token == ")" ) 
+            TrackSections = new uint[NoSections];
+            for (int i = 0; i < NoSections; ++i)
+            {
+                string token = stf.ReadString();
+                if (token == ")")
                 {
                     STFException.TraceWarning(stf, "Missing track section");
                     return;   // there are many TSECTION.DAT's with missing sections so we will accept this error
                 }
                 if (!uint.TryParse(token, out TrackSections[i]))
                     STFException.TraceWarning(stf, "Invalid track section " + token);
-			}
-			stf.SkipRestOfBlock();
-		}
-		public uint NoSections;
-		public double X,Y,Z;  // Offset
-		public double A;  // Angular offset 
-		public uint[] TrackSections;
-	}
-	
+            }
+            stf.SkipRestOfBlock();
+        }
+        public uint NoSections;
+        public double X, Y, Z;  // Offset
+        public double A;  // Angular offset 
+        public uint[] TrackSections;
+    }
 
-   [DebuggerDisplay("TrackShape {ShapeIndex}")]
-	public class TrackShape
-	{
-		public TrackShape(STFReader stf)
-		{
-			stf.MustMatch("(");
+
+    [DebuggerDisplay("TrackShape {ShapeIndex}")]
+    public class TrackShape
+    {
+        public TrackShape(STFReader stf)
+        {
+            stf.MustMatch("(");
             ShapeIndex = stf.ReadUInt(null);
-			int nextPath = 0;
+            int nextPath = 0;
             stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("filename", ()=>{ FileName = stf.ReadStringBlock(null); }),
                 new STFReader.TokenProcessor("numpaths", ()=>{ SectionIdxs = new SectionIdx[NumPaths = stf.ReadUIntBlock(null)]; }),
@@ -207,79 +207,79 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("tunnelshape", ()=>{ TunnelShape = stf.ReadBoolBlock(true); }),
                 new STFReader.TokenProcessor("roadshape", ()=>{ RoadShape = stf.ReadBoolBlock(true); }),
             });
-			// TODO - this was removed since TrackShape( 183 ) is blank
-			//if( FileName == null )	throw( new STFError( stf, "Missing FileName" ) );
-			//if( SectionIdxs == null )	throw( new STFError( stf, "Missing SectionIdxs" ) );
-			//if( NumPaths == 0 ) throw( new STFError( stf, "No Paths in TrackShape" ) );
-		}
-		public uint ShapeIndex;
-		public string FileName;
+            // TODO - this was removed since TrackShape( 183 ) is blank
+            //if( FileName == null )	throw( new STFError( stf, "Missing FileName" ) );
+            //if( SectionIdxs == null )	throw( new STFError( stf, "Missing SectionIdxs" ) );
+            //if( NumPaths == 0 ) throw( new STFError( stf, "No Paths in TrackShape" ) );
+        }
+        public uint ShapeIndex;
+        public string FileName;
         public uint NumPaths;
         public uint MainRoute;
-		public double ClearanceDistance = 0.0;
-		public SectionIdx[] SectionIdxs;
+        public double ClearanceDistance = 0.0;
+        public SectionIdx[] SectionIdxs;
         public bool TunnelShape;
         public bool RoadShape;
 
-	}
-	
-	public class TrackShapes: Dictionary<uint, TrackShape>
-	{
+    }
 
-      public uint MaxShapeIndex;
+    public class TrackShapes : Dictionary<uint, TrackShape>
+    {
 
-      
-		public TrackShapes(STFReader stf)
-		{
+        public uint MaxShapeIndex;
+
+
+        public TrackShapes(STFReader stf)
+        {
             AddRouteTrackShapes(stf);
-		}
+        }
 
         public void AddRouteTrackShapes(STFReader stf)
         {
             stf.MustMatch("(");
             MaxShapeIndex = stf.ReadUInt(null);
-            stf.ParseBlock(new STFReader.TokenProcessor[] 
+            stf.ParseBlock(new STFReader.TokenProcessor[]
             {
                 new STFReader.TokenProcessor("trackshape", ()=>{ Add(stf, new TrackShape(stf)); }),
             });
         }
 
-      private void Add(STFReader stf, TrackShape trackShape)
-      {
-          if (ContainsKey(trackShape.ShapeIndex))
-              STFException.TraceWarning(stf, "Replaced duplicate TrackShape " + trackShape.ShapeIndex);
-          this[trackShape.ShapeIndex] = trackShape;
-      }
+        private void Add(STFReader stf, TrackShape trackShape)
+        {
+            if (ContainsKey(trackShape.ShapeIndex))
+                STFException.TraceWarning(stf, "Replaced duplicate TrackShape " + trackShape.ShapeIndex);
+            this[trackShape.ShapeIndex] = trackShape;
+        }
 
 
-      /// <summary>
-      /// Returns the TrackShape corresponding to the given index value.
-      /// </summary>
-      /// <param name="targetShapeIndex">The index value of the desired TrackShape.</param>
-      /// <returns>The requested TrackShape.</returns>
-		public TrackShape Get(uint targetShapeIndex )
-		{
+        /// <summary>
+        /// Returns the TrackShape corresponding to the given index value.
+        /// </summary>
+        /// <param name="targetShapeIndex">The index value of the desired TrackShape.</param>
+        /// <returns>The requested TrackShape.</returns>
+        public TrackShape Get(uint targetShapeIndex)
+        {
             TrackShape returnValue;
 
-         if (ContainsKey(targetShapeIndex))
-         {
-            returnValue = this[targetShapeIndex];
-         }
-         else
-         {
-            throw new InvalidDataException("ShapeIndex not found");
-         }
+            if (ContainsKey(targetShapeIndex))
+            {
+                returnValue = this[targetShapeIndex];
+            }
+            else
+            {
+                throw new InvalidDataException("ShapeIndex not found");
+            }
 
-         return returnValue;
-		}
+            return returnValue;
+        }
 
-		
-	}
 
-	public class TrackSectionsFile
-	{
-		public void AddRouteTSectionDatFile( string pathNameExt )
-		{
+    }
+
+    public class TrackSectionsFile
+    {
+        public void AddRouteTSectionDatFile(string pathNameExt)
+        {
             using (STFReader stf = new STFReader(pathNameExt, false))
             {
                 if (stf.SimisSignature != "SIMISA@@@@@@@@@@JINX0T0t______")
@@ -293,20 +293,20 @@ namespace Orts.Formats.Msts
                     // todo read in SectionIdx part of RouteTSectionDat
                 });
             }
-		}
+        }
 
         public TrackSectionsFile(string filePath)
         {
             using (STFReader stf = new STFReader(filePath, false))
             {
                 stf.ParseFile(new STFReader.TokenProcessor[] {
-                    new STFReader.TokenProcessor("tracksections", ()=>{ 
+                    new STFReader.TokenProcessor("tracksections", ()=>{
                         if (TrackSections == null)
                             TrackSections = new TrackSections(stf);
                         else
                             TrackSections.AddRouteStandardTrackSections(stf);}),
-                    new STFReader.TokenProcessor("trackshapes", ()=>{ 
-                        if (TrackShapes == null) 
+                    new STFReader.TokenProcessor("trackshapes", ()=>{
+                        if (TrackShapes == null)
                             TrackShapes = new TrackShapes(stf);
                         else
                             TrackShapes.AddRouteTrackShapes(stf);}),
@@ -316,66 +316,66 @@ namespace Orts.Formats.Msts
                 if (TrackShapes == null) throw new STFException(stf, "Missing TrackShapes");
             }
         }
-		public TrackSections TrackSections;
-		public TrackShapes TrackShapes;
-		public TSectionIdx TSectionIdx; //route's tsection.dat
+        public TrackSections TrackSections;
+        public TrackShapes TrackShapes;
+        public TSectionIdx TSectionIdx; //route's tsection.dat
 
-	}
+    }
 
-	public class TSectionIdx //SectionIdx in the route's tsection.dat
-	{
+    public class TSectionIdx //SectionIdx in the route's tsection.dat
+    {
 
-		public TSectionIdx(STFReader stf)
-		{
-			stf.MustMatch("(");
-			NoSections = stf.ReadUInt(null);
-			TrackPaths = new Dictionary<uint, TrackPath>((int)NoSections);
-			stf.ParseBlock(new STFReader.TokenProcessor[] {
+        public TSectionIdx(STFReader stf)
+        {
+            stf.MustMatch("(");
+            NoSections = stf.ReadUInt(null);
+            TrackPaths = new Dictionary<uint, TrackPath>((int)NoSections);
+            stf.ParseBlock(new STFReader.TokenProcessor[] {
                 new STFReader.TokenProcessor("trackpath", ()=>{ AddPath(stf, new TrackPath(stf)); }),
             });
-			stf.SkipRestOfBlock();
-		}
+            stf.SkipRestOfBlock();
+        }
 
-		private void AddPath(STFReader stf, TrackPath path)
-		{
-			try
-			{
-				TrackPaths.Add(path.DynamicSectionIndex, path);
-			}
-			catch (Exception e)
-			{
-				System.Console.WriteLine("Warning: in route tsection.dat " + e.Message);
-			}
-		}
-		public uint NoSections;
-		public Dictionary<uint, TrackPath> TrackPaths;
-	}
+        private void AddPath(STFReader stf, TrackPath path)
+        {
+            try
+            {
+                TrackPaths.Add(path.DynamicSectionIndex, path);
+            }
+            catch (Exception e)
+            {
+                System.Console.WriteLine("Warning: in route tsection.dat " + e.Message);
+            }
+        }
+        public uint NoSections;
+        public Dictionary<uint, TrackPath> TrackPaths;
+    }
 
-	public class TrackPath //SectionIdx in the route's tsection.dat
-	{
+    public class TrackPath //SectionIdx in the route's tsection.dat
+    {
 
-		public TrackPath(STFReader stf)
-		{
-			stf.MustMatch("(");
-			DynamicSectionIndex = stf.ReadUInt(null);
-			NoSections = stf.ReadUInt(null);
-			TrackSections = new uint[NoSections];
-			for (int i = 0; i < NoSections; ++i)
-			{
-				string token = stf.ReadString();
-				if (token == ")")
-				{
-					STFException.TraceWarning(stf, "Missing track section");
-					return;   // there are many TSECTION.DAT's with missing sections so we will accept this error
-				}
-				if (!uint.TryParse(token, out TrackSections[i]))
-					STFException.TraceWarning(stf, "Invalid track section " + token);
-			}
-			stf.SkipRestOfBlock();
+        public TrackPath(STFReader stf)
+        {
+            stf.MustMatch("(");
+            DynamicSectionIndex = stf.ReadUInt(null);
+            NoSections = stf.ReadUInt(null);
+            TrackSections = new uint[NoSections];
+            for (int i = 0; i < NoSections; ++i)
+            {
+                string token = stf.ReadString();
+                if (token == ")")
+                {
+                    STFException.TraceWarning(stf, "Missing track section");
+                    return;   // there are many TSECTION.DAT's with missing sections so we will accept this error
+                }
+                if (!uint.TryParse(token, out TrackSections[i]))
+                    STFException.TraceWarning(stf, "Invalid track section " + token);
+            }
+            stf.SkipRestOfBlock();
 
-		}
-		public uint DynamicSectionIndex;
-		public uint NoSections;
-		public uint[] TrackSections;
-	}
+        }
+        public uint DynamicSectionIndex;
+        public uint NoSections;
+        public uint[] TrackSections;
+    }
 }

--- a/Source/Orts.Formats.Msts/TrackTypesFile.cs
+++ b/Source/Orts.Formats.Msts/TrackTypesFile.cs
@@ -26,12 +26,12 @@ using Orts.Parsers.Msts;
 namespace Orts.Formats.Msts
 {
 
-	// TODO - this is an incomplete parse of the cvf file.
-	public class TrackTypesFile: List<TrackTypesFile.TrackType>
-	{
-        
+    // TODO - this is an incomplete parse of the cvf file.
+    public class TrackTypesFile : List<TrackTypesFile.TrackType>
+    {
+
         public TrackTypesFile(string filePath)
-		{
+        {
             using (STFReader stf = new STFReader(filePath, false))
             {
                 var count = stf.ReadInt(null);
@@ -46,7 +46,7 @@ namespace Orts.Formats.Msts
                 if (count > 0)
                     STFException.TraceWarning(stf, count + " missing TrackType(s)");
             }
-		}
+        }
 
         public class TrackType
         {
@@ -64,6 +64,6 @@ namespace Orts.Formats.Msts
             }
         } // TrackType
 
-	} // class CVFFile
+    } // class CVFFile
 }
 

--- a/Source/Orts.Formats.Msts/TrafficFile.cs
+++ b/Source/Orts.Formats.Msts/TrafficFile.cs
@@ -55,7 +55,7 @@ namespace Orts.Formats.Msts
             stf.MustMatch("serial");
             Serial = stf.ReadIntBlock(null);
             stf.ParseBlock(new STFReader.TokenProcessor[] {
-    	        new STFReader.TokenProcessor("service_definition", ()=>{ TrafficItems.Add(new Traffic_Service_Definition(stf)); }),
+                new STFReader.TokenProcessor("service_definition", ()=>{ TrafficItems.Add(new Traffic_Service_Definition(stf)); }),
             });
         }
     }
@@ -89,7 +89,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("departtime", ()=>{ departTime = (int)stf.ReadFloatBlock(STFReader.UNITS.Time, null); }),
                 new STFReader.TokenProcessor("skipcount", ()=>{ skipCount = stf.ReadIntBlock(null); }),
                 new STFReader.TokenProcessor("distancedownpath", ()=>{ distanceDownPath = stf.ReadFloatBlock(STFReader.UNITS.Distance, null); }),
-                new STFReader.TokenProcessor("platformstartid", ()=>{ platformStartID = stf.ReadIntBlock(null); 
+                new STFReader.TokenProcessor("platformstartid", ()=>{ platformStartID = stf.ReadIntBlock(null);
                     TrafficDetails.Add(new Traffic_Traffic_Item(arrivalTime, departTime, skipCount, distanceDownPath, platformStartID));
                 }),
             });

--- a/Source/Orts.Formats.OR/AEItems.cs
+++ b/Source/Orts.Formats.OR/AEItems.cs
@@ -232,12 +232,12 @@ namespace Orts.Formats.OR
         public GlobalItem findSegmentFromMouse(PointF pt, double snapSize)
         {
             double positiveInfinity = double.PositiveInfinity;
-            
+
             if (snapSize < 1.0)
             {
                 snapSize = 1.0;
             }
-            
+
             PointF closest = new PointF(0f, 0f);
             TrackSegment segment = null;
             foreach (TrackSegment segment2 in segments)
@@ -337,7 +337,7 @@ namespace Orts.Formats.OR
         }
 
         public override void alignEdition(TypeEditor interfaceType, GlobalItem ownParent)
-        { 
+        {
             setMovable();
             asMetadata = true;
         }
@@ -347,7 +347,7 @@ namespace Orts.Formats.OR
             nameTag = "tag" + info;
         }
 
-        public override void configCoord (MSTSCoord coord)
+        public override void configCoord(MSTSCoord coord)
         {
             base.configCoord(coord);
             typeItem = (int)TypeItem.TAG_ITEM;
@@ -754,7 +754,7 @@ namespace Orts.Formats.OR
         {
             List<StationPath> paths = null;
             //StationPathsHelper.Clear();
-            
+
             for (int i = 0; i < this.stationArea.Count; i++)
             {
                 double positiveInfinity = double.PositiveInfinity;
@@ -821,13 +821,13 @@ namespace Orts.Formats.OR
             {
                 int num = 0;
                 List<System.Drawing.PointF> pointsIntersect = new List<System.Drawing.PointF>();
-                
+
                 List<AESegment> polySegments = getPolySegment();
                 if (segment.associateNodeIdx == 344)
                     num = 0;
                 for (int cntPointSegment = 0; cntPointSegment < polySegments.Count; cntPointSegment++)
                 {
-                    PointF pointIntersect = DrawUtility.FindIntersection(polySegments[cntPointSegment], new AESegment (segment));
+                    PointF pointIntersect = DrawUtility.FindIntersection(polySegments[cntPointSegment], new AESegment(segment));
                     if (!pointIntersect.IsEmpty)
                     {
                         StationAreaItem newPoint = new StationAreaItem(TypeEditor.ROUTECONFIG, this);
@@ -964,15 +964,15 @@ namespace Orts.Formats.OR
             stationConnector.setIcoAngle(Coord.ConvertToPointF(), polyPoint);
         }
 
-        public bool toggleSelected ()
+        public bool toggleSelected()
         {
             selected = !selected;
             return selected;
         }
 
         public override void Update(MSTSCoord coord)
-        {   
-                base.configCoord(coord);
+        {
+            base.configCoord(coord);
         }
 
         public bool IsInterface()
@@ -1153,7 +1153,7 @@ namespace Orts.Formats.OR
             return paths;
         }
 
- 
+
 
     }
     #endregion
@@ -1244,7 +1244,7 @@ namespace Orts.Formats.OR
                     lenFleche = (float)ts.SectionCurve.Radius - lenFleche;
                     if (double.IsNaN(lenFleche))
                         return;
-                    curve = new AESectionCurve (ts.SectionCurve);
+                    curve = new AESectionCurve(ts.SectionCurve);
                     Vector3 v = new Vector3((float)(vectorB.X - vectorA.X), 0, (float)(vectorB.Y - vectorA.Y));
                     Vector3 v2 = Vector3.Cross(Vector3.Up, v);
                     v2.Normalize();

--- a/Source/Orts.Formats.OR/AESignals.cs
+++ b/Source/Orts.Formats.OR/AESignals.cs
@@ -703,7 +703,7 @@ namespace Orts.Formats.OR
                             }
                         }
 
-        // Track Item is speedpost - check if really limit
+                        // Track Item is speedpost - check if really limit
                         else if (TrItems[TDBRef].ItemType == TrItem.trItemType.trSPEEDPOST)
                         {
                             SpeedPostItem speedItem = (SpeedPostItem)TrItems[TDBRef];
@@ -959,7 +959,7 @@ namespace Orts.Formats.OR
         }
 #endif
 
-     }// class AESignals
+    }// class AESignals
 
     //================================================================================================//
     //

--- a/Source/Orts.Formats.OR/AEStationPath.cs
+++ b/Source/Orts.Formats.OR/AEStationPath.cs
@@ -41,9 +41,9 @@ namespace Orts.Formats.OR
         }
     }
 
-    public class DestinationPoint : Dictionary<string, Possibility> 
+    public class DestinationPoint : Dictionary<string, Possibility>
     {
-        public Possibility Add(string desti) 
+        public Possibility Add(string desti)
         {
             if (ContainsKey(desti))
             {
@@ -51,8 +51,8 @@ namespace Orts.Formats.OR
             }
 
             var destination = new Possibility();
-            base.Add(desti,destination); 
-            return destination; 
+            base.Add(desti, destination);
+            return destination;
         }
     }
 
@@ -60,9 +60,9 @@ namespace Orts.Formats.OR
     {
         public DestinationPoint Add(string origin)
         {
-            if (ContainsKey(origin)) 
-            { 
-                return this[origin]; 
+            if (ContainsKey(origin))
+            {
+                return this[origin];
             }
             var desti = new DestinationPoint();
             base.Add(origin, desti);
@@ -189,7 +189,7 @@ namespace Orts.Formats.OR
 
                 if (node2.TrJunctionNode != null)
                 {
-                    AEJunctionItem junction = (AEJunctionItem)paths[pathChecked].ComponentItem[paths[pathChecked].ComponentItem.Count-1];
+                    AEJunctionItem junction = (AEJunctionItem)paths[pathChecked].ComponentItem[paths[pathChecked].ComponentItem.Count - 1];
                     if (!insideJunction.Contains(junction))
                     {
                         insideJunction.Add(junction);
@@ -207,7 +207,7 @@ namespace Orts.Formats.OR
                 }
                 else if (node2.TrEndNode)
                 {
-                    AEBufferItem buffer = (AEBufferItem)paths[pathChecked].ComponentItem[paths[pathChecked].ComponentItem.Count-1];
+                    AEBufferItem buffer = (AEBufferItem)paths[pathChecked].ComponentItem[paths[pathChecked].ComponentItem.Count - 1];
                     if (!buffer.Configured || buffer.DirBuffer == AllowedDir.OUT)
                     {
                         //AEJunctionItem junction = (AEJunctionItem)paths[pathChecked].ComponentItem[paths[pathChecked].jctnIdx];
@@ -228,16 +228,16 @@ namespace Orts.Formats.OR
 
                     }
                 }
-                else 
+                else
                 {
                     int lastIndex = (int)node2.Index;
                     //lastCommonTrack = (int)node2.Index;
                     if (paths[pathChecked].complete)
                     {
                         TrackSegment segment = (TrackSegment)paths[pathChecked].ComponentItem[paths[pathChecked].ComponentItem.Count - 1];
-                        
+
                         if (segment.HasConnector == null ||
-                            (segment.HasConnector != null && 
+                            (segment.HasConnector != null &&
                             (segment.HasConnector.dirConnector == AllowedDir.IN || !segment.HasConnector.isConfigured())))
                         {
                             paths.RemoveAt(pathChecked);
@@ -281,7 +281,7 @@ namespace Orts.Formats.OR
                     MaxPassingYard = path.PassingYard;
                 if (path.PassingYard < ShortPassingYard)
                     ShortPassingYard = path.PassingYard;
-           }
+            }
             return paths;
         }
 
@@ -498,7 +498,7 @@ namespace Orts.Formats.OR
                     elapse.Add(elapsedTime);
                     
 #endif
-                } while (traveller.NextVectorSection() && !complete) ;
+                } while (traveller.NextVectorSection() && !complete);
                 if (currentNode.Index != entryNode && !complete && traveller.TrackNodeLength > PassingYard)
                     PassingYard = traveller.TrackNodeLength;
                 traveller.NextTrackNode();
@@ -530,7 +530,7 @@ namespace Orts.Formats.OR
         public void setComplete(GlobalItem segment)
         {
             complete = true;
-            
+
             if (segment.GetType() == typeof(TrackSegment) && ((TrackSegment)segment).HasConnector != null)
             {
                 outLabel = ((TrackSegment)segment).HasConnector.label;

--- a/Source/Orts.Formats.OR/AETraveller.cs
+++ b/Source/Orts.Formats.OR/AETraveller.cs
@@ -161,7 +161,7 @@ namespace Orts.Formats.OR
         /// <param name="loc">Starting world location</param>
         public void place(WorldLocation loc)
         {
-            place (loc.TileX, loc.TileZ, loc.Location.X, loc.Location.Z);
+            place(loc.TileX, loc.TileZ, loc.Location.X, loc.Location.Z);
         }
 
         /// <summary>
@@ -889,7 +889,7 @@ namespace Orts.Formats.OR
             return TrackNodes[TrackNodeIndex];
         }
 
-       /// <summary>
+        /// <summary>
         /// Moves the traveller on to the next section of track, whether that is another section within the current track node or a new track node.
         /// </summary>
         /// <returns><c>true</c> if the next section exists, <c>false</c> if it does not.</returns>
@@ -1065,7 +1065,7 @@ namespace Orts.Formats.OR
 
         public float SuperElevationValue(float speed, float timeInterval, bool computed) //will test 1 second ahead, computed will return desired elev. only
         {
-            #if !ACTIVITY_EDITOR
+#if !ACTIVITY_EDITOR
             var tn = trackNode;
             if (tn.TrVectorNode == null) return 0f;
             var tvs = trackVectorSection;

--- a/Source/Orts.Formats.OR/AuxActionRef.cs
+++ b/Source/Orts.Formats.OR/AuxActionRef.cs
@@ -109,7 +109,7 @@ namespace Orts.Formats.OR
         [JsonIgnore]
         public List<AuxActionRef> SpecAuxActions;          // Actions To Do during activity, like WP with specific location
         [JsonProperty("GenActions")]
-        public List<KeyValuePair<string,AuxActionRef>> GenAuxActions;          // Action To Do during activity, without specific location
+        public List<KeyValuePair<string, AuxActionRef>> GenAuxActions;          // Action To Do during activity, without specific location
         [JsonIgnore]
         protected List<KeyValuePair<System.Type, AuxActionRef>> GenFunctions;
         [JsonIgnore]
@@ -273,7 +273,7 @@ namespace Orts.Formats.OR
         //public float RequiredDistance;
         //[JsonProperty("Param")]
         //public List<Object> Parameter;
-        
+
 
         public enum AUX_ACTION
         {
@@ -360,7 +360,7 @@ namespace Orts.Formats.OR
         public float RequiredDistance;
 
         public AuxActionHorn(bool isGeneric, int delay = 2, float requiredDistance = 0) :    //WorldLocation? location, float requiredSpeedMpS, , int endSignalIndex = -1, AUX_ACTION actionType = AUX_ACTION.SOUND_HORN, , float requiredDistance = 0) :
-            base(AUX_ACTION.SOUND_HORN ,isGeneric)                                          //location, requiredSpeedMpS, , endSignalIndex, actionType, delay, requiredDistance)
+            base(AUX_ACTION.SOUND_HORN, isGeneric)                                          //location, requiredSpeedMpS, , endSignalIndex, actionType, delay, requiredDistance)
         {
             Delay = delay;
             RequiredDistance = requiredDistance;
@@ -422,10 +422,10 @@ namespace Orts.Formats.OR
         }
 
     }
-    
+
     public class AuxControlStopped : AuxActionRef
     {
-        public AuxControlStopped(bool isGeneric):               //WorldLocation? location, float requiredSpeedMpS, bool isGeneric, int endSignalIndex = -1, AUX_ACTION actionType = AUX_ACTION.CONTROL_START, int delay = 2, float requiredDistance = 0, int duration = 10) :
+        public AuxControlStopped(bool isGeneric) :               //WorldLocation? location, float requiredSpeedMpS, bool isGeneric, int endSignalIndex = -1, AUX_ACTION actionType = AUX_ACTION.CONTROL_START, int delay = 2, float requiredDistance = 0, int duration = 10) :
             base(AUX_ACTION.CONTROL_STOPPED, isGeneric)           //location, requiredSpeedMpS, isGeneric, endSignalIndex, actionType, delay, requiredDistance)
         {
         }

--- a/Source/Orts.Formats.OR/DrawUtility.cs
+++ b/Source/Orts.Formats.OR/DrawUtility.cs
@@ -40,12 +40,12 @@ namespace Orts.Formats.OR
             if (!segment.isCurved)
             {
                 return FindDistanceToSegment(pt,
-                    new AESegment (segment.associateSegment),
+                    new AESegment(segment.associateSegment),
                     out closest);
             }
             else
             {
-                return FindDistanceToCurve (pt, new AESegment (segment.associateSegment), out closest);
+                return FindDistanceToCurve(pt, new AESegment(segment.associateSegment), out closest);
             }
         }
 
@@ -70,13 +70,13 @@ namespace Orts.Formats.OR
 
             if (t < 0)
             {
-                closest = new PointF (seg.startPoint.X, seg.startPoint.Y);
+                closest = new PointF(seg.startPoint.X, seg.startPoint.Y);
                 dx = pt.X - seg.startPoint.X;
                 dy = pt.Y - seg.startPoint.Y;
             }
             else if (t > 1)
             {
-                closest = new PointF (seg.endPoint.X, seg.endPoint.Y);
+                closest = new PointF(seg.endPoint.X, seg.endPoint.Y);
                 dx = pt.X - seg.endPoint.X;
                 dy = pt.Y - seg.endPoint.Y;
             }
@@ -86,7 +86,7 @@ namespace Orts.Formats.OR
                 dx = pt.X - closest.X;
                 dy = pt.Y - closest.Y;
             }
-            double info = Math.Sqrt (dx * dx + dy * dy);
+            double info = Math.Sqrt(dx * dx + dy * dy);
             return info;
         }
 
@@ -125,7 +125,7 @@ namespace Orts.Formats.OR
             float t2 = ((track.startPoint.X - segArea.startPoint.X) * dy12 + (segArea.startPoint.Y - track.startPoint.Y) * dx12) / -denominator;
 
             // Find the point of intersection.
-            intersection = new PointF (segArea.startPoint.X + dx12 * t1, segArea.startPoint.Y + dy12 * t1);
+            intersection = new PointF(segArea.startPoint.X + dx12 * t1, segArea.startPoint.Y + dy12 * t1);
 
             // The segments intersect if t1 and t2 are between 0 and 1.
             segments_intersect = ((t1 >= 0) && (t1 <= 1) && (t2 >= 0) && (t2 <= 1));
@@ -149,8 +149,8 @@ namespace Orts.Formats.OR
                 t2 = 1;
             }
 
-            close_p1 = new PointF (segArea.startPoint.X + dx12 * t1, segArea.startPoint.Y + dy12 * t1);
-            close_p2 = new PointF (track.startPoint.X + dx34 * t2, track.startPoint.Y + dy34 * t2);
+            close_p1 = new PointF(segArea.startPoint.X + dx12 * t1, segArea.startPoint.Y + dy12 * t1);
+            close_p2 = new PointF(track.startPoint.X + dx34 * t2, track.startPoint.Y + dy34 * t2);
         }
 
 
@@ -180,13 +180,13 @@ namespace Orts.Formats.OR
 
         public static PointF FindStraightIntersection(AESegment segArea, AESegment track)
         {
-//double Ax, double Ay,
-//double Bx, double By,
-//double Cx, double Cy,
-//double Dx, double Dy,
-//double *X, double *Y 
+            //double Ax, double Ay,
+            //double Bx, double By,
+            //double Cx, double Cy,
+            //double Dx, double Dy,
+            //double *X, double *Y 
             PointF pt = PointF.Empty;
-            double  distAB, theCos, theSin, newX, ABpos ;
+            double distAB, theCos, theSin, newX, ABpos;
             double distCD, theCos2, theSin2;
             double ABX, ABY, ACX, ACY, ADX, ADY;
             double AX = segArea.startPoint.X;
@@ -194,7 +194,7 @@ namespace Orts.Formats.OR
             double CDX, CDY, angle1, angle2;
 
             //  Fail if either line segment is zero-length.
-            if ((segArea.startPoint.X == segArea.endPoint.X && segArea.startPoint.Y == segArea.endPoint.Y) 
+            if ((segArea.startPoint.X == segArea.endPoint.X && segArea.startPoint.Y == segArea.endPoint.Y)
                 || (track.startPoint.X == track.endPoint.X && track.startPoint.Y == track.endPoint.Y))
                 return pt;
 
@@ -204,7 +204,7 @@ namespace Orts.Formats.OR
                 (segArea.startPoint.X == track.endPoint.X && segArea.startPoint.Y == track.endPoint.Y) ||
                 (segArea.endPoint.X == track.endPoint.X && segArea.endPoint.Y == track.endPoint.Y))
             {
-                return pt; 
+                return pt;
             }
 
             //  (1) Translate the system so that point A is on the origin.
@@ -230,23 +230,23 @@ namespace Orts.Formats.OR
             angle1 = Math.Acos(theCos) * 180 / Math.PI;   // sup
             angle2 = Math.Acos(theCos2) * 180 / Math.PI;   // sup
             newX = ACX * theCos + ACY * theSin;
-            ACY  = ACY * theCos - ACX * theSin; 
+            ACY = ACY * theCos - ACX * theSin;
             ACX = newX;
             newX = ADX * theCos + ADY * theSin;
-            ADY  = ADY * theCos - ADX * theSin; 
+            ADY = ADY * theCos - ADX * theSin;
             ADX = newX;
 
             if (Math.Abs(angle1 - angle2) < 5)   // sup
                 return pt;   // sup
             //  Fail if segment C-D doesn't cross line A-B.
-            if (ACY < 0 && ADY < 0 || ACY >= 0 && ADY >= 0) 
+            if (ACY < 0 && ADY < 0 || ACY >= 0 && ADY >= 0)
                 return pt;
 
             //  (3) Discover the position of the intersection point along line A-B.
             ABpos = ADX + (ACX - ADX) * ADY / (ADY - ACY);
 
             //  Fail if segment C-D crosses line A-B outside of segment A-B.
-            if (ABpos < 0 || ABpos > distAB) 
+            if (ABpos < 0 || ABpos > distAB)
                 return pt;
 
             //  (4) Apply the discovered position to line A-B in the original coordinate system.
@@ -379,7 +379,7 @@ namespace Orts.Formats.OR
 >>>>>>> .r37
         }
   
-	#endif
+#endif
         public static PointF FindCurveIntersection(AESegment segArea, AESegment track)
         {
             PointF pointA = track.startPoint;
@@ -415,19 +415,19 @@ namespace Orts.Formats.OR
             return PointF.Empty;
         }
 
-        public static double FindDistanceToCurve (PointF pt, AESegment segment, out PointF closest)
+        public static double FindDistanceToCurve(PointF pt, AESegment segment, out PointF closest)
         {
             double dist = 0;
             double savedDist = double.PositiveInfinity;
             PointF current = new PointF(0f, 0f);
             if (!segment.isCurved || segment.radius == 0)
-                return FindDistanceToSegment (pt, segment, out closest);
+                return FindDistanceToSegment(pt, segment, out closest);
 
             PointF pointA = segment.startPoint;
             PointF pointB = segment.endPoint;
             PointF pointCenter = segment.center;
             closest = current;
-            for (int i = 0; i <= segment.step; i++) 
+            for (int i = 0; i <= segment.step; i++)
             {
                 double sub_angle = ((float)i / segment.step) * segment.angleTot;
                 double infox = (1 - Math.Cos(sub_angle)) * (-pointB.X);
@@ -445,7 +445,7 @@ namespace Orts.Formats.OR
                     closest = current;
                 }
             }
-            savedDist = Math.Round (savedDist, 1);
+            savedDist = Math.Round(savedDist, 1);
             return savedDist;
         }
 
@@ -471,7 +471,7 @@ namespace Orts.Formats.OR
             return oddNodes;
         }
 
-        public static int getDirection (TrackNode fromNode, TrackNode toNode)
+        public static int getDirection(TrackNode fromNode, TrackNode toNode)
         {
             foreach (var pin in fromNode.TrPins)
             {

--- a/Source/Orts.Formats.OR/ExtCarSpawnerFile.cs
+++ b/Source/Orts.Formats.OR/ExtCarSpawnerFile.cs
@@ -41,7 +41,7 @@ namespace Orts.Formats.OR
                         else
                         {
                             stf.MustMatch("(");
-                            stf.MustMatch("ListName"); 
+                            stf.MustMatch("ListName");
                             listName = stf.ReadStringBlock(null);
                             var carSpawnerBlock = new CarSpawnerBlock(stf, shapePath, carSpawnerLists, listName);
                         }

--- a/Source/Orts.Formats.OR/MSTSCoord.cs
+++ b/Source/Orts.Formats.OR/MSTSCoord.cs
@@ -163,7 +163,7 @@ namespace Orts.Formats.OR
             int tileY = ((int)(point.Y / 2048f));
             X = (float)((point.X) % 2048f);
             Y = (float)((point.Y) % 2048f);
-            if (signX < 0) 
+            if (signX < 0)
             {
                 tileX -= 1;
                 X += 2048f;
@@ -209,13 +209,13 @@ namespace Orts.Formats.OR
             if (GetType() != obj.GetType())
                 return false;
 
-            MSTSCoord other = (MSTSCoord) obj;
+            MSTSCoord other = (MSTSCoord)obj;
             return (this.X == other.X && this.Y == other.Y && this.TileX == other.TileX && this.TileY == other.TileY);
         }
 
         public static bool operator ==(MSTSCoord x, MSTSCoord y)
         {
-            return Object.Equals(x, y);  
+            return Object.Equals(x, y);
         }
 
         public static bool operator !=(MSTSCoord x, MSTSCoord y)

--- a/Source/Orts.Formats.OR/MSTSData.cs
+++ b/Source/Orts.Formats.OR/MSTSData.cs
@@ -30,7 +30,7 @@ namespace Orts.Formats.OR
         public string MstsPath { get; set; }
         public AESignals Signals { get; protected set; }
 
-        public MSTSData (string mstsPath, string Route)
+        public MSTSData(string mstsPath, string Route)
         {
             MstsPath = mstsPath;
             RoutePath = Route;
@@ -57,7 +57,7 @@ namespace Orts.Formats.OR
                 TSectionDat = new TrackSectionsFile(MstsPath + @"\GLOBAL\TSECTION.DAT");
             if (File.Exists(RoutePath + @"\TSECTION.DAT"))
                 TSectionDat.AddRouteTSectionDatFile(RoutePath + @"\TSECTION.DAT");
-            Signals = new AESignals (this, SIGCFG);
+            Signals = new AESignals(this, SIGCFG);
         }
     }
 }

--- a/Source/Orts.Formats.OR/RouteConfigurationFile.cs
+++ b/Source/Orts.Formats.OR/RouteConfigurationFile.cs
@@ -220,47 +220,47 @@ namespace Orts.Formats.OR
             fileName += ".cfg.json";
             //try
             //{
-                // TODO: This code is BROKEN. It loads and saves file formats with internal type information included, which causes breakages if the types are moved. This is not acceptable for public, shared data.
-                //JsonSerializer serializer = new JsonSerializer();
-                //using (StreamReader sr = new StreamReader(fileName))
-                //{
-                //    ORRouteConfig orRouteConfig = JsonConvert.DeserializeObject<ORRouteConfig>((string)sr.ReadToEnd(), new JsonSerializerSettings
-                //    {
-                //        PreserveReferencesHandling = PreserveReferencesHandling.Objects,
-                //        TypeNameHandling = TypeNameHandling.Auto
-                //    });
-                //    p = orRouteConfig;
-                    
-                //    foreach (var item in p.routeItems)
-                //    {
-                //        p.AllItems.Add(item);
-                //        item.alignEdition(interfaceType, null);
-                //        if (item.GetType() == typeof(StationItem))
-                //        {
-                //            if (((StationItem)item).stationArea.Count > 0)
-                //            {
-                //                foreach (var item2 in ((StationItem)item).stationArea)
-                //                {
-                //                    ((StationAreaItem)item2).alignEdition(interfaceType, item);
-                //                }
-                //                ((StationItem)item).areaCompleted = true;
-                //            }
-                //        }
-                //        else if (item.GetType() == typeof(AEBufferItem))
-                //        {
-                //        }
-                //    }
-                //    //orRouteConfig.ReduceItems();
-                //}
-                //
+            // TODO: This code is BROKEN. It loads and saves file formats with internal type information included, which causes breakages if the types are moved. This is not acceptable for public, shared data.
+            //JsonSerializer serializer = new JsonSerializer();
+            //using (StreamReader sr = new StreamReader(fileName))
+            //{
+            //    ORRouteConfig orRouteConfig = JsonConvert.DeserializeObject<ORRouteConfig>((string)sr.ReadToEnd(), new JsonSerializerSettings
+            //    {
+            //        PreserveReferencesHandling = PreserveReferencesHandling.Objects,
+            //        TypeNameHandling = TypeNameHandling.Auto
+            //    });
+            //    p = orRouteConfig;
+
+            //    foreach (var item in p.routeItems)
+            //    {
+            //        p.AllItems.Add(item);
+            //        item.alignEdition(interfaceType, null);
+            //        if (item.GetType() == typeof(StationItem))
+            //        {
+            //            if (((StationItem)item).stationArea.Count > 0)
+            //            {
+            //                foreach (var item2 in ((StationItem)item).stationArea)
+            //                {
+            //                    ((StationAreaItem)item2).alignEdition(interfaceType, item);
+            //                }
+            //                ((StationItem)item).areaCompleted = true;
+            //            }
+            //        }
+            //        else if (item.GetType() == typeof(AEBufferItem))
+            //        {
+            //        }
+            //    }
+            //    //orRouteConfig.ReduceItems();
+            //}
+            //
             //}
             //catch (IOException)
             //{
-                p = new ORRouteConfig();
-                p.FileName = Path.GetFileName(fileName);
-                p.RoutePath = Path.GetDirectoryName(fileName);
-                p.RouteName = "";
-                p.toSave = true;
+            p = new ORRouteConfig();
+            p.FileName = Path.GetFileName(fileName);
+            p.RoutePath = Path.GetDirectoryName(fileName);
+            p.RouteName = "";
+            p.toSave = true;
 
             //}
             return p;
@@ -435,7 +435,7 @@ namespace Orts.Formats.OR
             currentProgFolder = Path.GetDirectoryName(currentProgFolder);
             string completeFileName = Path.Combine(currentProgFolder, "Open Rails");
             if (!Directory.Exists(completeFileName)) Directory.CreateDirectory(completeFileName);
-            completeFileName = Path.Combine (completeFileName, "ORConfig.json");
+            completeFileName = Path.Combine(completeFileName, "ORConfig.json");
             ORConfig loaded = DeserializeJSON(completeFileName);
             return loaded;
         }

--- a/Source/Orts.Formats.OR/RouteItems.cs
+++ b/Source/Orts.Formats.OR/RouteItems.cs
@@ -340,7 +340,7 @@ namespace Orts.Formats.OR
     {
         public string Name;
         public float sizeSiding;
-        public TrItem trItem{ get; protected set; }
+        public TrItem trItem { get; protected set; }
         public TrItem.trItemType type { get { return trItem.ItemType; } protected set { } }
         public float icoAngle;
         public int typeSiding;
@@ -349,7 +349,7 @@ namespace Orts.Formats.OR
     public class SideStartItem : SideItem
     {
         public SideEndItem endSiding { get; set; }
-       
+
         /// <summary>
         /// The underlying track sideItem.
         /// </summary>
@@ -363,7 +363,7 @@ namespace Orts.Formats.OR
             else if (item.ItemType == TrItem.trItemType.trSIDING)
                 typeSiding = (int)TypeSiding.SIDING_START;
             typeItem = (int)TypeItem.SIDING_START;
-            
+
             trItem = item;
             Name = trItem.ItemName;
             Location = new PointF(trItem.TileX * 2048f + trItem.X, trItem.TileZ * 2048f + trItem.Z);

--- a/Source/Orts.Formats.OR/TimetableFile.cs
+++ b/Source/Orts.Formats.OR/TimetableFile.cs
@@ -67,7 +67,7 @@ namespace Orts.Formats.OR
             }
             catch (Exception ex)
             {
-                Trace.TraceInformation("Load error for timetable {0} : {1}",System.IO.Path.GetFileNameWithoutExtension(filePath), ex.ToString());
+                Trace.TraceInformation("Load error for timetable {0} : {1}", System.IO.Path.GetFileNameWithoutExtension(filePath), ex.ToString());
                 Description = "<" + "load error:" + " " + System.IO.Path.GetFileNameWithoutExtension(filePath) + ">";
             }
         }
@@ -141,7 +141,7 @@ namespace Orts.Formats.OR
 
                 if (!pathFound)
                 {
-                    if (String.Compare(Parts[0].Trim().Substring(0,5), "#path", true) == 0)
+                    if (String.Compare(Parts[0].Trim().Substring(0, 5), "#path", true) == 0)
                     {
                         pathFound = true;
                         foreach (TrainInformation train in Trains)
@@ -272,7 +272,7 @@ namespace Orts.Formats.OR
 
             public int CompareTo(TrainInformation otherInfo)
             {
-                return(String.Compare(this.Train, otherInfo.Train));
+                return (String.Compare(this.Train, otherInfo.Train));
             }
 
             override public string ToString()

--- a/Source/Orts.Formats.OR/TimetableGroupFile.cs
+++ b/Source/Orts.Formats.OR/TimetableGroupFile.cs
@@ -98,7 +98,7 @@ namespace Orts.Formats.OR
     /// class TimetableGroupFile
     /// extracts filenames from multiTTfile, extents names to full path
     /// </summary>
-    
+
     public class TimetableGroupFile
     {
         public List<string> TTFiles = new List<string>();

--- a/Source/Orts.Formats.OR/TrackCircuitElement.cs
+++ b/Source/Orts.Formats.OR/TrackCircuitElement.cs
@@ -34,7 +34,7 @@ namespace Orts.Formats.OR
     public class TrackCircuitElementConnector : TrackCircuitElement
     {
         public TrackCircuitElementConnector(GlobalItem item, float position)
-            : base (item, position)
+            : base(item, position)
         {
             info = TypeItem.STATION_CONNECTOR;
         }

--- a/Source/Orts.Formats.OR/WeatherFile.cs
+++ b/Source/Orts.Formats.OR/WeatherFile.cs
@@ -274,7 +274,7 @@ namespace Orts.Formats.OR
 
         protected override bool TryParse(JsonReader item)
         {
-        if (base.TryParse(item)) return true;
+            if (base.TryParse(item)) return true;
             switch (item.Path)
             {
                 case "FogVisibility": FogVisibilityM = item.AsFloat(FogVisibilityM); break;

--- a/Source/Orts.Parsers.Msts/Interpolator.cs
+++ b/Source/Orts.Parsers.Msts/Interpolator.cs
@@ -47,7 +47,7 @@ namespace Orts.Parsers.Msts
         {
             X = other.X;
             Y = other.Y;
-            Y2= other.Y2;
+            Y2 = other.Y2;
             Size = other.Size;
         }
         public Interpolator(STFReader stf)
@@ -58,7 +58,7 @@ namespace Orts.Parsers.Msts
                 list.Add(stf.ReadFloat(STFReader.UNITS.Any, null));
             if (list.Count % 2 == 1)
                 STFException.TraceWarning(stf, "Ignoring extra odd value in Interpolator list.");
-            int n = list.Count/2;
+            int n = list.Count / 2;
             if (n < 2)
                 STFException.TraceWarning(stf, "Interpolator must have at least two value pairs.");
             X = new float[n];
@@ -66,8 +66,8 @@ namespace Orts.Parsers.Msts
             Size = n;
             for (int i = 0; i < n; i++)
             {
-                X[i] = list[2*i];
-                Y[i] = list[2*i+1];
+                X[i] = list[2 * i];
+                Y[i] = list[2 * i + 1];
                 if (i > 0 && X[i - 1] >= X[i])
                     STFException.TraceWarning(stf, "Interpolator x values must be increasing.");
             }
@@ -79,30 +79,30 @@ namespace Orts.Parsers.Msts
                 if (x < X[PrevIndex] || x > X[PrevIndex + 1])
                 {
                     if (x < X[1])
-                        PrevIndex= 0;
-                    else if (x > X[Size-2])
-                        PrevIndex= Size-2;
+                        PrevIndex = 0;
+                    else if (x > X[Size - 2])
+                        PrevIndex = Size - 2;
                     else
                     {
-                        int i= 0;
-                        int j= Size-1;
-                        while (j-i > 1)
+                        int i = 0;
+                        int j = Size - 1;
+                        while (j - i > 1)
                         {
-                            int k= (i+j)/2;
+                            int k = (i + j) / 2;
                             if (X[k] > x)
-                                j= k;
+                                j = k;
                             else
-                                i= k;
+                                i = k;
                         }
-                        PrevIndex= i;
+                        PrevIndex = i;
                     }
                 }
-                float d= X[PrevIndex+1] - X[PrevIndex];
-                float a= (X[PrevIndex+1]-x)/d;
-                float b= (x-X[PrevIndex])/d;
-                float y= a*Y[PrevIndex] + b*Y[PrevIndex+1];
-                if (Y2 != null && a>=0 && b>=0)
-                    y+= ((a*a*a-a)*Y2[PrevIndex] + (b*b*b-b)*Y2[PrevIndex+1])*d*d/6;
+                float d = X[PrevIndex + 1] - X[PrevIndex];
+                float a = (X[PrevIndex + 1] - x) / d;
+                float b = (x - X[PrevIndex]) / d;
+                float y = a * Y[PrevIndex] + b * Y[PrevIndex + 1];
+                if (Y2 != null && a >= 0 && b >= 0)
+                    y += ((a * a * a - a) * Y2[PrevIndex] + (b * b * b - b) * Y2[PrevIndex + 1]) * d * d / 6;
                 return y;
             }
             set
@@ -113,7 +113,7 @@ namespace Orts.Parsers.Msts
             }
         }
         public float MinX() { return X[0]; }
-        public float MaxX() { return X[Size-1]; }
+        public float MaxX() { return X[Size - 1]; }
         public float MaxY()
         {
             float x;
@@ -121,10 +121,10 @@ namespace Orts.Parsers.Msts
         }
         public float MaxY(out float x)
         {
-            int maxi= 0;
-            for (int i=1; i<Size; i++)
+            int maxi = 0;
+            for (int i = 1; i < Size; i++)
                 if (Y[maxi] < Y[i])
-                    maxi= i;
+                    maxi = i;
             x = X[maxi];
             return Y[maxi];
         }
@@ -149,50 +149,50 @@ namespace Orts.Parsers.Msts
             if (Y2 != null)
             {
                 for (int i = 0; i < Size; i++)
-                    Y2[i]*= factor;
+                    Y2[i] *= factor;
             }
         }
         public void ComputeSpline()
         {
-            ComputeSpline(null,null);
+            ComputeSpline(null, null);
         }
         public void ComputeSpline(float? yp1, float? yp2)
         {
-            Y2= new float[Size];
-            float[] u= new float[Size];
+            Y2 = new float[Size];
+            float[] u = new float[Size];
             if (yp1 == null)
             {
-                Y2[0]= 0;
-                u[0]= 0;
+                Y2[0] = 0;
+                u[0] = 0;
             }
             else
             {
-                Y2[0]= -.5f;
-                float d= X[1]-X[0];
-                u[0]= 3/d * ((Y[1]-Y[0])/d-yp1.Value);
+                Y2[0] = -.5f;
+                float d = X[1] - X[0];
+                u[0] = 3 / d * ((Y[1] - Y[0]) / d - yp1.Value);
             }
-            for (int i=1; i<Size-1; i++)
+            for (int i = 1; i < Size - 1; i++)
             {
-                float sig= (X[i]-X[i-1]) / (X[i+1]-X[i-1]);
-                float p= sig*Y2[i-1] + 2;
-                Y2[i]= (sig-1)/p;
-                u[i]= (6*((Y[i+1]-Y[i])/(X[i+1]-X[i]) -
-                    (Y[i]-Y[i-1])/(X[i]-X[i-1])) / (X[i+1]-X[i-1]) -
-                    sig*u[i-1]) / p;
+                float sig = (X[i] - X[i - 1]) / (X[i + 1] - X[i - 1]);
+                float p = sig * Y2[i - 1] + 2;
+                Y2[i] = (sig - 1) / p;
+                u[i] = (6 * ((Y[i + 1] - Y[i]) / (X[i + 1] - X[i]) -
+                    (Y[i] - Y[i - 1]) / (X[i] - X[i - 1])) / (X[i + 1] - X[i - 1]) -
+                    sig * u[i - 1]) / p;
             }
             if (yp2 == null)
             {
-                Y2[Size-1]= 0;
+                Y2[Size - 1] = 0;
             }
             else
             {
-                float d= X[Size-1]-X[Size-2];
-                Y2[Size-1]= (3/d *(yp2.Value-(Y[Size-1]-Y[Size-2])/d)- .5f*u[Size-2])/(.5f*Y2[Size-2]+1);
+                float d = X[Size - 1] - X[Size - 2];
+                Y2[Size - 1] = (3 / d * (yp2.Value - (Y[Size - 1] - Y[Size - 2]) / d) - .5f * u[Size - 2]) / (.5f * Y2[Size - 2] + 1);
             }
-            for (int i=Size-2; i>=0; i--)
-                Y2[i]= Y2[i]*Y2[i+1] + u[i];
+            for (int i = Size - 2; i >= 0; i--)
+                Y2[i] = Y2[i] * Y2[i + 1] + u[i];
         }
-        
+
         // restore game state
         public Interpolator(BinaryReader inf)
         {
@@ -229,7 +229,7 @@ namespace Orts.Parsers.Msts
 
         public void test(string label, int n)
         {
-            float dx = (MaxX() - MinX()) / (n-1);
+            float dx = (MaxX() - MinX()) / (n - 1);
             for (int i = 0; i < n; i++)
             {
                 float x = MinX() + i * dx;
@@ -480,9 +480,9 @@ namespace Orts.Parsers.Msts
         public bool AcceptsNegativeValues() { return HasNegativeValues; }
     }
 
-     /// <summary>
-     /// two dimensional Interpolated table lookup - Generic
-     /// </summary>
+    /// <summary>
+    /// two dimensional Interpolated table lookup - Generic
+    /// </summary>
     public class Interpolator2D
     {
         float[] X;  // must be in increasing order

--- a/Source/Orts.Parsers.Msts/SBR.cs
+++ b/Source/Orts.Parsers.Msts/SBR.cs
@@ -132,8 +132,8 @@ namespace Orts.Parsers.Msts
 
         public void VerifyID(TokenID desiredID)
         {
-           if (ID != desiredID)
-               TraceInformation("Expected block " + desiredID + "; got " + ID);
+            if (ID != desiredID)
+                TraceInformation("Expected block " + desiredID + "; got " + ID);
         }
 
         /// <summary>

--- a/Source/Orts.Parsers.Msts/STFReader.cs
+++ b/Source/Orts.Parsers.Msts/STFReader.cs
@@ -1614,7 +1614,7 @@ namespace Orts.Parsers.Msts
 
             int c;
             #region Skip past any leading whitespace characters
-            for (;;)
+            for (; ; )
             {
                 c = ReadChar();
                 if (IsEof(c)) return UpdateTreeAndStepBack("");
@@ -1637,7 +1637,7 @@ namespace Orts.Parsers.Msts
             else if ((!skip_mode && !string_mode) && ((c == '#') || (c == '_')))
             {
                 #region Move on to a whitespace so we can pick up any token starting with a #
-                for (;;)
+                for (; ; )
                 {
                     c = PeekChar();
                     if ((c == '(') || (c == ')')) break;
@@ -1670,7 +1670,7 @@ namespace Orts.Parsers.Msts
             #region Build Quoted Items - including append operations
             else if (c == '"')
             {
-                for (;;)
+                for (; ; )
                 {
                     c = ReadChar();
                     if (IsEof(c))
@@ -1719,7 +1719,7 @@ namespace Orts.Parsers.Msts
             else if (c != -1)
             {
                 itemBuilder.Append((char)c);
-                for (;;)
+                for (; ; )
                 {
                     c = PeekChar();
                     if ((c == '(') || (c == ')')) break;
@@ -1873,7 +1873,7 @@ namespace Orts.Parsers.Msts
     // * We demand a correct syntax even in comments and includes, so also not possible to skipa
     //      a syntactically wrong section by putting it in comments
 
-    #region Interfaces
+#region Interfaces
     /// <summary>
     /// Interface for classes that have a 'stream' of StfTokens as output
     /// </summary>
@@ -1903,9 +1903,9 @@ namespace Orts.Parsers.Msts
         StreamReader GetStreamReader(string name, out string simisSignature);
     }
 
-    #endregion
+#endregion
 
-    #region StfToken
+#region StfToken
     /// <summary>
     /// Single token from the MSTS STF format (Structured Text Format).
     /// Token contains obviously the string, but also the name and lineNumber (at the start of the token)
@@ -1955,9 +1955,9 @@ namespace Orts.Parsers.Msts
             return "token: " + this.Contents;
         }
     }
-    #endregion
+#endregion
 
-    #region StfTokenizer
+#region StfTokenizer
     /// <summary>
     /// Class to tokenize a stream. Tokenize means splitting into tokens, according to the rules of STF format
     /// Most tokens are just strings without white space.
@@ -2167,7 +2167,7 @@ namespace Orts.Parsers.Msts
             return new StfToken(itemBuilder.ToString(), storedStreamName, lineNumberAtStart);
         }
 
-        #region IDisposable
+#region IDisposable
         bool hasBeenDisposed;
         /// <summary>
         /// Implements the IDisposable interface so this class can be implemented with the 
@@ -2207,18 +2207,18 @@ namespace Orts.Parsers.Msts
             itemBuilder.Capacity = 0;
             hasBeenDisposed = true;
         }
-        #endregion
+#endregion
     }
-    #endregion
+#endregion
 
-    #region Buffering of a token
+#region Buffering of a token
     public abstract class StfTokenStreamBuffer
     {
         internal StfToken UpcomingTokenFromSource;
         internal StfToken CurrentTokenFromSource;
         internal IStfTokenStream SourceTokenStream;
         
-        #region stepback legacy
+#region stepback legacy
         private StfToken bufferedTokenFromSource;
         private bool didAStepBack;
 
@@ -2263,7 +2263,7 @@ namespace Orts.Parsers.Msts
             UpcomingTokenFromSource = CurrentTokenFromSource;
             didAStepBack = true;
         }
-        #endregion
+#endregion
 
         /// <summary>
         /// Return the next token from whatever the source it uses, and, importantly, after possible pre-processing
@@ -2271,9 +2271,9 @@ namespace Orts.Parsers.Msts
         /// </summary>
         internal abstract StfToken NextToken();
     }
-    #endregion
+#endregion
 
-    #region Block handling and mustmatch
+#region Block handling and mustmatch
     public abstract class StfTokenStreamBlockProcessor : StfTokenStreamBuffer 
     {
         /// <summary>Skip to the end of this block, ignoring any nested blocks
@@ -2372,9 +2372,9 @@ namespace Orts.Parsers.Msts
         }
 
     }
-    #endregion
+#endregion
 
-    #region Preprocessing of comments, include, ...
+#region Preprocessing of comments, include, ...
     class StfTokenStreamPreprocessor : StfTokenStreamBlockProcessor, IStfTokenStream
     {
         /// <summary>
@@ -2506,7 +2506,7 @@ namespace Orts.Parsers.Msts
             return String.Equals("include", CurrentTokenFromSource.Contents, StringComparison.OrdinalIgnoreCase);
         }
 
-        #region IDisposable
+#region IDisposable
         bool hasBeenDisposed;
         /// <summary>
         /// Implements the IDisposable interface so this class can be implemented with the 
@@ -2559,7 +2559,7 @@ namespace Orts.Parsers.Msts
             }
         }
 
-        #endregion
+#endregion
 
         private string directoryName = String.Empty;
         private IStfTokenStream sourceInclude;
@@ -2567,7 +2567,7 @@ namespace Orts.Parsers.Msts
         private bool inSkipMode;
 
     }
-    #endregion
+#endregion
 
     /// <exception cref="STFException"><para>
     /// STF reports errors using the exception static members</para><para>
@@ -2579,7 +2579,7 @@ namespace Orts.Parsers.Msts
     /// </exception>
     public sealed class STFReader : StfTokenStreamBlockProcessor, IDisposable
     {
-        #region Properties
+#region Properties
         /// <summary>Property that returns true when the EOF (End-of-file) has been reached </summary>
         public bool Eof { get { return this.UpcomingTokenFromSource.IsEOF; } }
         /// <summary>Property that returns the line number in the file we are reading, at the beginning of the last item that was read
@@ -2614,7 +2614,7 @@ namespace Orts.Parsers.Msts
         }
         static IStreamReaderFactory storedNextStreamReaderFactory;
 
-        #endregion
+#endregion
 
         private STFReader()
         {
@@ -2622,7 +2622,7 @@ namespace Orts.Parsers.Msts
             this.streamReaderFactory = STFReader.NextStreamReaderFactory;
         }
 
-        #region Constructor
+#region Constructor
         /// <summary>Open a file, reader the header line, and prepare for STF parsing
         /// </summary>
         /// <param name="fileName">Filename of the STF file to be opened and parsed.</param>
@@ -2658,9 +2658,9 @@ namespace Orts.Parsers.Msts
             InitBuffer();
             InitTree(useTree);
         }
-        #endregion
+#endregion
 
-        #region IDisposable
+#region IDisposable
         bool hasBeenDisposed;
         /// <summary>
         /// Implements the IDisposable interface so this class can be implemented with the 
@@ -2701,9 +2701,9 @@ namespace Orts.Parsers.Msts
                 }
             }
         }
-        #endregion
+#endregion
 
-        #region Get tokens and buffer it.
+#region Get tokens and buffer it.
         /// <summary>
         /// Initialize the single-token buffer, so that the upcoming token is known
         /// </summary>
@@ -2759,9 +2759,9 @@ namespace Orts.Parsers.Msts
             return false;
         }
 
-        #endregion
+#endregion
 
-        #region Tree
+#region Tree
         private Stack<string> treeTokens;
         private bool treeIsMaintained;
 
@@ -2830,9 +2830,9 @@ namespace Orts.Parsers.Msts
                 return String.Join("(", treeTokens.Reverse().ToArray());
             }
         }
-        #endregion
+#endregion
 
-        #region Units
+#region Units
         /// <summary>Enumeration specifying which units are valid when parsing a numeric constant.
         /// </summary>
         // Additional entries because MSTS has multiple default units, e.g. some speeds in metres/sec and others in miles/hr
@@ -3298,10 +3298,10 @@ namespace Orts.Parsers.Msts
             return 1;
         }
 
-        #endregion
+#endregion
 
-        #region Reading values, numbers, ...
-        #region Private methods for common functionality. Here all the real work goes on
+#region Reading values, numbers, ...
+#region Private methods for common functionality. Here all the real work goes on
         private static NumberStyles parseNum = NumberStyles.AllowLeadingWhite | NumberStyles.AllowLeadingSign | NumberStyles.AllowThousands | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowTrailingWhite;
         private static NumberStyles parseHex = NumberStyles.AllowLeadingWhite | NumberStyles.AllowHexSpecifier | NumberStyles.AllowTrailingWhite;
         private static IFormatProvider parseNFI = NumberFormatInfo.InvariantInfo;
@@ -3388,9 +3388,9 @@ namespace Orts.Parsers.Msts
             STFException.TraceWarning(CurrentTokenFromSource, "Block not found - instead found " + CurrentTokenFromSource.Contents);
             return valueOfDefault;
         }
-        #endregion
+#endregion
 
-        #region Reading values itself
+#region Reading values itself
         /// <summary>Return next whitespace delimited string from the STF file.
         /// </summary>
         /// <remarks>
@@ -3501,9 +3501,9 @@ namespace Orts.Parsers.Msts
             });
         }
 
-        #endregion
+#endregion
 
-        #region Reading blocks with values
+#region Reading blocks with values
         /// <summary>Read an string constant from the STF format '( {string_constant} ... )'
         /// </summary>
         /// <param name="defaultValue">the default value if the item is not found in the block.</param>
@@ -3619,10 +3619,10 @@ namespace Orts.Parsers.Msts
                 return result;
             });
         }
-        #endregion
-        #endregion
+#endregion
+#endregion
 
-        #region Tokenprocessor, Parseblock
+#region Tokenprocessor, Parseblock
         /// <summary>Parse an STF file until the EOF, using the array of lower case tokens, with a processor delegate/lambda
         /// </summary>
         /// <param name="processors">Array of lower case token, and the delegate/lambda to call when matched.</param>
@@ -3696,9 +3696,9 @@ namespace Orts.Parsers.Msts
             public TokenProcessor(string t, Processor p) { token = t; processor = p; }
             public string token; public Processor processor;
         }
-        #endregion
+#endregion
 
-        #region Legacy (todo: refactor away)
+#region Legacy (todo: refactor away)
         /// <summary>Property that returns true when the EOF has been reached</summary>
         public bool EOF() { return Eof; }
         public void VerifyStartOfBlock()
@@ -3718,10 +3718,10 @@ namespace Orts.Parsers.Msts
             return 0;
         }
 
-        #endregion
+#endregion
     }
 
-    #region StreamReaderFactory
+#region StreamReaderFactory
     /// <summary>
     /// Factory class that creates a StreamReader from a file.
     /// Reading from an STF file also means that the first lines is interpreted as a SIMIS signature
@@ -3747,9 +3747,9 @@ namespace Orts.Parsers.Msts
             return stream;
         }
     }
-    #endregion
+#endregion
 
-    #region StfExceptions
+#region StfExceptions
     /// <summary>
     /// Exceptions to be called during reading of STF files
     /// </summary>
@@ -3802,7 +3802,7 @@ namespace Orts.Parsers.Msts
                                     "{2} in {0}:line {1}\n", fileName, lineNumber, message)) { }        
     }
 
-    #endregion
+#endregion
 
 }
 #endif

--- a/Source/Orts.Parsers.Msts/TokenID.cs
+++ b/Source/Orts.Parsers.Msts/TokenID.cs
@@ -299,7 +299,7 @@ namespace Orts.Parsers.Msts
         Platform = 360,
         LevelCr = 362,
         Speedpost = 364,
-        Hazard=365,
+        Hazard = 365,
 
 
 
@@ -1691,12 +1691,12 @@ namespace Orts.Parsers.Msts
 
         // these assigned ID's are arbitrary - I haven't seen them in a compressed MSTS W file yet
         // TODO determine proper ID from a compressed world file
-        CarSpawner, 
-        Siding, 
+        CarSpawner,
+        Siding,
         Dyntrack,
         Transfer,
         Gantry,
-        Pickup,  
+        Pickup,
 
         Wagon,
         Engine,

--- a/Source/Orts.Simulation/Common/CommandLog.cs
+++ b/Source/Orts.Simulation/Common/CommandLog.cs
@@ -29,14 +29,16 @@ namespace Orts.Common
     /// <summary>
     /// User may specify an automatic pause in the replay at a time measured from the end of the replay.
     /// </summary>
-    public enum ReplayPauseState {
+    public enum ReplayPauseState
+    {
         Before,
         Due,        // Set by CommandLog.Replay(), tested by Viewer.Update()
         During,
         Done
     };
 
-    public class CommandLog {
+    public class CommandLog
+    {
 
         public List<ICommand> CommandList = new List<ICommand>();
         public Simulator Simulator { get; set; }
@@ -52,7 +54,8 @@ namespace Orts.Common
         /// <summary>
         /// Preferred constructor.
         /// </summary>
-        public CommandLog(Simulator simulator) {
+        public CommandLog(Simulator simulator)
+        {
             Simulator = simulator;
         }
 
@@ -60,11 +63,12 @@ namespace Orts.Common
         /// When a command is created, it adds itself to the log.
         /// </summary>
         /// <param name="Command"></param>
-        public void CommandAdd( ICommand command ) {
+        public void CommandAdd(ICommand command)
+        {
             command.Time = Simulator.ClockTime; // Note time that command was issued
-            CommandList.Add( command );
+            CommandList.Add(command);
         }
-        
+
         /// <summary>
         /// Replays any commands that have become due.
         /// Issues commands from the replayCommandList at the same time that they were originally issued.
@@ -72,74 +76,97 @@ namespace Orts.Common
         /// Assumes replayCommandList is already sorted by time.
         /// </para>
         /// </summary>
-        public void Update( List<ICommand> replayCommandList ) {
+        public void Update(List<ICommand> replayCommandList)
+        {
             double elapsedTime = Simulator.ClockTime;
 
-            if( PauseState == ReplayPauseState.Before ) {
-                if( elapsedTime > ReplayEndsAt - Simulator.Settings.ReplayPauseBeforeEndS ) {
+            if (PauseState == ReplayPauseState.Before)
+            {
+                if (elapsedTime > ReplayEndsAt - Simulator.Settings.ReplayPauseBeforeEndS)
+                {
                     PauseState = ReplayPauseState.Due;  // For Viewer.Update() to detect and pause.
                 }
             }
 
-            if( replayCommandList.Count > 0 ) {
+            if (replayCommandList.Count > 0)
+            {
                 var c = replayCommandList[0];
                 // Without a small margin, an activity event can pause simulator just before the ResumeActicityCommand is due, 
                 // so resume never happens.
                 double margin = (Simulator.Paused) ? 0.5 : 0;   // margin of 0.5 seconds
-                if( elapsedTime >= c.Time - margin ) {
-                    if( c is PausedCommand ) {
+                if (elapsedTime >= c.Time - margin)
+                {
+                    if (c is PausedCommand)
+                    {
                         // Wait for the right duration and then action the command.
                         // ActivityCommands need dedicated code as the clock is no longer advancing.
-                        if( resumeTime == null ) {
+                        if (resumeTime == null)
+                        {
                             var resumeCommand = (PausedCommand)c;
-                            resumeTime = DateTime.Now.AddSeconds(resumeCommand.PauseDurationS );
-                        } else {
-                            if( DateTime.Now >= resumeTime ) {
+                            resumeTime = DateTime.Now.AddSeconds(resumeCommand.PauseDurationS);
+                        }
+                        else
+                        {
+                            if (DateTime.Now >= resumeTime)
+                            {
                                 resumeTime = null;  // cancel trigger
-                                ReplayCommand( elapsedTime, replayCommandList, c );
+                                ReplayCommand(elapsedTime, replayCommandList, c);
                             }
                         }
-                    } else {
+                    }
+                    else
+                    {
                         // When the player uses a camera command during replay, replay continues but any camera commands in the 
                         // replayCommandList are skipped until the player pauses and exit from the Quit Menu.
                         // This allows some editing of the camera during a replay.
-                        if (!(c is CameraCommand && CameraReplaySuspended)) {
+                        if (!(c is CameraCommand && CameraReplaySuspended))
+                        {
                             ReplayCommand(elapsedTime, replayCommandList, c);
                         }
                         completeTime = elapsedTime + completeDelayS;  // Postpone the time for "Replay complete" message
                     }
                 }
-            } else {
-                if( completeTime != 0 && elapsedTime > completeTime ) {
+            }
+            else
+            {
+                if (completeTime != 0 && elapsedTime > completeTime)
+                {
                     completeTime = 0;       // Reset trigger so this only happens once
                     ReplayComplete = true;  // Flag seen by Viewer3D which announces "Replay complete".
                 }
             }
         }
 
-        private void ReplayCommand( double elapsedTime, List<ICommand> replayCommandList, ICommand c ) {
+        private void ReplayCommand(double elapsedTime, List<ICommand> replayCommandList, ICommand c)
+        {
             c.Redo();                           // Action the command
-            CommandList.Add( c );               // Add to the log of commands
-            replayCommandList.RemoveAt( 0 );    // Remove it from the head of the replay list
+            CommandList.Add(c);               // Add to the log of commands
+            replayCommandList.RemoveAt(0);    // Remove it from the head of the replay list
         }
 
         /// <summary>
         /// Copies the command objects from the log into the file specified, first creating the file.
         /// </summary>
         /// <param name="filePath"></param>
-        public void SaveLog( string filePath ) {
+        public void SaveLog(string filePath)
+        {
             Stream stream = null;
-            try {
-                stream = new FileStream( filePath, FileMode.Create );
+            try
+            {
+                stream = new FileStream(filePath, FileMode.Create);
                 BinaryFormatter formatter = new BinaryFormatter();
                 // Re-sort based on time as tests show that some commands are deferred.
-                CommandList.Sort( ( x, y ) => x.Time.CompareTo( y.Time ) );
-                formatter.Serialize( stream, CommandList );
-            } catch( IOException ) {
+                CommandList.Sort((x, y) => x.Time.CompareTo(y.Time));
+                formatter.Serialize(stream, CommandList);
+            }
+            catch (IOException)
+            {
                 // Do nothing but warn, ignoring errors.
-                Trace.TraceWarning( "SaveLog error writing command log " + filePath );
-            } finally {
-                if( stream != null )
+                Trace.TraceWarning("SaveLog error writing command log " + filePath);
+            }
+            finally
+            {
+                if (stream != null)
                 {
                     stream.Close();
                     Trace.WriteLine("\nList of commands to replay saved");
@@ -151,23 +178,30 @@ namespace Orts.Common
         /// Copies the command objects from the file specified into the log, replacing the log's contents.
         /// </summary>
         /// <param name="fullFilePath"></param>
-        public void LoadLog( string filePath ) {
+        public void LoadLog(string filePath)
+        {
             Stream stream = null;
-            try {
-                stream = new FileStream( filePath, FileMode.Open );
+            try
+            {
+                stream = new FileStream(filePath, FileMode.Open);
                 BinaryFormatter formatter = new BinaryFormatter();
-                CommandList = (List<ICommand>)formatter.Deserialize( stream );
-            } catch( IOException ) {
+                CommandList = (List<ICommand>)formatter.Deserialize(stream);
+            }
+            catch (IOException)
+            {
                 // Do nothing but warn, ignoring errors.
-                Trace.TraceWarning( "LoadLog error reading command log " + filePath );
-            } finally {
-                if( stream != null ) { stream.Close(); }
+                Trace.TraceWarning("LoadLog error reading command log " + filePath);
+            }
+            finally
+            {
+                if (stream != null) { stream.Close(); }
             }
         }
 
-        public static void ReportReplayCommands( List<ICommand> list ) {
-            Trace.WriteLine( "\nList of commands to replay:" );
-            foreach( var c in list ) { c.Report(); }
+        public static void ReportReplayCommands(List<ICommand> list)
+        {
+            Trace.WriteLine("\nList of commands to replay:");
+            foreach (var c in list) { c.Report(); }
         }
     }
 }

--- a/Source/Orts.Simulation/Common/Commands.cs
+++ b/Source/Orts.Simulation/Common/Commands.cs
@@ -52,7 +52,8 @@ namespace Orts.Common
     ///   ReverserCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
     /// 
     /// </summary>
-    public interface ICommand {
+    public interface ICommand
+    {
 
         /// <summary>
         /// The time when the command was issued (compatible with Simlator.ClockTime).
@@ -73,66 +74,76 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public abstract class Command : ICommand {
+    public abstract class Command : ICommand
+    {
         public double Time { get; set; }
 
         /// <summary>
         /// Each command adds itself to the log when it is constructed.
         /// </summary>
-        public Command( CommandLog log ) {
-            log.CommandAdd( this as ICommand );
+        public Command(CommandLog log)
+        {
+            log.CommandAdd(this as ICommand);
         }
 
         // Method required by ICommand
-        public virtual void Redo() { Trace.TraceWarning( "Dummy method" ); }
+        public virtual void Redo() { Trace.TraceWarning("Dummy method"); }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return this.GetType().ToString();
         }
 
         // Method required by ICommand
-        public virtual void Report() {
-            Trace.WriteLine( String.Format(
-               "Command: {0} {1}", FormatStrings.FormatPreciseTime( Time ), ToString() ) );
+        public virtual void Report()
+        {
+            Trace.WriteLine(String.Format(
+               "Command: {0} {1}", FormatStrings.FormatPreciseTime(Time), ToString()));
         }
     }
 
     // <Superclasses>
     [Serializable()]
-    public abstract class BooleanCommand : Command {
+    public abstract class BooleanCommand : Command
+    {
         protected bool ToState;
 
-        public BooleanCommand( CommandLog log, bool toState )
-            : base( log ) {
+        public BooleanCommand(CommandLog log, bool toState)
+            : base(log)
+        {
             ToState = toState;
         }
     }
 
     [Serializable()]
-    public abstract class IndexCommand : Command {
+    public abstract class IndexCommand : Command
+    {
         protected int Index;
 
-        public IndexCommand( CommandLog log, int index )
+        public IndexCommand(CommandLog log, int index)
             : base(log)
         {
             Index = index;
         }
     }
-    
+
     /// <summary>
     /// Superclass for continuous commands. Do not create a continuous command until the operation is complete.
     /// </summary>
     [Serializable()]
-    public abstract class ContinuousCommand : BooleanCommand {
+    public abstract class ContinuousCommand : BooleanCommand
+    {
         protected float? Target;
 
-        public ContinuousCommand( CommandLog log, bool toState, float? target, double startTime ) 
-            : base( log, toState ) {
+        public ContinuousCommand(CommandLog log, bool toState, float? target, double startTime)
+            : base(log, toState)
+        {
             Target = target;
             this.Time = startTime;   // Continuous commands are created at end of change, so overwrite time when command was created
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " - " + (ToState ? "increase" : "decrease") + ", target = " + Target.ToString();
         }
     }
@@ -164,85 +175,103 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class SaveCommand : Command {
+    public sealed class SaveCommand : Command
+    {
         public string FileStem;
 
-        public SaveCommand( CommandLog log, string fileStem ) 
-            : base( log ){
+        public SaveCommand(CommandLog log, string fileStem)
+            : base(log)
+        {
             this.FileStem = fileStem;
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             // Redo does nothing as SaveCommand is just a marker and saves the fileStem but is not used during replay to redo the save.
             // Report();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " to file \"" + FileStem + ".replay\"";
         }
     }
 
     // Direction
     [Serializable()]
-    public sealed class ReverserCommand : BooleanCommand {
+    public sealed class ReverserCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public ReverserCommand( CommandLog log, bool toState ) 
-            : base( log, toState ) {
+        public ReverserCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            if( ToState ) {
-                Receiver.StartReverseIncrease( null );
-            } else {
-                Receiver.StartReverseDecrease( null );
+        public override void Redo()
+        {
+            if (ToState)
+            {
+                Receiver.StartReverseIncrease(null);
+            }
+            else
+            {
+                Receiver.StartReverseDecrease(null);
             }
             // Report();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " - " + (ToState ? "step forward" : "step back");
         }
     }
 
     [Serializable()]
-    public sealed class ContinuousReverserCommand : ContinuousCommand {
+    public sealed class ContinuousReverserCommand : ContinuousCommand
+    {
         public static MSTSSteamLocomotive Receiver { get; set; }
 
-        public ContinuousReverserCommand( CommandLog log, bool toState, float? target, double startTime ) 
-            : base( log, toState, target, startTime ) {
+        public ContinuousReverserCommand(CommandLog log, bool toState, float? target, double startTime)
+            : base(log, toState, target, startTime)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver == null) return;
-            Receiver.ReverserChangeTo( ToState, Target );
+            Receiver.ReverserChangeTo(ToState, Target);
             // Report();
         }
     }
 
     // Power : Raise/lower pantograph
     [Serializable()]
-    public sealed class PantographCommand : BooleanCommand {
+    public sealed class PantographCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
         private int item;
 
-        public PantographCommand( CommandLog log, int item, bool toState ) 
-            : base( log, toState ) {
+        public PantographCommand(CommandLog log, int item, bool toState)
+            : base(log, toState)
+        {
             this.item = item;
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver != null && Receiver.Train != null)
             {
                 Receiver.Train.SignalEvent((ToState ? PowerSupplyEvent.RaisePantograph : PowerSupplyEvent.LowerPantograph), item);
             }
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " - " + (ToState ? "raise" : "lower") + ", item = " + item.ToString();
         }
     }
@@ -404,94 +433,113 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class NotchedThrottleCommand : BooleanCommand {
+    public sealed class NotchedThrottleCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public NotchedThrottleCommand( CommandLog log, bool toState ) : base( log, toState ) {
+        public NotchedThrottleCommand(CommandLog log, bool toState) : base(log, toState)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             Receiver.AdjustNotchedThrottle(ToState);
             // Report();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " - " + (ToState ? "step forward" : "step back");
         }
     }
 
     [Serializable()]
-    public sealed class ContinuousThrottleCommand : ContinuousCommand {
+    public sealed class ContinuousThrottleCommand : ContinuousCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public ContinuousThrottleCommand( CommandLog log, bool toState, float? target, double startTime ) 
-            : base( log, toState, target, startTime ){
+        public ContinuousThrottleCommand(CommandLog log, bool toState, float? target, double startTime)
+            : base(log, toState, target, startTime)
+        {
             Redo();
         }
 
-        public override void Redo() { 
-            Receiver.ThrottleChangeTo( ToState, Target );
+        public override void Redo()
+        {
+            Receiver.ThrottleChangeTo(ToState, Target);
             // Report();
         }
     }
-    
+
     // Brakes
     [Serializable()]
-    public sealed class TrainBrakeCommand : ContinuousCommand {
+    public sealed class TrainBrakeCommand : ContinuousCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public TrainBrakeCommand( CommandLog log, bool toState, float? target, double startTime ) 
-            : base( log, toState, target, startTime ) {
+        public TrainBrakeCommand(CommandLog log, bool toState, float? target, double startTime)
+            : base(log, toState, target, startTime)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            Receiver.TrainBrakeChangeTo( ToState, Target );
+        public override void Redo()
+        {
+            Receiver.TrainBrakeChangeTo(ToState, Target);
             // Report();
         }
     }
 
     [Serializable()]
-    public sealed class EngineBrakeCommand : ContinuousCommand {
+    public sealed class EngineBrakeCommand : ContinuousCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public EngineBrakeCommand( CommandLog log, bool toState, float? target, double startTime )
-            : base( log, toState, target, startTime ) {
+        public EngineBrakeCommand(CommandLog log, bool toState, float? target, double startTime)
+            : base(log, toState, target, startTime)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            Receiver.EngineBrakeChangeTo( ToState, Target );
+        public override void Redo()
+        {
+            Receiver.EngineBrakeChangeTo(ToState, Target);
             // Report();
         }
     }
 
     [Serializable()]
-    public sealed class DynamicBrakeCommand : ContinuousCommand {
+    public sealed class DynamicBrakeCommand : ContinuousCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public DynamicBrakeCommand( CommandLog log, bool toState, float? target, double startTime )
-            : base( log, toState, target, startTime ) {
+        public DynamicBrakeCommand(CommandLog log, bool toState, float? target, double startTime)
+            : base(log, toState, target, startTime)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            Receiver.DynamicBrakeChangeTo( ToState, Target );
+        public override void Redo()
+        {
+            Receiver.DynamicBrakeChangeTo(ToState, Target);
             // Report();
         }
     }
 
     [Serializable()]
-    public sealed class InitializeBrakesCommand : Command {
+    public sealed class InitializeBrakesCommand : Command
+    {
         public static Train Receiver { get; set; }
 
-        public InitializeBrakesCommand( CommandLog log ) 
-            : base( log ) {
+        public InitializeBrakesCommand(CommandLog log)
+            : base(log)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             Receiver.UnconditionalInitializeBrakes();
             // Report();
         }
@@ -517,39 +565,47 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class BailOffCommand : BooleanCommand {
+    public sealed class BailOffCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public BailOffCommand( CommandLog log, bool toState ) 
-            : base( log, toState ) {
+        public BailOffCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            Receiver.SetBailOff( ToState );
+        public override void Redo()
+        {
+            Receiver.SetBailOff(ToState);
             // Report();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " - " + (ToState ? "disengage" : "engage");
         }
     }
 
     [Serializable()]
-    public sealed class HandbrakeCommand : BooleanCommand {
+    public sealed class HandbrakeCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public HandbrakeCommand( CommandLog log, bool toState ) 
-            : base( log, toState ) {
+        public HandbrakeCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            Receiver.SetTrainHandbrake( ToState );
+        public override void Redo()
+        {
+            Receiver.SetTrainHandbrake(ToState);
             // Report();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " - " + (ToState ? "apply" : "release");
         }
     }
@@ -579,39 +635,47 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class RetainersCommand : BooleanCommand {
+    public sealed class RetainersCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public RetainersCommand( CommandLog log, bool toState ) 
-            : base( log, toState ) {
+        public RetainersCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            Receiver.SetTrainRetainers( ToState );
+        public override void Redo()
+        {
+            Receiver.SetTrainRetainers(ToState);
             // Report();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " - " + (ToState ? "apply" : "release");
         }
     }
 
     [Serializable()]
-    public sealed class BrakeHoseConnectCommand : BooleanCommand {
+    public sealed class BrakeHoseConnectCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public BrakeHoseConnectCommand( CommandLog log, bool toState ) 
-            : base( log, toState ) {
+        public BrakeHoseConnectCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            Receiver.BrakeHoseConnect( ToState );
+        public override void Redo()
+        {
+            Receiver.BrakeHoseConnect(ToState);
             // Report();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " - " + (ToState ? "connect" : "disconnect");
         }
     }
@@ -713,39 +777,49 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class SanderCommand : BooleanCommand {
+    public sealed class SanderCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public SanderCommand( CommandLog log, bool toState ) 
-            : base( log, toState ) {
+        public SanderCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            if( ToState ) {
+        public override void Redo()
+        {
+            if (ToState)
+            {
                 if (!Receiver.Sander)
                     Receiver.Train.SignalEvent(Event.SanderOn);
-            } else {
+            }
+            else
+            {
                 Receiver.Train.SignalEvent(Event.SanderOff);
             }
             // Report();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " - " + (ToState ? "on" : "off");
         }
     }
 
     [Serializable()]
-    public sealed class AlerterCommand : BooleanCommand {
+    public sealed class AlerterCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public AlerterCommand( CommandLog log, bool toState ) 
-            : base( log, toState ) {
+        public AlerterCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (ToState) Receiver.SignalEvent(Event.VigilanceAlarmReset); // There is no Event.VigilanceAlarmResetReleased
             Receiver.AlerterPressed(ToState);
             // Report();
@@ -753,15 +827,18 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class HornCommand : BooleanCommand {
+    public sealed class HornCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public HornCommand( CommandLog log, bool toState ) 
-            : base( log, toState ) {
+        public HornCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             Receiver.ManualHorn = ToState;
             if (ToState)
             {
@@ -770,17 +847,20 @@ namespace Orts.Common
             }
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " " + (ToState ? "sound" : "off");
         }
     }
 
     [Serializable()]
-    public sealed class BellCommand : BooleanCommand {
+    public sealed class BellCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public BellCommand( CommandLog log, bool toState ) 
-            : base( log, toState ) {
+        public BellCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
             Redo();
         }
 
@@ -789,50 +869,63 @@ namespace Orts.Common
             Receiver.ManualBell = ToState;
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + " " + (ToState ? "ring" : "off");
         }
     }
 
     [Serializable()]
-    public sealed class ToggleCabLightCommand : Command {
+    public sealed class ToggleCabLightCommand : Command
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public ToggleCabLightCommand( CommandLog log ) 
-            : base( log ) {
+        public ToggleCabLightCommand(CommandLog log)
+            : base(log)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            Receiver.ToggleCabLight( );
+        public override void Redo()
+        {
+            Receiver.ToggleCabLight();
             // Report();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString();
         }
     }
 
     [Serializable()]
-    public sealed class HeadlightCommand : BooleanCommand {
+    public sealed class HeadlightCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public HeadlightCommand( CommandLog log, bool toState ) 
-            : base( log, toState ) {
+        public HeadlightCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            if( ToState ) {
-                switch( Receiver.Headlight ) {
-                    case 0: Receiver.Headlight = 1; Receiver.Simulator.Confirmer.Confirm( CabControl.Headlight, CabSetting.Neutral ); break;
-                    case 1: Receiver.Headlight = 2; Receiver.Simulator.Confirmer.Confirm( CabControl.Headlight, CabSetting.On ); break;
+        public override void Redo()
+        {
+            if (ToState)
+            {
+                switch (Receiver.Headlight)
+                {
+                    case 0: Receiver.Headlight = 1; Receiver.Simulator.Confirmer.Confirm(CabControl.Headlight, CabSetting.Neutral); break;
+                    case 1: Receiver.Headlight = 2; Receiver.Simulator.Confirmer.Confirm(CabControl.Headlight, CabSetting.On); break;
                 }
                 Receiver.SignalEvent(Event.LightSwitchToggle);
-            } else {
-                switch( Receiver.Headlight ) {
-                    case 1: Receiver.Headlight = 0; Receiver.Simulator.Confirmer.Confirm( CabControl.Headlight, CabSetting.Off ); break;
-                    case 2: Receiver.Headlight = 1; Receiver.Simulator.Confirmer.Confirm( CabControl.Headlight, CabSetting.Neutral ); break;
+            }
+            else
+            {
+                switch (Receiver.Headlight)
+                {
+                    case 1: Receiver.Headlight = 0; Receiver.Simulator.Confirmer.Confirm(CabControl.Headlight, CabSetting.Off); break;
+                    case 2: Receiver.Headlight = 1; Receiver.Simulator.Confirmer.Confirm(CabControl.Headlight, CabSetting.Neutral); break;
                 }
                 Receiver.SignalEvent(Event.LightSwitchToggle);
             }
@@ -841,46 +934,55 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class WipersCommand : BooleanCommand {
+    public sealed class WipersCommand : BooleanCommand
+    {
         public static MSTSLocomotive Receiver { get; set; }
 
-        public WipersCommand( CommandLog log , bool toState) 
-            : base( log , toState ) { 
-            Redo(); 
+        public WipersCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
+            Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             Receiver.ToggleWipers(ToState);
             // Report();
         }
     }
 
     [Serializable()]
-    public sealed class ToggleDoorsLeftCommand : Command {
+    public sealed class ToggleDoorsLeftCommand : Command
+    {
         public static MSTSWagon Receiver { get; set; }
 
-        public ToggleDoorsLeftCommand( CommandLog log ) 
-            : base( log ) {
+        public ToggleDoorsLeftCommand(CommandLog log)
+            : base(log)
+        {
             Redo();
         }
 
-        public override void Redo() {
-            if (Receiver.GetCabFlipped())  Receiver.ToggleDoorsRight();
+        public override void Redo()
+        {
+            if (Receiver.GetCabFlipped()) Receiver.ToggleDoorsRight();
             else Receiver.ToggleDoorsLeft();
             // Report();
         }
     }
 
     [Serializable()]
-    public sealed class ToggleDoorsRightCommand : Command {
+    public sealed class ToggleDoorsRightCommand : Command
+    {
         public static MSTSWagon Receiver { get; set; }
 
-        public ToggleDoorsRightCommand( CommandLog log ) 
-            : base( log ) {
+        public ToggleDoorsRightCommand(CommandLog log)
+            : base(log)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver.GetCabFlipped()) Receiver.ToggleDoorsLeft();
             else Receiver.ToggleDoorsRight();
             // Report();
@@ -888,26 +990,29 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class ToggleMirrorsCommand : Command {
+    public sealed class ToggleMirrorsCommand : Command
+    {
         public static MSTSWagon Receiver { get; set; }
 
-        public ToggleMirrorsCommand( CommandLog log ) 
-            : base( log ) {
+        public ToggleMirrorsCommand(CommandLog log)
+            : base(log)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             Receiver.ToggleMirrors();
             // Report();
         }
     }
-    
+
     // Steam controls
     [Serializable()]
     public sealed class ContinuousSteamHeatCommand : ContinuousCommand
     {
         public static MSTSLocomotive Receiver { get; set; }
-        
+
         public ContinuousSteamHeatCommand(CommandLog log, int injector, bool toState, float? target, double startTime)
             : base(log, toState, target, startTime)
         {
@@ -919,9 +1024,9 @@ namespace Orts.Common
             if (Receiver == null) return;
             {
                 Receiver.SteamHeatChangeTo(ToState, Target);
-                           }
+            }
             // Report();
-        }   
+        }
     }
 
     [Serializable()]
@@ -946,84 +1051,100 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class ContinuousInjectorCommand : ContinuousCommand {
+    public sealed class ContinuousInjectorCommand : ContinuousCommand
+    {
         public static MSTSSteamLocomotive Receiver { get; set; }
         int Injector;
 
-        public ContinuousInjectorCommand( CommandLog log, int injector, bool toState, float? target, double startTime ) 
-            : base( log, toState, target, startTime ) {
+        public ContinuousInjectorCommand(CommandLog log, int injector, bool toState, float? target, double startTime)
+            : base(log, toState, target, startTime)
+        {
             Injector = injector;
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver == null) return;
-            switch( Injector ) {
-                case 1: { Receiver.Injector1ChangeTo( ToState, Target ); break; }
-                case 2: { Receiver.Injector2ChangeTo( ToState, Target ); break; }
+            switch (Injector)
+            {
+                case 1: { Receiver.Injector1ChangeTo(ToState, Target); break; }
+                case 2: { Receiver.Injector2ChangeTo(ToState, Target); break; }
             }
             // Report();
         }
 
-        public override string ToString() {
-            return String.Format( "Command: {0} {1} {2}", FormatStrings.FormatPreciseTime( Time ), this.GetType().ToString(), Injector) 
+        public override string ToString()
+        {
+            return String.Format("Command: {0} {1} {2}", FormatStrings.FormatPreciseTime(Time), this.GetType().ToString(), Injector)
                 + (ToState ? "open" : "close") + ", target = " + Target.ToString();
         }
     }
 
     [Serializable()]
-    public sealed class ToggleInjectorCommand : Command {
+    public sealed class ToggleInjectorCommand : Command
+    {
         public static MSTSSteamLocomotive Receiver { get; set; }
         private int injector;
 
-        public ToggleInjectorCommand( CommandLog log, int injector ) 
-            : base( log ) {
+        public ToggleInjectorCommand(CommandLog log, int injector)
+            : base(log)
+        {
             this.injector = injector;
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver == null) return;
-            switch( injector ) {
+            switch (injector)
+            {
                 case 1: { Receiver.ToggleInjector1(); break; }
                 case 2: { Receiver.ToggleInjector2(); break; }
             }
             // Report();
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString() + injector.ToString();
         }
     }
 
     [Serializable()]
-    public sealed class ContinuousBlowerCommand : ContinuousCommand {
+    public sealed class ContinuousBlowerCommand : ContinuousCommand
+    {
         public static MSTSSteamLocomotive Receiver { get; set; }
 
-        public ContinuousBlowerCommand( CommandLog log, bool toState, float? target, double startTime ) 
-            : base( log, toState, target, startTime ) {
+        public ContinuousBlowerCommand(CommandLog log, bool toState, float? target, double startTime)
+            : base(log, toState, target, startTime)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver == null) return;
-            Receiver.BlowerChangeTo( ToState, Target );
+            Receiver.BlowerChangeTo(ToState, Target);
             // Report();
         }
     }
 
     [Serializable()]
-    public sealed class ContinuousDamperCommand : ContinuousCommand {
+    public sealed class ContinuousDamperCommand : ContinuousCommand
+    {
         public static MSTSSteamLocomotive Receiver { get; set; }
 
-        public ContinuousDamperCommand( CommandLog log, bool toState, float? target, double startTime )
-            : base( log, toState, target, startTime ) {
+        public ContinuousDamperCommand(CommandLog log, bool toState, float? target, double startTime)
+            : base(log, toState, target, startTime)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver == null) return;
-            Receiver.DamperChangeTo( ToState, Target );
+            Receiver.DamperChangeTo(ToState, Target);
             // Report();
         }
     }
@@ -1048,31 +1169,37 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class ContinuousFiringRateCommand : ContinuousCommand {
+    public sealed class ContinuousFiringRateCommand : ContinuousCommand
+    {
         public static MSTSSteamLocomotive Receiver { get; set; }
 
-        public ContinuousFiringRateCommand( CommandLog log, bool toState, float? target, double startTime )
-            : base( log, toState, target, startTime ) {
+        public ContinuousFiringRateCommand(CommandLog log, bool toState, float? target, double startTime)
+            : base(log, toState, target, startTime)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver == null) return;
-            Receiver.FiringRateChangeTo( ToState, Target );
+            Receiver.FiringRateChangeTo(ToState, Target);
             // Report();
         }
     }
 
     [Serializable()]
-    public sealed class ToggleManualFiringCommand : Command {
+    public sealed class ToggleManualFiringCommand : Command
+    {
         public static MSTSSteamLocomotive Receiver { get; set; }
 
-        public ToggleManualFiringCommand( CommandLog log ) 
-            : base( log ) {
+        public ToggleManualFiringCommand(CommandLog log)
+            : base(log)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver == null) return;
             Receiver.ToggleManualFiring();
             // Report();
@@ -1085,7 +1212,7 @@ namespace Orts.Common
         public static MSTSSteamLocomotive Receiver { get; set; }
 
         public AIFireOnCommand(CommandLog log)
-            : base( log )
+            : base(log)
         {
             Redo();
         }
@@ -1096,7 +1223,7 @@ namespace Orts.Common
 
         }
 
-     }
+    }
 
     [Serializable()]
     public sealed class AIFireOffCommand : Command
@@ -1137,15 +1264,18 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class FireShovelfullCommand : Command {
+    public sealed class FireShovelfullCommand : Command
+    {
         public static MSTSSteamLocomotive Receiver { get; set; }
 
-        public FireShovelfullCommand( CommandLog log ) 
-            : base( log ) {
+        public FireShovelfullCommand(CommandLog log)
+            : base(log)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver == null) return;
             Receiver.FireShovelfull();
             // Report();
@@ -1240,15 +1370,18 @@ namespace Orts.Common
     }
 
     [Serializable()]
-    public sealed class ToggleCylinderCocksCommand : Command {
+    public sealed class ToggleCylinderCocksCommand : Command
+    {
         public static MSTSSteamLocomotive Receiver { get; set; }
 
-        public ToggleCylinderCocksCommand( CommandLog log ) 
-            : base( log ) {
+        public ToggleCylinderCocksCommand(CommandLog log)
+            : base(log)
+        {
             Redo();
         }
 
-        public override void Redo() {
+        public override void Redo()
+        {
             if (Receiver == null) return;
             Receiver.ToggleCylinderCocks();
             // Report();
@@ -1257,7 +1390,8 @@ namespace Orts.Common
 
     // Compound Valve command
     [Serializable()]
-    public sealed class ToggleCylinderCompoundCommand : Command {
+    public sealed class ToggleCylinderCompoundCommand : Command
+    {
         public static MSTSSteamLocomotive Receiver { get; set; }
 
         public ToggleCylinderCompoundCommand(CommandLog log)

--- a/Source/Orts.Simulation/Common/ErrorLogger.cs
+++ b/Source/Orts.Simulation/Common/ErrorLogger.cs
@@ -128,7 +128,7 @@ namespace Orts.Common
             var errorLevel = (int)Math.Round(Math.Log((int)eventType) / Math.Log(2));
             if (errorLevel < Counts.Length)
                 Counts[errorLevel]++;
-            
+
             // Event is less important than error (and critical) and we're logging only errors... bail.
             if (eventType > TraceEventType.Error && OnlyErrors)
                 return;

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -65,8 +65,8 @@ namespace Orts.Common
         EngineBrakeChange,
         EngineBrakePressureDecrease,
         EngineBrakePressureIncrease,
-        EnginePowerOff, 
-        EnginePowerOn, 
+        EnginePowerOff,
+        EnginePowerOn,
         FireboxDoorChange,
         FireboxDoorOpen,
         FireboxDoorClose,
@@ -79,8 +79,8 @@ namespace Orts.Common
         HornOff,
         HornOn,
         LightSwitchToggle,
-        MirrorClose, 
-        MirrorOpen, 
+        MirrorClose,
+        MirrorOpen,
         Pantograph1Down,
         PantographToggle,
         Pantograph1Up,
@@ -104,7 +104,7 @@ namespace Orts.Common
         WaterInjector1On,
         WaterInjector2Off,
         WaterInjector2On,
-        SteamHeatChange, 
+        SteamHeatChange,
         SteamPulse1,
         SteamPulse2,
         SteamPulse3,
@@ -281,7 +281,7 @@ namespace Orts.Common
                         case 104: return Event.ReverserToNeutral; // reversed moved to neutral
                         case 105: return Event.DoorOpen; // door opened; propagated to all locos and wagons of the consist
                         case 106: return Event.DoorClose; // door closed; propagated to all locos and wagons of the consist
-                        case 107: return Event.MirrorOpen; 
+                        case 107: return Event.MirrorOpen;
                         case 108: return Event.MirrorClose;
                         case 109: return Event.TrainControlSystemInfo1;
                         case 110: return Event.TrainControlSystemInfo2;
@@ -294,7 +294,7 @@ namespace Orts.Common
                         case 117: return Event.TrainControlSystemAlert1;
                         case 118: return Event.TrainControlSystemAlert2;
                         case 119: return Event.CylinderCompoundToggle; // Locomotive switched to compound
-                        
+
                         case 121: return Event.SteamPulse1;
                         case 122: return Event.SteamPulse2;
                         case 123: return Event.SteamPulse3;

--- a/Source/Orts.Simulation/Common/Math.cs
+++ b/Source/Orts.Simulation/Common/Math.cs
@@ -21,88 +21,88 @@ using System;
 namespace Orts.Common
 {
     public static class ORTSMath
-   {
-      //
-      // from http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToEuler/index.htm
-      //
-      public static void MatrixToAngles(Matrix m, out float heading, out float attitude, out float bank)
-      {    // Assuming the angles are in radians.
-         if (m.M21 > 0.998)
-         { // singularity at north pole
-            heading = (float)Math.Atan2(m.M13, m.M33);
-            attitude = (float)Math.PI / 2;
-            bank = 0;
-            return;
-         }
-         if (m.M21 < -0.998)
-         { // singularity at south pole
-            heading = (float)Math.Atan2(m.M13, m.M33);
-            attitude = -(float)Math.PI / 2;
-            bank = 0;
-            return;
-         }
-         heading = (float)Math.Atan2(-m.M31, m.M11);
-         bank = (float)Math.Atan2(-m.M23, m.M22);
-         attitude = (float)Math.Asin(m.M21);
-      }
+    {
+        //
+        // from http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToEuler/index.htm
+        //
+        public static void MatrixToAngles(Matrix m, out float heading, out float attitude, out float bank)
+        {    // Assuming the angles are in radians.
+            if (m.M21 > 0.998)
+            { // singularity at north pole
+                heading = (float)Math.Atan2(m.M13, m.M33);
+                attitude = (float)Math.PI / 2;
+                bank = 0;
+                return;
+            }
+            if (m.M21 < -0.998)
+            { // singularity at south pole
+                heading = (float)Math.Atan2(m.M13, m.M33);
+                attitude = -(float)Math.PI / 2;
+                bank = 0;
+                return;
+            }
+            heading = (float)Math.Atan2(-m.M31, m.M11);
+            bank = (float)Math.Atan2(-m.M23, m.M22);
+            attitude = (float)Math.Asin(m.M21);
+        }
 
-     public static float MatrixToYAngle(Matrix m)
-     {    // Assuming the angles are in radians.
-        if (m.M21 > 0.998 || m.M21 < -0.998)
-            // singularity at poles
-            return (float)Math.Atan2(m.M13, m.M33);
+        public static float MatrixToYAngle(Matrix m)
+        {    // Assuming the angles are in radians.
+            if (m.M21 > 0.998 || m.M21 < -0.998)
+                // singularity at poles
+                return (float)Math.Atan2(m.M13, m.M33);
 
-        else return (float)Math.Atan2(-m.M31, m.M11);
-     }
+            else return (float)Math.Atan2(-m.M31, m.M11);
+        }
 
-      public struct Matrix2x2
-      {
-         public float M00, M01, M10, M11;
+        public struct Matrix2x2
+        {
+            public float M00, M01, M10, M11;
 
-         public Matrix2x2(float m00, float m01, float m10, float m11)
-         {
-            M00 = m00; M01 = m01; M10 = m10; M11 = m11;
-         }
-      }
+            public Matrix2x2(float m00, float m01, float m10, float m11)
+            {
+                M00 = m00; M01 = m01; M10 = m10; M11 = m11;
+            }
+        }
 
-      public static float Interpolate2D(float x, float z, Matrix2x2 y)
-      {
-         float result = 0;
+        public static float Interpolate2D(float x, float z, Matrix2x2 y)
+        {
+            float result = 0;
 
-         result += (1 - x) * (1 - z) * y.M00;
-         result += (x) * (1 - z) * y.M01;
-         result += (1 - x) * (z) * y.M10;
-         result += (x) * (z) * y.M11;
+            result += (1 - x) * (1 - z) * y.M00;
+            result += (x) * (1 - z) * y.M01;
+            result += (1 - x) * (z) * y.M10;
+            result += (x) * (z) * y.M11;
 
-         return result;
-      }
+            return result;
+        }
 
-      public static float LineSegmentDistanceSq(Vector3 pt, Vector3 end1, Vector3 end2)
-      {
-         float dx = end2.X - end1.X;
-         float dy = end2.Y - end1.Y;
-         float dz = end2.Z - end1.Z;
-         float d = dx * dx + dy * dy + dz * dz;
-         float n = dx * (pt.X - end1.X) + dy * (pt.Y - end1.Y) + dz * (pt.Z - end1.Z);
-         if (d == 0 || n < 0)
-         {
-            dx = end1.X - pt.X;
-            dy = end1.Y - pt.Y;
-            dz = end1.Z - pt.Z;
-         }
-         else if (n > d)
-         {
-            dx = end2.X - pt.X;
-            dy = end2.Y - pt.Y;
-            dz = end2.Z - pt.Z;
-         }
-         else
-         {
-            dx = end1.X + dx * n / d - pt.X;
-            dy = end1.Y + dy * n / d - pt.Y;
-            dz = end1.Z + dz * n / d - pt.Z;
-         }
-         return dx * dx + dy * dy + dz * dz;
-      }
-   }
+        public static float LineSegmentDistanceSq(Vector3 pt, Vector3 end1, Vector3 end2)
+        {
+            float dx = end2.X - end1.X;
+            float dy = end2.Y - end1.Y;
+            float dz = end2.Z - end1.Z;
+            float d = dx * dx + dy * dy + dz * dz;
+            float n = dx * (pt.X - end1.X) + dy * (pt.Y - end1.Y) + dz * (pt.Z - end1.Z);
+            if (d == 0 || n < 0)
+            {
+                dx = end1.X - pt.X;
+                dy = end1.Y - pt.Y;
+                dz = end1.Z - pt.Z;
+            }
+            else if (n > d)
+            {
+                dx = end2.X - pt.X;
+                dy = end2.Y - pt.Y;
+                dz = end2.Z - pt.Z;
+            }
+            else
+            {
+                dx = end1.X + dx * n / d - pt.X;
+                dy = end1.Y + dy * n / d - pt.Y;
+                dz = end1.Z + dz * n / d - pt.Z;
+            }
+            return dx * dx + dy * dy + dz * dz;
+        }
+    }
 }

--- a/Source/Orts.Simulation/Common/ORTSPaths.cs
+++ b/Source/Orts.Simulation/Common/ORTSPaths.cs
@@ -24,13 +24,13 @@ namespace Orts.Common
     public static class ORTSPaths
     {
         //<CJComment> Cleaner to use GetFileFromFolders() instead, but not sure how to test this. </CJComment>
-        public static string FindTrainCarPlugin( string initialFolder, string filename )
+        public static string FindTrainCarPlugin(string initialFolder, string filename)
         {
             string dllPath = initialFolder + "\\" + filename;  // search in trainset folder
             if (File.Exists(dllPath))
                 return dllPath;
-            string rootFolder = Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(initialFolder)))+ "\\OpenRails";
-            if( Directory.Exists( rootFolder ) )
+            string rootFolder = Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(initialFolder))) + "\\OpenRails";
+            if (Directory.Exists(rootFolder))
             {
                 dllPath = rootFolder + "\\" + filename;
                 if (File.Exists(dllPath))

--- a/Source/Orts.Simulation/Common/Scripting/ScriptManager.cs
+++ b/Source/Orts.Simulation/Common/Scripting/ScriptManager.cs
@@ -71,7 +71,7 @@ namespace Orts.Common.Scripting
 
             if (path == null || path == "")
                 return null;
-            
+
             path = path.ToLowerInvariant();
 
             var type = String.Format("ORTS.Scripting.Script.{0}", Path.GetFileNameWithoutExtension(path));

--- a/Source/Orts.Simulation/Common/SteamTable.cs
+++ b/Source/Orts.Simulation/Common/SteamTable.cs
@@ -92,44 +92,44 @@ namespace Orts.Common
             75.83f, 81.88f, 83.75f, 85.63f, 87.50f, 89.37f, 91.25f, 93.12f, 93.75f, 94.37f,
             94.99f, 95.62f, 96.24f, 96.87f, 97.49f, 98.12f, 98.74f, 99.37f, 99.99f, 100.61f
         };
-        
-      // injector 14mm flowrates (gallons (uk) per minute) - data extrapolated below from info in 1928 Sellers Injector Manual
+
+        // injector 14mm flowrates (gallons (uk) per minute) - data extrapolated below from info in 1928 Sellers Injector Manual
         static float[] Injector14FlowTableUKGpM = new float[]
         {
             9.30f, 16.79f, 24.28f, 31.77f, 39.26f, 46.75f, 54.24f, 61.73f, 69.21f, 76.70f, 84.19f,
             91.68f, 99.17f, 100.81f, 102.45f, 104.09f, 105.72f, 107.36f, 109.00f, 111.65f, 114.30f,
             115.94f, 117.58f, 119.21f, 120.85f, 122.49f, 124.13f, 125.77f, 127.40f, 129.04f, 130.68f
         };
-        
-      // injector 15mm flowrates (gallons (uk) per minute) - data extrapolated below from info in 1928 Sellers Injector Manual
+
+        // injector 15mm flowrates (gallons (uk) per minute) - data extrapolated below from info in 1928 Sellers Injector Manual
         static float[] Injector15FlowTableUKGpM = new float[]
         {
             9.30f, 17.82f, 26.33f, 34.85f, 43.36f, 51.88f, 60.40f, 68.91f, 77.43f, 85.94f, 94.46f,
             102.98f, 111.49f, 113.33f, 115.16f, 117.0f, 118.83f, 120.67f, 122.50f, 125.50f, 128.50f,
             130.14f, 131.78f, 133.41f, 135.05f, 136.69f, 138.33f, 139.97f, 141.60f, 143.24f, 144.88f
-        };        
+        };
 
         // Specific heat table for water - volume heat capacity?? - 
         static float[] SpecificHeatTableKJpKGpK = new float[]
         {
             4.2170f, 4.2049f, 4.2165f, 4.2223f, 4.2287f, 4.2355f, 4.2427f, 4.2505f, 4.2587f, 4.2675f, 4.2769f,
-            4.2926f, 4.3035f, 4.3151f, 4.3274f, 4.3405f, 4.3543f, 4.3690f, 4.3846f, 4.4012f, 4.4187f, 
-            4.4374f, 4.4573f, 4.4784f, 4.5009f, 4.5248f, 4.5503f, 4.5774f, 4.6064f, 4.6373f, 4.6703f 
+            4.2926f, 4.3035f, 4.3151f, 4.3274f, 4.3405f, 4.3543f, 4.3690f, 4.3846f, 4.4012f, 4.4187f,
+            4.4374f, 4.4573f, 4.4784f, 4.5009f, 4.5248f, 4.5503f, 4.5774f, 4.6064f, 4.6373f, 4.6703f
         };
 
         // Water temp in deg Kelvin
         static float[] WaterTemperatureTableK = new float[]
         {
             274.00f, 281.40f, 288.80f, 296.20f, 303.60f, 311.00f, 318.40f, 325.80f, 333.20f, 340.60f, 348.00f,
-            355.40f, 362.80f, 370.20f, 377.60f, 385.00f, 392.40f, 399.80f, 407.20f, 414.60f, 422.00f, 
-            429.40f, 436.80f, 444.20f, 451.60f, 459.00f, 466.40f, 473.80f, 481.20f, 488.60f, 496.00f 
+            355.40f, 362.80f, 370.20f, 377.60f, 385.00f, 392.40f, 399.80f, 407.20f, 414.60f, 422.00f,
+            429.40f, 436.80f, 444.20f, 451.60f, 459.00f, 466.40f, 473.80f, 481.20f, 488.60f, 496.00f
         };
-       
+
         static float[] SaturationPressureTablePSI = new float[]
         {
             0.00f, 10.00f, 20.00f, 30.00f, 40.00f, 50.00f, 60.00f, 70.00f, 80.00f, 90.00f, 100.00f,
-            110.00f, 120.00f, 130.00f, 140.00f, 150.00f, 160.00f, 170.00f, 180.00f, 190.00f, 200.00f, 
-            210.00f, 220.00f, 230.00f, 240.00f, 250.00f, 260.00f, 270.00f, 280.00f, 290.00f, 300.00f 
+            110.00f, 120.00f, 130.00f, 140.00f, 150.00f, 160.00f, 170.00f, 180.00f, 190.00f, 200.00f,
+            210.00f, 220.00f, 230.00f, 240.00f, 250.00f, 260.00f, 270.00f, 280.00f, 290.00f, 300.00f
         };
 
         // Temperature of water in deg Kelvin
@@ -145,7 +145,7 @@ namespace Orts.Common
         {
             0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 120.0f, 140.0f, 160.0f, 180.0f, 200.0f, 220.0f
         };
-        
+
         // Boiler Efficiency - based upon average results from test papers
         static float[] SatBoilerEfficiencyTableX = new float[]
         {
@@ -157,7 +157,7 @@ namespace Orts.Common
         {
             0.903f, 0.8484f, 0.7936f, 0.7390f, 0.6843f, 0.6296f, 0.5749f, 0.5202f, 0.4655f, 0.4108f, 0.3561f, 0.3014f
         };
-        
+
         // pressure tables for Injectors temperature and steam usage
         static float[] InjectorUsePressureTablePSI = new float[]
         {
@@ -187,8 +187,8 @@ namespace Orts.Common
         {
             0.366f, 0.395f, 0.419f, 0.454f, 0.509f
         };
- 
-// Cylinder Indicator Card Events
+
+        // Cylinder Indicator Card Events
 
         // cutoff fraction
         static float[] CutOffFractionEventTableX = new float[]
@@ -216,7 +216,7 @@ namespace Orts.Common
         };
 
 
-// Cylinder condensation and superheat
+        // Cylinder condensation and superheat
 
         // cutoff fraction
         static float[] CutOffFractionTableX = new float[]
@@ -242,7 +242,7 @@ namespace Orts.Common
             0.0f, 2000.0f, 4000.0f, 6000.0f, 8000.0f, 10000.0f, 12000.0f, 14000.0f, 16000.0f, 18000.0f, 20000.0f, 22000.0f, 24000.0f, 26000.0f, 28000.0f, 30000.0f,
             32000.0f, 34000.0f, 36000.0f
         };
-        
+
         // Superheat Temp - deg F - from BTC Test Results for Std 8
         static float[] SuperheatTempTableDegF = new float[]
         {
@@ -259,64 +259,64 @@ namespace Orts.Common
         // Allowance for drop in initial pressure (steam chest) as speed increases - Various sources - Saturated
         static float[] SatInitialPressureDropRatio = new float[]
         {
-            0.98f, 0.965f, 0.95f, 0.935f, 0.92f, 0.905f, 0.89f, 0.875f, 0.87f, 0.8650f, 0.8625f, 0.86f, 0.8575f, 0.855f, 0.8525f, 0.85f 
-            
+            0.98f, 0.965f, 0.95f, 0.935f, 0.92f, 0.905f, 0.89f, 0.875f, 0.87f, 0.8650f, 0.8625f, 0.86f, 0.8575f, 0.855f, 0.8525f, 0.85f
+
         };
-        
-       // Allowance for pressure drop in Steam chest pressure compared to Boiler Pressure - (To be confirmed) - Superheated
+
+        // Allowance for pressure drop in Steam chest pressure compared to Boiler Pressure - (To be confirmed) - Superheated
         static float[] SuperInitialPressureDropRatio = new float[]
         {
             0.99f, 0.98f, 0.97f, 0.96f, 0.95f, 0.94f, 0.93f, 0.92f, 0.915f, 0.910f, 0.905f, 0.90f, 0.8975f, 0.8950f, 0.8925f, 0.8900f
         };
-        
-// piston speed (feet per minute) - American Locomotive Company
+
+        // piston speed (feet per minute) - American Locomotive Company
         static float[] PistonSpeedFtpMin = new float[]
         {
               0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900, 2000, 2100
         };
-        
-// Speed factor - Saturated (0 and 2000, 2100 value extrapolated for Open Rails to limit TE) - Based upon dat from American Locomotive Company
+
+        // Speed factor - Saturated (0 and 2000, 2100 value extrapolated for Open Rails to limit TE) - Based upon dat from American Locomotive Company
         static float[] SpeedFactorSat = new float[]
         {
              1.0f, 1.0f, 1.0f, 0.954f, 0.863f, 0.772f, 0.680f, 0.590f, 0.517f, 0.460f, 0.412f, 0.372f, 0.337f, 0.307f, 0.283f, 0.261f, 0.241f, 0.225f, 0.213f, 0.202f, 0.190f, 0.185f
         };
-        
-// Speed factor - Superheated (0 and 2000, 2100 value extrapolated for Open Rails to limit TE) - American Locomotive Company
+
+        // Speed factor - Superheated (0 and 2000, 2100 value extrapolated for Open Rails to limit TE) - American Locomotive Company
         static float[] SpeedFactorSuper = new float[]
         {
               1.0f, 1.0f, 1.0f, 0.988f, 0.965f, 0.912f, 0.859f, 0.800f, 0.753f, 0.706f, 0.659f, 0.612f, 0.571f, 0.535f, 0.500f, 0.471f, 0.447f, 0.433f, 0.424f, 0.420f, 0.410f, 0.410f
         };
 
-// Indicated HorsePower - 
+        // Indicated HorsePower - 
         static float[] IndicatedHorsepowerIHP = new float[]
         {
               0.0f, 200.0f, 400.0f, 600.0f, 800.0f, 1000.0f, 1200.0f, 1400.0f, 1600.0f,
               1800.0f, 2000.0f, 2200.0f, 2400.0f, 2600.0f, 2800.0f, 3000.0f
         };
 
-// BackPressure - Saturated locomotive -  Ref Principles of Locomotive Operation - Assume atmospheric - extrapolated beyond 1800IHP
+        // BackPressure - Saturated locomotive -  Ref Principles of Locomotive Operation - Assume atmospheric - extrapolated beyond 1800IHP
         static float[] BackPressureSatPSI = new float[]
         {
               0.0f, 1.0f, 2.0f, 2.33f, 3.0f, 5.3f, 5.6f, 8.0f, 11.2f,
               14.25f, 16.0f, 20.0f, 24.0f, 26.0f, 28.0f, 30.0f
         };
 
-// BackPressure - Superheated locomotive -  Ref Principles of Locomotive Operation - Assume atmospheric - extrapolated beyond 1800IHP
+        // BackPressure - Superheated locomotive -  Ref Principles of Locomotive Operation - Assume atmospheric - extrapolated beyond 1800IHP
         static float[] BackPressureSuperPSI = new float[]
         {
               0.0f, 0.25f, 0.5f, 0.75f, 1.25f, 1.75f, 2.5f, 3.5f, 4.8f,
               7.2f, 11.25f, 16.0f, 20.0f, 22.0f, 24.0f, 26.0f
         };
 
-  // Allowance for drop in initial pressure (steam chest) as speed increases - Various sources
+        // Allowance for drop in initial pressure (steam chest) as speed increases - Various sources
         static float[] CondensationWheelRotationRpM = new float[]
         {
             0.0f, 50.0f, 100.0f, 150.0f, 200.0f, 250.0f, 300.0f, 350.0f
         };
 
-// Steam Tables
+        // Steam Tables
 
-// Indicator Diagram - Cylinder Events
+        // Indicator Diagram - Cylinder Events
 
         // Indicator Diagram Event - Exhaust Open - Perwall program - http://5at.co.uk/index.php/references-and-links/software.html
         public static Interpolator CylinderEventExhausttoCutoff()
@@ -334,88 +334,88 @@ namespace Orts.Common
         public static Interpolator CylinderEventAdmissiontoCutoff()
         {
             return new Interpolator(CutOffFractionEventTableX, CylinderAdmissionTableX);
-        }   
-          
-// cylinder condensation fraction per cutoff fraction - saturated steam - Ref Elseco Superheater manual
+        }
+
+        // cylinder condensation fraction per cutoff fraction - saturated steam - Ref Elseco Superheater manual
         public static Interpolator CylinderCondensationFractionInterpolatorX()
         {
             return new Interpolator(CutOffFractionTableX, CylinderCondensationFractionTableX);
         }
 
-// Superheat temp required to prevent cylinder condensation - Ref Elseco Superheater manual
+        // Superheat temp required to prevent cylinder condensation - Ref Elseco Superheater manual
         public static Interpolator SuperheatTempLimitInterpolatorXtoDegF()
         {
             return new Interpolator(CutOffFractionTableX, SuperheatCondenstationLimitTableDegF);
-        }           
+        }
 
-// Saturated Backpressure - Ref Principles of Locomotive Operation
+        // Saturated Backpressure - Ref Principles of Locomotive Operation
         public static Interpolator BackpressureSatIHPtoPSI()
         {
             return new Interpolator(IndicatedHorsepowerIHP, BackPressureSatPSI);
         }
 
-// Superheated Backpressure - Ref Principles of Locomotive Operation
+        // Superheated Backpressure - Ref Principles of Locomotive Operation
         public static Interpolator BackpressureSuperIHPtoPSI()
         {
             return new Interpolator(IndicatedHorsepowerIHP, BackPressureSuperPSI);
-        }  
+        }
 
 
-// Saturated Speed factor - ie drop in TE as speed increases due to piston impacts - Ref American locomotive Company
+        // Saturated Speed factor - ie drop in TE as speed increases due to piston impacts - Ref American locomotive Company
         public static Interpolator SaturatedSpeedFactorSpeedDropFtpMintoX()
         {
             return new Interpolator(PistonSpeedFtpMin, SpeedFactorSat);
-        }  
-        
-        
-// Superheated Speed factor - ie drop in TE as speed increases due to piston impacts - Ref American locomotive Company
+        }
+
+
+        // Superheated Speed factor - ie drop in TE as speed increases due to piston impacts - Ref American locomotive Company
         public static Interpolator SuperheatedSpeedFactorSpeedDropFtpMintoX()
         {
             return new Interpolator(PistonSpeedFtpMin, SpeedFactorSuper);
-        }          
-        
+        }
 
-       // Allowance for pressure drop in Steam chest pressure compared to Boiler Pressure - Ref LOCOMOTIVE OPERATION - A TECHNICAL AND PRACTICAL ANALYSIS - BY G. R. HENDERSON
+
+        // Allowance for pressure drop in Steam chest pressure compared to Boiler Pressure - Ref LOCOMOTIVE OPERATION - A TECHNICAL AND PRACTICAL ANALYSIS - BY G. R. HENDERSON
         public static Interpolator SuperInitialPressureDropRatioInterpolatorRpMtoX()
         {
             return new Interpolator(WheelRotationRpM, SuperInitialPressureDropRatio);
-        }       
+        }
 
         // Allowance for wire-drawing - ie drop in initial pressure (cutoff) as speed increases - Ref Principles of Locomotive Operation
         public static Interpolator SatInitialPressureDropRatioInterpolatorRpMtoX()
         {
             return new Interpolator(WheelRotationRpM, SatInitialPressureDropRatio);
-        }    
+        }
 
         // Superheat temp per lbs of steam to cylinder - from BTC Test Results for Std 8
         public static Interpolator SuperheatTempInterpolatorLbpHtoDegF()
         {
             return new Interpolator(CylinderSteamTableLbpH, SuperheatTempTableDegF);
-        }    
+        }
 
         // Injector factor to determine the min capacity of the injector
         public static Interpolator InjCapMinFactorInterpolatorX()
         {
             return new Interpolator(InjectorUsePressureTablePSI, InjMinCapFactorTableX);
-        }       
+        }
 
         // Injector max delivery water temp (Fahr) per pressure of steam (psi)
         public static Interpolator InjDelWaterTempMaxPressureInterpolatorFtoPSI()
         {
             return new Interpolator(InjectorUsePressureTablePSI, WaterTemPDeliveryMaxTableF);
-        }        
-        
+        }
+
         // Injector min delivery water temp (Fahr) per pressure of steam (psi)
         public static Interpolator InjDelWaterTempMinPressureInterpolatorFtoPSI()
         {
             return new Interpolator(InjectorUsePressureTablePSI, WaterTemPDeliveryMinTableF);
-        }  
-        
+        }
+
         // Injector water fed per lb of steam at pressure of steam (psi)
         public static Interpolator InjWaterFedSteamPressureInterpolatorFtoPSI()
         {
             return new Interpolator(InjectorUsePressureTablePSI, WaterDelFedSteamTableLbs);
-        }    
+        }
 
         // Boiler Efficiency based on lbs of coal per sq. ft of Grate Area - Saturated
         public static Interpolator SatBoilerEfficiencyGrateAreaInterpolatorLbstoX()
@@ -428,7 +428,7 @@ namespace Orts.Common
         {
             return new Interpolator(CoalGrateAreaTableLbspFt2, SuperBoilerEfficiencyTableX);
         }
-           
+
         // Saturated pressure of steam (psi) @ water temperature (K)
         public static Interpolator SaturationPressureInterpolatorKtoPSI()
         {
@@ -457,25 +457,25 @@ namespace Orts.Common
         public static Interpolator Injector11FlowrateInterpolatorPSItoUKGpM()
         {
             return new Interpolator(PressureTableGaugePSI, Injector11FlowTableUKGpM);
-        } 
- 
+        }
+
         // Flowrate table vs Boiler Pressure for 13mm Injector
         public static Interpolator Injector13FlowrateInterpolatorPSItoUKGpM()
         {
             return new Interpolator(PressureTableGaugePSI, Injector13FlowTableUKGpM);
-        } 
-        
+        }
+
         // Flowrate table vs Boiler Pressure for 14mm Injector
         public static Interpolator Injector14FlowrateInterpolatorPSItoUKGpM()
         {
             return new Interpolator(PressureTableGaugePSI, Injector14FlowTableUKGpM);
-        } 
-        
+        }
+
         // Flowrate table vs Boiler Pressure for 15mm Injector
         public static Interpolator Injector15FlowrateInterpolatorPSItoUKGpM()
         {
             return new Interpolator(PressureTableGaugePSI, Injector15FlowTableUKGpM);
-        }       
+        }
 
         public static Interpolator WaterHeatInterpolatorPSItoBTUpLB()
         {
@@ -524,18 +524,18 @@ namespace Orts.Common
         // revolutions - z value
         static float[] WheelRevolutionsRpM = new float[]
         {
-            0.0f, 50.0f, 100.0f, 150.0f, 200.0f, 250.0f, 300.0f, 350.0f  
+            0.0f, 50.0f, 100.0f, 150.0f, 200.0f, 250.0f, 300.0f, 350.0f
         };
 
         // Cutoff - x Value
         static float[] CutOff = new float[]
         {
-            0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f  
+            0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f
         };
-       
+
         // ++++++++++++++++++++++ Upper Limit ++++++++++++
 
-       // % Initial Pressure @ 0rpm - y Value
+        // % Initial Pressure @ 0rpm - y Value
         static float[] InitialPressureUpper0RpM = new float[]
         {
             1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f
@@ -652,7 +652,7 @@ namespace Orts.Common
             return new Interpolator2D(WheelRevolutionsRpM, Initial_pressure_upper);
         }
 
-      // ++++++++++++++++++++++ Lower Limit ++++++++++++
+        // ++++++++++++++++++++++ Lower Limit ++++++++++++
 
         // % Initial Pressure @ 0rpm - y Value
         static float[] InitialPressureLower0RpM = new float[]

--- a/Source/Orts.Simulation/Common/WorldLatLon.cs
+++ b/Source/Orts.Simulation/Common/WorldLatLon.cs
@@ -35,7 +35,7 @@ using System;
 namespace Orts.Common
 {
     public class WorldLatLon
-    {      
+    {
         int earthRadius = 6370997; // Average radius of the earth, meters
         double Epsilon = 0.0000000001; // Error factor (arbitrary)
         double[] Lon_Center = new double[12];
@@ -159,7 +159,7 @@ namespace Orts.Common
             switch (region)
             {
                 case 1:
-                case 3: 
+                case 3:
                 case 4:
                 case 5:
                 case 8:

--- a/Source/Orts.Simulation/MultiPlayer/ClientComm.cs
+++ b/Source/Orts.Simulation/MultiPlayer/ClientComm.cs
@@ -30,26 +30,26 @@ using System.Threading;
 namespace Orts.MultiPlayer
 {
     public class ClientComm
-	{
-		private Thread listenThread;
-		private TcpClient client;
-		public string UserName;
-		public string Code;
-		public Decoder decoder;
-		public bool Connected = false;
+    {
+        private Thread listenThread;
+        private TcpClient client;
+        public string UserName;
+        public string Code;
+        public Decoder decoder;
+        public bool Connected = false;
 
-		public void Stop()
-		{
-			try
-			{
-				client.Close();
-				listenThread.Abort();
-			}
-			catch (Exception) { }
-		}
-		public ClientComm(string serverIP, int serverPort, string s)
-		{
-			client = new TcpClient();
+        public void Stop()
+        {
+            try
+            {
+                client.Close();
+                listenThread.Abort();
+            }
+            catch (Exception) { }
+        }
+        public ClientComm(string serverIP, int serverPort, string s)
+        {
+            client = new TcpClient();
 
             IPAddress address;
 
@@ -59,131 +59,131 @@ namespace Orts.MultiPlayer
                      .AddressList
                      .First(ip => ip.AddressFamily == AddressFamily.InterNetwork);
             }
-			IPEndPoint serverEndPoint = new IPEndPoint(address, serverPort);
+            IPEndPoint serverEndPoint = new IPEndPoint(address, serverPort);
 #if DEBUG_MULTIPLAYER
             Trace.TraceInformation("ClientComm data: {0} , ServerIP: {1}", s, serverIP);
 #endif
 
             client.Connect(serverEndPoint);
-			string[] tmp = s.Split(' ');
-			UserName = tmp[0];
-			Code = tmp[1];
-			decoder = new Decoder();
+            string[] tmp = s.Split(' ');
+            UserName = tmp[0];
+            Code = tmp[1];
+            decoder = new Decoder();
 
-			listenThread = new Thread(new ParameterizedThreadStart(this.Receive));
-			listenThread.Name = "Multiplayer Client-Server";
-			listenThread.Start(client);
+            listenThread = new Thread(new ParameterizedThreadStart(this.Receive));
+            listenThread.Name = "Multiplayer Client-Server";
+            listenThread.Start(client);
 
-		}
+        }
 
-		public void Receive(object client)
-		{
+        public void Receive(object client)
+        {
 
-			TcpClient tcpClient = (TcpClient)client;
-			NetworkStream clientStream = tcpClient.GetStream();
+            TcpClient tcpClient = (TcpClient)client;
+            NetworkStream clientStream = tcpClient.GetStream();
 
-			byte[] message = new byte[8192];
-			int bytesRead;
+            byte[] message = new byte[8192];
+            int bytesRead;
 
-			while (true)
-			{
-				bytesRead = 0;
-				//System.Threading.Thread.Sleep(Program.Random.Next(50, 200));
-				try
-				{
-					//blocks until a client sends a message
-					bytesRead = clientStream.Read(message, 0, 8192);
-				}
-				catch
-				{
-					//a socket error has occured
-					break;
-				}
+            while (true)
+            {
+                bytesRead = 0;
+                //System.Threading.Thread.Sleep(Program.Random.Next(50, 200));
+                try
+                {
+                    //blocks until a client sends a message
+                    bytesRead = clientStream.Read(message, 0, 8192);
+                }
+                catch
+                {
+                    //a socket error has occured
+                    break;
+                }
 
-				if (bytesRead == 0)
-				{
-					//the client has disconnected from the server
-					break;
-				}
+                if (bytesRead == 0)
+                {
+                    //the client has disconnected from the server
+                    break;
+                }
 
-				//message has successfully been received
-				string info = "";
-				try
-				{
-					decoder.PushMsg(Encoding.Unicode.GetString(message, 0, bytesRead));//encoder.GetString(message, 0, bytesRead));
-					info = decoder.GetMsg();
-					while (info != null)
-					{
-						//System.Console.WriteLine(info);
-						Message msg = Message.Decode(info);
-						if (Connected || msg is MSGRequired) msg.HandleMsg();
-						info = decoder.GetMsg();
-					}
-				}
-				catch (MultiPlayerError)
-				{
-					break;
-				}
-				catch (SameNameError) //I have conflict with some one in the game, will close, and abort.
-				{
-					if (MPManager.Simulator.Confirmer != null)
+                //message has successfully been received
+                string info = "";
+                try
+                {
+                    decoder.PushMsg(Encoding.Unicode.GetString(message, 0, bytesRead));//encoder.GetString(message, 0, bytesRead));
+                    info = decoder.GetMsg();
+                    while (info != null)
+                    {
+                        //System.Console.WriteLine(info);
+                        Message msg = Message.Decode(info);
+                        if (Connected || msg is MSGRequired) msg.HandleMsg();
+                        info = decoder.GetMsg();
+                    }
+                }
+                catch (MultiPlayerError)
+                {
+                    break;
+                }
+                catch (SameNameError) //I have conflict with some one in the game, will close, and abort.
+                {
+                    if (MPManager.Simulator.Confirmer != null)
                         MPManager.Simulator.Confirmer.Error(MPManager.Catalog.GetString("Connection to the server is lost, will play as single mode"));
                     MPManager.Client = null;
-					tcpClient.Close();
-					listenThread.Abort();
-				}
-				catch (Exception e)
-				{
-					System.Console.WriteLine(e.Message + e.StackTrace);
-					Trace.TraceWarning(e.Message + e.StackTrace);
-				}
-			}
-			if (MPManager.Simulator.Confirmer != null)
+                    tcpClient.Close();
+                    listenThread.Abort();
+                }
+                catch (Exception e)
+                {
+                    System.Console.WriteLine(e.Message + e.StackTrace);
+                    Trace.TraceWarning(e.Message + e.StackTrace);
+                }
+            }
+            if (MPManager.Simulator.Confirmer != null)
                 MPManager.Simulator.Confirmer.Error(MPManager.Catalog.GetString("Connection to the server is lost, will play as single mode"));
-			try
-			{
-				foreach (var p in MPManager.OnlineTrains.Players)
-				{
-					MPManager.Instance().AddRemovedPlayer(p.Value);
-				}
-			}
-			catch (Exception) { }
-			
-			//no matter what, let player gain back the control of the player train
-			if (MPManager.Simulator.PlayerLocomotive != null && MPManager.Simulator.PlayerLocomotive.Train != null)
-			{
-				MPManager.Simulator.PlayerLocomotive.Train.TrainType = Train.TRAINTYPE.PLAYER;
-				MPManager.Simulator.PlayerLocomotive.Train.LeadLocomotive = MPManager.Simulator.PlayerLocomotive;
-			}
-			if (MPManager.Simulator.Confirmer != null)
+            try
+            {
+                foreach (var p in MPManager.OnlineTrains.Players)
+                {
+                    MPManager.Instance().AddRemovedPlayer(p.Value);
+                }
+            }
+            catch (Exception) { }
+
+            //no matter what, let player gain back the control of the player train
+            if (MPManager.Simulator.PlayerLocomotive != null && MPManager.Simulator.PlayerLocomotive.Train != null)
+            {
+                MPManager.Simulator.PlayerLocomotive.Train.TrainType = Train.TRAINTYPE.PLAYER;
+                MPManager.Simulator.PlayerLocomotive.Train.LeadLocomotive = MPManager.Simulator.PlayerLocomotive;
+            }
+            if (MPManager.Simulator.Confirmer != null)
                 MPManager.Simulator.Confirmer.Information(MPManager.Catalog.GetString("Alt-E to gain control of your train"));
 
             MPManager.Client = null;
-			tcpClient.Close();
-			listenThread.Abort();
-		}
+            tcpClient.Close();
+            listenThread.Abort();
+        }
 
-		private object lockObj = new object();
-		public void Send(string msg)
-		{
+        private object lockObj = new object();
+        public void Send(string msg)
+        {
 
-			try
-			{
-				NetworkStream clientStream = client.GetStream();
-				lock (lockObj)//in case two threads want to write at the same buffer
-				{
+            try
+            {
+                NetworkStream clientStream = client.GetStream();
+                lock (lockObj)//in case two threads want to write at the same buffer
+                {
 #if DEBUG_MULTIPLAYER
                     Trace.TraceInformation("MPClientSend: {0}", msg);
 #endif
                     byte[] buffer = Encoding.Unicode.GetBytes(msg);//encoder.GetBytes(msg);
-					clientStream.Write(buffer, 0, buffer.Length);
-					clientStream.Flush();
-				}
-			}
-			catch
-			{
-			}
-		}
+                    clientStream.Write(buffer, 0, buffer.Length);
+                    clientStream.Flush();
+                }
+            }
+            catch
+            {
+            }
+        }
 
-	}
+    }
 }

--- a/Source/Orts.Simulation/MultiPlayer/Decoder.cs
+++ b/Source/Orts.Simulation/MultiPlayer/Decoder.cs
@@ -20,9 +20,9 @@ using System;
 namespace Orts.MultiPlayer
 {
     public class Decoder
-	{
-		string msg = "";
-		/*
+    {
+        string msg = "";
+        /*
 		static Decoder decoder= null;
 		private Decoder()
 		{
@@ -34,43 +34,43 @@ namespace Orts.MultiPlayer
 			return decoder;
 		}
 		*/
-		public void PushMsg(string s)
-		{
+        public void PushMsg(string s)
+        {
             //if (msg.Length > 10 && !msg.Contains(":") && s.Contains(":")) msg = "";
-			msg += s; //add to existing string of msgs
-		}
-		public string GetMsg()
-		{
-//			System.Console.WriteLine(msg);
-			if (msg.Length < 1) return null;
-			int index = msg.IndexOf(':');
-			if (index < 0)
-			{
-				if (msg.Length > 10) msg = msg.Remove(0); //no ':', clear the messages, no way to recover anyway, except the first few digits
-				throw new Exception("Parsing error, no : found");
-			}
-			try
-			{
-				int last = index - 1;
-				while (last >= 0)
-				{
-					if (!char.IsDigit(msg[last])) break;
-					last--;
-				} //shift back to get all digits
-				last += 1;
-				if (last < 0) last = 0;
-				string tmp = msg.Substring(last, index - last);
-				int len;
-				if (!int.TryParse(tmp, out len)) { msg = msg.Remove(0); return null; }
-				if (len < 0) return null;
+            msg += s; //add to existing string of msgs
+        }
+        public string GetMsg()
+        {
+            //			System.Console.WriteLine(msg);
+            if (msg.Length < 1) return null;
+            int index = msg.IndexOf(':');
+            if (index < 0)
+            {
+                if (msg.Length > 10) msg = msg.Remove(0); //no ':', clear the messages, no way to recover anyway, except the first few digits
+                throw new Exception("Parsing error, no : found");
+            }
+            try
+            {
+                int last = index - 1;
+                while (last >= 0)
+                {
+                    if (!char.IsDigit(msg[last])) break;
+                    last--;
+                } //shift back to get all digits
+                last += 1;
+                if (last < 0) last = 0;
+                string tmp = msg.Substring(last, index - last);
+                int len;
+                if (!int.TryParse(tmp, out len)) { msg = msg.Remove(0); return null; }
+                if (len < 0) return null;
                 if (index + 2 + len > msg.Length)
                 {
                     //if (msg.LastIndexOf(":") > 64) { msg = msg.Remove(0, index + 1); }//if there is a : further down, means the length is wrong, needs to remove until next :
                     return null;
                 }
-				tmp = msg.Substring(index + 2, len); //not taking ": "
-				msg = msg.Remove(0, index + 2 + len); //remove :
-				if (len > 1000000) return null;//a long message, will ignore it
+                tmp = msg.Substring(index + 2, len); //not taking ": "
+                msg = msg.Remove(0, index + 2 + len); //remove :
+                if (len > 1000000) return null;//a long message, will ignore it
 #if false
 				int last = index-1;
 				while (last >= 0 && char.IsDigit(msg[last--])) ; //shift back to get all digits
@@ -82,17 +82,17 @@ namespace Orts.MultiPlayer
 				tmp = msg.Substring(index+2, len); //not taking ": "
 				msg = msg.Remove(last, index+2+len); //remove :
 #endif
-				return tmp;
-			}
-			catch (Exception)
-			{
-				//System.Console.WriteLine(msg);
-				//msg = ""; //clear the messages
-				return null;
-			}
-			
-		}
-	}
+                return tmp;
+            }
+            catch (Exception)
+            {
+                //System.Console.WriteLine(msg);
+                //msg = ""; //clear the messages
+                return null;
+            }
+
+        }
+    }
 
     public class MultiPlayerError : Exception
     {

--- a/Source/Orts.Simulation/MultiPlayer/MPManager.cs
+++ b/Source/Orts.Simulation/MultiPlayer/MPManager.cs
@@ -43,7 +43,7 @@ namespace Orts.MultiPlayer
 {
     //a singleton class handles communication, update and stop etc.
     public class MPManager
-	{
+    {
         public static GettextResourceManager Catalog { get; private set; }
         public static Random Random { get; private set; }
         public static Simulator Simulator { get; internal set; }
@@ -56,39 +56,39 @@ namespace Orts.MultiPlayer
         public double lastSwitchTime;
         public double lastSyncTime = 0;
         double lastSendTime;
-		string metric = "";
-		double metricbase = 1.0f;
-		public static OnlineTrains OnlineTrains = new OnlineTrains();
+        string metric = "";
+        double metricbase = 1.0f;
+        public static OnlineTrains OnlineTrains = new OnlineTrains();
         private static MPManager localUser;
 
-		public List<Train> removedTrains;
-		private List<Train> addedTrains;
+        public List<Train> removedTrains;
+        private List<Train> addedTrains;
         public List<OnlineLocomotive> removedLocomotives;
         private List<OnlineLocomotive> addedLocomotives;
 
         private List<Train> uncoupledTrains;
 
-		public bool weatherChanged = false;
-		public int weather = -1;
+        public bool weatherChanged = false;
+        public int weather = -1;
         public float fogDistance = -1f;
         public float pricipitationIntensity = -1f;
         public float overcastFactor = -1f;
         public double serverTimeDifference = 0;
 
         public double lastPlayerAddedTime;
-		public int MPUpdateInterval = 10;
-		static public bool AllowedManualSwitch = true;
-		public bool TrySwitch = true;
-		public bool AllowNewPlayer = true;
-		public bool ComposingText = false;
-		public string lastSender = ""; //who last sends me a message
-		public bool AmAider = false; //am I aiding the dispatcher?
-		public List<string> aiderList;
-		public Dictionary<string, OnlinePlayer> lostPlayer = new Dictionary<string,OnlinePlayer>();
-		public bool NotServer = true;
-		public bool CheckSpad = true;
-		public static bool PreferGreen = true;
-		public string MD5Check = "";
+        public int MPUpdateInterval = 10;
+        static public bool AllowedManualSwitch = true;
+        public bool TrySwitch = true;
+        public bool AllowNewPlayer = true;
+        public bool ComposingText = false;
+        public string lastSender = ""; //who last sends me a message
+        public bool AmAider = false; //am I aiding the dispatcher?
+        public List<string> aiderList;
+        public Dictionary<string, OnlinePlayer> lostPlayer = new Dictionary<string, OnlinePlayer>();
+        public bool NotServer = true;
+        public bool CheckSpad = true;
+        public static bool PreferGreen = true;
+        public string MD5Check = "";
 
         public class ServerChangedEventArgs : EventArgs
         {
@@ -129,82 +129,82 @@ namespace Orts.MultiPlayer
         public event EventHandler<MessageReceivedEventArgs> MessageReceived;
 
         public void AddUncoupledTrains(Train t)
-		{
-			lock (uncoupledTrains)
-			{
-				uncoupledTrains.Add(t);
-			}
-		}
+        {
+            lock (uncoupledTrains)
+            {
+                uncoupledTrains.Add(t);
+            }
+        }
 
-		public void RemoveUncoupledTrains(Train t)
-		{
-			lock (uncoupledTrains)
-			{
-				uncoupledTrains.Remove(t);
-			}
-		}
+        public void RemoveUncoupledTrains(Train t)
+        {
+            lock (uncoupledTrains)
+            {
+                uncoupledTrains.Remove(t);
+            }
+        }
 
-		public string OriginalSwitchState = "";
+        public string OriginalSwitchState = "";
 
-		public void RememberOriginalSwitchState()
-		{
-			MSGSwitchStatus msg = new MSGSwitchStatus();
-			var str = msg.ToString();
-			var index = str.IndexOf("SWITCHSTATES ");
-			OriginalSwitchState = str.Remove(0, index + 13);
-		}
-		//handles singleton
-		private MPManager()
-		{
-			playersRemoved = new List<OnlinePlayer>();
-			uncoupledTrains = new List<Train>();
-			addedTrains = new List<Train>();
-			removedTrains = new List<Train>();
+        public void RememberOriginalSwitchState()
+        {
+            MSGSwitchStatus msg = new MSGSwitchStatus();
+            var str = msg.ToString();
+            var index = str.IndexOf("SWITCHSTATES ");
+            OriginalSwitchState = str.Remove(0, index + 13);
+        }
+        //handles singleton
+        private MPManager()
+        {
+            playersRemoved = new List<OnlinePlayer>();
+            uncoupledTrains = new List<Train>();
+            addedTrains = new List<Train>();
+            removedTrains = new List<Train>();
             addedLocomotives = new List<OnlineLocomotive>();
             removedLocomotives = new List<OnlineLocomotive>();
             aiderList = new List<string>();
-			if (Server != null) NotServer = false;
-			users = new SortedList<double,string>();
-			GetMD5HashFromTDBFile();
-		}
-		public static MPManager Instance()
-		{
+            if (Server != null) NotServer = false;
+            users = new SortedList<double, string>();
+            GetMD5HashFromTDBFile();
+        }
+        public static MPManager Instance()
+        {
             if (localUser == null)
             {
                 Catalog = new GettextResourceManager("Orts.Simulation");
                 Random = new Random();
                 localUser = new MPManager();
             }
-			return localUser;
-		}
+            return localUser;
+        }
 
-		public static void RequestControl()
-		{
-			try
-			{
-				Train train = Simulator.PlayerLocomotive.Train;
-				
-				MSGControl msgctl;
-				//I am the server, I have control
-				if (IsServer())
-				{
-					train.TrainType = Train.TRAINTYPE.PLAYER; train.LeadLocomotive = Simulator.PlayerLocomotive;
+        public static void RequestControl()
+        {
+            try
+            {
+                Train train = Simulator.PlayerLocomotive.Train;
+
+                MSGControl msgctl;
+                //I am the server, I have control
+                if (IsServer())
+                {
+                    train.TrainType = Train.TRAINTYPE.PLAYER; train.LeadLocomotive = Simulator.PlayerLocomotive;
                     InitializeBrakesCommand.Receiver = MPManager.Simulator.PlayerLocomotive.Train;
                     train.InitializeSignals(false);
                     if (Simulator.Confirmer != null)
                         Simulator.Confirmer.Information(MPManager.Catalog.GetString("You gained back the control of your train"));
-					msgctl = new MSGControl(GetUserName(), "Confirm", train);
-					BroadCast(msgctl.ToString());
-				}
-				else //client, send request
-				{
-					msgctl = new MSGControl(GetUserName(), "Request", train);
-					SendToServer(msgctl.ToString());
-				}
-			}
-			catch (Exception)
-			{ }
-		}
+                    msgctl = new MSGControl(GetUserName(), "Confirm", train);
+                    BroadCast(msgctl.ToString());
+                }
+                else //client, send request
+                {
+                    msgctl = new MSGControl(GetUserName(), "Request", train);
+                    SendToServer(msgctl.ToString());
+                }
+            }
+            catch (Exception)
+            { }
+        }
 
         public void PreUpdate()
         {
@@ -231,15 +231,15 @@ namespace Orts.MultiPlayer
         {
             if (begineZeroTime == 0) begineZeroTime = newtime - 10;
 
-			CheckPlayerTrainSpad();//over speed or pass a red light
+            CheckPlayerTrainSpad();//over speed or pass a red light
 
-			//server update train location of all
-			if (Server != null && newtime - lastMoveTime >= 1f)
-			{
-				MSGMove move = new MSGMove();
+            //server update train location of all
+            if (Server != null && newtime - lastMoveTime >= 1f)
+            {
+                MSGMove move = new MSGMove();
                 if (Simulator.PlayerLocomotive.Train.TrainType != Train.TRAINTYPE.REMOTE)
                     move.AddNewItem(GetUserName(), Simulator.PlayerLocomotive.Train);
-				Server.BroadCast(OnlineTrains.MoveTrains(move));
+                Server.BroadCast(OnlineTrains.MoveTrains(move));
                 MSGExhaust exhaust = new MSGExhaust(); // Also updating loco exhaust
                 Train t = Simulator.PlayerLocomotive.Train;
                 for (int iCar = 0; iCar < t.Cars.Count; iCar++)
@@ -261,29 +261,29 @@ namespace Orts.MultiPlayer
 					Server.BroadCast((new MSGLocoInfo(Simulator.PlayerLocomotive, GetUserName())).ToString());
 				}
 #endif
-			}
-			
-			//server updates switch
-			if (Server != null && newtime - lastSwitchTime >= MPUpdateInterval)
-			{
-				lastSwitchTime = lastSendTime = newtime;
-				var switchStatus = new MSGSwitchStatus();
+            }
 
-				if (switchStatus.OKtoSend) BroadCast(switchStatus.ToString());
-				var signalStatus = new MSGSignalStatus();
-				if (signalStatus.OKtoSend) BroadCast(signalStatus.ToString());
+            //server updates switch
+            if (Server != null && newtime - lastSwitchTime >= MPUpdateInterval)
+            {
+                lastSwitchTime = lastSendTime = newtime;
+                var switchStatus = new MSGSwitchStatus();
 
-			}
-			
-			//client updates itself
-			if (Client != null && Server == null && newtime - lastMoveTime >= 1f)
-			{
-				Train t = Simulator.PlayerLocomotive.Train;
-				MSGMove move = new MSGMove();
+                if (switchStatus.OKtoSend) BroadCast(switchStatus.ToString());
+                var signalStatus = new MSGSignalStatus();
+                if (signalStatus.OKtoSend) BroadCast(signalStatus.ToString());
+
+            }
+
+            //client updates itself
+            if (Client != null && Server == null && newtime - lastMoveTime >= 1f)
+            {
+                Train t = Simulator.PlayerLocomotive.Train;
+                MSGMove move = new MSGMove();
                 MSGExhaust exhaust = new MSGExhaust(); // Also updating loco exhaust
                 //if I am still controlling the train
                 if (t.TrainType != Train.TRAINTYPE.REMOTE)
-				{
+                {
                     if (Math.Abs(t.SpeedMpS) > 0.001 || newtime - begineZeroTime < 5f || Math.Abs(t.LastReportedSpeed) > 0)
                     {
                         move.AddNewItem(GetUserName(), t);
@@ -303,16 +303,16 @@ namespace Orts.MultiPlayer
                         }
                     }
 
-				}
-				//MoveUncoupledTrains(move); //if there are uncoupled trains
-				//if there are messages to send
-				if (move.OKtoSend())
-				{
-					Client.Send(move.ToString());
+                }
+                //MoveUncoupledTrains(move); //if there are uncoupled trains
+                //if there are messages to send
+                if (move.OKtoSend())
+                {
+                    Client.Send(move.ToString());
                     if (exhaust.OKtoSend()) Client.Send(exhaust.ToString());
-					lastMoveTime = lastSendTime = newtime;
-				}
-				previousSpeed = t.SpeedMpS;
+                    lastMoveTime = lastSendTime = newtime;
+                }
+                previousSpeed = t.SpeedMpS;
 
 #if INDIVIDUAL_CONTROL
 
@@ -324,14 +324,14 @@ namespace Orts.MultiPlayer
             }
 
 
-			//need to send a keep-alive message if have not sent one to the server for the last 30 seconds
-			if (Client != null && Server == null && newtime - lastSendTime >= 30f)
-			{
-				Notify((new MSGAlive(GetUserName())).ToString());
-				lastSendTime = newtime;
-			}
+            //need to send a keep-alive message if have not sent one to the server for the last 30 seconds
+            if (Client != null && Server == null && newtime - lastSendTime >= 30f)
+            {
+                Notify((new MSGAlive(GetUserName())).ToString());
+                lastSendTime = newtime;
+            }
 
-			//some players are removed
+            //some players are removed
             //need to send a keep-alive message if have not sent one to the server for the last 30 seconds
             if (IsServer() && newtime - lastSyncTime >= 60f)
             {
@@ -340,55 +340,55 @@ namespace Orts.MultiPlayer
             }
             RemovePlayer();
 
-			//some players are disconnected more than 1 minute ago, will not care if they come back later
-			CleanLostPlayers();
+            //some players are disconnected more than 1 minute ago, will not care if they come back later
+            CleanLostPlayers();
 
-			//some trains are added/removed
-			HandleTrainList();
+            //some trains are added/removed
+            HandleTrainList();
 
             //some locos are added/removed
             if (IsServer()) HandleLocoList();
 
             AddPlayer(); //a new player joined? handle it
 
-			/* will have this in the future so that helpers can also control
+            /* will have this in the future so that helpers can also control
 			//I am a helper, will see if I need to update throttle and dynamic brake
 			if (Simulator.PlayerLocomotive.Train != null && Simulator.PlayerLocomotive.Train.TrainType == Train.TRAINTYPE.REMOTE) 
 			{
 
 			}
 			 * */
-		}
+        }
 
 
-		void CheckPlayerTrainSpad()
-		{
-			if (CheckSpad == false) return;
-			var Locomotive = (MSTSLocomotive)Simulator.PlayerLocomotive;
-			if (Locomotive == null) return;
-			var train = Locomotive.Train;
-			if (train == null ||train.TrainType == Train.TRAINTYPE.REMOTE) return;//no train or is remotely controlled
+        void CheckPlayerTrainSpad()
+        {
+            if (CheckSpad == false) return;
+            var Locomotive = (MSTSLocomotive)Simulator.PlayerLocomotive;
+            if (Locomotive == null) return;
+            var train = Locomotive.Train;
+            if (train == null || train.TrainType == Train.TRAINTYPE.REMOTE) return;//no train or is remotely controlled
 
-			//var spad = false;
-			var maxSpeed = Math.Abs(train.AllowedMaxSpeedMpS) + 3;//allow some margin of error (about 10km/h)
-			var speed = Math.Abs(Locomotive.SpeedMpS);
-			//if (speed > maxSpeed) spad = true;
-			//if (train.TMaspect == ORTS.Popups.TrackMonitorSignalAspect.Stop && Math.Abs(train.distanceToSignal) < 2*speed && speed > 5) spad = true; //red light and cannot stop within 2 seconds, if the speed is large
+            //var spad = false;
+            var maxSpeed = Math.Abs(train.AllowedMaxSpeedMpS) + 3;//allow some margin of error (about 10km/h)
+            var speed = Math.Abs(Locomotive.SpeedMpS);
+            //if (speed > maxSpeed) spad = true;
+            //if (train.TMaspect == ORTS.Popups.TrackMonitorSignalAspect.Stop && Math.Abs(train.distanceToSignal) < 2*speed && speed > 5) spad = true; //red light and cannot stop within 2 seconds, if the speed is large
 
-		}
-		//check if it is in the server mode
-		public static bool IsServer()
-		{
-			if (Server != null) return true;
-			else return false;
-		}
+        }
+        //check if it is in the server mode
+        public static bool IsServer()
+        {
+            if (Server != null) return true;
+            else return false;
+        }
 
-		//check if it is in the client mode
-		public static bool IsClient()
-		{
-			if (!MPManager.IsMultiPlayer() || MPManager.IsServer()) return false;
-			return true; 
-		}
+        //check if it is in the client mode
+        public static bool IsClient()
+        {
+            if (!MPManager.IsMultiPlayer() || MPManager.IsServer()) return false;
+            return true;
+        }
         //check if it is in the server mode && they are players && not allow autoswitch
         public static bool NoAutoSwitch()
         {
@@ -397,110 +397,110 @@ namespace Orts.MultiPlayer
             return !MPManager.AllowedManualSwitch; //aloow manual switch or not
         }
         //user name
-		static public string GetUserName()
-		{
-			if (Server != null) return Server.UserName;
-			else if (Client != null) return Client.UserName;
-			else return "";
-		}
+        static public string GetUserName()
+        {
+            if (Server != null) return Server.UserName;
+            else if (Client != null) return Client.UserName;
+            else return "";
+        }
 
-		//check if it is in the multiplayer session
-		static public bool IsMultiPlayer()
-		{
-			if (Server != null || Client != null) return true;
-			else return false;
-		}
+        //check if it is in the multiplayer session
+        static public bool IsMultiPlayer()
+        {
+            if (Server != null || Client != null) return true;
+            else return false;
+        }
 
-		static public void BroadCast(string m)
-		{
-			if (m == null) return;
-			if (Server != null) Server.BroadCast(m);
-		}
+        static public void BroadCast(string m)
+        {
+            if (m == null) return;
+            if (Server != null) Server.BroadCast(m);
+        }
 
-		//notify others (server will broadcast, client will send msg to server)
-		static public void Notify(string m)
-		{
-			if (m == null) return;
-			if (Client != null && Server == null) Client.Send(m); //client notify server
-			if (Server != null) Server.BroadCast(m); //server notify everybody else
-		}
+        //notify others (server will broadcast, client will send msg to server)
+        static public void Notify(string m)
+        {
+            if (m == null) return;
+            if (Client != null && Server == null) Client.Send(m); //client notify server
+            if (Server != null) Server.BroadCast(m); //server notify everybody else
+        }
 
-		static public void SendToServer(string m)
-		{
-			if (m!= null && Client != null) Client.Send(m);
-		}
+        static public void SendToServer(string m)
+        {
+            if (m != null && Client != null) Client.Send(m);
+        }
 
-		//nicely shutdown listening threads, and notify the server/other player
-		static public void Stop()
-		{
-			if (Client != null && Server == null)
-			{
-				Client.Send((new MSGQuit(GetUserName())).ToString()); //client notify server
-				Thread.Sleep(1000);
-				Client.Stop();
-			}
-			if (Server != null)
-			{
-				Server.BroadCast((new MSGQuit("ServerHasToQuit\t"+GetUserName())).ToString()); //server notify everybody else
-				Thread.Sleep(1000);
-				if (Server.ServerComm != null) Server.Stop();
-				if (Client != null) Client.Stop();
-			}
-		}
+        //nicely shutdown listening threads, and notify the server/other player
+        static public void Stop()
+        {
+            if (Client != null && Server == null)
+            {
+                Client.Send((new MSGQuit(GetUserName())).ToString()); //client notify server
+                Thread.Sleep(1000);
+                Client.Stop();
+            }
+            if (Server != null)
+            {
+                Server.BroadCast((new MSGQuit("ServerHasToQuit\t" + GetUserName())).ToString()); //server notify everybody else
+                Thread.Sleep(1000);
+                if (Server.ServerComm != null) Server.Stop();
+                if (Client != null) Client.Stop();
+            }
+        }
 
-		//when two player trains connected, require decouple at speed 0.
-		public static bool TrainOK2Decouple(Confirmer confirmer, Train t)
-		{
-			if (t == null) return false;
-			if (Math.Abs(t.SpeedMpS) < 0.001) return true;
-			try
-			{
-				var count = 0;
-				foreach (var p in OnlineTrains.Players.Keys)
-				{
-					string p1 = p + " ";
-					foreach (var car in t.Cars)
-					{
-						if (car.CarID.Contains(p1)) count++;
-					}
-				}
-				if (count >= 2)
-				{
-					if (confirmer != null)
-						confirmer.Information(MPManager.Catalog.GetPluralStringFmt("Cannot decouple: train has {0} player, need to completely stop.", "Cannot decouple: train has {0} players, need to completely stop.", count));
-					return false;
-				}
-			}
-			catch { return false; }
-			return true;
-		}
+        //when two player trains connected, require decouple at speed 0.
+        public static bool TrainOK2Decouple(Confirmer confirmer, Train t)
+        {
+            if (t == null) return false;
+            if (Math.Abs(t.SpeedMpS) < 0.001) return true;
+            try
+            {
+                var count = 0;
+                foreach (var p in OnlineTrains.Players.Keys)
+                {
+                    string p1 = p + " ";
+                    foreach (var car in t.Cars)
+                    {
+                        if (car.CarID.Contains(p1)) count++;
+                    }
+                }
+                if (count >= 2)
+                {
+                    if (confirmer != null)
+                        confirmer.Information(MPManager.Catalog.GetPluralStringFmt("Cannot decouple: train has {0} player, need to completely stop.", "Cannot decouple: train has {0} players, need to completely stop.", count));
+                    return false;
+                }
+            }
+            catch { return false; }
+            return true;
+        }
 
-		public bool PlayerAdded = false;
+        public bool PlayerAdded = false;
 
-		public void AddPlayer()
-		{
-			if (!MPManager.IsServer()) return;
-			if (PlayerAdded == true)
-			{
-				PlayerAdded = false;
-				MPManager.Instance().lastPlayerAddedTime = Simulator.GameTime;
-				MPManager.Instance().lastSwitchTime = Simulator.GameTime;
+        public void AddPlayer()
+        {
+            if (!MPManager.IsServer()) return;
+            if (PlayerAdded == true)
+            {
+                PlayerAdded = false;
+                MPManager.Instance().lastPlayerAddedTime = Simulator.GameTime;
+                MPManager.Instance().lastSwitchTime = Simulator.GameTime;
 
-				MSGPlayer host = new  MSGPlayer(MPManager.GetUserName(), "1234", Simulator.conFileName, Simulator.patFileName, Simulator.PlayerLocomotive.Train,
-					Simulator.PlayerLocomotive.Train.Number, Simulator.Settings.AvatarURL);
-				MPManager.BroadCast(host.ToString() + MPManager.OnlineTrains.AddAllPlayerTrain());
-				foreach (Train t in Simulator.Trains)
-				{
-					if (Simulator.PlayerLocomotive != null && t == Simulator.PlayerLocomotive.Train) continue; //avoid broadcast player train
-					if (MPManager.FindPlayerTrain(t)) continue;
-					if (removedTrains.Contains(t)) continue;//this train is going to be removed, should avoid it.
-					MPManager.BroadCast((new MSGTrain(t, t.Number)).ToString());
-				}
-				if (CheckSpad == false) { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "OverSpeedOK", "OK to go overspeed and pass stop light")).ToString()); }
-				else { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "NoOverSpeed", "Penalty for overspeed and passing stop light")).ToString()); }
+                MSGPlayer host = new MSGPlayer(MPManager.GetUserName(), "1234", Simulator.conFileName, Simulator.patFileName, Simulator.PlayerLocomotive.Train,
+                    Simulator.PlayerLocomotive.Train.Number, Simulator.Settings.AvatarURL);
+                MPManager.BroadCast(host.ToString() + MPManager.OnlineTrains.AddAllPlayerTrain());
+                foreach (Train t in Simulator.Trains)
+                {
+                    if (Simulator.PlayerLocomotive != null && t == Simulator.PlayerLocomotive.Train) continue; //avoid broadcast player train
+                    if (MPManager.FindPlayerTrain(t)) continue;
+                    if (removedTrains.Contains(t)) continue;//this train is going to be removed, should avoid it.
+                    MPManager.BroadCast((new MSGTrain(t, t.Number)).ToString());
+                }
+                if (CheckSpad == false) { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "OverSpeedOK", "OK to go overspeed and pass stop light")).ToString()); }
+                else { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "NoOverSpeed", "Penalty for overspeed and passing stop light")).ToString()); }
                 MPManager.BroadCast(GetEnvInfo());
-			}
-		}
+            }
+        }
 
         //create weather message
         public string GetEnvInfo()
@@ -518,170 +518,170 @@ namespace Orts.MultiPlayer
         }
 
         //this will be used in the server, in Simulator.cs
-		public static bool TrainOK2Couple(Simulator simulator, Train t1, Train t2)
-		{
-			//if (Math.Abs(t1.SpeedMpS) > 10 || Math.Abs(t2.SpeedMpS) > 10) return false; //we do not like high speed punch in MP, will mess up a lot.
+        public static bool TrainOK2Couple(Simulator simulator, Train t1, Train t2)
+        {
+            //if (Math.Abs(t1.SpeedMpS) > 10 || Math.Abs(t2.SpeedMpS) > 10) return false; //we do not like high speed punch in MP, will mess up a lot.
 
-			if (t1.TrainType != Train.TRAINTYPE.REMOTE && t2.TrainType != Train.TRAINTYPE.REMOTE) return true;
+            if (t1.TrainType != Train.TRAINTYPE.REMOTE && t2.TrainType != Train.TRAINTYPE.REMOTE) return true;
 
-			bool result = true;
-			try
-			{
-				foreach (var p in OnlineTrains.Players)
-				{
-					if (p.Value.Train == t1 && simulator.GameTime  - p.Value.CreatedTime < 120) { result = false; break; }
-					if (p.Value.Train == t2 && simulator.GameTime - p.Value.CreatedTime < 120) { result = false; break; }
-				}
-			}
-			catch (Exception)
-			{
-			}
-			return result;
-		}
-		/// <summary>
-		/// Return a string of information of how many players online and those users who are close
-		/// </summary>
-		
-		SortedList<double, string> users;
+            bool result = true;
+            try
+            {
+                foreach (var p in OnlineTrains.Players)
+                {
+                    if (p.Value.Train == t1 && simulator.GameTime - p.Value.CreatedTime < 120) { result = false; break; }
+                    if (p.Value.Train == t2 && simulator.GameTime - p.Value.CreatedTime < 120) { result = false; break; }
+                }
+            }
+            catch (Exception)
+            {
+            }
+            return result;
+        }
+        /// <summary>
+        /// Return a string of information of how many players online and those users who are close
+        /// </summary>
 
-		public string GetOnlineUsersInfo()
-		{
+        SortedList<double, string> users;
 
-			string info = "";
-			if (Simulator.PlayerLocomotive.Train.TrainType == Train.TRAINTYPE.REMOTE) info = "Your locomotive is a helper\t";
-			info += ("" + (OnlineTrains.Players.Count + 1)+ (OnlineTrains.Players.Count <= 0 ? " player " : "  players "));
-			info += ("" + Simulator.Trains.Count + (Simulator.Trains.Count <= 1 ? " train" : "  trains"));
-			TrainCar mine = Simulator.PlayerLocomotive;
-			users.Clear();
-			try//the list of players may be changed during the following process
-			{
-				//foreach (var train in Simulator.Trains) info += "\t" + train.Number + " " + train.Cars.Count;
-				//info += "\t" + MPManager.OnlineTrains.Players.Count;
-				//foreach (var p in MPManager.OnlineTrains.Players) info += "\t" + p.Value.Train.Number + " " + p.Key;
-				foreach (OnlinePlayer p in OnlineTrains.Players.Values)
-				{
-					if (p.Train == null) continue;
-					if (p.Train.Cars.Count <= 0) continue;
-					var d = WorldLocation.GetDistanceSquared(p.Train.RearTDBTraveller.WorldLocation, mine.Train.RearTDBTraveller.WorldLocation);
-					users.Add(Math.Sqrt(d)+MPManager.Random.NextDouble(), p.Username);
-				}
-			}
-			catch (Exception)
-			{
-			}
-			if (metric == "")
-			{
-				metric = Simulator.TRK.Tr_RouteFile.MilepostUnitsMetric == true ? " m" : " yd";
-				metricbase = Simulator.TRK.Tr_RouteFile.MilepostUnitsMetric == true ? 1.0f : 1.0936133f;
-			}
+        public string GetOnlineUsersInfo()
+        {
 
-			int count = 0;
-			foreach (var pair in users)
-			{
-				if (count >= 10) break;
-				info += "\t" + pair.Value + ": distance of " + (int)(pair.Key / metricbase) + metric;
-				count++;
-			}
-			if (count < OnlineTrains.Players.Count) { info += "\t ..."; }
-			return info;
-		}
+            string info = "";
+            if (Simulator.PlayerLocomotive.Train.TrainType == Train.TRAINTYPE.REMOTE) info = "Your locomotive is a helper\t";
+            info += ("" + (OnlineTrains.Players.Count + 1) + (OnlineTrains.Players.Count <= 0 ? " player " : "  players "));
+            info += ("" + Simulator.Trains.Count + (Simulator.Trains.Count <= 1 ? " train" : "  trains"));
+            TrainCar mine = Simulator.PlayerLocomotive;
+            users.Clear();
+            try//the list of players may be changed during the following process
+            {
+                //foreach (var train in Simulator.Trains) info += "\t" + train.Number + " " + train.Cars.Count;
+                //info += "\t" + MPManager.OnlineTrains.Players.Count;
+                //foreach (var p in MPManager.OnlineTrains.Players) info += "\t" + p.Value.Train.Number + " " + p.Key;
+                foreach (OnlinePlayer p in OnlineTrains.Players.Values)
+                {
+                    if (p.Train == null) continue;
+                    if (p.Train.Cars.Count <= 0) continue;
+                    var d = WorldLocation.GetDistanceSquared(p.Train.RearTDBTraveller.WorldLocation, mine.Train.RearTDBTraveller.WorldLocation);
+                    users.Add(Math.Sqrt(d) + MPManager.Random.NextDouble(), p.Username);
+                }
+            }
+            catch (Exception)
+            {
+            }
+            if (metric == "")
+            {
+                metric = Simulator.TRK.Tr_RouteFile.MilepostUnitsMetric == true ? " m" : " yd";
+                metricbase = Simulator.TRK.Tr_RouteFile.MilepostUnitsMetric == true ? 1.0f : 1.0936133f;
+            }
 
-		private List<OnlinePlayer> playersRemoved;
-		public void AddRemovedPlayer(OnlinePlayer p)
-		{
-			lock (playersRemoved)
-			{
-				if (playersRemoved.Contains(p)) return;
-				playersRemoved.Add(p);
-			}
-		}
+            int count = 0;
+            foreach (var pair in users)
+            {
+                if (count >= 10) break;
+                info += "\t" + pair.Value + ": distance of " + (int)(pair.Key / metricbase) + metric;
+                count++;
+            }
+            if (count < OnlineTrains.Players.Count) { info += "\t ..."; }
+            return info;
+        }
 
-		private void CleanLostPlayers()
-		{
-			//check if any of the lost player list has been lost for more than 600 seconds. If so, remove it and will not worry about it anymore
-			if (lostPlayer.Count > 0)
-			{
-				List<string> removeLost = null;
-				foreach (var x in lostPlayer)
-				{
-					if (Simulator.GameTime - x.Value.quitTime > 600) //within 10 minutes it will be held
-					{
-						if (removeLost == null) removeLost = new List<string>();
-						removeLost.Add(x.Key);
-					}
-				}
-				if (removeLost != null)
-				{
-					foreach (var name in removeLost)
-					{
-						lostPlayer.Remove(name);
-					}
-				}
-			}
-		}
-		//only can be called by Update
-		private void RemovePlayer()
-		{
-			//if (Server == null) return; //client will do it by decoding message
-			if (playersRemoved.Count == 0) return;
+        private List<OnlinePlayer> playersRemoved;
+        public void AddRemovedPlayer(OnlinePlayer p)
+        {
+            lock (playersRemoved)
+            {
+                if (playersRemoved.Contains(p)) return;
+                playersRemoved.Add(p);
+            }
+        }
 
-			try //do it with lock, but may still have exception
-			{
-				lock (playersRemoved)
-				{
-					foreach (OnlinePlayer p in playersRemoved)
-					{
-						if (Server != null) Server.Players.Remove(p);
-						//player is not in this train
-						if (p.Train != null && p.Train != Simulator.PlayerLocomotive.Train)
-						{
-							//make sure this train has no other player on it
-							bool hasOtherPlayer = false;
-							foreach (var p1 in OnlineTrains.Players)
-							{
-								if (p == p1.Value) continue;
-								if (p1.Value.Train == p.Train) { hasOtherPlayer = true; break; }//other player has the same train
-							}
-                            if (hasOtherPlayer == false) 
+        private void CleanLostPlayers()
+        {
+            //check if any of the lost player list has been lost for more than 600 seconds. If so, remove it and will not worry about it anymore
+            if (lostPlayer.Count > 0)
+            {
+                List<string> removeLost = null;
+                foreach (var x in lostPlayer)
+                {
+                    if (Simulator.GameTime - x.Value.quitTime > 600) //within 10 minutes it will be held
+                    {
+                        if (removeLost == null) removeLost = new List<string>();
+                        removeLost.Add(x.Key);
+                    }
+                }
+                if (removeLost != null)
+                {
+                    foreach (var name in removeLost)
+                    {
+                        lostPlayer.Remove(name);
+                    }
+                }
+            }
+        }
+        //only can be called by Update
+        private void RemovePlayer()
+        {
+            //if (Server == null) return; //client will do it by decoding message
+            if (playersRemoved.Count == 0) return;
+
+            try //do it with lock, but may still have exception
+            {
+                lock (playersRemoved)
+                {
+                    foreach (OnlinePlayer p in playersRemoved)
+                    {
+                        if (Server != null) Server.Players.Remove(p);
+                        //player is not in this train
+                        if (p.Train != null && p.Train != Simulator.PlayerLocomotive.Train)
+                        {
+                            //make sure this train has no other player on it
+                            bool hasOtherPlayer = false;
+                            foreach (var p1 in OnlineTrains.Players)
+                            {
+                                if (p == p1.Value) continue;
+                                if (p1.Value.Train == p.Train) { hasOtherPlayer = true; break; }//other player has the same train
+                            }
+                            if (hasOtherPlayer == false)
                             {
                                 AddOrRemoveLocomotives(p.Username, p.Train, false);
                                 p.Train.RemoveFromTrack();
                                 Simulator.Trains.Remove(p.Train);
                             }
-						}
-						OnlineTrains.Players.Remove(p.Username);
-					}
-				}
-			}
-			catch (Exception e)
-			{
-				System.Console.WriteLine(e + e.StackTrace); return;
-			}
-			playersRemoved.Clear();
+                        }
+                        OnlineTrains.Players.Remove(p.Username);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                System.Console.WriteLine(e + e.StackTrace); return;
+            }
+            playersRemoved.Clear();
 
-		}
+        }
 
-		public bool AddOrRemoveTrain(Train t, bool add)
-		{
-			if (add)
-			{
-				lock (addedTrains)
-				{
-					foreach (var t1 in addedTrains)
-					{
-						if (t1.Number == t.Number) return false;
-					}
-					addedTrains.Add(t); return true;
-				}
-			}
-			else
-			{
-				lock (removedTrains)
-				{
-					removedTrains.Add(t); return true;
-				}
-			}
-		}
+        public bool AddOrRemoveTrain(Train t, bool add)
+        {
+            if (add)
+            {
+                lock (addedTrains)
+                {
+                    foreach (var t1 in addedTrains)
+                    {
+                        if (t1.Number == t.Number) return false;
+                    }
+                    addedTrains.Add(t); return true;
+                }
+            }
+            else
+            {
+                lock (removedTrains)
+                {
+                    removedTrains.Add(t); return true;
+                }
+            }
+        }
 
         public bool AddOrRemoveLocomotive(string userName, int tNumber, int trainCarPosition, bool add)
         {
@@ -715,7 +715,7 @@ namespace Orts.MultiPlayer
             }
         }
 
-        public bool AddOrRemoveLocomotives (string userName, Train t, bool add)
+        public bool AddOrRemoveLocomotives(string userName, Train t, bool add)
         {
             for (int iCar = 0; iCar < t.Cars.Count; iCar++)
             {
@@ -730,40 +730,40 @@ namespace Orts.MultiPlayer
 
         //only can be called by Update
         private void HandleTrainList()
-		{
-			if (addedTrains.Count != 0)
-			{
+        {
+            if (addedTrains.Count != 0)
+            {
 
-				try //do it without lock, so may have exception
-				{
-					foreach (var t in addedTrains)
-					{
-						var hasIt = false;
-						foreach (var t1 in Simulator.Trains)
-						{
-							if (t1.Number == t.Number) { hasIt = true; break; }
-						}
-						if (!hasIt) Simulator.Trains.Add(t);
-					}
-					addedTrains.Clear();
-				}
-				catch (Exception) { }
-			}
-			if (removedTrains.Count != 0)
-			{
+                try //do it without lock, so may have exception
+                {
+                    foreach (var t in addedTrains)
+                    {
+                        var hasIt = false;
+                        foreach (var t1 in Simulator.Trains)
+                        {
+                            if (t1.Number == t.Number) { hasIt = true; break; }
+                        }
+                        if (!hasIt) Simulator.Trains.Add(t);
+                    }
+                    addedTrains.Clear();
+                }
+                catch (Exception) { }
+            }
+            if (removedTrains.Count != 0)
+            {
 
-				try //do it without lock, so may have exception
-				{
-					foreach (var t in removedTrains)
-					{
+                try //do it without lock, so may have exception
+                {
+                    foreach (var t in removedTrains)
+                    {
                         t.RemoveFromTrack();
-						Simulator.Trains.Remove(t);
-					}
-					removedTrains.Clear();
-				}
-				catch (Exception) { }
-			}
-		}
+                        Simulator.Trains.Remove(t);
+                    }
+                    removedTrains.Clear();
+                }
+                catch (Exception) { }
+            }
+        }
 
         //only can be called by Update
         private void HandleLocoList()
@@ -810,134 +810,134 @@ namespace Orts.MultiPlayer
         }
 
         public static Train FindPlayerTrain(string user)
-		{
-			return OnlineTrains.findTrain(user);
-		}
+        {
+            return OnlineTrains.findTrain(user);
+        }
 
-		public static bool FindPlayerTrain(Train t)
-		{
-			return OnlineTrains.findTrain(t);
-		}
+        public static bool FindPlayerTrain(Train t)
+        {
+            return OnlineTrains.findTrain(t);
+        }
 
-		public static void LocoChange(Train t, TrainCar lead)
-		{
+        public static void LocoChange(Train t, TrainCar lead)
+        {
             var frontOrRearCab = (lead as MSTSLocomotive).UsingRearCab ? "R" : "F";
-			Notify((new MSGLocoChange(GetUserName(), lead.CarID, frontOrRearCab, t)).ToString());
-		}
+            Notify((new MSGLocoChange(GetUserName(), lead.CarID, frontOrRearCab, t)).ToString());
+        }
 
         public TrainCar SubCar(string wagonFilePath, int length)
-		{
-			System.Console.WriteLine("Will substitute with your existing stocks\n.");
+        {
+            System.Console.WriteLine("Will substitute with your existing stocks\n.");
             TrainCar car;
-			try
-			{
-				char type = 'w';
-				if (wagonFilePath.ToLower().Contains(".eng")) type = 'e';
-				string newWagonFilePath = SubMissingCar(length, type);
+            try
+            {
+                char type = 'w';
+                if (wagonFilePath.ToLower().Contains(".eng")) type = 'e';
+                string newWagonFilePath = SubMissingCar(length, type);
                 car = RollingStock.Load(Simulator, newWagonFilePath);
-				car.CarLengthM = length;
-				car.RealWagFilePath = wagonFilePath;
-				if (Simulator.Confirmer != null)
+                car.CarLengthM = length;
+                car.RealWagFilePath = wagonFilePath;
+                if (Simulator.Confirmer != null)
                     Simulator.Confirmer.Information(MPManager.Catalog.GetString("Missing car, have substituted with other one."));
 
-			}
-			catch (Exception error)
-			{
-				System.Console.WriteLine(error.Message + "Substitution failed, will ignore it\n.");
-				car = null;
-			}
-			return car;
-		}
+            }
+            catch (Exception error)
+            {
+                System.Console.WriteLine(error.Message + "Substitution failed, will ignore it\n.");
+                car = null;
+            }
+            return car;
+        }
         SortedList<double, string> coachList;
         SortedList<double, string> engList;
 
         public string SubMissingCar(int length, char type)
-		{
+        {
 
-			type = char.ToLower(type);
-			SortedList<double, string> copyList;
-			if (type == 'w')
-			{
-				if (coachList == null)
-					coachList = GetList(Simulator, type);
-				copyList = coachList;
-			}
-			else
-			{
-				if (engList == null)
-					engList = GetList(Simulator, type);
-				copyList = engList;
-			}
-			string bestName = "Default\\default.wag"; double bestDist = 1000;
+            type = char.ToLower(type);
+            SortedList<double, string> copyList;
+            if (type == 'w')
+            {
+                if (coachList == null)
+                    coachList = GetList(Simulator, type);
+                copyList = coachList;
+            }
+            else
+            {
+                if (engList == null)
+                    engList = GetList(Simulator, type);
+                copyList = engList;
+            }
+            string bestName = "Default\\default.wag"; double bestDist = 1000;
 
-			foreach (var item in copyList)
-			{
-				var dist = Math.Abs(item.Key - length);
-				if (dist < bestDist) { bestDist = dist; bestName = item.Value; }
-			}
-			return Simulator.BasePath + "\\trains\\trainset\\" + bestName;
+            foreach (var item in copyList)
+            {
+                var dist = Math.Abs(item.Key - length);
+                if (dist < bestDist) { bestDist = dist; bestName = item.Value; }
+            }
+            return Simulator.BasePath + "\\trains\\trainset\\" + bestName;
 
-		}
+        }
 
-		static SortedList<double, string> GetList(Simulator simulator, char type)
-		{
-			string ending = "*.eng";
-			if (type == 'w') ending = "*.wag";
-			string[] filePaths = Directory.GetFiles(simulator.BasePath + "\\trains\\trainset", ending, SearchOption.AllDirectories);
-			string temp;
-			List<string> allEngines = new List<string>();
-			SortedList<double, string> carList = new SortedList<double, string>();
-			for (var i = 0; i < filePaths.Length; i++)
-			{
-				int index = filePaths[i].LastIndexOf("\\trains\\trainset\\");
-				temp = filePaths[i].Substring(index + 17);
-				if (!temp.Contains("\\")) continue;
-				allEngines.Add(temp);
-			}
-			foreach (string name in allEngines)
-			{
-				double len = 0.0f;
-				Microsoft.Xna.Framework.Vector3 def = new Microsoft.Xna.Framework.Vector3();
+        static SortedList<double, string> GetList(Simulator simulator, char type)
+        {
+            string ending = "*.eng";
+            if (type == 'w') ending = "*.wag";
+            string[] filePaths = Directory.GetFiles(simulator.BasePath + "\\trains\\trainset", ending, SearchOption.AllDirectories);
+            string temp;
+            List<string> allEngines = new List<string>();
+            SortedList<double, string> carList = new SortedList<double, string>();
+            for (var i = 0; i < filePaths.Length; i++)
+            {
+                int index = filePaths[i].LastIndexOf("\\trains\\trainset\\");
+                temp = filePaths[i].Substring(index + 17);
+                if (!temp.Contains("\\")) continue;
+                allEngines.Add(temp);
+            }
+            foreach (string name in allEngines)
+            {
+                double len = 0.0f;
+                Microsoft.Xna.Framework.Vector3 def = new Microsoft.Xna.Framework.Vector3();
 
-				try
-				{
-					using (var stf = new STFReader(simulator.BasePath + "\\trains\\trainset\\" + name, false))
-						stf.ParseFile(new STFReader.TokenProcessor[] {
-							new STFReader.TokenProcessor("wagon", ()=>{
-								stf.ReadString();
-								stf.ParseBlock(new STFReader.TokenProcessor[] {
-									new STFReader.TokenProcessor("size", ()=>{ def = stf.ReadVector3Block(STFReader.UNITS.Distance, def); }),
-								});
-							}),
-						});
+                try
+                {
+                    using (var stf = new STFReader(simulator.BasePath + "\\trains\\trainset\\" + name, false))
+                        stf.ParseFile(new STFReader.TokenProcessor[] {
+                            new STFReader.TokenProcessor("wagon", ()=>{
+                                stf.ReadString();
+                                stf.ParseBlock(new STFReader.TokenProcessor[] {
+                                    new STFReader.TokenProcessor("size", ()=>{ def = stf.ReadVector3Block(STFReader.UNITS.Distance, def); }),
+                                });
+                            }),
+                        });
 
-					len = def.Z;
-					carList.Add(len + MPManager.Random.NextDouble() / 10.0f, name);
-				}
-				catch { }
-			}
-			return carList;
-		}
+                    len = def.Z;
+                    carList.Add(len + MPManager.Random.NextDouble() / 10.0f, name);
+                }
+                catch { }
+            }
+            return carList;
+        }
 
-		//md5 check of TDB file
-		public void GetMD5HashFromTDBFile()
-		{
-			try
-			{
-				string fileName = Simulator.RoutePath + @"\" + Simulator.TRK.Tr_RouteFile.FileName + ".tdb";
-				FileStream file = new FileStream(fileName, FileMode.Open);
-				MD5 md5 = new MD5CryptoServiceProvider();
-				byte[] retVal = md5.ComputeHash(file);
-				file.Close();
+        //md5 check of TDB file
+        public void GetMD5HashFromTDBFile()
+        {
+            try
+            {
+                string fileName = Simulator.RoutePath + @"\" + Simulator.TRK.Tr_RouteFile.FileName + ".tdb";
+                FileStream file = new FileStream(fileName, FileMode.Open);
+                MD5 md5 = new MD5CryptoServiceProvider();
+                byte[] retVal = md5.ComputeHash(file);
+                file.Close();
 
-				MD5Check = Encoding.Unicode.GetString(retVal, 0, retVal.Length);
-			}
-			catch (Exception e)
-			{
-				Trace.TraceWarning("{0} Cannot get MD5 check of TDB file, use NA instead but server may not connect you.", e.Message);
-				MD5Check = "NA";
-			}
-		}
+                MD5Check = Encoding.Unicode.GetString(retVal, 0, retVal.Length);
+            }
+            catch (Exception e)
+            {
+                Trace.TraceWarning("{0} Cannot get MD5 check of TDB file, use NA instead but server may not connect you.", e.Message);
+                MD5Check = "NA";
+            }
+        }
 
         internal void OnServerChanged(bool weAreTheServer)
         {

--- a/Source/Orts.Simulation/MultiPlayer/Message.cs
+++ b/Source/Orts.Simulation/MultiPlayer/Message.cs
@@ -82,7 +82,7 @@ namespace Orts.MultiPlayer
         public virtual void HandleMsg() { System.Console.WriteLine("test"); return; }
     }
 
-#region MSGMove
+    #region MSGMove
     public class MSGMove : Message
     {
         class MSGMoveItem
@@ -169,7 +169,7 @@ namespace Orts.MultiPlayer
         {
             string tmp = "MOVE ";
             if (items != null && items.Count > 0)
-            for (var i = 0; i < items.Count; i++) tmp += items[i].ToString() + " ";
+                for (var i = 0; i < items.Count; i++) tmp += items[i].ToString() + " ";
             return " " + tmp.Length + ": " + tmp;
         }
 
@@ -214,11 +214,11 @@ namespace Orts.MultiPlayer
                             if (t.TrainType == Train.TRAINTYPE.REMOTE)
                             {
                                 var reverseTrav = false;
-//                                 Alternate way to check for train flip
-//                                if (m.user.Contains("0xAI") && m.trackNodeIndex == t.RearTDBTraveller.TrackNodeIndex && m.tdbDir != (int)t.RearTDBTraveller.Direction)
-//                                {
-//                                    reverseTrav = true;
-//                                }
+                                //                                 Alternate way to check for train flip
+                                //                                if (m.user.Contains("0xAI") && m.trackNodeIndex == t.RearTDBTraveller.TrackNodeIndex && m.tdbDir != (int)t.RearTDBTraveller.Direction)
+                                //                                {
+                                //                                    reverseTrav = true;
+                                //                                }
                                 t.ToDoUpdate(m.trackNodeIndex, m.TileX, m.TileZ, m.X, m.Z, m.travelled, m.speed, m.direction, m.tdbDir, m.Length, reverseTrav);
                                 break;
                             }
@@ -238,7 +238,7 @@ namespace Orts.MultiPlayer
                         t.ToDoUpdate(m.trackNodeIndex, m.TileX, m.TileZ, m.X, m.Z, m.travelled, m.speed, m.direction, m.tdbDir, m.Length);
                         // This is necessary as sometimes a train isn't in the Trains list
                         MPManager.Instance().AddOrRemoveTrain(t, true);
- //                       if (MPManager.IsServer()) MPManager.Instance().AddOrRemoveLocomotives(m.user, t, true);
+                        //                       if (MPManager.IsServer()) MPManager.Instance().AddOrRemoveLocomotives(m.user, t, true);
                     }
                 }
                 if (found == false) //I do not have the train, tell server to send it to me
@@ -248,16 +248,16 @@ namespace Orts.MultiPlayer
             }
         }
     }
-#endregion MSGMove
+    #endregion MSGMove
 
-#region MSGRequired
+    #region MSGRequired
     public class MSGRequired : Message
     {
 
     }
-#endregion
+    #endregion
 
-#region MSGPlayer
+    #region MSGPlayer
     public class MSGPlayer : MSGRequired
     {
         public string user = "";
@@ -568,9 +568,9 @@ namespace Orts.MultiPlayer
                                 }
                             }
                             if (!identical)
-                            { 
-                            var carsCount = t.Cars.Count;
-                            t.Cars.RemoveRange(0, carsCount);
+                            {
+                                var carsCount = t.Cars.Count;
+                                t.Cars.RemoveRange(0, carsCount);
                                 for (int i = 0; i < cars.Length; i++)
                                 {
                                     string wagonFilePath = MPManager.Simulator.BasePath + @"\trains\trainset\" + cars[i];
@@ -735,9 +735,9 @@ namespace Orts.MultiPlayer
 
     }
 
-#endregion MSGPlayer
+    #endregion MSGPlayer
 
-#region MSGPlayerTrainSw
+    #region MSGPlayerTrainSw
     public class MSGPlayerTrainSw : MSGRequired
     {
         public string user = "";
@@ -832,9 +832,9 @@ namespace Orts.MultiPlayer
                 }*/
     }
 
-#endregion MSGPlayerTrainSw
+    #endregion MSGPlayerTrainSw
 
-#region MGSwitch
+    #region MGSwitch
 
     public class MSGSwitch : Message
     {
@@ -929,9 +929,9 @@ namespace Orts.MultiPlayer
         }
     }
 
-#endregion MGSwitch
+    #endregion MGSwitch
 
-#region MSGResetSignal
+    #region MSGResetSignal
     public class MSGResetSignal : Message
     {
         public string user;
@@ -963,9 +963,9 @@ namespace Orts.MultiPlayer
             }
         }
     }
-#endregion MSGResetSignal
+    #endregion MSGResetSignal
 
-#region MSGOrgSwitch
+    #region MSGOrgSwitch
     public class MSGOrgSwitch : MSGRequired
     {
         SortedList<uint, TrJunctionNode> SwitchState;
@@ -1053,9 +1053,9 @@ namespace Orts.MultiPlayer
             return " " + tmp.Length + ": " + tmp;
         }
     }
-#endregion MSGOrgSwitch
+    #endregion MSGOrgSwitch
 
-#region MSGSwitchStatus
+    #region MSGSwitchStatus
     public class MSGSwitchStatus : Message
     {
         static byte[] preState;
@@ -1218,8 +1218,8 @@ namespace Orts.MultiPlayer
             return " " + tmp.Length + ": " + tmp;
         }
     }
-#endregion MSGSwitchStatus
-#region MSGTrain
+    #endregion MSGSwitchStatus
+    #region MSGTrain
     //message to add new train from either a string (received message), or a Train (building a message)
     public class MSGTrain : Message
     {
@@ -1398,14 +1398,14 @@ namespace Orts.MultiPlayer
 
                 tmp += "\"" + c + "\"" + " " + ids[i] + "\n" + flipped[i] + "\n" + lengths[i] + "\t";
             }
-            tmp += "\n" + name  + "\t";
+            tmp += "\n" + name + "\t";
             return " " + tmp.Length + ": " + tmp;
         }
     }
 
-#endregion MSGTrain
+    #endregion MSGTrain
 
-#region MSGUpdateTrain
+    #region MSGUpdateTrain
 
     //message to add new train from either a string (received message), or a Train (building a message)
     public class MSGUpdateTrain : Message
@@ -1634,9 +1634,9 @@ namespace Orts.MultiPlayer
         }
     }
 
-#endregion MSGUpdateTrain
+    #endregion MSGUpdateTrain
 
-#region MSGRemoveTrain
+    #region MSGRemoveTrain
     //remove AI trains
     public class MSGRemoveTrain : Message
     {
@@ -1689,9 +1689,9 @@ namespace Orts.MultiPlayer
 
     }
 
-#endregion MSGRemoveTrain
+    #endregion MSGRemoveTrain
 
-#region MSGServer
+    #region MSGServer
     public class MSGServer : MSGRequired
     {
         string user; //true: I am a server now, false, not
@@ -1744,9 +1744,9 @@ namespace Orts.MultiPlayer
             }
         }
     }
-#endregion MSGServer
+    #endregion MSGServer
 
-#region MSGAlive
+    #region MSGAlive
     public class MSGAlive : Message
     {
         string user;
@@ -1768,9 +1768,9 @@ namespace Orts.MultiPlayer
             //System.Console.WriteLine(this.ToString());
         }
     }
-#endregion MSGAlive
+    #endregion MSGAlive
 
-#region MSGTrainMerge
+    #region MSGTrainMerge
     //message to add new train from either a string (received message), or a Train (building a message)
     public class MSGTrainMerge : Message
     {
@@ -1816,9 +1816,9 @@ namespace Orts.MultiPlayer
             return " " + tmp.Length + ": " + tmp;
         }
     }
-#endregion MSGTrainMerge
+    #endregion MSGTrainMerge
 
-#region MSGMessage
+    #region MSGMessage
     //warning, error or information from the server, a client receives Error will disconnect itself
     public class MSGMessage : MSGRequired
     {
@@ -1905,9 +1905,9 @@ namespace Orts.MultiPlayer
         }
     }
 
-#endregion MSGMessage
+    #endregion MSGMessage
 
-#region MSGControl
+    #region MSGControl
     //message to ask for the control of a train or confirm it
     public class MSGControl : Message
     {
@@ -1990,9 +1990,9 @@ namespace Orts.MultiPlayer
         }
     }
 
-#endregion MSGControl
+    #endregion MSGControl
 
-#region MSGLocoChange
+    #region MSGLocoChange
     //message to add new train from either a string (received message), or a Train (building a message)
     public class MSGLocoChange : Message
     {
@@ -2050,9 +2050,9 @@ namespace Orts.MultiPlayer
         }
     }
 
-#endregion MSGLocoChange
+    #endregion MSGLocoChange
 
-#region MSGEvent
+    #region MSGEvent
     public class MSGEvent : Message
     {
         public string user;
@@ -2161,9 +2161,9 @@ namespace Orts.MultiPlayer
 
     }
 
-#endregion MSGEvent
+    #endregion MSGEvent
 
-#region MSGQuit
+    #region MSGQuit
     public class MSGQuit : Message
     {
         public string user;
@@ -2236,10 +2236,10 @@ namespace Orts.MultiPlayer
 
     }
 
-#endregion MSGQuit
+    #endregion MSGQuit
 
 
-#region MSGLost
+    #region MSGLost
     public class MSGLost : Message
     {
         public string user;
@@ -2292,9 +2292,9 @@ namespace Orts.MultiPlayer
 
     }
 
-#endregion MSGLost
+    #endregion MSGLost
 
-#region MSGGetTrain
+    #region MSGGetTrain
     public class MSGGetTrain : Message
     {
         public int num;
@@ -2334,9 +2334,9 @@ namespace Orts.MultiPlayer
         }
 
     }
-#endregion MSGGetTrain
+    #endregion MSGGetTrain
 
-#region MSGUncouple
+    #region MSGUncouple
 
     public class MSGUncouple : Message
     {
@@ -2762,9 +2762,9 @@ namespace Orts.MultiPlayer
             }
         }
     }
-#endregion MSGUncouple
+    #endregion MSGUncouple
 
-#region MSGCouple
+    #region MSGCouple
     public class MSGCouple : Message
     {
         string[] cars;
@@ -3010,9 +3010,9 @@ namespace Orts.MultiPlayer
             }
         }
     }
-#endregion MSGCouple
+    #endregion MSGCouple
 
-#region MSGSignalStatus
+    #region MSGSignalStatus
     public class MSGSignalStatus : Message
     {
         static byte[] preState;
@@ -3146,9 +3146,9 @@ namespace Orts.MultiPlayer
             return " " + tmp.Length + ": " + tmp;
         }
     }
-#endregion MSGSignalStatus
+    #endregion MSGSignalStatus
 
-#region MSGLocoInfo
+    #region MSGLocoInfo
     public class MSGLocoInfo : Message
     {
 
@@ -3264,9 +3264,9 @@ namespace Orts.MultiPlayer
             return " " + tmp.Length + ": " + tmp;
         }
     }
-#endregion MSGLocoInfo
+    #endregion MSGLocoInfo
 
-#region MSGAvatar
+    #region MSGAvatar
     public class MSGAvatar : Message
     {
         public string user;
@@ -3309,10 +3309,10 @@ namespace Orts.MultiPlayer
 
     }
 
-#endregion MSGAvatar
+    #endregion MSGAvatar
 
 
-#region MSGText
+    #region MSGText
     //message to add new train from either a string (received message), or a Train (building a message)
     public class MSGText : MSGRequired
     {
@@ -3368,9 +3368,9 @@ namespace Orts.MultiPlayer
         }
     }
 
-#endregion MSGText
+    #endregion MSGText
 
-#region MSGWeather
+    #region MSGWeather
     public class MSGWeather : Message
     {
         public int weather;
@@ -3426,9 +3426,9 @@ namespace Orts.MultiPlayer
         }
     }
 
-#endregion MSGWeather
+    #endregion MSGWeather
 
-#region MSGAider
+    #region MSGAider
     public class MSGAider : Message
     {
         public string user;
@@ -3472,9 +3472,9 @@ namespace Orts.MultiPlayer
 
     }
 
-#endregion MSGAider
+    #endregion MSGAider
 
-#region MSGSignalChange
+    #region MSGSignalChange
     public class MSGSignalChange : Message
     {
         int index;
@@ -3542,9 +3542,9 @@ namespace Orts.MultiPlayer
             return " " + tmp.Length + ": " + tmp;
         }
     }
-#endregion MSGSignalChange
+    #endregion MSGSignalChange
 
-#region MSGExhaust
+    #region MSGExhaust
     public class MSGExhaust : Message
     {
         class MSGExhaustItem
@@ -3634,9 +3634,9 @@ namespace Orts.MultiPlayer
             }
         }
     }
-#endregion MSGExhaust
+    #endregion MSGExhaust
 
-#region MSGFlip
+    #region MSGFlip
     //message to indicate that a train has been flipped (reverse formation)
     // message contains data before flip
     public class MSGFlip : Message
@@ -3800,7 +3800,7 @@ namespace Orts.MultiPlayer
 
         public override string ToString()
         {
-            string tmp = "FLIP " + TrainNum + " " + direction + " " + TileX + " " + TileZ + " " + X.ToString(CultureInfo.InvariantCulture) + " " + Z.ToString(CultureInfo.InvariantCulture) + " " + Travelled.ToString(CultureInfo.InvariantCulture) + " " + mDirection + " " + 
+            string tmp = "FLIP " + TrainNum + " " + direction + " " + TileX + " " + TileZ + " " + X.ToString(CultureInfo.InvariantCulture) + " " + Z.ToString(CultureInfo.InvariantCulture) + " " + Travelled.ToString(CultureInfo.InvariantCulture) + " " + mDirection + " " +
                 speed.ToString(CultureInfo.InvariantCulture) + " " + tni + " " + count + " " + tdir + " " + len.ToString(CultureInfo.InvariantCulture) + " " + reverseMU + " ";
             for (var i = 0; i < cars.Length; i++)
             {
@@ -3817,6 +3817,6 @@ namespace Orts.MultiPlayer
         }
     }
 
-#endregion MSGFlip
+    #endregion MSGFlip
 
 }

--- a/Source/Orts.Simulation/MultiPlayer/OnlinePlayer.cs
+++ b/Source/Orts.Simulation/MultiPlayer/OnlinePlayer.cs
@@ -26,23 +26,23 @@ using System.Threading;
 namespace Orts.MultiPlayer
 {
     public class OnlinePlayer
-	{
-		public Decoder decoder;
-		public OnlinePlayer(TcpClient t, Server s) { Client = t; Server = s; decoder = new Decoder(); CreatedTime = MPManager.Simulator.GameTime; url = "NA";}// "http://trainsimchina.com/discuz/uc_server/avatar.php?uid=72965&size=middle"; }
-		public TcpClient Client;
-		public Server Server;
-		public string Username = "";
-		public string LeadingLocomotiveID = "";
-		public Train Train;
-		public string con;
-		public string path; //pat and consist files
-		public Thread thread;
-		public double CreatedTime;
-		private object lockObj = new object();
-		public string url = ""; //avatar location
-		public double quitTime = -100f;
-		public enum Status {Valid, Quit, Removed};
-		public Status status = Status.Valid;//is this player removed by the dispatcher
+    {
+        public Decoder decoder;
+        public OnlinePlayer(TcpClient t, Server s) { Client = t; Server = s; decoder = new Decoder(); CreatedTime = MPManager.Simulator.GameTime; url = "NA"; }// "http://trainsimchina.com/discuz/uc_server/avatar.php?uid=72965&size=middle"; }
+        public TcpClient Client;
+        public Server Server;
+        public string Username = "";
+        public string LeadingLocomotiveID = "";
+        public Train Train;
+        public string con;
+        public string path; //pat and consist files
+        public Thread thread;
+        public double CreatedTime;
+        private object lockObj = new object();
+        public string url = ""; //avatar location
+        public double quitTime = -100f;
+        public enum Status { Valid, Quit, Removed };
+        public Status status = Status.Valid;//is this player removed by the dispatcher
         public bool protect = false; //when in true, will not force this player out, to protect the one that others uses the same name
 
         // Used to restore
@@ -75,117 +75,117 @@ namespace Orts.MultiPlayer
             }
         }
 
-		public void Send(string msg)
-		{
-			if (msg == null) return;
-			try
-			{
-				NetworkStream clientStream = Client.GetStream();
+        public void Send(string msg)
+        {
+            if (msg == null) return;
+            try
+            {
+                NetworkStream clientStream = Client.GetStream();
 
-				lock (lockObj)//lock the buffer in case two threads want to write at once
-				{
-					byte[] buffer = Encoding.Unicode.GetBytes(msg);//encoder.GetBytes(msg);
-					clientStream.Write(buffer, 0, buffer.Length);
-					clientStream.Flush();
-				}
-			}
-			catch
-			{
-			}
-		}
+                lock (lockObj)//lock the buffer in case two threads want to write at once
+                {
+                    byte[] buffer = Encoding.Unicode.GetBytes(msg);//encoder.GetBytes(msg);
+                    clientStream.Write(buffer, 0, buffer.Length);
+                    clientStream.Flush();
+                }
+            }
+            catch
+            {
+            }
+        }
 
-		public void Receive(object client)
-		{
-			NetworkStream clientStream = Client.GetStream();
+        public void Receive(object client)
+        {
+            NetworkStream clientStream = Client.GetStream();
 
-			byte[] message = new byte[8192];
-			int bytesRead;
-			int errorCount = 0;
-			double firstErrorTick = 0;
-			double nowTicks = 0;
+            byte[] message = new byte[8192];
+            int bytesRead;
+            int errorCount = 0;
+            double firstErrorTick = 0;
+            double nowTicks = 0;
 
-			while (true)
-			{
-				//System.Threading.Thread.Sleep(Program.Random.Next(50, 200));
+            while (true)
+            {
+                //System.Threading.Thread.Sleep(Program.Random.Next(50, 200));
 
-				bytesRead = 0;
+                bytesRead = 0;
 
-				try
-				{
-					//blocks until a client sends a message
-					bytesRead = clientStream.Read(message, 0, 8192);
-				}
-				catch
-				{
-					//a socket error has occured
-					break;
-				}
+                try
+                {
+                    //blocks until a client sends a message
+                    bytesRead = clientStream.Read(message, 0, 8192);
+                }
+                catch
+                {
+                    //a socket error has occured
+                    break;
+                }
 
-				if (bytesRead == 0)
-				{
-					//the client has disconnected from the server
-					break;
-				}
+                if (bytesRead == 0)
+                {
+                    //the client has disconnected from the server
+                    break;
+                }
 
-				//message has successfully been received
-				string info = "";
-				try
-				{
-					decoder.PushMsg(Encoding.Unicode.GetString(message, 0, bytesRead));//encoder.GetString(message, 0, bytesRead));
-					info = decoder.GetMsg();
-					while (info != null)
-					{
-						//System.Console.WriteLine(info);
-						Message msg = Message.Decode(info);
-						if (msg is MSGPlayer) ((MSGPlayer)msg).HandleMsg(this);
-						else msg.HandleMsg();
+                //message has successfully been received
+                string info = "";
+                try
+                {
+                    decoder.PushMsg(Encoding.Unicode.GetString(message, 0, bytesRead));//encoder.GetString(message, 0, bytesRead));
+                    info = decoder.GetMsg();
+                    while (info != null)
+                    {
+                        //System.Console.WriteLine(info);
+                        Message msg = Message.Decode(info);
+                        if (msg is MSGPlayer) ((MSGPlayer)msg).HandleMsg(this);
+                        else msg.HandleMsg();
 
-						info = decoder.GetMsg();
-					}
-				}
-				catch (MultiPlayerError)
-				{
-					break;
-				}
-				catch (SameNameError)
-				{
-					Client.Close();
-					thread.Abort();
-				}
-				catch (Exception)
-				{
-					nowTicks = MPManager.Simulator.GameTime;
-					if (firstErrorTick == 0)
-					{
-						firstErrorTick = nowTicks;
-						errorCount = 1;
-					}
-					if (errorCount >= 5 && nowTicks - firstErrorTick < 10) //5 errors last 10 seconds
-					{
-						MSGMessage emsg = new MSGMessage(this.Username, "Error", "Too many errors received from you in a short period of time.");
-						MPManager.BroadCast(emsg.ToString());
-						break;
-					}
-					else if (errorCount < 5) { errorCount++; }
-					else { firstErrorTick = nowTicks; errorCount = 0; }
-					//System.Console.WriteLine(e.Message + info);
-				}
-			}
+                        info = decoder.GetMsg();
+                    }
+                }
+                catch (MultiPlayerError)
+                {
+                    break;
+                }
+                catch (SameNameError)
+                {
+                    Client.Close();
+                    thread.Abort();
+                }
+                catch (Exception)
+                {
+                    nowTicks = MPManager.Simulator.GameTime;
+                    if (firstErrorTick == 0)
+                    {
+                        firstErrorTick = nowTicks;
+                        errorCount = 1;
+                    }
+                    if (errorCount >= 5 && nowTicks - firstErrorTick < 10) //5 errors last 10 seconds
+                    {
+                        MSGMessage emsg = new MSGMessage(this.Username, "Error", "Too many errors received from you in a short period of time.");
+                        MPManager.BroadCast(emsg.ToString());
+                        break;
+                    }
+                    else if (errorCount < 5) { errorCount++; }
+                    else { firstErrorTick = nowTicks; errorCount = 0; }
+                    //System.Console.WriteLine(e.Message + info);
+                }
+            }
 
-			System.Console.WriteLine("{0} quit", this.Username);
-			if (MPManager.Simulator.Confirmer != null) MPManager.Simulator.Confirmer.Information(MPManager.Catalog.GetStringFmt("{0} quit.", this.Username));
-			Client.Close();
-			if (this.Train != null && this.status != Status.Removed) //remember the location of the train in case the player comes back later, if he is not removed by the dispatcher
-			{
-				if (!MPManager.Instance().lostPlayer.ContainsKey(this.Username)) MPManager.Instance().lostPlayer.Add(this.Username, this);
-				this.quitTime = MPManager.Simulator.GameTime;
-				this.Train.SpeedMpS = 0.0f;
-				this.status = Status.Quit;
-			}
-			MPManager.Instance().AddRemovedPlayer(this);//add this player to be removed
-			MPManager.BroadCast((new MSGQuit(this.Username)).ToString());
-			thread.Abort();
-		}
+            System.Console.WriteLine("{0} quit", this.Username);
+            if (MPManager.Simulator.Confirmer != null) MPManager.Simulator.Confirmer.Information(MPManager.Catalog.GetStringFmt("{0} quit.", this.Username));
+            Client.Close();
+            if (this.Train != null && this.status != Status.Removed) //remember the location of the train in case the player comes back later, if he is not removed by the dispatcher
+            {
+                if (!MPManager.Instance().lostPlayer.ContainsKey(this.Username)) MPManager.Instance().lostPlayer.Add(this.Username, this);
+                this.quitTime = MPManager.Simulator.GameTime;
+                this.Train.SpeedMpS = 0.0f;
+                this.status = Status.Quit;
+            }
+            MPManager.Instance().AddRemovedPlayer(this);//add this player to be removed
+            MPManager.BroadCast((new MSGQuit(this.Username)).ToString());
+            thread.Abort();
+        }
 
         public void Save(BinaryWriter outf)
         {
@@ -202,13 +202,13 @@ namespace Orts.MultiPlayer
 
 
 
-/*
-        public TcpClient Client;
-        public Server Server;
+            /*
+                    public TcpClient Client;
+                    public Server Server;
 
-        public Thread thread;
-        private object lockObj = new object();
-        public bool protect = false; //when in true, will not force this player out, to protect the one that others uses the same name*/
+                    public Thread thread;
+                    private object lockObj = new object();
+                    public bool protect = false; //when in true, will not force this player out, to protect the one that others uses the same name*/
         }
-	}
+    }
 }

--- a/Source/Orts.Simulation/MultiPlayer/OnlineTrains.cs
+++ b/Source/Orts.Simulation/MultiPlayer/OnlineTrains.cs
@@ -266,7 +266,7 @@ namespace Orts.MultiPlayer
             {
                 train.Name = train.GetTrainName(train.Cars[0].CarID);
             }
-            else if (player !=null && player.user != null) train.Name = player.user;
+            else if (player != null && player.user != null) train.Name = player.user;
 
             if (MPManager.IsServer())
             {
@@ -317,10 +317,10 @@ namespace Orts.MultiPlayer
                     Train t = MPManager.FindPlayerTrain(l.userName);
                     if (t != null && l.trainCarPosition < t.Cars.Count && (Math.Abs(t.SpeedMpS) > 0.001 || Math.Abs(t.LastReportedSpeed) > 0))
                     {
-                            if (t.Cars[l.trainCarPosition] is MSTSDieselLocomotive)
-                            {
-                                exhaust.AddNewItem(l.userName, t, l.trainCarPosition);
-                            }
+                        if (t.Cars[l.trainCarPosition] is MSTSDieselLocomotive)
+                        {
+                            exhaust.AddNewItem(l.userName, t, l.trainCarPosition);
+                        }
                     }
                 }
             }
@@ -329,7 +329,7 @@ namespace Orts.MultiPlayer
         }
 
         // Save
-        public void Save (BinaryWriter outf)
+        public void Save(BinaryWriter outf)
         {
             outf.Write(Players.Count);
             foreach (var onlinePlayer in Players.Values)
@@ -339,7 +339,7 @@ namespace Orts.MultiPlayer
         }
 
         // Restore
-        public void Restore (BinaryReader inf)
+        public void Restore(BinaryReader inf)
         {
             var onlinePlayersCount = inf.ReadInt32();
             if (onlinePlayersCount > 0)

--- a/Source/Orts.Simulation/MultiPlayer/Server.cs
+++ b/Source/Orts.Simulation/MultiPlayer/Server.cs
@@ -25,64 +25,64 @@ using System.Diagnostics;
 namespace Orts.MultiPlayer
 {
     public class Server
-	{
-		public List<OnlinePlayer> Players;
-		public string UserName;
-		public string Code;
-		ClientComm Connection;
-		public ServerComm ServerComm;
-		public int ConnectionMode;
+    {
+        public List<OnlinePlayer> Players;
+        public string UserName;
+        public string Code;
+        ClientComm Connection;
+        public ServerComm ServerComm;
+        public int ConnectionMode;
 
-		public void Stop()
-		{
-			if (ServerComm != null) ServerComm.Stop();
-			if (Connection != null) Connection.Stop();
-		}
-		public Server(string s, ClientComm c)
-		{
-			Players = new List<OnlinePlayer>();
-			string[] tmp = s.Split(' ');
-			UserName = tmp[0];
-			Code = tmp[1];
-			Connection = c;
-			ServerComm = null;
-			ConnectionMode = 0;
-		}
+        public void Stop()
+        {
+            if (ServerComm != null) ServerComm.Stop();
+            if (Connection != null) Connection.Stop();
+        }
+        public Server(string s, ClientComm c)
+        {
+            Players = new List<OnlinePlayer>();
+            string[] tmp = s.Split(' ');
+            UserName = tmp[0];
+            Code = tmp[1];
+            Connection = c;
+            ServerComm = null;
+            ConnectionMode = 0;
+        }
 
-		public bool IsRemoteServer()
-		{
-			if (ConnectionMode == 0) return true;
-			else return false;
-		}
-		public Server(string s, int port)
-		{
-			Players = new List<OnlinePlayer>();
-			string[] tmp = s.Split(' ');
-			UserName = tmp[0];
-			Code = tmp[1];
+        public bool IsRemoteServer()
+        {
+            if (ConnectionMode == 0) return true;
+            else return false;
+        }
+        public Server(string s, int port)
+        {
+            Players = new List<OnlinePlayer>();
+            string[] tmp = s.Split(' ');
+            UserName = tmp[0];
+            Code = tmp[1];
 
-			ServerComm = new ServerComm(this, port);
-			Connection = null;
-			ConnectionMode = 1;
-		}
-		
-		public void BroadCast(string msg)
-		{
+            ServerComm = new ServerComm(this, port);
+            Connection = null;
+            ConnectionMode = 1;
+        }
+
+        public void BroadCast(string msg)
+        {
 #if DEBUG_MULTIPLAYER
                     Trace.TraceInformation("MPServerBroadcast: {0}", msg);
 #endif
             if (ServerComm == null) Connection.Send(msg);
-			else
-			{
-				try
-				{
-					foreach (OnlinePlayer p in Players)
-					{
-						p.Send(msg);
-					}
-				}
-				catch (Exception) { }
-			}
-		}
-	}
+            else
+            {
+                try
+                {
+                    foreach (OnlinePlayer p in Players)
+                    {
+                        p.Send(msg);
+                    }
+                }
+                catch (Exception) { }
+            }
+        }
+    }
 }

--- a/Source/Orts.Simulation/MultiPlayer/ServerComm.cs
+++ b/Source/Orts.Simulation/MultiPlayer/ServerComm.cs
@@ -23,55 +23,55 @@ using System.Threading;
 namespace Orts.MultiPlayer
 {
     public class ServerComm
-	{
-		private TcpListener tcpListener;
-		private Thread listenThread;
-		private Server Server;
-		private int count = 0;
-		public void Stop()
-		{
-			tcpListener.Stop();
-			listenThread.Abort();
-			foreach (OnlinePlayer p in Server.Players)
-			{
-				p.thread.Abort();
-			}
-		}
+    {
+        private TcpListener tcpListener;
+        private Thread listenThread;
+        private Server Server;
+        private int count = 0;
+        public void Stop()
+        {
+            tcpListener.Stop();
+            listenThread.Abort();
+            foreach (OnlinePlayer p in Server.Players)
+            {
+                p.thread.Abort();
+            }
+        }
 
-		public ServerComm(Server s, int port)
-		{
-			Server = s;
-			this.tcpListener = new TcpListener(IPAddress.Any, port);
-			this.listenThread = new Thread(new ThreadStart(ListenForClients));
+        public ServerComm(Server s, int port)
+        {
+            Server = s;
+            this.tcpListener = new TcpListener(IPAddress.Any, port);
+            this.listenThread = new Thread(new ThreadStart(ListenForClients));
             this.listenThread.Name = "Multiplayer Server";
-			this.listenThread.Start();
-		}
+            this.listenThread.Start();
+        }
 
-		private void ListenForClients()
-		{
-			this.tcpListener.Start();
+        private void ListenForClients()
+        {
+            this.tcpListener.Start();
 
-			while (true)
-			{
-				TcpClient client = null;
-				try
-				{
-					//blocks until a client has connected to the server
-					client = this.tcpListener.AcceptTcpClient();
-				}
-				catch (Exception) { break; }
-				count++;
-				OnlinePlayer player = new OnlinePlayer(client, Server);
-				Server.Players.Add(player);
-				System.Console.WriteLine("New Player Joined");
+            while (true)
+            {
+                TcpClient client = null;
+                try
+                {
+                    //blocks until a client has connected to the server
+                    client = this.tcpListener.AcceptTcpClient();
+                }
+                catch (Exception) { break; }
+                count++;
+                OnlinePlayer player = new OnlinePlayer(client, Server);
+                Server.Players.Add(player);
+                System.Console.WriteLine("New Player Joined");
 
-				//create a thread to handle communication
-				//with connected client
-				Thread clientThread = new Thread(new ParameterizedThreadStart(player.Receive));
-				clientThread.Name = "Multiplayer Server-Client";// +count;
-				player.thread = clientThread;
-				clientThread.Start(client);
-			}
-		}
-	}
+                //create a thread to handle communication
+                //with connected client
+                Thread clientThread = new Thread(new ParameterizedThreadStart(player.Receive));
+                clientThread.Name = "Multiplayer Server-Client";// +count;
+                player.thread = clientThread;
+                clientThread.Start(client);
+            }
+        }
+    }
 }

--- a/Source/Orts.Simulation/Simulation/AIs/AI.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AI.cs
@@ -174,7 +174,8 @@ namespace Orts.Simulation.AIs
                 }
 
                 // timetable mode trains
-                else {
+                else
+                {
                     TTTrain aiTrain = new TTTrain(Simulator, inf, this);
                     if (aiTrain.TrainType != Train.TRAINTYPE.PLAYER) // add to AITrains except when it is player train
                     {
@@ -612,7 +613,7 @@ namespace Orts.Simulation.AIs
                 Trace.TraceInformation("Player train started on time");
                 TTTrain playerTTTrain = playerTrain as TTTrain;
                 playerTTTrain.InitalizePlayerTrain();
-                
+
                 clockTime = Simulator.ClockTime = playerTTTrain.StartTime.Value;
             }
 

--- a/Source/Orts.Simulation/Simulation/AIs/AIAuxAction.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AIAuxAction.cs
@@ -50,7 +50,7 @@ namespace Orts.Simulation.AIs
         public Train.DistanceTravelledActions genRequiredActions = new Train.DistanceTravelledActions(); // distance travelled Generic action list for AITrain
         public Train.DistanceTravelledActions specRequiredActions = new Train.DistanceTravelledActions();
 
-       Train ThisTrain;
+        Train ThisTrain;
 
         public AuxActionsContainer(Train thisTrain, ORRouteConfig orRouteConfig)
         {
@@ -145,12 +145,12 @@ namespace Orts.Simulation.AIs
 
                 if (ThisTrain is AITrain && ((aiTrain.MovementState == AITrain.AI_MOVEMENT_STATE.HANDLE_ACTION && aiTrain.nextActionInfo != null &&
                 aiTrain.nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.AUX_ACTION && aiTrain.nextActionInfo != null && aiTrain.nextActionInfo is AuxActionWPItem)
-                || ( aiTrain.AuxActionsContain.SpecAuxActions.Count > 0 &&
+                || (aiTrain.AuxActionsContain.SpecAuxActions.Count > 0 &&
                 aiTrain.AuxActionsContain.SpecAuxActions[0] is AIActionWPRef && (aiTrain.AuxActionsContain.SpecAuxActions[0] as AIActionWPRef).keepIt != null &&
                 (aiTrain.AuxActionsContain.SpecAuxActions[0] as AIActionWPRef).keepIt.currentMvmtState == AITrain.AI_MOVEMENT_STATE.HANDLE_ACTION)))
                 // WP is running
                 {
-                    int remainingDelay;                  
+                    int remainingDelay;
                     if (aiTrain.nextActionInfo != null && aiTrain.nextActionInfo is AuxActionWPItem) remainingDelay = ((AuxActionWPItem)aiTrain.nextActionInfo).ActualDepart - currentClock;
                     else remainingDelay = ((AIActionWPRef)SpecAuxActions[0]).keepIt.ActualDepart - currentClock;
                     ((AIActionWPRef)SpecAuxActions[0]).SetDelay(remainingDelay);
@@ -182,7 +182,7 @@ namespace Orts.Simulation.AIs
             List<KeyValuePair<string, AuxActionRef>> converted = new List<KeyValuePair<string, AuxActionRef>>();
             foreach (var action in actionContainer.GenAuxActions)
             {
-                if (action.Value.GetType() ==  typeof(AuxActionHorn))
+                if (action.Value.GetType() == typeof(AuxActionHorn))
                 {
                     AIActionHornRef horn = new AIActionHornRef(thisTrain, (AuxActionHorn)action.Value, 0);
                     List<KeyValuePair<System.Type, AuxActionRef>> listInfo = horn.GetCallFunction();
@@ -212,7 +212,7 @@ namespace Orts.Simulation.AIs
         }
 
         protected List<KeyValuePair<string, AuxActionRef>> SetGenAuxActions(AITrain thisTrain, ORRouteConfig orRouteConfig)  //  Add here the new Generic Action
-         {
+        {
             List<KeyValuePair<string, AuxActionRef>> loaded = null;
 #if WITH_GEN_ACTION
             //AIActionSignalRef actionSignal = new AIActionSignalRef(thisTrain, 0f, 0f, 0, 0, 0, 0);
@@ -324,7 +324,7 @@ namespace Orts.Simulation.AIs
             List<Train.DistanceTravelledItem> itemList = new List<Train.DistanceTravelledItem>();
             foreach (var action in genRequiredActions)
             {
-                AIActionItem actionItem = action as AIActionItem; 
+                AIActionItem actionItem = action as AIActionItem;
                 if (actionItem.RequiredDistance <= ThisTrain.DistanceTravelledM)
                 {
                     itemList.Add(actionItem);
@@ -348,7 +348,7 @@ namespace Orts.Simulation.AIs
             {
                 AIActionItem actionItem = action as AIActionItem;
                 if (actionItem.RequiredDistance >= ThisTrain.DistanceTravelledM)
-                     continue;
+                    continue;
                 if (actionItem is AuxActSigDelegate)
                 {
                     var actionRef = (actionItem as AuxActSigDelegate).ActionRef;
@@ -408,7 +408,7 @@ namespace Orts.Simulation.AIs
             }
             set
             {
-                
+
             }
         }
 
@@ -434,7 +434,7 @@ namespace Orts.Simulation.AIs
             AIAuxActionsRef thisAction;
             int specAuxActionsIndex = 0;
             bool requiredActionsInserted = false;
-            while (specAuxActionsIndex <= SpecAuxActions.Count-1)
+            while (specAuxActionsIndex <= SpecAuxActions.Count - 1)
             {
                 while (SpecAuxActions.Count > 0)
                 {
@@ -538,7 +538,7 @@ namespace Orts.Simulation.AIs
             if (thisAction.SubrouteIndex != thisTrain.TCRoute.activeSubpath) return;
             thisAction.LinkedAuxAction = false;
             return;
-         }
+        }
 
         //================================================================================================//
         //  
@@ -564,7 +564,7 @@ namespace Orts.Simulation.AIs
                         thisWPItem.ActivateDistanceM = thisTrain.PresentPosition[0].DistanceTravelledM - 5;
                         thisAction.LinkedAuxAction = true;
                     }
-                 }
+                }
                 thisAction.RequiredDistance = thisTrain.PresentPosition[0].TCOffset - 5;
             }
         }
@@ -580,8 +580,8 @@ namespace Orts.Simulation.AIs
                 return;
             AIAuxActionsRef thisAction;
             thisAction = (AIAuxActionsRef)SpecAuxActions[0];
-            if (thisAction is AIActionWPRef && thisAction.SubrouteIndex == thisTrain.TCRoute.activeSubpath+1 && thisAction.TCSectionIndex == thisTrain.PresentPosition[1].TCSectionIndex)
-                // Waiting point is just in the same section where the train is; move it under the train
+            if (thisAction is AIActionWPRef && thisAction.SubrouteIndex == thisTrain.TCRoute.activeSubpath + 1 && thisAction.TCSectionIndex == thisTrain.PresentPosition[1].TCSectionIndex)
+            // Waiting point is just in the same section where the train is; move it under the train
             {
                 int thisSectionIndex = thisTrain.PresentPosition[1].TCSectionIndex;
                 TrackCircuitSection thisSection = thisTrain.signalRef.TrackCircuitList[thisSectionIndex];
@@ -878,7 +878,7 @@ namespace Orts.Simulation.AIs
         }
 
         public AIActionWPRef(Train thisTrain, BinaryReader inf)
-            : base (thisTrain, inf)
+            : base(thisTrain, inf)
         {
             Delay = inf.ReadInt32();
             NextAction = AUX_ACTION.WAITING_POINT;
@@ -1033,7 +1033,7 @@ namespace Orts.Simulation.AIs
             else
             {
                 activateDistanceTravelledM = thisTrain.PresentPosition[0].DistanceTravelledM + thisTrain.ValidRoute[0].GetDistanceAlongRoute(actionIndex0, leftInSectionM, actionRouteIndex, this.RequiredDistance, true, thisTrain.signalRef);
-                triggerDistanceM = activateDistanceTravelledM - Math.Min(this.RequiredDistance, 300); 
+                triggerDistanceM = activateDistanceTravelledM - Math.Min(this.RequiredDistance, 300);
 
                 if (activateDistanceTravelledM < thisTrain.PresentPosition[0].DistanceTravelledM &&
                     thisTrain.PresentPosition[0].DistanceTravelledM - activateDistanceTravelledM < thisTrain.Length)
@@ -1053,7 +1053,7 @@ namespace Orts.Simulation.AIs
         {
             List<KeyValuePair<System.Type, AuxActionRef>> listInfo = new List<KeyValuePair<System.Type, AuxActionRef>>();
 
-            System.Type managed  = typeof(SignalObject);
+            System.Type managed = typeof(SignalObject);
             KeyValuePair<System.Type, AuxActionRef> info = new KeyValuePair<System.Type, AuxActionRef>(managed, this);
             listInfo.Add(info);
             return listInfo;
@@ -1118,7 +1118,7 @@ namespace Orts.Simulation.AIs
                 info = new AuxActionHornItem(this, AIActionItem.AI_ACTION_TYPE.AUX_ACTION);
                 info.SetParam((float)list[0], (float)list[1], (float)list[2], (float)list[3]);
                 ((AuxActionHornItem)info).SetDelay(Delay);
-//                ((AuxActionHornItem)info).RequiredDistance = RequiredDistance;
+                //                ((AuxActionHornItem)info).RequiredDistance = RequiredDistance;
             }
             return (AIActionItem)info;
         }
@@ -1133,7 +1133,7 @@ namespace Orts.Simulation.AIs
             float minDist = Math.Min(Math.Abs(rearDist), frontDist);
 
             float[] distances = GetActivationDistances(thisTrain, location);
-            
+
 #if WITH_PATH_DEBUG
             File.AppendAllText(@"C:\temp\checkpath.txt", "GenFunctions not yet defined for train:" + thisTrain.Number + 
                 " Activation Distance: " + distances[0] + " & train distance: " + (-minDist) + "\n");
@@ -1283,7 +1283,7 @@ namespace Orts.Simulation.AIs
             if (SpeedMps == 0 && (int)list[0] >= Delay)   //  We call the handler to generate an actionRef
             {
                 newAction = Handler(thisTrain.SpeedMpS, (int)list[0]);
-                
+
                 Register(thisTrain.Number, location);
 #if WITH_PATH_DEBUG
             File.AppendAllText(@"C:\temp\checkpath.txt", "Caller registered for\n");
@@ -1423,8 +1423,8 @@ namespace Orts.Simulation.AIs
             AssociatedWPAction = associatedWPAction;
             NextAction = AUX_ACTION.SIGNAL_DELEGATE;
             IsGeneric = true;
- 
-                brakeSection = distance; // Set to 1 later when applicable
+
+            brakeSection = distance; // Set to 1 later when applicable
         }
 
         public AIActSigDelegateRef(Train thisTrain, BinaryReader inf)
@@ -1480,7 +1480,7 @@ namespace Orts.Simulation.AIs
                 return null;
             AuxActSigDelegate info = new AuxActSigDelegate(this, AIActionItem.AI_ACTION_TYPE.AUX_ACTION);
             info.SetParam((float)list[0], (float)list[1], (float)list[2], (float)list[3]);
-            AssociatedItem = info;  
+            AssociatedItem = info;
             return (AIActionItem)info;
         }
 
@@ -1553,7 +1553,7 @@ namespace Orts.Simulation.AIs
         public bool Triggered = false;
         public bool Processing = false;
         public AITrain.AI_MOVEMENT_STATE currentMvmtState = AITrain.AI_MOVEMENT_STATE.INIT_ACTION;
-        public SignalObject SignalReferenced { get { return ((AIAuxActionsRef)ActionRef).SignalReferenced; } set {} }
+        public SignalObject SignalReferenced { get { return ((AIAuxActionsRef)ActionRef).SignalReferenced; } set { } }
 
         //================================================================================================//
         /// <summary>
@@ -1562,7 +1562,7 @@ namespace Orts.Simulation.AIs
         /// </summary>
 
         public AuxActionItem(AuxActionRef thisItem, AI_ACTION_TYPE thisAction) :
-            base ( null, thisAction)
+            base(null, thisAction)
         {
             NextAction = AI_ACTION_TYPE.AUX_ACTION;
             ActionRef = thisItem;
@@ -1746,7 +1746,7 @@ namespace Orts.Simulation.AIs
                 }
                 int correctedTime = presentTime;
                 // If delay between 40000 and 60000 an uncoupling is performed and delay is returned with the two lowest digits of the original one
-                aiTrain.TestUncouple( ref Delay);
+                aiTrain.TestUncouple(ref Delay);
                 // If delay between 30000 and 40000 it is considered an absolute delay in the form 3HHMM, where HH and MM are hour and minute where the delay ends
                 thisTrain.TestAbsDelay(ref Delay, correctedTime);
                 // If delay equal to 60001 it is considered as a command to unconditionally attach to the nearby train;
@@ -1770,7 +1770,7 @@ namespace Orts.Simulation.AIs
             {
                 if (thisTrain.TrainType != Train.TRAINTYPE.AI_PLAYERDRIVEN)
                 {
-                     thisTrain.SpeedMpS = 0;
+                    thisTrain.SpeedMpS = 0;
                 }
                 AITrain aiTrain = thisTrain as AITrain;
 
@@ -1858,7 +1858,7 @@ namespace Orts.Simulation.AIs
                             thisTrain.AuxActionsContain.Remove(this);
 
 
- #if WITH_PATH_DEBUG
+#if WITH_PATH_DEBUG
                     else
                     {
                         File.AppendAllText(@"C:\temp\checkpath.txt", "AITRain " + thisTrain.Number + "!  No more AuxActions...\n");
@@ -1869,7 +1869,7 @@ namespace Orts.Simulation.AIs
                         AITrain aiTrain = thisTrain as AITrain;
 
                         //movementState = thisTrain.UpdateStoppedState();   // Don't call UpdateStoppedState(), WP can't touch Signal
-                         movementState = AITrain.AI_MOVEMENT_STATE.BRAKING;
+                        movementState = AITrain.AI_MOVEMENT_STATE.BRAKING;
                         aiTrain.ResetActions(true);
 #if WITH_PATH_DEBUG
                         File.AppendAllText(@"C:\temp\checkpath.txt", "AITRain " + aiTrain.Number + " is " + movementState.ToString() + " at " + presentTime + "\n");
@@ -1877,7 +1877,7 @@ namespace Orts.Simulation.AIs
                     }
                     break;
                 default:
-                    break; 
+                    break;
             }
             if (ActionRef.IsGeneric)
                 currentMvmtState = movementState;
@@ -1901,7 +1901,7 @@ namespace Orts.Simulation.AIs
         int Delay;
         [JsonIgnore]
         public int ActualDepart;
-        
+
 
         //================================================================================================//
         /// <summary>
@@ -2615,7 +2615,7 @@ namespace Orts.Simulation.AIs
             if (!reschedule && ((AIActSigDelegateRef)ActionRef).IsAbsolute)
             {
                 TrackCircuitSection thisSection = thisTrain.signalRef.TrackCircuitList[((AIActSigDelegateRef)ActionRef).TCSectionIndex];
-                if (((thisSection.CircuitState.TrainReserved != null && thisSection.CircuitState.TrainReserved.Train == thisTrain) || thisSection.CircuitState.ThisTrainOccupying(thisTrain) ) && 
+                if (((thisSection.CircuitState.TrainReserved != null && thisSection.CircuitState.TrainReserved.Train == thisTrain) || thisSection.CircuitState.ThisTrainOccupying(thisTrain)) &&
                     ((AIActSigDelegateRef)ActionRef).EndSignalIndex != -1)
                     return true;
             }
@@ -2677,7 +2677,7 @@ namespace Orts.Simulation.AIs
                     SignalReferenced.UnlockForTrain(thisTrain.Number, thisTrain.TCRoute.activeSubpath);
                 else
                 {
-//                    locked = true;
+                    //                    locked = true;
                     Trace.TraceWarning("SignalObject trItem={0}, trackNode={1}, wasn't locked for train {2}.",
                         SignalReferenced.trItem, SignalReferenced.trackNode, thisTrain.Number);
                 }
@@ -2718,10 +2718,10 @@ namespace Orts.Simulation.AIs
 
         public override AITrain.AI_MOVEMENT_STATE ProcessAction(Train thisTrain, int presentTime, float elapsedClockSeconds, AITrain.AI_MOVEMENT_STATE movementState)
         {
-         movementState = base.ProcessAction(thisTrain, presentTime, elapsedClockSeconds, movementState);
+            movementState = base.ProcessAction(thisTrain, presentTime, elapsedClockSeconds, movementState);
             return movementState;
         }
     }
 
-#endregion
+    #endregion
 }

--- a/Source/Orts.Simulation/Simulation/AIs/AIPath.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AIPath.cs
@@ -88,7 +88,7 @@ namespace Orts.Simulation.AIs
                 if (tpn.HasNextMainNode)
                 {
                     node.NextMainNode = Nodes[(int)tpn.nextMainNode];
-                    node.NextMainTVNIndex = node.FindTVNIndex(node.NextMainNode, TDB, tsectiondat, i == 0 ? -1 : Nodes[i-1].NextMainTVNIndex );
+                    node.NextMainTVNIndex = node.FindTVNIndex(node.NextMainNode, TDB, tsectiondat, i == 0 ? -1 : Nodes[i - 1].NextMainTVNIndex);
                     if (node.JunctionIndex >= 0)
                         node.IsFacingPoint = TestFacingPoint(node.JunctionIndex, node.NextMainTVNIndex);
                     if (node.NextMainTVNIndex < 0)
@@ -292,7 +292,7 @@ namespace Orts.Simulation.AIs
         /// Constructor from other AIPathNode
         /// </summary>
         /// <param name="otherNode"></param>
-        
+
         public AIPathNode(AIPathNode otherNode)
         {
             ID = otherNode.ID;
@@ -348,34 +348,34 @@ namespace Orts.Simulation.AIs
             }
 
             WaitTimeS = (int)((tpn.pathFlags >> 16) & 0xffff); // get the AAAA part.
-            // computations for absolute wait times are made within AITrain.cs
-/*            if (WaitTimeS >= 30000 && WaitTimeS < 40000)
-            {
-                // real wait time. 
-                // waitTimeS (in decimal notation) = 3HHMM  (hours and minuts)
-                int hour = (WaitTimeS / 100) % 100;
-                int minute = WaitTimeS % 100;
-                WaitUntil = 60 * (minute + 60 * hour);
-                WaitTimeS = 0;
-            }*/
-            // computations are made within AITrain.cs
-/*            else if (WaitTimeS >= 40000 && WaitTimeS < 60000)
-            {
-                // Uncouple if a wait=stop point
-                // waitTimeS (in decimal notation) = 4NNSS (uncouple NN cars, wait SS seconds)
-                //                                or 5NNSS (uncouple NN cars, keep rear, wait SS seconds)
-                NCars = (WaitTimeS / 100) % 100;
-                if (WaitTimeS >= 50000)
-                    NCars = -NCars;
-                WaitTimeS %= 100;
-                if (Type == AIPathNodeType.Stop)
-                    Type = AIPathNodeType.Uncouple;
-            }
-            else if (WaitTimeS >= 60000)  // this is old and should be removed/reused
-            {
-                // waitTimes = 6xSSS  with waitTime SSS seconds.
-                WaitTimeS %= 1000;
-            } */
+                                                               // computations for absolute wait times are made within AITrain.cs
+                                                               /*            if (WaitTimeS >= 30000 && WaitTimeS < 40000)
+                                                                           {
+                                                                               // real wait time. 
+                                                                               // waitTimeS (in decimal notation) = 3HHMM  (hours and minuts)
+                                                                               int hour = (WaitTimeS / 100) % 100;
+                                                                               int minute = WaitTimeS % 100;
+                                                                               WaitUntil = 60 * (minute + 60 * hour);
+                                                                               WaitTimeS = 0;
+                                                                           }*/
+                                                               // computations are made within AITrain.cs
+                                                               /*            else if (WaitTimeS >= 40000 && WaitTimeS < 60000)
+                                                                           {
+                                                                               // Uncouple if a wait=stop point
+                                                                               // waitTimeS (in decimal notation) = 4NNSS (uncouple NN cars, wait SS seconds)
+                                                                               //                                or 5NNSS (uncouple NN cars, keep rear, wait SS seconds)
+                                                                               NCars = (WaitTimeS / 100) % 100;
+                                                                               if (WaitTimeS >= 50000)
+                                                                                   NCars = -NCars;
+                                                                               WaitTimeS %= 100;
+                                                                               if (Type == AIPathNodeType.Stop)
+                                                                                   Type = AIPathNodeType.Uncouple;
+                                                                           }
+                                                                           else if (WaitTimeS >= 60000)  // this is old and should be removed/reused
+                                                                           {
+                                                                               // waitTimes = 6xSSS  with waitTime SSS seconds.
+                                                                               WaitTimeS %= 1000;
+                                                                           } */
 
         }
 

--- a/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
@@ -244,7 +244,7 @@ namespace Orts.Simulation.AIs
             UncondAttach = inf.ReadBoolean();
             doorCloseAdvance = inf.ReadSingle();
             doorOpenDelay = inf.ReadSingle();
-            if ( !Simulator.TimetableMode && doorOpenDelay <= 0 && doorCloseAdvance > 0 && Simulator.OpenDoorsInAITrains &&
+            if (!Simulator.TimetableMode && doorOpenDelay <= 0 && doorCloseAdvance > 0 && Simulator.OpenDoorsInAITrains &&
                 MovementState == AI_MOVEMENT_STATE.STATION_STOP && StationStops.Count > 0)
             {
                 StationStop thisStation = StationStops[0];
@@ -447,7 +447,7 @@ namespace Orts.Simulation.AIs
                 BuildStationList(activityClearingDistanceM);
 
                 // <CSComment> This creates problems in push-pull paths </CSComment>
-//                StationStops.Sort();
+                //                StationStops.Sort();
                 if (!atStation && StationStops.Count > 0 && this != Simulator.Trains[0])
                 {
                     if (MaxVelocityA > 0 &&
@@ -572,13 +572,13 @@ namespace Orts.Simulation.AIs
             return (ControlMode == TRAIN_CONTROL.INACTIVE ? AI_MOVEMENT_STATE.AI_STATIC : MovementState);
         }
 
- 
+
         //================================================================================================//
         /// <summary>
         /// Get AI Movement State
         /// </summary>
         /// 
-        private void RandomizeEfficiency (ref float efficiency)
+        private void RandomizeEfficiency(ref float efficiency)
         {
             efficiency *= 100;
             var incOrDecEfficiency = DateTime.Now.Millisecond % 2 == 0 ? true : false;
@@ -587,13 +587,13 @@ namespace Orts.Simulation.AIs
             efficiency /= 100;
         }
 
-    //================================================================================================//
-    /// <summary>
-    /// Update
-    /// Update function for a single AI train.
-    /// </summary>
+        //================================================================================================//
+        /// <summary>
+        /// Update
+        /// Update function for a single AI train.
+        /// </summary>
 
-    public void AIUpdate(float elapsedClockSeconds, double clockTime, bool preUpdate)
+        public void AIUpdate(float elapsedClockSeconds, double clockTime, bool preUpdate)
         {
 #if DEBUG_CHECKTRAIN
             if (!CheckTrain)
@@ -956,8 +956,8 @@ namespace Orts.Simulation.AIs
                 countRequiredAction = requiredActions.Count;
             }
 #endif
- //            Trace.TraceWarning ("Time {0} Train no. {1} Speed {2} AllowedMaxSpeed {3} Throttle percent {4} Distance travelled {5} Movement State {6} BrakePerCent {7}",
- //               clockTime, Number, SpeedMpS, AllowedMaxSpeedMpS, AITrainThrottlePercent, DistanceTravelledM, MovementState, AITrainBrakePercent);
+            //            Trace.TraceWarning ("Time {0} Train no. {1} Speed {2} AllowedMaxSpeed {3} Throttle percent {4} Distance travelled {5} Movement State {6} BrakePerCent {7}",
+            //               clockTime, Number, SpeedMpS, AllowedMaxSpeedMpS, AITrainThrottlePercent, DistanceTravelledM, MovementState, AITrainBrakePercent);
         }
 
         //================================================================================================//
@@ -1290,7 +1290,7 @@ namespace Orts.Simulation.AIs
                 while (!validStop)
                 {
                     float[] distancesM = CalculateDistancesToNextStation(thisStation, TrainMaxSpeedMpS, false);
-                    if (distancesM[0] < 0f && !(MovementState == AI_MOVEMENT_STATE.STATION_STOP &&  distancesM[0] != -1)) // stop is not valid
+                    if (distancesM[0] < 0f && !(MovementState == AI_MOVEMENT_STATE.STATION_STOP && distancesM[0] != -1)) // stop is not valid
                     {
 
                         StationStops.RemoveAt(0);
@@ -2063,9 +2063,9 @@ namespace Orts.Simulation.AIs
             else if (thisStation.ExitSignal >= 0 && NextSignalObject[0] != null && NextSignalObject[0].thisRef == thisStation.ExitSignal)
             {
                 MstsSignalAspect nextAspect = GetNextSignalAspect(0);
-                if (nextAspect == MstsSignalAspect.STOP && !NextSignalObject[0].HasLockForTrain(Number, TCRoute.activeSubpath) && 
+                if (nextAspect == MstsSignalAspect.STOP && !NextSignalObject[0].HasLockForTrain(Number, TCRoute.activeSubpath) &&
                     !(TCRoute.TCRouteSubpaths[TCRoute.activeSubpath].Count - 1 == PresentPosition[0].RouteListIndex &&
-                        TCRoute.TCRouteSubpaths.Count -1 == TCRoute.activeSubpath))
+                        TCRoute.TCRouteSubpaths.Count - 1 == TCRoute.activeSubpath))
                 {
                     return;  // do not depart if exit signal at danger
                 }
@@ -2986,14 +2986,14 @@ namespace Orts.Simulation.AIs
         public virtual void UpdateFollowingState(float elapsedClockSeconds, int presentTime)
         {
             if (nextActionInfo != null && nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.TRAIN_AHEAD && nextActionInfo.ActivateDistanceM - PresentPosition[0].DistanceTravelledM < -5)
-            if (CheckTrain)
-            {
-                File.AppendAllText(@"C:\temp\checktrain.txt",
-                                        "Update Train Ahead - now at : " +
-                                        PresentPosition[0].TCSectionIndex.ToString() + " " +
-                                        PresentPosition[0].TCOffset.ToString() +
-                                        " ; speed : " + FormatStrings.FormatSpeed(SpeedMpS, true) + "\n");
-            }
+                if (CheckTrain)
+                {
+                    File.AppendAllText(@"C:\temp\checktrain.txt",
+                                            "Update Train Ahead - now at : " +
+                                            PresentPosition[0].TCSectionIndex.ToString() + " " +
+                                            PresentPosition[0].TCOffset.ToString() +
+                                            " ; speed : " + FormatStrings.FormatSpeed(SpeedMpS, true) + "\n");
+                }
 
             if (ControlMode != TRAIN_CONTROL.AUTO_NODE || EndAuthorityType[0] != END_AUTHORITY.TRAIN_AHEAD) // train is gone
             {
@@ -3087,8 +3087,8 @@ namespace Orts.Simulation.AIs
                             if (OtherTrain.TrainType == TRAINTYPE.STATIC || (OtherTrain.PresentPosition[0].TCSectionIndex ==
                                 TCRoute.TCRouteSubpaths[TCRoute.activeSubpath][TCRoute.TCRouteSubpaths[TCRoute.activeSubpath].Count - 1].TCSectionIndex
                                 || OtherTrain.PresentPosition[1].TCSectionIndex ==
-                                TCRoute.TCRouteSubpaths[TCRoute.activeSubpath][TCRoute.TCRouteSubpaths[TCRoute.activeSubpath].Count - 1].TCSectionIndex) && 
-                                (TCRoute.ReversalInfo[TCRoute.activeSubpath].Valid || TCRoute.activeSubpath == TCRoute.TCRouteSubpaths.Count - 1) 
+                                TCRoute.TCRouteSubpaths[TCRoute.activeSubpath][TCRoute.TCRouteSubpaths[TCRoute.activeSubpath].Count - 1].TCSectionIndex) &&
+                                (TCRoute.ReversalInfo[TCRoute.activeSubpath].Valid || TCRoute.activeSubpath == TCRoute.TCRouteSubpaths.Count - 1)
                                 || UncondAttach)
                             {
                                 attachToTrain = true;
@@ -3324,7 +3324,7 @@ namespace Orts.Simulation.AIs
                             bool runningAgainst = false;
                             if (PresentPosition[0].TCSectionIndex == OtherTrain.PresentPosition[0].TCSectionIndex &&
                                 PresentPosition[0].TCDirection != OtherTrain.PresentPosition[0].TCDirection) runningAgainst = true;
-                            if ((SpeedMpS > (OtherTrain.SpeedMpS + hysterisMpS) && !runningAgainst)||
+                            if ((SpeedMpS > (OtherTrain.SpeedMpS + hysterisMpS) && !runningAgainst) ||
                                 SpeedMpS > (maxFollowSpeedMpS + hysterisMpS) ||
                                 distanceToTrain < (keepDistanceTrainM - clearingDistanceM))
                             {
@@ -3856,7 +3856,7 @@ namespace Orts.Simulation.AIs
                 {
                     endSectionFound = true;
                     if (routeIndex < thisRoute.Count - 1)
-                    endSignalIndex = thisSection.EndSignals[direction].thisRef;
+                        endSignalIndex = thisSection.EndSignals[direction].thisRef;
                 }
 
                 // check if next section is junction
@@ -3879,7 +3879,7 @@ namespace Orts.Simulation.AIs
                         endSectionFound = true;
                         lastIndex = nextIndex;
                         if (lastIndex < thisRoute.Count - 1)
-                        endSignalIndex = nextSection.EndSignals[direction].thisRef;
+                            endSignalIndex = nextSection.EndSignals[direction].thisRef;
                     }
                     else if (nextSection.CircuitType != TrackCircuitSection.TrackCircuitType.Normal)
                     {
@@ -3990,7 +3990,7 @@ namespace Orts.Simulation.AIs
                     {
                         RandomizedWPDelay(ref randomizedDelay);
                     }
-                    action.SetDelay( (randomizedDelay >= 30000 && randomizedDelay < 40000)? randomizedDelay : 0);
+                    action.SetDelay((randomizedDelay >= 30000 && randomizedDelay < 40000) ? randomizedDelay : 0);
                     AuxActionsContain.Add(action);
                     AIActSigDelegateRef delegateAction = new AIActSigDelegateRef(this, waitingPoint[5], 0f, waitingPoint[0], lastIndex, thisRoute[lastIndex].TCSectionIndex, direction, action);
                     signalRef.SignalObjects[signalIndex[iWait]].LockForTrain(this.Number, waitingPoint[0]);
@@ -4178,7 +4178,7 @@ namespace Orts.Simulation.AIs
                     MovementState = AI_MOVEMENT_STATE.FROZEN;
                 }
             }
-            else 
+            else
             {
                 TrackCircuitSection thisSection = signalRef.TrackCircuitList[PresentPosition[1].TCSectionIndex];
                 if (TCRoute.ReversalInfo[TCRoute.activeSubpath - 1].Valid && PresentPosition[1].DistanceTravelledM < distanceThreshold && PresentPosition[1].TCOffset < 25)
@@ -4192,7 +4192,7 @@ namespace Orts.Simulation.AIs
                     }
                 }
             }
-            
+
             if (removeIt)
             {
                 if (IncorporatedTrainNo >= 0 && Simulator.TrainDictionary.Count > IncorporatedTrainNo &&
@@ -5715,7 +5715,7 @@ namespace Orts.Simulation.AIs
                                     + StationStops[0].DistanceToTrainM.ToString() + " ; now is " + thisItem.ActiveItem.distance_to_train.ToString() + "\n");
                             }
                             StationStops[0].DistanceToTrainM = thisItem.ActiveItem.distance_to_train;
-                        } 
+                        }
                     }
 
                     // check if present action is signal and new action is station - if so, check actual position of signal in relation to stop
@@ -5746,8 +5746,8 @@ namespace Orts.Simulation.AIs
                     if (!earlier && thisItem.NextAction == AIActionItem.AI_ACTION_TYPE.STATION_STOP &&
                                (nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.END_OF_ROUTE || nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.END_OF_AUTHORITY))
                     {
-                            earlier = true;
-                            nextActionInfo.ActivateDistanceM = thisItem.ActivateDistanceM + 1.0f;
+                        earlier = true;
+                        nextActionInfo.ActivateDistanceM = thisItem.ActivateDistanceM + 1.0f;
                     }
 
                     // if not earlier and is a waiting point and present action is signal stop : check if signal is locking signal, if so set waiting
@@ -5868,8 +5868,8 @@ namespace Orts.Simulation.AIs
 
 #endif
 
-                if (MovementState != AI_MOVEMENT_STATE.STATION_STOP && 
-                    MovementState != AI_MOVEMENT_STATE.STOPPED && 
+                if (MovementState != AI_MOVEMENT_STATE.STATION_STOP &&
+                    MovementState != AI_MOVEMENT_STATE.STOPPED &&
                     MovementState != AI_MOVEMENT_STATE.HANDLE_ACTION &&
                     MovementState != AI_MOVEMENT_STATE.FOLLOWING &&
                     MovementState != AI_MOVEMENT_STATE.BRAKING)
@@ -6502,7 +6502,7 @@ namespace Orts.Simulation.AIs
                             {
                                 float distanceToNextSignal = -1;
                                 if (NextSignalObject[0] != null) distanceToNextSignal = NextSignalObject[0].DistanceTo(FrontTDBTraveller);
-                                                                        // check if signal ahead is cleared - if not, do not allow depart
+                                // check if signal ahead is cleared - if not, do not allow depart
                                 if (NextSignalObject[0] != null && distanceToNextSignal >= 0 && distanceToNextSignal < 300 &&
                                         NextSignalObject[0].this_sig_lr(MstsSignalFunction.NORMAL) == MstsSignalAspect.STOP
                                     && NextSignalObject[0].hasPermission != SignalObject.Permission.Granted)
@@ -6534,7 +6534,7 @@ namespace Orts.Simulation.AIs
                     if (Math.Abs(SpeedMpS) == 0.0f)
                     {
                         AtStation = IsAtPlatform();
-                         if (AtStation)
+                        if (AtStation)
                         {
                             int presentTime = Convert.ToInt32(Math.Floor(Simulator.ClockTime));
                             StationStops[0].ActualArrival = presentTime;

--- a/Source/Orts.Simulation/Simulation/Activity.cs
+++ b/Source/Orts.Simulation/Simulation/Activity.cs
@@ -102,7 +102,7 @@ namespace Orts.Simulation
 
                     foreach (var i in sd.Player_Traffic_Definition.Player_Traffic_List)
                     {
-                        if (i.PlatformStartID < Simulator.TDB.TrackDB.TrItemTable.Length && i.PlatformStartID >= 0 && 
+                        if (i.PlatformStartID < Simulator.TDB.TrackDB.TrItemTable.Length && i.PlatformStartID >= 0 &&
                             Simulator.TDB.TrackDB.TrItemTable[i.PlatformStartID] is PlatformItem)
                             Platform = Simulator.TDB.TrackDB.TrItemTable[i.PlatformStartID] as PlatformItem;
                         else
@@ -520,18 +520,18 @@ namespace Orts.Simulation
             const float MaxDistanceOfWarningPost = 2000;
 
             for (int idxZone = 0; idxZone < zones.ActivityRestrictedSpeedZoneList.Count; idxZone++)
-			{
-               var worldPosition1 = new WorldPosition();
-                newSpeedPostItems[0]   = new TempSpeedPostItem(routeFile,
+            {
+                var worldPosition1 = new WorldPosition();
+                newSpeedPostItems[0] = new TempSpeedPostItem(routeFile,
                     zones.ActivityRestrictedSpeedZoneList[idxZone].StartPosition, true, worldPosition1, false);
                 var worldPosition2 = new WorldPosition();
                 newSpeedPostItems[1] = new TempSpeedPostItem(routeFile,
                     zones.ActivityRestrictedSpeedZoneList[idxZone].EndPosition, false, worldPosition2, false);
-			
-                // Add the speedposts to the track database. This will set the TrItemId's of all speedposts
-            trackDB.AddTrItems(newSpeedPostItems);
 
-            // And now update the various (vector) tracknodes (this needs the TrItemIds.
+                // Add the speedposts to the track database. This will set the TrItemId's of all speedposts
+                trackDB.AddTrItems(newSpeedPostItems);
+
+                // And now update the various (vector) tracknodes (this needs the TrItemIds.
                 var endOffset = AddItemIdToTrackNode(ref zones.ActivityRestrictedSpeedZoneList[idxZone].EndPosition,
                     tsectionDat, trackDB, newSpeedPostItems[1], out traveller);
                 var startOffset = AddItemIdToTrackNode(ref zones.ActivityRestrictedSpeedZoneList[idxZone].StartPosition,
@@ -555,15 +555,15 @@ namespace Orts.Simulation
                 {
                     FlipRestrSpeedPost((TempSpeedPostItem)speedWarningPostItem);
                 }
-                ComputeTablePosition((TempSpeedPostItem)newSpeedPostItems[0]); 
+                ComputeTablePosition((TempSpeedPostItem)newSpeedPostItems[0]);
                 TempSpeedPostItems.Add((TempSpeedPostItem)newSpeedPostItems[0]);
-                ComputeTablePosition((TempSpeedPostItem)newSpeedPostItems[1]); 
+                ComputeTablePosition((TempSpeedPostItem)newSpeedPostItems[1]);
                 TempSpeedPostItems.Add((TempSpeedPostItem)newSpeedPostItems[1]);
-                ComputeTablePosition((TempSpeedPostItem)speedWarningPostItem); 
+                ComputeTablePosition((TempSpeedPostItem)speedWarningPostItem);
                 TempSpeedPostItems.Add((TempSpeedPostItem)speedWarningPostItem);
             }
         }
-        
+
         /// <summary>
         /// Add a reference to a new TrItemId to the correct trackNode (which needs to be determined from the position)
         /// </summary>
@@ -889,7 +889,7 @@ namespace Orts.Simulation
                     }
                     else
                     {
-                    // <CSComment> MSTS mode - player
+                        // <CSComment> MSTS mode - player
                         if (Simulator.GameTime < 2)
                         {
                             // If the simulation starts with a scheduled arrive in the past, assume the train arrived on time.
@@ -900,29 +900,29 @@ namespace Orts.Simulation
                         }
                         BoardingS = (double)MyPlayerTrain.StationStops[0].ComputeStationBoardingTime(Simulator.PlayerLocomotive.Train);
                         if (BoardingS > 0 || ((double)(SchDepart - SchArrive).TotalSeconds > 0 &&
-                            MyPlayerTrain.PassengerCarsNumber == 1 && MyPlayerTrain.Cars.Count > 10 ))
+                            MyPlayerTrain.PassengerCarsNumber == 1 && MyPlayerTrain.Cars.Count > 10))
                         {
-                        // accepted station stop because either freight train or passenger train or fake passenger train with passenger car on platform or fake passenger train
+                            // accepted station stop because either freight train or passenger train or fake passenger train with passenger car on platform or fake passenger train
                             // with Scheduled Depart > Scheduled Arrive
-                                // ActArrive is usually same as ClockTime
-                                BoardingEndS = Simulator.ClockTime + BoardingS;
+                            // ActArrive is usually same as ClockTime
+                            BoardingEndS = Simulator.ClockTime + BoardingS;
 
-                                if (ActArrive == null)
-                                {
-                                    ActArrive = new DateTime().Add(TimeSpan.FromSeconds(Simulator.ClockTime));
-                                }
-
-                                arrived = true;
-                                // But not if game starts after scheduled arrival. In which case actual arrival is assumed to be same as schedule arrival.
-                                double sinceActArriveS = (new DateTime().Add(TimeSpan.FromSeconds(Simulator.ClockTime))
-                                                        - ActArrive).Value.TotalSeconds;
-                                BoardingEndS -= sinceActArriveS;
-                                BoardingEndS = CompareTimes.LatestTime((int)SchDepart.TimeOfDay.TotalSeconds, (int)BoardingEndS);
-
+                            if (ActArrive == null)
+                            {
+                                ActArrive = new DateTime().Add(TimeSpan.FromSeconds(Simulator.ClockTime));
                             }
+
+                            arrived = true;
+                            // But not if game starts after scheduled arrival. In which case actual arrival is assumed to be same as schedule arrival.
+                            double sinceActArriveS = (new DateTime().Add(TimeSpan.FromSeconds(Simulator.ClockTime))
+                                                    - ActArrive).Value.TotalSeconds;
+                            BoardingEndS -= sinceActArriveS;
+                            BoardingEndS = CompareTimes.LatestTime((int)SchDepart.TimeOfDay.TotalSeconds, (int)BoardingEndS);
+
                         }
-                    if  (MyPlayerTrain.NextSignalObject[0] != null)
-                           distanceToNextSignal =  MyPlayerTrain.NextSignalObject[0].DistanceTo(MyPlayerTrain.FrontTDBTraveller);
+                    }
+                    if (MyPlayerTrain.NextSignalObject[0] != null)
+                        distanceToNextSignal = MyPlayerTrain.NextSignalObject[0].DistanceTo(MyPlayerTrain.FrontTDBTraveller);
 
                 }
             }
@@ -936,7 +936,7 @@ namespace Orts.Simulation
                     // Completeness depends on the elapsed waiting time
                     IsCompleted = maydepart;
                     if (MyPlayerTrain.TrainType != Train.TRAINTYPE.AI_PLAYERHOSTING)
-                       MyPlayerTrain.ClearStation(PlatformEnd1.LinkedPlatformItemId, PlatformEnd2.LinkedPlatformItemId, true);
+                        MyPlayerTrain.ClearStation(PlatformEnd1.LinkedPlatformItemId, PlatformEnd2.LinkedPlatformItemId, true);
 
                     if (LogStationStops)
                     {
@@ -996,7 +996,7 @@ namespace Orts.Simulation
                     else if (!maydepart)
                     {
                         // check if signal ahead is cleared - if not, do not allow depart
-                        if (distanceToNextSignal >= 0 && distanceToNextSignal< 300 && MyPlayerTrain.NextSignalObject[0] != null &&
+                        if (distanceToNextSignal >= 0 && distanceToNextSignal < 300 && MyPlayerTrain.NextSignalObject[0] != null &&
                             MyPlayerTrain.NextSignalObject[0].this_sig_lr(MstsSignalFunction.NORMAL) == MstsSignalAspect.STOP
                             && MyPlayerTrain.NextSignalObject[0].hasPermission != SignalObject.Permission.Granted)
                         {
@@ -1253,7 +1253,7 @@ namespace Orts.Simulation
             }
             return false;
         }
-     
+
     }
 
     public class EventCategoryActionWrapper : EventWrapper
@@ -1448,7 +1448,7 @@ namespace Orts.Simulation
                     lNotFound = false; break;//wagon still part of the train
                 }
             }
-            return (lNotFound? true : false);
+            return (lNotFound ? true : false);
         }
         /// <summary>
         /// Like platforms, checking that one end of the train is within the siding.

--- a/Source/Orts.Simulation/Simulation/Confirmer.cs
+++ b/Source/Orts.Simulation/Simulation/Confirmer.cs
@@ -27,11 +27,12 @@ namespace Orts.Simulation
         [GetString("Information")] Information,
         [GetString("Warning")] Warning,
         [GetString("Error")] Error,
-		[GetString("MSG")] MSG,
+        [GetString("MSG")] MSG,
     };
 
     // <CJComment> Some of these are not cab controls or even controls. However they all make good use of structured text. </CJComment>
-    public enum CabControl {
+    public enum CabControl
+    {
         None
         // Power
       , Reverser
@@ -109,7 +110,8 @@ namespace Orts.Simulation
       , CabRadio
     }
 
-    public enum CabSetting {
+    public enum CabSetting
+    {
         Name        // name of control
         , Off       // 2 or 3 state control/reset/initialise
         , Neutral   // 2 or 3 state control
@@ -149,7 +151,7 @@ namespace Orts.Simulation
         // be replaced with French and other languages.
         //
         //                      control, off/reset/initialize, neutral, on/apply/switch, decrease, increase, warn
-        readonly string[][] ConfirmText; 
+        readonly string[][] ConfirmText;
 
         readonly Simulator Simulator;
         readonly double DefaultDurationS;
@@ -168,12 +170,12 @@ namespace Orts.Simulation
             ConfirmText = new string[][] {
                 new string [] { GetString("<none>") } 
                 // Power
-                , new string [] { GetParticularString("NonSteam", "Reverser"), GetString("reverse"), GetString("neutral"), GetString("forward"), null, null, GetString("locked. Close throttle, stop train then re-try.") } 
-                , new string [] { GetString("Throttle"), null, null, null, GetString("close"), GetString("open"), GetString("locked. Release dynamic brake then re-try.") } 
+                , new string [] { GetParticularString("NonSteam", "Reverser"), GetString("reverse"), GetString("neutral"), GetString("forward"), null, null, GetString("locked. Close throttle, stop train then re-try.") }
+                , new string [] { GetString("Throttle"), null, null, null, GetString("close"), GetString("open"), GetString("locked. Release dynamic brake then re-try.") }
                 , new string [] { GetString("Wheel-slip"), GetString("over"), null, GetString("occurring. Tractive power greatly reduced."), null, null, GetString("warning") } 
                 // Electric power
                 , new string [] { GetString("Power"), GetString("off"), null, GetString("on") }
-                , new string [] { GetString("Pantograph 1"), GetString("lower"), null, GetString("raise") } 
+                , new string [] { GetString("Pantograph 1"), GetString("lower"), null, GetString("raise") }
                 , new string [] { GetString("Pantograph 2"), GetString("lower"), null, GetString("raise") }
                 , new string [] { GetString("Pantograph 3"), GetString("lower"), null, GetString("raise") }
                 , new string [] { GetString("Pantograph 4"), GetString("lower"), null, GetString("raise") }
@@ -185,58 +187,58 @@ namespace Orts.Simulation
                 , new string [] { GetString("Helper Diesel Power"), GetString("off"), null, GetString("on") }
                 , new string [] { GetString("Diesel Tank"), null, null, GetString("re-fueled"), null, GetString("level") } 
                 // Steam power
-                , new string [] { GetParticularString("Steam", "Reverser"), GetString("reverse"), GetString("neutral"), GetString("forward"), null, null, GetString("locked. Close throttle, stop train then re-try.") } 
+                , new string [] { GetParticularString("Steam", "Reverser"), GetString("reverse"), GetString("neutral"), GetString("forward"), null, null, GetString("locked. Close throttle, stop train then re-try.") }
                 , new string [] { GetString("Regulator"), null, null, null, GetString("close"), GetString("open") }    // Throttle for steam locomotives
-                , new string [] { GetString("Injector 1"), GetString("off"), null, GetString("on"), GetString("close"), GetString("open") } 
-                , new string [] { GetString("Injector 2"), GetString("off"), null, GetString("on"), GetString("close"), GetString("open") } 
-                , new string [] { GetString("Blower"), null, null, null, GetString("decrease"), GetString("increase") } 
-                , new string [] { GetString("SteamHeat"), null, null, null, GetString("decrease"), GetString("increase") } 
-                , new string [] { GetString("Damper"), null, null, null, GetString("close"), GetString("open") } 
+                , new string [] { GetString("Injector 1"), GetString("off"), null, GetString("on"), GetString("close"), GetString("open") }
+                , new string [] { GetString("Injector 2"), GetString("off"), null, GetString("on"), GetString("close"), GetString("open") }
+                , new string [] { GetString("Blower"), null, null, null, GetString("decrease"), GetString("increase") }
+                , new string [] { GetString("SteamHeat"), null, null, null, GetString("decrease"), GetString("increase") }
+                , new string [] { GetString("Damper"), null, null, null, GetString("close"), GetString("open") }
                 , new string [] { GetString("Firebox Door"), null, null, null, GetString("close"), GetString("open") }
-                , new string [] { GetString("Firing Rate"), null, null, null, GetString("decrease"), GetString("increase") } 
-                , new string [] { GetString("Manual Firing"), GetString("off"), null, GetString("on") } 
-                , new string [] { GetString("Fire"), null, null, GetString("add shovel-full") } 
-                , new string [] { GetString("Cylinder Cocks"), GetString("close"), null, GetString("open") } 
-                , new string [] { GetString("Cylinder Compound"), GetString("close"), null, GetString("open") } 
-                , new string [] { GetString("SmallEjector"), null, null, null, GetString("decrease"), GetString("increase") } 
-                , new string [] { GetString("Tender"), null, null, GetString("Coal re-filled"), null, GetString("Coal level") } 
+                , new string [] { GetString("Firing Rate"), null, null, null, GetString("decrease"), GetString("increase") }
+                , new string [] { GetString("Manual Firing"), GetString("off"), null, GetString("on") }
+                , new string [] { GetString("Fire"), null, null, GetString("add shovel-full") }
+                , new string [] { GetString("Cylinder Cocks"), GetString("close"), null, GetString("open") }
+                , new string [] { GetString("Cylinder Compound"), GetString("close"), null, GetString("open") }
+                , new string [] { GetString("SmallEjector"), null, null, null, GetString("decrease"), GetString("increase") }
+                , new string [] { GetString("Tender"), null, null, GetString("Coal re-filled"), null, GetString("Coal level") }
                 , new string [] { GetString("Tender"), null, null, GetString("Water re-filled"), null, GetString("Water level") }
                 // General
                 , new string [] { GetString("Water Scoop"), GetString("up"), null, GetString("down") }
                 // Braking
-                , new string [] { GetString("Train Brake"), null, null, null, GetString("release"), GetString("apply") } 
-                , new string [] { GetString("Engine Brake"), null, null, null, GetString("release"), GetString("apply") } 
+                , new string [] { GetString("Train Brake"), null, null, null, GetString("release"), GetString("apply") }
+                , new string [] { GetString("Engine Brake"), null, null, null, GetString("release"), GetString("apply") }
                 , new string [] { GetString("Dynamic Brake"), GetString("off"), null, GetString("setup"), GetString("decrease"), GetString("increase") }
-                , new string [] { GetString("Emergency Brake"), GetString("release"), null, GetString("apply") } 
-                , new string [] { GetString("Bail Off"), GetString("disengage"), null, GetString("engage") } 
-                , new string [] { GetString("Brakes"), GetString("initialize"), null, null, null, null, GetString("cannot initialize. Stop train then re-try.") } 
-                , new string [] { GetString("Handbrake"), GetString("none"), null, GetString("full") } 
-                , new string [] { GetString("Retainers"), GetString("off"), null, GetString("on"), null, null, null, null, GetString("Exhaust"), GetString("High Pressure"), GetString("Low Pressure"), GetString("Slow Direct") } 
+                , new string [] { GetString("Emergency Brake"), GetString("release"), null, GetString("apply") }
+                , new string [] { GetString("Bail Off"), GetString("disengage"), null, GetString("engage") }
+                , new string [] { GetString("Brakes"), GetString("initialize"), null, null, null, null, GetString("cannot initialize. Stop train then re-try.") }
+                , new string [] { GetString("Handbrake"), GetString("none"), null, GetString("full") }
+                , new string [] { GetString("Retainers"), GetString("off"), null, GetString("on"), null, null, null, null, GetString("Exhaust"), GetString("High Pressure"), GetString("Low Pressure"), GetString("Slow Direct") }
                 , new string [] { GetString("Brake Hose"), GetString("disconnect"), null, GetString("connect") } 
                 // Cab Devices
-                , new string [] { GetString("Sander"), GetString("off"), null, GetString("on") } 
-                , new string [] { GetString("Alerter"), GetString("acknowledge"), null, GetParticularString("Alerter", "sound") } 
-                , new string [] { GetString("Horn"), GetString("off"), null, GetParticularString("Horn", "sound") } 
+                , new string [] { GetString("Sander"), GetString("off"), null, GetString("on") }
+                , new string [] { GetString("Alerter"), GetString("acknowledge"), null, GetParticularString("Alerter", "sound") }
+                , new string [] { GetString("Horn"), GetString("off"), null, GetParticularString("Horn", "sound") }
                 , new string [] { GetString("Whistle"), GetString("off"), null, GetString("blow") }        // Horn for steam locomotives
-                , new string [] { GetString("Bell"), GetString("off"), null, GetString("ring") } 
-                , new string [] { GetString("Headlight"), GetString("off"), GetString("dim"), GetString("bright") } 
-                , new string [] { GetString("Cab Light"), GetString("off"), null, GetString("on") } 
-                , new string [] { GetString("Wipers"), GetString("off"), null, GetString("on") } 
-                , new string [] { GetString("Cab"), null, null, GetParticularString("Cab", "change"), null, null, GetString("changing is not available"), GetString("changing disabled. Close throttle, set reverser to neutral, stop train then re-try.") } 
+                , new string [] { GetString("Bell"), GetString("off"), null, GetString("ring") }
+                , new string [] { GetString("Headlight"), GetString("off"), GetString("dim"), GetString("bright") }
+                , new string [] { GetString("Cab Light"), GetString("off"), null, GetString("on") }
+                , new string [] { GetString("Wipers"), GetString("off"), null, GetString("on") }
+                , new string [] { GetString("Cab"), null, null, GetParticularString("Cab", "change"), null, null, GetString("changing is not available"), GetString("changing disabled. Close throttle, set reverser to neutral, stop train then re-try.") }
                 , new string [] { GetString("Odometer"), null, null, GetParticularString("Odometer", "reset"), GetParticularString("Odometer", "counting down"), GetParticularString("Odometer", "counting up") }
                 // Train Devices
-                , new string [] { GetString("Doors Left"), GetString("close"), null, GetString("open") } 
-                , new string [] { GetString("Doors Right"), GetString("close"), null, GetString("open") } 
+                , new string [] { GetString("Doors Left"), GetString("close"), null, GetString("open") }
+                , new string [] { GetString("Doors Right"), GetString("close"), null, GetString("open") }
                 , new string [] { GetString("Mirror"), GetString("retract"), null, GetString("extend") } 
                 // Track Devices
-                , new string [] { GetString("Switch Ahead"), null, null, GetParticularString("Switch", "change"), null, null, GetString("locked. Use Control+M to change signals to manual mode then re-try.") } 
+                , new string [] { GetString("Switch Ahead"), null, null, GetParticularString("Switch", "change"), null, null, GetString("locked. Use Control+M to change signals to manual mode then re-try.") }
                 , new string [] { GetString("Switch Behind"), null, null, GetParticularString("Switch", "change"), null, null, GetString("locked. Use Control+M to change signals to manual mode then re-try.") } 
                 // Simulation
-                , new string [] { GetString("Simulation Speed"), GetString("reset"), null, null, GetString("decrease"), GetString("increase") } 
-                , new string [] { GetString("Uncouple After") } 
-                , new string [] { GetString("Activity"), GetString("quit"), null, GetString("resume") } 
-                , new string [] { GetString("Replay"), null, null, null, null, null, GetString("Overriding camera replay. Press Escape to resume camera replay.") } 
-                , new string [] { GetString("Gearbox"), null, null, null, GetString("down"), GetString("up"), GetString("locked. Use shaft before changing gear.") } 
+                , new string [] { GetString("Simulation Speed"), GetString("reset"), null, null, GetString("decrease"), GetString("increase") }
+                , new string [] { GetString("Uncouple After") }
+                , new string [] { GetString("Activity"), GetString("quit"), null, GetString("resume") }
+                , new string [] { GetString("Replay"), null, null, null, null, null, GetString("Overriding camera replay. Press Escape to resume camera replay.") }
+                , new string [] { GetString("Gearbox"), null, null, null, GetString("down"), GetString("up"), GetString("locked. Use shaft before changing gear.") }
                 , new string [] { GetString("Signal mode"), GetString("manual"), null, GetString("auto"), null, null, GetString("locked. Stop train, then re-try.") } 
                 // Freight Load
                 , new string [] { GetString("Wagon"), GetString("Wagon fully unloaded"), null, GetString("Wagon fully loaded"), null, GetString("Freight load") }
@@ -254,7 +256,8 @@ namespace Orts.Simulation
             Message(control, Simulator.Catalog.GetString("{0} {1}"), ConfirmText[(int)control][0], text);
         }
 
-        public void Confirm( CabControl control, CabSetting setting ) {
+        public void Confirm(CabControl control, CabSetting setting)
+        {
             Message(control, Simulator.Catalog.GetString("{0}"), ConfirmText[(int)control][(int)setting]);
         }
 
@@ -323,11 +326,11 @@ namespace Orts.Simulation
             Message(CabControl.None, ConfirmLevel.Information, message);
         }
 
-		public void MSG(string message)
-		{
-			Message(CabControl.None, ConfirmLevel.MSG, message);
-		}
-		
+        public void MSG(string message)
+        {
+            Message(CabControl.None, ConfirmLevel.MSG, message);
+        }
+
         public void Warning(string message)
         {
             Message(CabControl.None, ConfirmLevel.Warning, message);
@@ -358,9 +361,9 @@ namespace Orts.Simulation
                 format = "{0}: " + format;
             if (level >= ConfirmLevel.Information)
                 format = "{1} - " + format;
-			var duration = DefaultDurationS;
-			if (level >= ConfirmLevel.Warning) duration *= 2;
-			if (level >= ConfirmLevel.MSG) duration *= 5;
+            var duration = DefaultDurationS;
+            if (level >= ConfirmLevel.Warning) duration *= 2;
+            if (level >= ConfirmLevel.MSG) duration *= 5;
             if (DisplayMessage != null) DisplayMessage(this, new DisplayMessageEventArgs(String.Format("{0}/{1}", control, level), String.Format(format, ConfirmText[(int)control][0], Simulator.Catalog.GetString(GetStringAttribute.GetPrettyName(level)), message), duration));
         }
     }

--- a/Source/Orts.Simulation/Simulation/Hazzard.cs
+++ b/Source/Orts.Simulation/Simulation/Hazzard.cs
@@ -25,134 +25,134 @@ using System.Linq;
 namespace Orts.Simulation
 {
     public class HazzardManager
-	{
-		readonly int hornDist = 200;
-		readonly int approachDist = 160;
+    {
+        readonly int hornDist = 200;
+        readonly int approachDist = 160;
         readonly int scaredDist = 147;
-		readonly Simulator Simulator;
-		public readonly Dictionary<int, Hazzard> Hazzards;
-		public readonly Dictionary<int, Hazzard> CurrentHazzards;
-		public readonly Dictionary<string, HazardFile> HazFiles;
-		List<int> InterestedHazzards;//those hazards is closed to player, needs to listen to horn
-		public HazzardManager(Simulator simulator)
-		{
-			Simulator = simulator;
-			InterestedHazzards = new List<int>();
-			CurrentHazzards = new Dictionary<int, Hazzard>();
-			HazFiles = new Dictionary<string, HazardFile>();
-			Hazzards = simulator.TDB != null && simulator.TDB.TrackDB != null ? GetHazardsFromDB(simulator.TDB.TrackDB.TrackNodes, simulator.TDB.TrackDB.TrItemTable) : new Dictionary<int, Hazzard>();
-		}
+        readonly Simulator Simulator;
+        public readonly Dictionary<int, Hazzard> Hazzards;
+        public readonly Dictionary<int, Hazzard> CurrentHazzards;
+        public readonly Dictionary<string, HazardFile> HazFiles;
+        List<int> InterestedHazzards;//those hazards is closed to player, needs to listen to horn
+        public HazzardManager(Simulator simulator)
+        {
+            Simulator = simulator;
+            InterestedHazzards = new List<int>();
+            CurrentHazzards = new Dictionary<int, Hazzard>();
+            HazFiles = new Dictionary<string, HazardFile>();
+            Hazzards = simulator.TDB != null && simulator.TDB.TrackDB != null ? GetHazardsFromDB(simulator.TDB.TrackDB.TrackNodes, simulator.TDB.TrackDB.TrItemTable) : new Dictionary<int, Hazzard>();
+        }
 
-		static Dictionary<int, Hazzard> GetHazardsFromDB(TrackNode[] trackNodes, TrItem[] trItemTable)
-		{
-			return (from trackNode in trackNodes
-					where trackNode != null && trackNode.TrVectorNode != null && trackNode.TrVectorNode.NoItemRefs > 0
-					from itemRef in trackNode.TrVectorNode.TrItemRefs.Distinct()
-					where trItemTable[itemRef] != null && trItemTable[itemRef].ItemType == TrItem.trItemType.trHAZZARD
-					select new KeyValuePair<int, Hazzard>(itemRef, new Hazzard(trackNode, trItemTable[itemRef])))
-					.ToDictionary(_ => _.Key, _ => _.Value);
-		}
+        static Dictionary<int, Hazzard> GetHazardsFromDB(TrackNode[] trackNodes, TrItem[] trItemTable)
+        {
+            return (from trackNode in trackNodes
+                    where trackNode != null && trackNode.TrVectorNode != null && trackNode.TrVectorNode.NoItemRefs > 0
+                    from itemRef in trackNode.TrVectorNode.TrItemRefs.Distinct()
+                    where trItemTable[itemRef] != null && trItemTable[itemRef].ItemType == TrItem.trItemType.trHAZZARD
+                    select new KeyValuePair<int, Hazzard>(itemRef, new Hazzard(trackNode, trItemTable[itemRef])))
+                    .ToDictionary(_ => _.Key, _ => _.Value);
+        }
 
-		[CallOnThread("Loader")]
-		public Hazzard AddHazzardIntoGame(int itemID, string hazFileName)
-		{
-			try
-			{
-				if (!CurrentHazzards.ContainsKey(itemID))
-				{
-					if (HazFiles.ContainsKey(hazFileName)) Hazzards[itemID].HazFile = HazFiles[hazFileName];
-					else
-					{
-						var hazF = new HazardFile(Simulator.RoutePath + "\\" + hazFileName);
-						HazFiles.Add(hazFileName, hazF);
-						Hazzards[itemID].HazFile = hazF;
-					}
-					//based on act setting for frequency
+        [CallOnThread("Loader")]
+        public Hazzard AddHazzardIntoGame(int itemID, string hazFileName)
+        {
+            try
+            {
+                if (!CurrentHazzards.ContainsKey(itemID))
+                {
+                    if (HazFiles.ContainsKey(hazFileName)) Hazzards[itemID].HazFile = HazFiles[hazFileName];
+                    else
+                    {
+                        var hazF = new HazardFile(Simulator.RoutePath + "\\" + hazFileName);
+                        HazFiles.Add(hazFileName, hazF);
+                        Hazzards[itemID].HazFile = hazF;
+                    }
+                    //based on act setting for frequency
                     if (Hazzards[itemID].animal == true && Simulator.Activity != null)
                     {
                         if (Simulator.Random.Next(100) > Simulator.Activity.Tr_Activity.Tr_Activity_Header.Animals) return null;
                     }
-					else if (Simulator.Activity != null)
-					{
-						if (Simulator.Random.Next(100) > Simulator.Activity.Tr_Activity.Tr_Activity_Header.Animals) return null;
-					}
-					else //in explore mode
-					{
-						if (Hazzards[itemID].animal == false) return null;//not show worker in explore mode
-						if (Simulator.Random.Next(100) > 20) return null;//show 10% animals
-					}
-					CurrentHazzards.Add(itemID, Hazzards[itemID]);
-					return Hazzards[itemID];//successfully added the hazard with associated haz file
-				}
-			}
-			catch { }
-			return null;
-		}
+                    else if (Simulator.Activity != null)
+                    {
+                        if (Simulator.Random.Next(100) > Simulator.Activity.Tr_Activity.Tr_Activity_Header.Animals) return null;
+                    }
+                    else //in explore mode
+                    {
+                        if (Hazzards[itemID].animal == false) return null;//not show worker in explore mode
+                        if (Simulator.Random.Next(100) > 20) return null;//show 10% animals
+                    }
+                    CurrentHazzards.Add(itemID, Hazzards[itemID]);
+                    return Hazzards[itemID];//successfully added the hazard with associated haz file
+                }
+            }
+            catch { }
+            return null;
+        }
 
-		public void RemoveHazzardFromGame(int itemID)
-		{
-			try
-			{
-				if (CurrentHazzards.ContainsKey(itemID))
-				{
-					CurrentHazzards.Remove(itemID);
-				}
-			}
-			catch { };
-		}
+        public void RemoveHazzardFromGame(int itemID)
+        {
+            try
+            {
+                if (CurrentHazzards.ContainsKey(itemID))
+                {
+                    CurrentHazzards.Remove(itemID);
+                }
+            }
+            catch { };
+        }
 
-		[CallOnThread("Updater")]
-		public void Update(float elapsedClockSeconds)
-		{
-			var playerLocation = Simulator.PlayerLocomotive.WorldPosition.WorldLocation;
+        [CallOnThread("Updater")]
+        public void Update(float elapsedClockSeconds)
+        {
+            var playerLocation = Simulator.PlayerLocomotive.WorldPosition.WorldLocation;
 
-			foreach (var haz in Hazzards)
-			{
-				haz.Value.Update(playerLocation, approachDist, scaredDist);
-			}
-		}
+            foreach (var haz in Hazzards)
+            {
+                haz.Value.Update(playerLocation, approachDist, scaredDist);
+            }
+        }
 
-		public void Horn()
-		{
-			var playerLocation = Simulator.PlayerLocomotive.WorldPosition.WorldLocation;
-			foreach (var haz in Hazzards)
-			{
-				if (WorldLocation.Within(haz.Value.Location, playerLocation, hornDist))
-				{
-					haz.Value.state = Hazzard.State.LookLeft;
-				}
-			}
-		}
-	}
+        public void Horn()
+        {
+            var playerLocation = Simulator.PlayerLocomotive.WorldPosition.WorldLocation;
+            foreach (var haz in Hazzards)
+            {
+                if (WorldLocation.Within(haz.Value.Location, playerLocation, hornDist))
+                {
+                    haz.Value.state = Hazzard.State.LookLeft;
+                }
+            }
+        }
+    }
 
-	public class Hazzard
-	{
+    public class Hazzard
+    {
         readonly TrackNode TrackNode;
 
         internal WorldLocation Location;
-		public HazardFile HazFile { get { return hazF; } set { hazF = value; if (hazF.Tr_HazardFile.Workers != null) animal = false; else animal = true; } }
-		public HazardFile hazF;
-		public enum State { Idle1, Idle2, LookLeft, LookRight, Scared };
-		public State state;
-		public bool animal = true;
+        public HazardFile HazFile { get { return hazF; } set { hazF = value; if (hazF.Tr_HazardFile.Workers != null) animal = false; else animal = true; } }
+        public HazardFile hazF;
+        public enum State { Idle1, Idle2, LookLeft, LookRight, Scared };
+        public State state;
+        public bool animal = true;
 
-		public Hazzard(TrackNode trackNode, TrItem trItem)
+        public Hazzard(TrackNode trackNode, TrItem trItem)
         {
             TrackNode = trackNode;
             Location = new WorldLocation(trItem.TileX, trItem.TileZ, trItem.X, trItem.Y, trItem.Z);
-			state = State.Idle1;
+            state = State.Idle1;
         }
 
-		public void Update(WorldLocation playerLocation, int approachDist, int scaredDist)
-		{
-			if (state == State.Idle1)
-			{
-				if (Simulator.Random.Next(10) == 0) state = State.Idle2;
-			}
-			else if (state == State.Idle2)
-			{
-				if (Simulator.Random.Next(5) == 0) state = State.Idle1;
-			}
+        public void Update(WorldLocation playerLocation, int approachDist, int scaredDist)
+        {
+            if (state == State.Idle1)
+            {
+                if (Simulator.Random.Next(10) == 0) state = State.Idle2;
+            }
+            else if (state == State.Idle2)
+            {
+                if (Simulator.Random.Next(5) == 0) state = State.Idle1;
+            }
 
             if (!WorldLocation.Within(Location, playerLocation, scaredDist) && state < State.LookLeft)
             {
@@ -165,6 +165,6 @@ namespace Orts.Simulation
             {
                 state = State.Scared;
             }
-       }
-	}
+        }
+    }
 }

--- a/Source/Orts.Simulation/Simulation/LevelCrossing.cs
+++ b/Source/Orts.Simulation/Simulation/LevelCrossing.cs
@@ -31,7 +31,7 @@ namespace Orts.Simulation
     public class LevelCrossings
     {
         const float MaximumActivationDistance = 2000;
-        
+
         readonly Simulator Simulator;
         public readonly Dictionary<int, LevelCrossingItem> TrackCrossingItems;
         public readonly Dictionary<int, LevelCrossingItem> RoadCrossingItems;
@@ -42,7 +42,7 @@ namespace Orts.Simulation
         public LevelCrossings(Simulator simulator)
         {
             Simulator = simulator;
-            TrackCrossingItems = simulator.TDB != null && simulator.TDB.TrackDB != null && simulator.TDB.TrackDB.TrackNodes != null && simulator.TDB.TrackDB.TrItemTable != null 
+            TrackCrossingItems = simulator.TDB != null && simulator.TDB.TrackDB != null && simulator.TDB.TrackDB.TrackNodes != null && simulator.TDB.TrackDB.TrItemTable != null
                 ? GetLevelCrossingsFromDB(simulator.TDB.TrackDB.TrackNodes, simulator.TDB.TrackDB.TrItemTable) : new Dictionary<int, LevelCrossingItem>();
             RoadCrossingItems = simulator.RDB != null && simulator.RDB.RoadTrackDB != null && simulator.RDB.RoadTrackDB.TrackNodes != null && simulator.RDB.RoadTrackDB.TrItemTable != null
                 ? GetLevelCrossingsFromDB(simulator.RDB.RoadTrackDB.TrackNodes, simulator.RDB.RoadTrackDB.TrItemTable) : new Dictionary<int, LevelCrossingItem>();
@@ -94,7 +94,7 @@ namespace Orts.Simulation
             var absSpeedMpS = Math.Abs(speedMpS);
             var maxSpeedMpS = train.AllowedMaxSpeedMpS;
             var minCrossingActivationSpeed = 5.0f;  //5.0MpS is equalivalent to 11.1mph.  This is the estimated min speed that MSTS uses to activate the gates when in range.
-            
+
 
             bool validTrain = false;
             bool validStaticConsist = false;
@@ -205,11 +205,11 @@ namespace Orts.Simulation
                 if ((train.TrainType == Train.TRAINTYPE.STATIC) && validStaticConsist)
                 {
                     // This process is to raise the crossing gates if a loose consist rolls through the crossing.
-                    if(speedMpS > 0)
+                    if (speedMpS > 0)
                     {
                         frontDist = crossing.DistanceTo(train.FrontTDBTraveller, minimumDist);
                         rearDist = crossing.DistanceTo(train.RearTDBTraveller, minimumDist);
-                                                
+
                         if (frontDist < 0 && rearDist < 0)
                             crossing.RemoveTrain(train);
                     }
@@ -225,7 +225,7 @@ namespace Orts.Simulation
                     if (frontDist < 0 && rearDist < 0)
                         rearDist = crossing.DistanceTo(new Traveller(train.RearTDBTraveller, Traveller.TravellerDirection.Backward), adjustDist);
 
-                   // Testing distance before crossing
+                    // Testing distance before crossing
                     if (frontDist > 0 && frontDist <= adjustDist)
                         crossing.AddTrain(train);
 
@@ -302,7 +302,7 @@ namespace Orts.Simulation
         public LevelCrossingItem SearchNearLevelCrossing(Train train, float reqDist, bool trainForwards, out float frontDist)
         {
             LevelCrossingItem roadItem = LevelCrossingItem.None;
-           frontDist = -1;
+            frontDist = -1;
             Traveller traveller = trainForwards ? train.FrontTDBTraveller :
                 new Traveller(train.RearTDBTraveller, Traveller.TravellerDirection.Backward);
             foreach (var crossing in TrackCrossingItems.Values.Where(ci => ci.CrossingGroup != null))
@@ -347,7 +347,7 @@ namespace Orts.Simulation
             Location = new WorldLocation(trItem.TileX, trItem.TileZ, trItem.X, trItem.Y, trItem.Z);
         }
 
-        public LevelCrossingItem ()
+        public LevelCrossingItem()
         {
 
         }
@@ -355,7 +355,7 @@ namespace Orts.Simulation
         [CallOnThread("Updater")]
         public void AddTrain(Train train)
         {
-            if(train.TrainType == Train.TRAINTYPE.STATIC)
+            if (train.TrainType == Train.TRAINTYPE.STATIC)
             {
                 var staticConsists = StaticConsists;
                 if (!staticConsists.Contains(train))
@@ -407,7 +407,7 @@ namespace Orts.Simulation
                     StaticConsists = newStaticConsists;
                 }
             }
-            else if(trains.Count > 0)
+            else if (trains.Count > 0)
             {
                 if (trains.Contains(train))
                 {
@@ -434,7 +434,7 @@ namespace Orts.Simulation
         internal readonly List<LevelCrossingItem> Items;
         internal readonly float WarningTime;
         internal readonly float MinimumDistance;
-        
+
         public LevelCrossing(IEnumerable<LevelCrossingItem> items, float warningTime, float minimumDistance)
         {
             Items = new List<LevelCrossingItem>(items);

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -160,8 +160,8 @@ namespace Orts.Simulation.Physics
             }
         }
 
-// Carriage Steam Heating
-public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
+        // Carriage Steam Heating
+        public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         public float TrainInsideTempC;                  // Desired inside temperature for carriage steam heating depending upon season
         public float TrainOutsideTempC;                 // External ambient temeprature for carriage steam heating.
         public float TrainSteamHeatLossWpT;             // Total Steam Heat loss of train
@@ -194,7 +194,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         {
             get
             {
-               return Simulator.Settings.WindResistanceDependent;
+                return Simulator.Settings.WindResistanceDependent;
             }
         }
 
@@ -208,7 +208,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         //To investigate coupler breaks on route
         private bool numOfCouplerBreaksNoted = false;
         public static int NumOfCouplerBreaks = 0;//Debrief Eval
-        public bool DbfEvalValueChanged { get;set; }//Debrief Eval
+        public bool DbfEvalValueChanged { get; set; }//Debrief Eval
 
         public enum TRAINTYPE
         {
@@ -502,7 +502,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         public virtual bool GetWagonsAttachedIndication()
         {
             WagonsAttached = false;
-             foreach (TrainCar car in Cars)
+            foreach (TrainCar car in Cars)
             {
                 // Test to see if freight or passenger wagons attached (used to set BC pressure in locomotive or wagons)
                 if (car.WagonType == MSTSWagon.WagonTypes.Freight || car.WagonType == MSTSWagon.WagonTypes.Passenger)
@@ -514,8 +514,8 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 {
                     WagonsAttached = false;
                 }
-             }
-             return WagonsAttached; 
+            }
+            return WagonsAttached;
         }
 
         //================================================================================================//
@@ -1371,7 +1371,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     }
                 }
                 return skip;
-            } 
+            }
         }
 
         //================================================================================================//
@@ -1570,7 +1570,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
             if (IsActualPlayerTrain && Simulator.Settings.Autopilot && Simulator.Settings.ActRandomizationLevel > 0 && Simulator.ActivityRun != null) // defects might occur
             {
-                CheckFailures (elapsedClockSeconds);
+                CheckFailures(elapsedClockSeconds);
             }
 
             // Update train physics, position and movement
@@ -1785,7 +1785,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             UpdateCarSpeeds(elapsedClockSeconds);
             UpdateCouplerSlack(elapsedClockSeconds);
 
-//            Trace.TraceInformation("CouplerSlack - CarID {0} Slack1M {1} Slack2M {2}", Cars[3].CarID, Cars[3].CouplerSlackM, Cars[3].CouplerSlack2M);
+            //            Trace.TraceInformation("CouplerSlack - CarID {0} Slack1M {1} Slack2M {2}", Cars[3].CarID, Cars[3].CouplerSlackM, Cars[3].CouplerSlack2M);
 
             // Update wind elements for the train, ie the wind speed, and direction, as well as the angle between the train and wind
             UpdateWindComponents();
@@ -1871,7 +1871,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 else
                     ResultantWindComponentDeg = 0.0f;
 
-//                Trace.TraceInformation("WindDeg {0} TrainDeg {1} ResWindDeg {2}", PhysicsWindDirectionDeg, PhysicsTrainLocoDirectionDeg, ResultantWindComponentDeg);
+                //                Trace.TraceInformation("WindDeg {0} TrainDeg {1} ResWindDeg {2}", PhysicsWindDirectionDeg, PhysicsTrainLocoDirectionDeg, ResultantWindComponentDeg);
 
                 // Correct wind direction if it is greater then 360 deg, then correct to a value less then 360
                 if (Math.Abs(ResultantWindComponentDeg) > 360)
@@ -1885,7 +1885,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
                 WindResultantSpeedMpS = (float)Math.Sqrt(TrainSpeedMpS * TrainSpeedMpS + PhysicsWindSpeedMpS * PhysicsWindSpeedMpS + 2.0f * TrainSpeedMpS * PhysicsWindSpeedMpS * (float)Math.Cos(WindAngleRad));
 
-//                Trace.TraceInformation("WindResultant {0} ResWindDeg {1}", WindResultantSpeedMpS, ResultantWindComponentDeg);
+                //                Trace.TraceInformation("WindResultant {0} ResWindDeg {1}", WindResultantSpeedMpS, ResultantWindComponentDeg);
             }
             else
             {
@@ -1982,7 +1982,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         {
             var mstsLocomotive = Cars[0] as MSTSLocomotive;
             if (mstsLocomotive != null)
-            { 
+            {
 
                 // Check to confirm that train is player driven and has passenger cars in the consist.
                 if (IsPlayerDriven && PassengerCarsNumber > 0 && mstsLocomotive.TrainFittedSteamHeat)
@@ -2037,10 +2037,10 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                                 // TO BE CHECKED
                                 TrainCurrentCarriageHeatTempC = TrainOutsideTempC - (((TrainInsideTempC - TrainOutsideTempC) * TrainCurrentTrainSteamHeatW) / TrainTotalSteamHeatW);
                             }
-                            
+
                         }
 
-        
+
                         TrainSteamPipeHeatConvW = (PipeHeatTransCoeffWpM2K * TrainHeatPipeAreaM2 * (C.ToK(TrainCurrentSteamHeatPipeTempC) - C.ToK(TrainCurrentCarriageHeatTempC)));
                         float PipeTempAK = (float)Math.Pow(C.ToK(TrainCurrentSteamHeatPipeTempC), 4.0f);
                         float PipeTempBK = (float)Math.Pow(C.ToK(TrainCurrentCarriageHeatTempC), 4.0f);
@@ -2524,13 +2524,13 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
         public void UpdateTurntable(float elapsedClockSeconds)
         {
- //           UpdateTrainPosition();                                                                // position update                  //
+            //           UpdateTrainPosition();                                                                // position update                  //
             if (LeadLocomotive != null && (LeadLocomotive.ThrottlePercent >= 1 || Math.Abs(LeadLocomotive.SpeedMpS) > 0.05 || !(LeadLocomotive.Direction == Direction.N
             || Math.Abs(MUReverserPercent) <= 1)) || ControlMode != TRAIN_CONTROL.TURNTABLE)
-                // Go to emergency.
-                {
-                    ((MSTSLocomotive)LeadLocomotive).SetEmergency(true);
-                }
+            // Go to emergency.
+            {
+                ((MSTSLocomotive)LeadLocomotive).SetEmergency(true);
+            }
         }
 
         //================================================================================================//
@@ -2643,7 +2643,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     var speed_info = thisSpeedpost.this_lim_speed(MstsSignalFunction.SPEED);
 
                     AllowedMaxSpeedMpS = Math.Min(AllowedMaxSpeedMpS, IsFreight ? speed_info.speed_freight : speed_info.speed_pass);
-                    allowedAbsoluteMaxSpeedLimitMpS =  Math.Min(allowedAbsoluteMaxSpeedLimitMpS , IsFreight ? speed_info.speed_freight : speed_info.speed_pass);
+                    allowedAbsoluteMaxSpeedLimitMpS = Math.Min(allowedAbsoluteMaxSpeedLimitMpS, IsFreight ? speed_info.speed_freight : speed_info.speed_pass);
                 }
 
                 float validSpeedMpS = AllowedMaxSpeedMpS;
@@ -2967,7 +2967,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                             {
                                 speedLimit = new ActivateSpeedLimit(reqDistance, firstObject.actual_speed, firstObject.actual_speed);
                             }
-                            
+
                             requiredActions.InsertAction(speedLimit);
                             requiredActions.UpdatePendingSpeedlimits(firstObject.actual_speed);  // update any older pending speed limits
                         }
@@ -3348,7 +3348,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 }
 
                 if (validModeSwitch)
-                { 
+                {
                     SwitchToNodeControl(LastReservedSection[0]);
                 }
             }
@@ -4085,7 +4085,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             {
                 Cars[i].CouplerForceU -= Cars[i + 1].CouplerForceG * Cars[i + 1].CouplerForceU;
             }
-                
+
         }
 
 
@@ -4103,18 +4103,18 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             {
                 TrainCar car = Cars[i];
 
-            // if coupler in compression on this car, or coupler is not to be solved, then jump car
-                if (car.CouplerSlackM < 0 || car.CouplerForceB >= 1) 
+                // if coupler in compression on this car, or coupler is not to be solved, then jump car
+                if (car.CouplerSlackM < 0 || car.CouplerForceB >= 1)
                     continue;
 
                 if (Simulator.UseAdvancedAdhesion && car.IsAdvancedCoupler) // "Advanced coupler" - operates in three extension zones
                 {
                     float maxs0 = car.GetMaximumCouplerSlack0M();
 
-                    if (car.CouplerSlackM < maxs0 )
- //               if (car.CouplerSlackM < maxs0 || car.CouplerForceU > 0)  // In Zone 1 set coupler forces to zero, as coupler faces not touching, or if coupler force is in the opposite direction, ie compressing ( +ve CouplerForceU )
+                    if (car.CouplerSlackM < maxs0)
+                    //               if (car.CouplerSlackM < maxs0 || car.CouplerForceU > 0)  // In Zone 1 set coupler forces to zero, as coupler faces not touching, or if coupler force is in the opposite direction, ie compressing ( +ve CouplerForceU )
                     {
-//                        Trace.TraceInformation("FixCoupler #1 - Tension - CardId {0} SlackM {1} Slack2M {2} Maxs0 {3} Force {4}", car.CarID, car.CouplerSlackM, car.CouplerSlack2M, maxs0, car.CouplerForceU);
+                        //                        Trace.TraceInformation("FixCoupler #1 - Tension - CardId {0} SlackM {1} Slack2M {2} Maxs0 {3} Force {4}", car.CarID, car.CouplerSlackM, car.CouplerSlack2M, maxs0, car.CouplerForceU);
                         SetCouplerForce(car, 0);
                         return true;
                     }
@@ -4123,7 +4123,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 {
                     float maxs1 = car.GetMaximumCouplerSlack1M();
                     // In Zone 1 set coupler forces to zero, as coupler faces not touching, or if coupler force is in the opposite direction, ie compressing ( +ve CouplerForceU )
-                    if (car.CouplerSlackM < maxs1 || car.CouplerForceU > 0) 
+                    if (car.CouplerSlackM < maxs1 || car.CouplerForceU > 0)
                     {
                         SetCouplerForce(car, 0);
                         return true;
@@ -4132,7 +4132,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             }
 
 
-           // Coupler in compression
+            // Coupler in compression
             for (int i = Cars.Count - 1; i >= 0; i--)
             {
                 TrainCar car = Cars[i];
@@ -4146,9 +4146,9 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     float maxs0 = car.GetMaximumCouplerSlack0M();
 
                     if (car.CouplerSlackM > -maxs0)
-//                    if (car.CouplerSlackM > -maxs0 || car.CouplerForceU < 0) // In Zone 1 set coupler forces to zero, as coupler faces not touching, or if coupler force is in the opposite direction, ie in tension ( -ve CouplerForceU )
+                    //                    if (car.CouplerSlackM > -maxs0 || car.CouplerForceU < 0) // In Zone 1 set coupler forces to zero, as coupler faces not touching, or if coupler force is in the opposite direction, ie in tension ( -ve CouplerForceU )
                     {
-//                        Trace.TraceInformation("FixCoupler #2 - Compression - CardId {0} SlackM {1} Slack2M {2} Maxs0 {3} Force {4}", car.CarID, car.CouplerSlackM, car.CouplerSlack2M, maxs0, car.CouplerForceU);
+                        //                        Trace.TraceInformation("FixCoupler #2 - Compression - CardId {0} SlackM {1} Slack2M {2} Maxs0 {3} Force {4}", car.CarID, car.CouplerSlackM, car.CouplerSlack2M, maxs0, car.CouplerForceU);
                         SetCouplerForce(car, 0);
                         return true;
                     }
@@ -4158,7 +4158,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
                     float maxs1 = car.GetMaximumCouplerSlack1M();
                     // In Zone 1 set coupler forces to zero, as coupler faces not touching, or if coupler force is in the opposite direction, ie in tension ( -ve CouplerForceU )
-                    if (car.CouplerSlackM > -maxs1 || car.CouplerForceU < 0) 
+                    if (car.CouplerSlackM > -maxs1 || car.CouplerForceU < 0)
                     {
                         SetCouplerForce(car, 0);
                         return true;
@@ -4197,7 +4197,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     continue;
                 if (car.CouplerSlackM < car.CouplerSlack2M || car.CouplerForceU > 0)
                 {
- //                   Trace.TraceInformation("FixCouplerImpulse #1 - Tension - CardId {0} SlackM {1} Slack2M {2} Force {3}", car.CarID, car.CouplerSlackM, car.CouplerSlack2M, car.CouplerForceU);
+                    //                   Trace.TraceInformation("FixCouplerImpulse #1 - Tension - CardId {0} SlackM {1} Slack2M {2} Force {3}", car.CarID, car.CouplerSlackM, car.CouplerSlack2M, car.CouplerForceU);
                     SetCouplerForce(car, 0);
                     return true;
                 }
@@ -4211,7 +4211,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     continue;
                 if (car.CouplerSlackM > -car.CouplerSlack2M || car.CouplerForceU < 0)
                 {
-//                    Trace.TraceInformation("FixCouplerImpulse #2 - Tension - CardId {0} SlackM {1} Slack2M {2} Force {3}", car.CarID, car.CouplerSlackM, car.CouplerSlack2M, car.CouplerForceU);
+                    //                    Trace.TraceInformation("FixCouplerImpulse #2 - Tension - CardId {0} SlackM {1} Slack2M {2} Force {3}", car.CarID, car.CouplerSlackM, car.CouplerSlack2M, car.CouplerForceU);
                     SetCouplerForce(car, 0);
                     return true;
                 }
@@ -4235,14 +4235,14 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             {
                 TrainCar car = Cars[i];
 
-                    float max = car.CouplerSlack2M;
-                    if (-max < car.CouplerSlackM && car.CouplerSlackM < max)
-                    {
-                        car.CouplerForceB = 1;
-                        car.CouplerForceA = car.CouplerForceC = car.CouplerForceR = 0;
-                    }
-                    else
-                        car.CouplerForceR = Cars[i + 1].SpeedMpS - car.SpeedMpS;
+                float max = car.CouplerSlack2M;
+                if (-max < car.CouplerSlackM && car.CouplerSlackM < max)
+                {
+                    car.CouplerForceB = 1;
+                    car.CouplerForceA = car.CouplerForceC = car.CouplerForceR = 0;
+                }
+                else
+                    car.CouplerForceR = Cars[i + 1].SpeedMpS - car.SpeedMpS;
             }
 
             do
@@ -4297,23 +4297,23 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     Cars[i].TotalForceN += Cars[i].FrictionForceN + Cars[i].BrakeForceN + Cars[i].CurveForceN + Cars[i].WindForceN + Cars[i].TunnelForceN + +Cars[i].DynamicBrakeForceN;
             }
 
-                if (Cars.Count < 2)
-                    return;
+            if (Cars.Count < 2)
+                return;
 
-                SetupCouplerForceEquations(); // Based upon the car Mass, set up LH side forces (ABC) parameters
+            SetupCouplerForceEquations(); // Based upon the car Mass, set up LH side forces (ABC) parameters
 
-                // Calculate RH side coupler force
-                // Whilever coupler faces not in contact, then "zero coupler force" by setting A = C = R = 0
-                // otherwise R is calculated based on difference in acceleration between cars, or stiffness and damping value
-                for (int i = 0; i < Cars.Count - 1; i++)
+            // Calculate RH side coupler force
+            // Whilever coupler faces not in contact, then "zero coupler force" by setting A = C = R = 0
+            // otherwise R is calculated based on difference in acceleration between cars, or stiffness and damping value
+            for (int i = 0; i < Cars.Count - 1; i++)
+            {
+                TrainCar car = Cars[i];
+                if (Simulator.UseAdvancedAdhesion && car.IsAdvancedCoupler) // "Advanced coupler" - operates in three extension zones
                 {
-                        TrainCar car = Cars[i];
-                    if (Simulator.UseAdvancedAdhesion && car.IsAdvancedCoupler) // "Advanced coupler" - operates in three extension zones
-                    {
                     float max0 = car.GetMaximumCouplerSlack0M();
                     float max1 = car.GetMaximumCouplerSlack1M();
 
-                    if ( car.CouplerSlackM > -max0 && car.CouplerSlackM < max0) // Zone 1 coupler faces not in contact - no force generated
+                    if (car.CouplerSlackM > -max0 && car.CouplerSlackM < max0) // Zone 1 coupler faces not in contact - no force generated
                     {
                         car.CouplerForceB = 1;
                         car.CouplerForceA = car.CouplerForceC = car.CouplerForceR = 0;
@@ -4328,41 +4328,41 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     }
 
                 }
-                    else // "Simple coupler" - operates on two extension zones, coupler faces not in contact, and coupler fuller in contact
-                    {
-                        float max = car.GetMaximumCouplerSlack1M();
-                        if (-max < car.CouplerSlackM && car.CouplerSlackM < max)
-                        {
-                            car.CouplerForceB = 1;
-                            car.CouplerForceA = car.CouplerForceC = car.CouplerForceR = 0;
-                        }
-                        else
-                            car.CouplerForceR = Cars[i + 1].TotalForceN / Cars[i + 1].MassKG - car.TotalForceN / car.MassKG;
-                    }
-                }
-
-                // Solve coupler forces to find CouplerForceU
-                do
-                    SolveCouplerForceEquations();
-                while (FixCouplerForceEquations());
-
-                for (int i = 0; i < Cars.Count - 1; i++)
+                else // "Simple coupler" - operates on two extension zones, coupler faces not in contact, and coupler fuller in contact
                 {
-                    // Calculate total forces on cars
-                    TrainCar car = Cars[i];
-                    car.TotalForceN += car.CouplerForceU;
-                    Cars[i + 1].TotalForceN -= car.CouplerForceU;
+                    float max = car.GetMaximumCouplerSlack1M();
+                    if (-max < car.CouplerSlackM && car.CouplerSlackM < max)
+                    {
+                        car.CouplerForceB = 1;
+                        car.CouplerForceA = car.CouplerForceC = car.CouplerForceR = 0;
+                    }
+                    else
+                        car.CouplerForceR = Cars[i + 1].TotalForceN / Cars[i + 1].MassKG - car.TotalForceN / car.MassKG;
+                }
+            }
 
-                    // Find max coupler force on the car - currently doesn't appear to be used anywhere
-                    if (MaximumCouplerForceN < Math.Abs(car.CouplerForceU))
-                        MaximumCouplerForceN = Math.Abs(car.CouplerForceU);
+            // Solve coupler forces to find CouplerForceU
+            do
+                SolveCouplerForceEquations();
+            while (FixCouplerForceEquations());
 
-                    // Update couplerslack2m which acts as an upper limit in slack calculations
-                    float maxs = car.GetMaximumCouplerSlack2M();
+            for (int i = 0; i < Cars.Count - 1; i++)
+            {
+                // Calculate total forces on cars
+                TrainCar car = Cars[i];
+                car.TotalForceN += car.CouplerForceU;
+                Cars[i + 1].TotalForceN -= car.CouplerForceU;
+
+                // Find max coupler force on the car - currently doesn't appear to be used anywhere
+                if (MaximumCouplerForceN < Math.Abs(car.CouplerForceU))
+                    MaximumCouplerForceN = Math.Abs(car.CouplerForceU);
+
+                // Update couplerslack2m which acts as an upper limit in slack calculations
+                float maxs = car.GetMaximumCouplerSlack2M();
 
                 if (Simulator.UseAdvancedAdhesion && car.IsAdvancedCoupler) // "Advanced coupler" - operates in three extension zones
                 {
-                             car.CouplerSlack2M = maxs;
+                    car.CouplerSlack2M = maxs;
                 }
                 else
                 {
@@ -4467,7 +4467,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 int j = i;
                 float f = 0;
                 float m = 0;
-                for (;;)
+                for (; ; )
                 {
                     f += car.TotalForceN - (car.FrictionForceN + car.BrakeForceN + car.CurveForceN + car.WindForceN + car.TunnelForceN + car.DynamicBrakeForceN);
                     m += car.MassKG;
@@ -4508,7 +4508,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 int j = i;
                 float f = 0;
                 float m = 0;
-                for (;;)
+                for (; ; )
                 {
                     f += car.TotalForceN + car.FrictionForceN + car.BrakeForceN + car.CurveForceN + car.WindForceN + car.TunnelForceN + car.DynamicBrakeForceN;
                     m += car.MassKG;
@@ -4563,16 +4563,16 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
                 TotalCouplerSlackM += car.CouplerSlackM; // Total coupler slack displayed in HUD only
 
-//                Trace.TraceInformation("Slack - CarID {0} Slack {1} Zero {2} MaxSlack0 {3} MaxSlack1 {4} MaxSlack2 {5} Damping1 {6} Damping2 {7} Stiffness1 {8} Stiffness2 {9} AdvancedCpl {10} CplSlackA {11} CplSlackB {12}", 
-//                    car.CarID, car.CouplerSlackM, car.GetCouplerZeroLengthM(), car.GetMaximumCouplerSlack0M(),
-//                    car.GetMaximumCouplerSlack1M(), car.GetMaximumCouplerSlack2M(), car.GetCouplerDamping1NMpS(), car.GetCouplerDamping2NMpS(), 
-//                    car.GetCouplerStiffness1NpM(), car.GetCouplerStiffness1NpM(), car.IsAdvancedCoupler, car.GetCouplerSlackAM(), car.GetCouplerSlackBM());
+                //                Trace.TraceInformation("Slack - CarID {0} Slack {1} Zero {2} MaxSlack0 {3} MaxSlack1 {4} MaxSlack2 {5} Damping1 {6} Damping2 {7} Stiffness1 {8} Stiffness2 {9} AdvancedCpl {10} CplSlackA {11} CplSlackB {12}", 
+                //                    car.CarID, car.CouplerSlackM, car.GetCouplerZeroLengthM(), car.GetMaximumCouplerSlack0M(),
+                //                    car.GetMaximumCouplerSlack1M(), car.GetMaximumCouplerSlack2M(), car.GetCouplerDamping1NMpS(), car.GetCouplerDamping2NMpS(), 
+                //                    car.GetCouplerStiffness1NpM(), car.GetCouplerStiffness1NpM(), car.IsAdvancedCoupler, car.GetCouplerSlackAM(), car.GetCouplerSlackBM());
 
                 if (car.CouplerSlackM >= 0.001) // Coupler pulling
                 {
                     NPull++;
-                    car.HUDCouplerForceIndication = 1; 
-                }                    
+                    car.HUDCouplerForceIndication = 1;
+                }
                 else if (car.CouplerSlackM <= -0.001)
                 {
                     NPush++;
@@ -4582,7 +4582,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 {
                     car.HUDCouplerForceIndication = 0;
                 }
-                    
+
             }
             foreach (TrainCar car in Cars)
                 car.DistanceM += Math.Abs(car.SpeedMpS * elapsedTime);
@@ -4965,15 +4965,15 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             // if rear is in platform, station is valid
             if (((((beginSectionRouteIndex != -1 && PresentPosition[1].RouteListIndex == beginSectionRouteIndex) || (PresentPosition[1].RouteListIndex == -1 && PresentPosition[1].TCSectionIndex == beginSectionIndex))
                 && PresentPosition[1].TCOffset >= platformBeginOffset) || PresentPosition[1].RouteListIndex > beginSectionRouteIndex) &&
-                ((PresentPosition[1].TCSectionIndex == endSectionIndex && PresentPosition[1].TCOffset <= platformEndOffset) || endSectionRouteIndex == -1 || 
+                ((PresentPosition[1].TCSectionIndex == endSectionIndex && PresentPosition[1].TCOffset <= platformEndOffset) || endSectionRouteIndex == -1 ||
                 PresentPosition[1].RouteListIndex < endSectionRouteIndex))
             {
                 atStation = true;
             }
             // if front is in platform and most of the train is as well, station is valid
             else if (((((endSectionRouteIndex != -1 && PresentPosition[0].RouteListIndex == endSectionRouteIndex) || (PresentPosition[0].RouteListIndex == -1 && PresentPosition[0].TCSectionIndex == endSectionIndex))
-                && PresentPosition[0].TCOffset <= platformEndOffset) && ((thisPlatform.Length - (platformEndOffset - PresentPosition[0].TCOffset)) > Length / 2)) || 
-                (PresentPosition[0].RouteListIndex != -1 && PresentPosition[0].RouteListIndex < endSectionRouteIndex && 
+                && PresentPosition[0].TCOffset <= platformEndOffset) && ((thisPlatform.Length - (platformEndOffset - PresentPosition[0].TCOffset)) > Length / 2)) ||
+                (PresentPosition[0].RouteListIndex != -1 && PresentPosition[0].RouteListIndex < endSectionRouteIndex &&
                 (PresentPosition[0].RouteListIndex > beginSectionRouteIndex || (PresentPosition[0].RouteListIndex == beginSectionRouteIndex && PresentPosition[0].TCOffset >= platformBeginOffset))))
             {
                 atStation = true;
@@ -4985,7 +4985,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 atStation = true;
             }
             // if front is beyond platform and rear is not on route or before platform : train spans platform
-            else if (((endSectionRouteIndex != -1 && PresentPosition[0].RouteListIndex > endSectionRouteIndex )|| (endSectionRouteIndex != -1 && PresentPosition[0].RouteListIndex == endSectionRouteIndex && PresentPosition[0].TCOffset >= platformEndOffset))
+            else if (((endSectionRouteIndex != -1 && PresentPosition[0].RouteListIndex > endSectionRouteIndex) || (endSectionRouteIndex != -1 && PresentPosition[0].RouteListIndex == endSectionRouteIndex && PresentPosition[0].TCOffset >= platformEndOffset))
                   && (PresentPosition[1].RouteListIndex < beginSectionRouteIndex || (PresentPosition[1].RouteListIndex == beginSectionRouteIndex && PresentPosition[1].TCOffset <= platformBeginOffset)))
             {
                 atStation = true;
@@ -5293,9 +5293,9 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             foreach (var tcRouteSubpath in TCRoute.TCRouteSubpaths)
             {
                 tcRouteSubpathIndex++;
-                if (tcRouteSubpathIndex > 0 && TCRoute.ReversalInfo[tcRouteSubpathIndex-1].Valid) pathLength += TCRoute.ReversalInfo[tcRouteSubpathIndex-1].ReverseReversalOffset;
-                else if (tcRouteSubpathIndex > 0) pathLength += TCRoute.ReversalInfo[tcRouteSubpathIndex-1].ReverseReversalOffset -
-                    signalRef.TrackCircuitList[TCRoute.ReversalInfo[tcRouteSubpathIndex-1].ReversalSectionIndex].Length;
+                if (tcRouteSubpathIndex > 0 && TCRoute.ReversalInfo[tcRouteSubpathIndex - 1].Valid) pathLength += TCRoute.ReversalInfo[tcRouteSubpathIndex - 1].ReverseReversalOffset;
+                else if (tcRouteSubpathIndex > 0) pathLength += TCRoute.ReversalInfo[tcRouteSubpathIndex - 1].ReverseReversalOffset -
+                    signalRef.TrackCircuitList[TCRoute.ReversalInfo[tcRouteSubpathIndex - 1].ReversalSectionIndex].Length;
                 else { } //start point offset?
                 int routeListIndex = 1;
                 TrackCircuitSection thisSection;
@@ -5828,7 +5828,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             bool[] nextRoute = UpdateRouteActions(elapsedClockSeconds, false);
 
             AuxActionsContain.SetAuxAction(this);
-            if (!nextRoute[0]) return(true);  // not at end of route
+            if (!nextRoute[0]) return (true);  // not at end of route
 
             // check if train reversed
 
@@ -6263,7 +6263,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                         endOfRoute = true;
                     }
                 }
-                
+
                 //<CSComment: check of vicinity to reverse point; only in subpaths ending with reversal
                 if (TCRoute.ReversalInfo[TCRoute.activeSubpath].Valid)
                 {
@@ -7954,7 +7954,8 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     foreach (var tcRouteElement in ValidRoute[1])
                     {
                         var tcSection = signalRef.TrackCircuitList[tcRouteElement.TCSectionIndex];
-                        if (tcSection.CheckReserved(routedBackward) && !tcSection.CircuitState.TrainOccupy.ContainsTrain(this))                        {
+                        if (tcSection.CheckReserved(routedBackward) && !tcSection.CircuitState.TrainOccupy.ContainsTrain(this))
+                        {
                             tcSection.Unreserve();
                             tcSection.UnreserveTrain();
                         }
@@ -9579,7 +9580,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         {
             // check for any stations in abandoned path
             if (ControlMode == TRAIN_CONTROL.AUTO_SIGNAL || ControlMode == TRAIN_CONTROL.AUTO_NODE)
-                // Local trains, having a defined TCRoute
+            // Local trains, having a defined TCRoute
             {
                 int actSubpath = TCRoute.activeSubpath;
                 Dictionary<int, StationStop> abdStations = new Dictionary<int, StationStop>();
@@ -9696,7 +9697,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                         TCRoute.LoopEnd.RemoveAt(TCRoute.activeSubpath);
                     }
                     TCRoute.activeSubpath = TCRoute.OriginalSubpath;
-                    TCRoute.OriginalSubpath = - 1;
+                    TCRoute.OriginalSubpath = -1;
 
                     // readjust item indexes
                     // Reindexes ReversalInfo items
@@ -9952,7 +9953,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
             if (ValidRoute[1] != null && ValidRoute[1].Count > 0)
             {
-                for(int iIndex = 0; iIndex < ValidRoute[1].Count; iIndex++)
+                for (int iIndex = 0; iIndex < ValidRoute[1].Count; iIndex++)
                 {
                     TCRouteElement thisElement = ValidRoute[1][iIndex];
                     TrackCircuitSection thisSection = signalRef.TrackCircuitList[thisElement.TCSectionIndex];
@@ -10167,7 +10168,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             // add present occupied sections to train route to avoid out-of-path detection
 
             AddTrackSections();
- 
+
             // reset signals etc.
 
             SignalObjectItems.Clear();
@@ -10699,7 +10700,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                                     (PresentPosition[1].TCSectionIndex == otherTrain.PresentPosition[1].TCSectionIndex && thisSectionIndex == PresentPosition[1].TCSectionIndex &&
                                     PresentPosition[1].TCOffset + otherTrain.PresentPosition[1].TCOffset - 1 > thisSection.Length))
                                 {
-                                    iElement = EndCommonSection(iElement, thisRoute, otherRoute); 
+                                    iElement = EndCommonSection(iElement, thisRoute, otherRoute);
                                 }
                                 else
                                 {
@@ -10896,7 +10897,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                                     PresentPosition[1].TCOffset + otherTrain.PresentPosition[1].TCOffset - 1 > thisSection.Length))
                                 {
                                     iElement = EndCommonSection(iElement, thisRoute, otherRoute);
-  
+
                                 }
                                 else
                                 {
@@ -11584,7 +11585,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 int sectionIndex = thisPlatform.TCSectionIndex[0];
                 int routeIndex = thisRoute.GetRouteIndex(sectionIndex, activeSubrouteNodeIndex);
                 // No backwards!
-                if (routeIndex >=0 && StationStops.Count > 0 && StationStops[StationStops.Count - 1].RouteIndex == routeIndex
+                if (routeIndex >= 0 && StationStops.Count > 0 && StationStops[StationStops.Count - 1].RouteIndex == routeIndex
                     && StationStops[StationStops.Count - 1].SubrouteIndex == activeSubroute
                     && StationStops[StationStops.Count - 1].PlatformItem.TCOffset[1, thisRoute[routeIndex].Direction] >= thisPlatform.TCOffset[1, thisRoute[routeIndex].Direction])
                 {
@@ -11604,7 +11605,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     routeIndex = thisRoute.GetRouteIndex(sectionIndex, activeSubrouteNodeIndex);
                 }
 
-                if (!Simulator.TimetableMode && routeIndex == thisRoute.Count -1 && TCRoute.ReversalInfo[activeSubroute].Valid)
+                if (!Simulator.TimetableMode && routeIndex == thisRoute.Count - 1 && TCRoute.ReversalInfo[activeSubroute].Valid)
                 {
                     // Check if station beyond reversal point
                     var direction = thisRoute[routeIndex].Direction;
@@ -11818,7 +11819,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 // determine stop position
                 float stopOffset = endOffset - (0.5f * deltaLength);
                 if (terminalStation && deltaLength > 0 && !Simulator.TimetableMode)
-                        stopOffset = endOffset - 1;
+                    stopOffset = endOffset - 1;
 
                 // beyond section : check for route validity (may not exceed route)
 
@@ -11916,7 +11917,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
                             if ((stopOffset - Length - beginOffset + thisPlatform.DistanceToSignals[useDirection]) < clearingDistanceM)
                             {
-                                if (!(terminalStation && deltaLength > 0 && !Simulator.TimetableMode)) 
+                                if (!(terminalStation && deltaLength > 0 && !Simulator.TimetableMode))
                                     stopOffset = beginOffset - thisPlatform.DistanceToSignals[useDirection] + Length + clearingDistanceM + 1.0f;
                             }
                         }
@@ -12135,13 +12136,13 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             return false;
         }
 
-            //================================================================================================//
-            /// <summary>
-            /// Check vicinity of reversal point to Platform
-            /// returns false if distance greater than preset value 
-            /// </summary>
+        //================================================================================================//
+        /// <summary>
+        /// Check vicinity of reversal point to Platform
+        /// returns false if distance greater than preset value 
+        /// </summary>
 
-            public bool CheckVicinityOfPlatformToReversalPoint(float tcOffset, int routeListIndex, int activeSubpath)
+        public bool CheckVicinityOfPlatformToReversalPoint(float tcOffset, int routeListIndex, int activeSubpath)
         {
             float Threshold = 100.0f;
             float lengthToGoM = -tcOffset;
@@ -12151,7 +12152,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 Trace.TraceWarning("Train {0} service {1}, platform off path; reversal point considered remote", Number, Name);
                 return false;
             }
-            int reversalRouteIndex =  TCRoute.TCRouteSubpaths[activeSubpath].GetRouteIndex(TCRoute.ReversalInfo[TCRoute.activeSubpath].ReversalSectionIndex, routeListIndex);
+            int reversalRouteIndex = TCRoute.TCRouteSubpaths[activeSubpath].GetRouteIndex(TCRoute.ReversalInfo[TCRoute.activeSubpath].ReversalSectionIndex, routeListIndex);
             if (reversalRouteIndex == -1)
             {
                 Trace.TraceWarning("Train {0} service {1}, reversal or end point off path; reversal point considered remote", Number, Name);
@@ -12219,7 +12220,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 {
                     endSectionFound = true;
                     if (routeIndex < thisRoute.Count - 1)
-                    endSignalIndex = thisSection.EndSignals[direction].thisRef;
+                        endSignalIndex = thisSection.EndSignals[direction].thisRef;
                 }
 
                 // check if next section is junction
@@ -12242,7 +12243,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                         endSectionFound = true;
                         lastIndex = nextIndex;
                         if (lastIndex < thisRoute.Count - 1)
-                        endSignalIndex = nextSection.EndSignals[direction].thisRef;
+                            endSignalIndex = nextSection.EndSignals[direction].thisRef;
                     }
                     else if (nextSection.CircuitType != TrackCircuitSection.TrackCircuitType.Normal)
                     {
@@ -12254,11 +12255,11 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
                 if (endSignalIndex > -1)
                 {
-                    AIActSigDelegateRef action = new AIActSigDelegateRef(this, Math.Max(waitingPoint[5]-1500, 0), 0f, waitingPoint[0], lastIndex, thisRoute[lastIndex].TCSectionIndex, direction);
+                    AIActSigDelegateRef action = new AIActSigDelegateRef(this, Math.Max(waitingPoint[5] - 1500, 0), 0f, waitingPoint[0], lastIndex, thisRoute[lastIndex].TCSectionIndex, direction);
                     signalRef.SignalObjects[endSignalIndex].LockForTrain(this.Number, waitingPoint[0]);
                     action.SetEndSignalIndex(endSignalIndex);
                     action.SetSignalObject(signalRef.SignalObjects[endSignalIndex]);
-//                    action.Delay = waitingPoint[2] <= 5 ? 5 : waitingPoint[2];
+                    //                    action.Delay = waitingPoint[2] <= 5 ? 5 : waitingPoint[2];
                     action.Delay = waitingPoint[2];
                     if (waitingPoint[2] >= 30000 && waitingPoint[2] < 40000) action.IsAbsolute = true;
                     AuxActionsContain.Add(action);
@@ -13347,10 +13348,10 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             if (StationStops != null && StationStops.Count > 0 &&
                 (!maxAuthSet || StationStops[0].DistanceToTrainM < DistanceToEndNodeAuthorityM[0]) &&
                 StationStops[0].SubrouteIndex == TCRoute.activeSubpath)
-             {
+            {
                 TrainObjectItem nextItem = new TrainObjectItem(StationStops[0].DistanceToTrainM, (int)StationStops[0].PlatformItem.Length);
                 thisInfo.ObjectInfoForward.Add(nextItem);
-             }            
+            }
 
 
             // Draft to display more station stops
@@ -13371,7 +13372,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
             AddSwitch_MilepostInfo(ref thisInfo, 0);
 
-             // set object items - backward
+            // set object items - backward
 
             if (ClearanceAtRearM <= 0)
             {
@@ -13431,7 +13432,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                                 // diverging 
                                 isDiverging = true;
                                 var junctionAngle = junctionNode.GetAngle(Simulator.TSectionDat);
-                                if (junctionAngle < 0) isRightSwitch = false; 
+                                if (junctionAngle < 0) isRightSwitch = false;
                             }
                             if (isDiverging)
                             {
@@ -13625,11 +13626,11 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 }
             }
 
-                // do it separately for switches and mileposts
+            // do it separately for switches and mileposts
             // run along forward path to catch all diverging switches and mileposts
 
             AddSwitch_MilepostInfo(ref thisInfo, 0);
- 
+
             // set backward information
 
             // set authority
@@ -13686,8 +13687,8 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     sectionStart += thisSection.Length;
                 }
             }
-            
-                // do it separately for switches and mileposts
+
+            // do it separately for switches and mileposts
             AddSwitch_MilepostInfo(ref thisInfo, 1);
         }
 
@@ -13958,7 +13959,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
             // check for abandoned stations - try to find alternative on passing path
             LookForReplacementStations(abdStations, newRoute, altRoute);
- 
+
             // set signal route
             // part upto split
 
@@ -14128,7 +14129,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
             // check for abandoned stations - try to find alternative on passing path
             LookForReplacementStations(abdStations, newRoute, altRoute);
- 
+
             // set signal route
             // part upto split
 
@@ -14952,15 +14953,15 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             foreach (TrainCar car in Cars)
             {
                 var mstsWagon = car as MSTSWagon;
-                    if (!car.Flipped && right || car.Flipped && !right)
-                    {
-                        mstsWagon.DoorRightOpen = open;
-                    }
-                    else
-                    {
-                        mstsWagon.DoorLeftOpen = open;
-                    }
-                mstsWagon.SignalEvent(open? Event.DoorOpen : Event.DoorClose); // hook for sound trigger
+                if (!car.Flipped && right || car.Flipped && !right)
+                {
+                    mstsWagon.DoorRightOpen = open;
+                }
+                else
+                {
+                    mstsWagon.DoorLeftOpen = open;
+                }
+                mstsWagon.SignalEvent(open ? Event.DoorOpen : Event.DoorClose); // hook for sound trigger
             }
         }
 
@@ -14970,9 +14971,9 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         /// </summary>
         /// 
 
-        public void CheckFailures (float elapsedClockSeconds)
+        public void CheckFailures(float elapsedClockSeconds)
         {
-            if ( IsFreight ) CheckBrakes(elapsedClockSeconds);
+            if (IsFreight) CheckBrakes(elapsedClockSeconds);
             CheckLocoPower(elapsedClockSeconds);
         }
 
@@ -14981,7 +14982,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         /// Check if it's time to have a car with stuck brakes
         /// </summary>
 
-        public void CheckBrakes (float elapsedClockSeconds)
+        public void CheckBrakes(float elapsedClockSeconds)
         {
             if (BrakingTime == -1) return;
             if (BrakingTime == -2)
@@ -15000,7 +15001,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                         {
                             BrakingTime += elapsedClockSeconds;
                             ContinuousBrakingTime += elapsedClockSeconds;
-                            if (BrakingTime >= 1200.0f/ Simulator.Settings.ActRandomizationLevel || ContinuousBrakingTime >= 600.0f / Simulator.Settings.ActRandomizationLevel)
+                            if (BrakingTime >= 1200.0f / Simulator.Settings.ActRandomizationLevel || ContinuousBrakingTime >= 600.0f / Simulator.Settings.ActRandomizationLevel)
                             {
                                 var randInt = Simulator.Random.Next(200000);
                                 var brakesStuck = false;
@@ -15123,8 +15124,8 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         /// <summary>
         /// Check first electric or diesel loco searching towards back of train
         /// </summary>
-        
-        private bool SearchBackOfTrain( ref int iLocoUnpoweredCar)
+
+        private bool SearchBackOfTrain(ref int iLocoUnpoweredCar)
         {
             var locoUnpowered = false;
             while (iLocoUnpoweredCar < Cars.Count && !((Cars[iLocoUnpoweredCar] is MSTSElectricLocomotive || Cars[iLocoUnpoweredCar] is MSTSDieselLocomotive) && Cars[iLocoUnpoweredCar].Parts.Count >= 2))
@@ -15535,7 +15536,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                                 SetStationReference(TCRouteSubpaths, thisElement.TCSectionIndex, orgSignals);
                                 if (thisNode.TCCrossReference[iTC].Index == RoughReversalInfos[sublist].ReversalSectionIndex)
                                 {
-                                     break;
+                                    break;
                                 }
                             }
                             newDir = thisNode.TrPins[currentDir].Direction;
@@ -15551,7 +15552,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                                 SetStationReference(TCRouteSubpaths, thisElement.TCSectionIndex, orgSignals);
                                 if (thisNode.TCCrossReference[iTC].Index == RoughReversalInfos[sublist].ReversalSectionIndex)
                                 {
-                                     break;
+                                    break;
                                 }
                             }
                             newDir = thisNode.TrPins[currentDir].Direction;
@@ -15918,7 +15919,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                                     endSubPath[iSection].TCSectionIndex == RoughReversalInfos[RoughReversalInfos.Count - 1].ReversalSectionIndex)
                                 {
                                     RoughReversalInfos[RoughReversalInfos.Count - 1].ReversalSectionIndex = endSubPath[sigIndex].TCSectionIndex;
-                                    RoughReversalInfos[RoughReversalInfos.Count - 1].ReverseReversalOffset = 
+                                    RoughReversalInfos[RoughReversalInfos.Count - 1].ReverseReversalOffset =
                                         orgSignals.TrackCircuitList[endSubPath[sigIndex].TCSectionIndex].Length;
                                 }
                                 endSubPath.RemoveAt(iSection);
@@ -18212,7 +18213,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     }
 
                     // if next route ends within last one, last diverge index can be set to endLastIndex
-                    if (firstIndex > firstRoute.Count -1)
+                    if (firstIndex > firstRoute.Count - 1)
                     {
                         LastDivergeIndex = endLastIndex;
                         DivergeSectorIndex = lastRoute[endLastIndex].TCSectionIndex;
@@ -18937,7 +18938,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
             public StationStop(int platformReference, PlatformDetails platformItem, int subrouteIndex, int routeIndex,
                 int tcSectionIndex, int direction, int exitSignal, bool holdSignal, bool noWaitSignal, bool noClaimAllowed, float stopOffset,
-                int arrivalTime, int departTime, bool terminal, int? actualMinStopTime, float? keepClearFront, float? keepClearRear, 
+                int arrivalTime, int departTime, bool terminal, int? actualMinStopTime, float? keepClearFront, float? keepClearRear,
                 bool forcePosition, bool closeupSignal, bool closeup,
                 bool restrictPlatformToSignal, bool extendPlatformToSignal, bool endStop, STOPTYPE actualStopType)
             {
@@ -19180,7 +19181,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     thisWait.Save(outf);
                 }
 
-                if ( ActualMinStopTime.HasValue)
+                if (ActualMinStopTime.HasValue)
                 {
                     outf.Write(true);
                     outf.Write(ActualMinStopTime.Value);
@@ -19384,7 +19385,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             /// Randomization can be upwards or downwards
             /// </summary>
 
-            private void RandomizePassengersWaiting (ref int actualNumPassengersWaiting, Train stopTrain)
+            private void RandomizePassengersWaiting(ref int actualNumPassengersWaiting, Train stopTrain)
             {
                 if (stopTrain.Simulator.Settings.ActRandomizationLevel > 0)
                 {
@@ -19668,7 +19669,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         public void UpdateRemoteTrainPos(float elapsedClockSeconds)
         {
             float newDistanceTravelledM = DistanceTravelledM;
- //           float xx = 0;
+            //           float xx = 0;
 
             if (updateMSGReceived)
             {
@@ -19679,7 +19680,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     if (doReverseTrav)
                     {
                         doReverseTrav = false;
-                        ReverseFormation(doReverseMU == 1? true : false);
+                        ReverseFormation(doReverseMU == 1 ? true : false);
                         UpdateCarSlack(expectedLength);//update car slack first
                         CalculatePositionOfCars(elapsedClockSeconds, SpeedMpS * elapsedClockSeconds);
                         newDistanceTravelledM = DistanceTravelledM + (SpeedMpS * elapsedClockSeconds);
@@ -19750,7 +19751,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 {
                     car.SpeedMpS = SpeedMpS;
                     if (car.Flipped) car.SpeedMpS = -car.SpeedMpS;
-                    car.AbsSpeedMpS = car.AbsSpeedMpS * (1 - elapsedClockSeconds ) + targetSpeedMpS * elapsedClockSeconds;
+                    car.AbsSpeedMpS = car.AbsSpeedMpS * (1 - elapsedClockSeconds) + targetSpeedMpS * elapsedClockSeconds;
                     if (car.IsDriveable && car is MSTSWagon)
                     {
                         (car as MSTSWagon).WheelSpeedMpS = SpeedMpS;
@@ -19786,8 +19787,8 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 #endif  
                 }
             }
-//            Trace.TraceWarning("SpeedMpS {0}  LastSpeedMpS {1}  AbsSpeedMpS {2}  targetSpeedMpS {7} x {3}  expectedTravelled {4}  travelled {5}  newDistanceTravelledM {6}",
-//                SpeedMpS, LastSpeedMpS, Cars[0].AbsSpeedMpS, xx, expectedTravelled, travelled, newDistanceTravelledM, targetSpeedMpS);
+            //            Trace.TraceWarning("SpeedMpS {0}  LastSpeedMpS {1}  AbsSpeedMpS {2}  targetSpeedMpS {7} x {3}  expectedTravelled {4}  travelled {5}  newDistanceTravelledM {6}",
+            //                SpeedMpS, LastSpeedMpS, Cars[0].AbsSpeedMpS, xx, expectedTravelled, travelled, newDistanceTravelledM, targetSpeedMpS);
             LastSpeedMpS = SpeedMpS;
             DistanceTravelledM = newDistanceTravelledM;
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
@@ -189,7 +189,7 @@ namespace Orts.Simulation.RollingStocks
             }
 
             InitialMassKg = MassKG;
- 
+
         }
 
         /// <summary>
@@ -328,7 +328,7 @@ namespace Orts.Simulation.RollingStocks
                 Simulator.Confirmer.UpdateWithPerCent(CabControl.DieselFuel, CabSetting.Increase, FuelController.CurrentValue * 100);
 
             UpdateSteamHeat(elapsedClockSeconds);
-        
+
         }
 
 
@@ -428,7 +428,7 @@ namespace Orts.Simulation.RollingStocks
                             de.Stop();
                     }
                 }
- //               MassKG = InitialMassKg - MaxDieselLevelL * DieselWeightKgpL + DieselLevelL * DieselWeightKgpL;
+                //               MassKG = InitialMassKg - MaxDieselLevelL * DieselWeightKgpL + DieselLevelL * DieselWeightKgpL;
             }
 
             if (MaxForceN > 0 && MaxContinuousForceN > 0 && PowerReduction < 1)
@@ -549,12 +549,12 @@ namespace Orts.Simulation.RollingStocks
 
             if (DieselEngines.HasGearBox)
                 status.AppendFormat("\t{0} {1}", Simulator.Catalog.GetString("Gear"), DieselEngines[0].GearBox.CurrentGearIndex);
-            status.AppendFormat("\t{0} {1}\t\t{2}", 
-                Simulator.Catalog.GetString("Fuel"), 
+            status.AppendFormat("\t{0} {1}\t\t{2}",
+                Simulator.Catalog.GetString("Fuel"),
                 FormatStrings.FormatFuelVolume(DieselLevelL, IsMetric, IsUK), DieselEngines.GetStatus());
 
             if (IsSteamHeatFitted && TrainFittedSteamHeat && this.IsLeadLocomotive() && Train.PassengerCarsNumber > 0)
-               {
+            {
 
                 // Only show steam heating HUD if fitted to locomotive and the train, has passenger cars attached, and is the lead locomotive
                 // Display Steam Heat info
@@ -572,7 +572,7 @@ namespace Orts.Simulation.RollingStocks
                    Train.DisplayTrainNetSteamHeatLossWpTime,
                    Simulator.Catalog.GetString("FuelLvl"),
                    CurrentSteamHeatFuelCapacityL);
-               }
+            }
 
 
             return status.ToString();
@@ -625,7 +625,7 @@ namespace Orts.Simulation.RollingStocks
         public override void SetStepSize(PickupObj matchPickup)
         {
             if (MaxDieselLevelL != 0)
-                FuelController.SetStepSize(matchPickup.PickupCapacity.FeedRateKGpS / MSTSNotchController.StandardBoost / (MaxDieselLevelL * DieselWeightKgpL)); 
+                FuelController.SetStepSize(matchPickup.PickupCapacity.FeedRateKGpS / MSTSNotchController.StandardBoost / (MaxDieselLevelL * DieselWeightKgpL));
         }
 
         /// <summary>
@@ -779,7 +779,7 @@ namespace Orts.Simulation.RollingStocks
             if (GearBox != null && GearBox.mstsParams != null && GearBox.mstsParams.GearBoxMaxTractiveForceForGearsN.Count > 0)
             {
                 if (ThrottleController != null && ThrottleController.MaximumValue > 1 && MaxForceN / GearBox.mstsParams.GearBoxMaxTractiveForceForGearsN[0] > 3)
-                    // Tricky things have been made with this .eng file, see e.g Cravens 105; let's correct them
+                // Tricky things have been made with this .eng file, see e.g Cravens 105; let's correct them
                 {
                     for (int i = 0; i < GearBox.mstsParams.GearBoxMaxTractiveForceForGearsN.Count; i++)
                         GearBox.mstsParams.GearBoxMaxTractiveForceForGearsN[i] *= ThrottleController.MaximumValue;
@@ -791,7 +791,7 @@ namespace Orts.Simulation.RollingStocks
                     {
                         if (cabView.CVFFile != null && cabView.CVFFile.CabViewControls != null && cabView.CVFFile.CabViewControls.Count > 0)
                         {
-                            foreach ( var control in cabView.CVFFile.CabViewControls)
+                            foreach (var control in cabView.CVFFile.CabViewControls)
                             {
                                 if (control is CVCDiscrete && control.ControlType == CABViewControlTypes.THROTTLE && (control as CVCDiscrete).Values.Count > 0 && (control as CVCDiscrete).Values[(control as CVCDiscrete).Values.Count - 1] > 1)
                                 {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -167,7 +167,7 @@ namespace Orts.Simulation.RollingStocks
         public MSTSNotchController WaterController = new MSTSNotchController(0, 1, 0.01f);
         public float CombinedTenderWaterVolumeUKG          // Decreased by running injectors and increased by refilling
         {
-            get { return WaterController.CurrentValue* MaxTotalCombinedWaterVolumeUKG; }
+            get { return WaterController.CurrentValue * MaxTotalCombinedWaterVolumeUKG; }
             set { WaterController.CurrentValue = value / MaxTotalCombinedWaterVolumeUKG; }
         }
 
@@ -375,8 +375,8 @@ namespace Orts.Simulation.RollingStocks
         public MSTSLocomotive(Simulator simulator, string wagPath)
             : base(simulator, wagPath)
         {
-          //  BrakePipeChargingRatePSIpS = Simulator.Settings.BrakePipeChargingRate;
-                        
+            //  BrakePipeChargingRatePSIpS = Simulator.Settings.BrakePipeChargingRate;
+
             MilepostUnitsMetric = Simulator.TRK.Tr_RouteFile.MilepostUnitsMetric;
             BrakeCutsPowerAtBrakeCylinderPressurePSI = 4.0f;
 
@@ -769,7 +769,7 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(ortsbrakeemergencytimefactor": BrakeEmergencyTimeFactorS = stf.ReadFloatBlock(STFReader.UNITS.Time, null); break;
                 case "engine(ortsbrakepipechargingrate": BrakePipeChargingRatePSIorInHgpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null); break;
                 case "engine(ortsbrakepipedischargetimemult": BrakePipeDischargeTimeFactor = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;
-                case "engine(ortsmaxtractiveforcecurves": TractiveForceCurves = new InterpolatorDiesel2D(stf, false); TractiveForceCurves.HasNegativeValue();  break;
+                case "engine(ortsmaxtractiveforcecurves": TractiveForceCurves = new InterpolatorDiesel2D(stf, false); TractiveForceCurves.HasNegativeValue(); break;
                 case "engine(ortstractioncharacteristics": TractiveForceCurves = new InterpolatorDiesel2D(stf, true); break;
                 case "engine(ortsdynamicbrakeforcecurves": DynamicBrakeForceCurves = new InterpolatorDiesel2D(stf, false); break;
                 case "engine(ortscontinuousforcetimefactor": ContinuousForceTimeFactor = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;
@@ -807,7 +807,7 @@ namespace Orts.Simulation.RollingStocks
                         {
                             switch (brakesenginecontrollers)
                             {
-                                case "blended":                              
+                                case "blended":
                                     DynamicBrakeBlendingEnabled = true;
                                     break;
                                 case "dynamic":
@@ -824,13 +824,13 @@ namespace Orts.Simulation.RollingStocks
                     foreach (var brakestrainbraketype in stf.ReadStringBlock("").ToLower().Replace(" ", "").Split(','))
                     {
                         switch (brakestrainbraketype)
-                            {
-                                case "vacuum_single_pipe_eq":
-                                    VacuumBrakeEQFitted = true;
-                                    break;
-                                 default:
-                                    break;
-                            }
+                        {
+                            case "vacuum_single_pipe_eq":
+                                VacuumBrakeEQFitted = true;
+                                break;
+                            default:
+                                break;
+                        }
                     }
                     break;
                 case "engine(ortsdynamicblendingoverride": DynamicBrakeBlendingOverride = stf.ReadBoolBlock(false); break;
@@ -847,7 +847,7 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(ortswaterscoopdepth": WaterScoopDepthM = stf.ReadFloatBlock(STFReader.UNITS.Distance, 0.0f); break;
                 case "engine(ortswaterscoopwidth": WaterScoopWidthM = stf.ReadFloatBlock(STFReader.UNITS.Distance, 0.0f); break;
                 default: base.Parse(lowercasetoken, stf); break;
-                    
+
             }
         }
 
@@ -1120,7 +1120,7 @@ namespace Orts.Simulation.RollingStocks
             if (WaterScoopFillElevationM == 0)
             {
                 WaterScoopFillElevationM = 2.7432f; // Set to default of 9 ft
-            } 
+            }
 
             if (WaterScoopDepthM == 0)
             {
@@ -1131,7 +1131,7 @@ namespace Orts.Simulation.RollingStocks
             {
                 WaterScoopWidthM = 0.3048f; // Set to default of 1 ft
             }
-            
+
             // Calculate minimum speed to pickup water
             const float Aconst = 2;
             WaterScoopMinSpeedMpS = Me.FromFt((float)Math.Sqrt(Aconst * GravitationalAccelerationFtpSpS * Me.ToFt(WaterScoopFillElevationM)));
@@ -1175,7 +1175,7 @@ namespace Orts.Simulation.RollingStocks
                     BrakePipeDischargeTimeFactor = 1.5f; // Air brakes
                 }
             }
-            
+
             // Initialise the resistance of the vacuum pump
             if (VacuumPumpResistanceN == 0)
             {
@@ -1321,7 +1321,7 @@ namespace Orts.Simulation.RollingStocks
             {
                 if (MaxDynamicBrakeForceN > 0 && MaxContinuousForceN > 0 &&
                 (MaxDynamicBrakeForceN / MaxContinuousForceN < 0.3f && MaxDynamicBrakeForceN == 20000))
-                    MaxDynamicBrakeForceN = Math.Min (MaxContinuousForceN * 0.5f, 150000); // 20000 is suggested as standard value in the MSTS documentation, but in general it is a too low value
+                    MaxDynamicBrakeForceN = Math.Min(MaxContinuousForceN * 0.5f, 150000); // 20000 is suggested as standard value in the MSTS documentation, but in general it is a too low value
             }
         }
 
@@ -1352,7 +1352,7 @@ namespace Orts.Simulation.RollingStocks
                 {
                     float diff = DynamicBrakeBlendingForceMatch ? targetDynamicBrakePercent * MaxBrakeForceN - DynamicBrakeForceN : targetDynamicBrakePercent - DynamicBrakeIntervention;
                     if (diff > threshold && DynamicBrakeIntervention <= 1)
-                        DynamicBrakeIntervention = Math.Min( DynamicBrakeIntervention + elapsedClockSeconds * (airPipeSystem.GetMaxApplicationRatePSIpS() / maxCylPressurePSI), 1.0f);
+                        DynamicBrakeIntervention = Math.Min(DynamicBrakeIntervention + elapsedClockSeconds * (airPipeSystem.GetMaxApplicationRatePSIpS() / maxCylPressurePSI), 1.0f);
                     else if (diff < -threshold)
                         DynamicBrakeIntervention -= elapsedClockSeconds * (airPipeSystem.GetMaxReleaseRatePSIpS() / maxCylPressurePSI);
                 }
@@ -1392,12 +1392,12 @@ namespace Orts.Simulation.RollingStocks
                     }
                 }
             }
- 
+
             // TODO  this is a wild simplification for electric and diesel electric
-                        float t = ThrottlePercent / 100f;
+            float t = ThrottlePercent / 100f;
 
             if (!AdvancedAdhesionModel)  // Advanced adhesion model turned off.
-               AbsWheelSpeedMpS = AbsSpeedMpS;
+                AbsWheelSpeedMpS = AbsSpeedMpS;
 
             UpdateMotiveForce(elapsedClockSeconds, t, AbsSpeedMpS, AbsWheelSpeedMpS);
 
@@ -1415,7 +1415,7 @@ namespace Orts.Simulation.RollingStocks
                     DynamicBrakeForceN = 0f;
                 }
             }
-//            else if (DynamicBrakePercent == -1) DynamicBrakeForceN = 0;
+            //            else if (DynamicBrakePercent == -1) DynamicBrakeForceN = 0;
 
             UpdateFrictionCoefficient(elapsedClockSeconds); // Find the current coefficient of friction depending upon the weather
 
@@ -1467,7 +1467,7 @@ namespace Orts.Simulation.RollingStocks
                             DynamicBrakeController.CurrentValue * 100);
                     }
 
-                    if ((Simulator.UseAdvancedAdhesion) && (!Simulator.Paused)) 
+                    if ((Simulator.UseAdvancedAdhesion) && (!Simulator.Paused))
                     {
                         AdvancedAdhesion(elapsedClockSeconds); // Use advanced adhesion model
                         AdvancedAdhesionModel = true;  // Set flag to advise advanced adhesion model is in use
@@ -1507,29 +1507,29 @@ namespace Orts.Simulation.RollingStocks
             }
 
             // always set AntiSlip for AI trains
-              if (Train.TrainType == Train.TRAINTYPE.AI || Train.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING)
-                 {
-                    AntiSlip = true;
-                 }
+            if (Train.TrainType == Train.TRAINTYPE.AI || Train.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING)
+            {
+                AntiSlip = true;
+            }
 
             // If the train is vacuumed braked then no need to update the compressor, but udate the ejector instead
-              if (BrakeSystem is VacuumSinglePipe)
-                 {
-                    
-                    if (VacuumBrakeEQFitted) // Only update exhauster/main reservoir on locomotives fitted ith an EQ reservoir
-                    {
+            if (BrakeSystem is VacuumSinglePipe)
+            {
+
+                if (VacuumBrakeEQFitted) // Only update exhauster/main reservoir on locomotives fitted ith an EQ reservoir
+                {
                     UpdateVacuumExhauster(elapsedClockSeconds);
-                    }
-                    else
-                    {
-                        UpdateSteamEjector(elapsedClockSeconds);
-                    }
-                
-                 }
-                 else
-                 {
-                   UpdateCompressor(elapsedClockSeconds);
-                 }
+                }
+                else
+                {
+                    UpdateSteamEjector(elapsedClockSeconds);
+                }
+
+            }
+            else
+            {
+                UpdateCompressor(elapsedClockSeconds);
+            }
 
             UpdateHornAndBell(elapsedClockSeconds);
 
@@ -1878,7 +1878,7 @@ namespace Orts.Simulation.RollingStocks
         /// </summary>
         protected virtual void UpdateSteamEjector(float elapsedClockSeconds)
         {
-            if (TrainBrakeController.TrainBrakeControllerState == ControllerState.Release || TrainBrakeController.TrainBrakeControllerState == ControllerState.FullQuickRelease )
+            if (TrainBrakeController.TrainBrakeControllerState == ControllerState.Release || TrainBrakeController.TrainBrakeControllerState == ControllerState.FullQuickRelease)
             {
                 LargeSteamEjectorIsOn = true;  // If brake is set to a release controller, then turn ejector on
             }
@@ -2004,17 +2004,17 @@ namespace Orts.Simulation.RollingStocks
             }
 
             //Curtius-Kniffler computation for the basic model
-    //        float max0 = 1.0f;  //Adhesion conditions [N]
+            //        float max0 = 1.0f;  //Adhesion conditions [N]
 
-            if (EngineType == EngineTypes.Steam && SteamEngineType != MSTSSteamLocomotive.SteamEngineTypes.Geared )
-             {
+            if (EngineType == EngineTypes.Steam && SteamEngineType != MSTSSteamLocomotive.SteamEngineTypes.Geared)
+            {
                 // Steam locomotive details updated in UpdateMotiveForce method, and inserted into adhesion module
                 // ****************  NB WheelSpeed updated within Steam Locomotive module at the moment - to be fixed to prevent discrepancies ******************
             }
-            
-            else 
+
+            else
             {
-               
+
                 //Compute axle inertia from parameters if possible
                 if (AxleInertiaKgm2 > 10000.0f) // if axleinertia value supplied in ENG file, then use in calculations
                 {
@@ -2043,8 +2043,8 @@ namespace Orts.Simulation.RollingStocks
 
                 //Set axle model parameters
 
-               //LocomotiveAxle.BrakeForceN = FrictionForceN;
-              //  LocomotiveAxle.BrakeRetardForceN = BrakeForceN;
+                //LocomotiveAxle.BrakeForceN = FrictionForceN;
+                //  LocomotiveAxle.BrakeRetardForceN = BrakeForceN;
                 LocomotiveAxle.BrakeRetardForceN = BrakeRetardForceN;
                 LocomotiveAxle.AxleWeightN = 9.81f * DrvWheelWeightKg;   //will be computed each time considering the tilting
                 LocomotiveAxle.DriveForceN = MotiveForceN;           //Developed force
@@ -2069,7 +2069,7 @@ namespace Orts.Simulation.RollingStocks
                 WheelSpeedMpS = AbsSpeedMpS;
                 return;
             }
-            
+
             if (LocoNumDrvWheels <= 0)
                 return;
             //float max0 = MassKG * 9.8f * Adhesion3 / NumWheelsAdhesionFactor;   //Not used
@@ -2351,11 +2351,11 @@ namespace Orts.Simulation.RollingStocks
                 if (Simulator.WeatherType == WeatherType.Rain) // Wet weather
                 {
                     if (Simulator.Settings.AdhesionProportionalToWeather && AdvancedAdhesionModel && !Simulator.Paused)  // Adjust clear weather for precipitation presence - base friction value will be approximately between 0.15 and 0.2
-                        // ie base value between 0.607 and 0.45 
-                        // note lowest friction will be for drizzle rain; friction will increase for precipitation both higher and lower than drizzle rail
+                                                                                                                         // ie base value between 0.607 and 0.45 
+                                                                                                                         // note lowest friction will be for drizzle rain; friction will increase for precipitation both higher and lower than drizzle rail
                     {
-                       float pric = Simulator.Weather.PricipitationIntensityPPSPM2 * 1000;
-                // precipitation will calculate a value between 0.15 (light rain) and 0.2 (heavy rain) - this will be a factor that is used to adjust the base value - assume linear value between upper and lower precipitation values
+                        float pric = Simulator.Weather.PricipitationIntensityPPSPM2 * 1000;
+                        // precipitation will calculate a value between 0.15 (light rain) and 0.2 (heavy rain) - this will be a factor that is used to adjust the base value - assume linear value between upper and lower precipitation values
                         if (pric >= 0.5)
                             BaseFrictionCoefficientFactor = Math.Min((pric * 0.0078f + 0.45f), 0.607f);
                         else
@@ -2384,7 +2384,7 @@ namespace Orts.Simulation.RollingStocks
                     else
                     {
                         BaseFrictionCoefficientFactor = Math.Min((fog * 2.75e-4f + 0.45f), 1.0f); // If fog is less then 2km then it will impact friction
-                    }                                        
+                    }
                 }
                 else // if not proportional to fog use fixed friction value approximately equal to 0.33, thus factor will be 1.0 x friction coefficient of 0.33
                 {
@@ -2443,7 +2443,7 @@ namespace Orts.Simulation.RollingStocks
                 LocomotiveAxle.AdhesionConditions = MathHelper.Clamp(LocomotiveAxle.AdhesionConditions, 0.05f, 2.5f); // Avoids NaNs in axle speed computing
             }
 
-           // Set adhesion conditions for other steam locomotives
+            // Set adhesion conditions for other steam locomotives
             if (EngineType == EngineTypes.Steam && SteamEngineType != MSTSSteamLocomotive.SteamEngineTypes.Geared)  // ToDo explore adhesion factors
             {
                 LocomotiveCoefficientFrictionHUD = Train.LocomotiveCoefficientFriction; // Set display value for HUD - steam
@@ -2453,7 +2453,7 @@ namespace Orts.Simulation.RollingStocks
                 LocomotiveCoefficientFrictionHUD = BaseuMax * LocomotiveAxle.AdhesionConditions; // Set display value for HUD - diesel
             }
 
-            
+
         }
 
         #endregion
@@ -2461,9 +2461,9 @@ namespace Orts.Simulation.RollingStocks
 
         public void UpdateTrackSander(float elapsedClockSeconds)
         {
-        // updates track sander in terms of sand usage and impact on air compressor
-        // The following assumptions have been made:
-        //
+            // updates track sander in terms of sand usage and impact on air compressor
+            // The following assumptions have been made:
+            //
 
             if (Sander)  // If sander is on adjust parameters
             {
@@ -2479,9 +2479,9 @@ namespace Orts.Simulation.RollingStocks
                     }
                 }
 
-          // Calculate air consumption and change in main air reservoir pressure
+                // Calculate air consumption and change in main air reservoir pressure
                 float ActualAirConsumptionFt3pS = pS.FrompM(TrackSanderAirComsumptionFt3pM) * elapsedClockSeconds;
-                float SanderPressureDiffPSI = ActualAirConsumptionFt3pS / Me3.ToFt3(MainResVolumeM3) ;
+                float SanderPressureDiffPSI = ActualAirConsumptionFt3pS / Me3.ToFt3(MainResVolumeM3);
                 MainResPressurePSI -= SanderPressureDiffPSI;
                 MainResPressurePSI = MathHelper.Clamp(MainResPressurePSI, 0.001f, MaxMainResPressurePSI);
             }
@@ -2728,7 +2728,7 @@ namespace Orts.Simulation.RollingStocks
                     WaterScoopSlowSpeedFlag = false;
                     WaterScoopDirectionFlag = false;
                 }
-                    Simulator.Confirmer.Confirm(CabControl.WaterScoop, WaterScoopDown? CabSetting.On : CabSetting.Off);
+                Simulator.Confirmer.Confirm(CabControl.WaterScoop, WaterScoopDown ? CabSetting.On : CabSetting.Off);
             }
         }
 
@@ -2996,11 +2996,11 @@ namespace Orts.Simulation.RollingStocks
         {
             var train = Simulator.PlayerLocomotive.Train;//Debrief Eval
             string s = TrainBrakeController.GetStatus();
- 
+
 
             if (s == "Emergency" && train.LeadLocomotive != null && !ldbfevalfulltrainbrakeunder8kmh && train.LeadLocomotive.IsPlayerTrain && Math.Abs(train.SpeedMpS) < 2.22222)
             {
-                
+
                 DbfEvalFullTrainBrakeUnder8kmh++;
                 ldbfevalfulltrainbrakeunder8kmh = true;
                 train.DbfEvalValueChanged = true;//Debrief eval
@@ -3135,7 +3135,7 @@ namespace Orts.Simulation.RollingStocks
             if (EngineBrakeController == null)
                 return null;
             // If brake type is only a state, and no numerical fraction application is displayed in the HUD, then display Brake Cylinder (BC) pressure
-                if (String.IsNullOrEmpty(EngineBrakeController.GetStateFractionScripted())) // Test to see if a brake state only is present without a fraction of application, if no fraction display BC pressure
+            if (String.IsNullOrEmpty(EngineBrakeController.GetStateFractionScripted())) // Test to see if a brake state only is present without a fraction of application, if no fraction display BC pressure
             {
                 if ((BrakeSystem is VacuumSinglePipe))
                 {
@@ -3145,7 +3145,7 @@ namespace Orts.Simulation.RollingStocks
                 {
                     return string.Format("{0} BC {1} {2}", EngineBrakeController.GetStatus(), FormatStrings.FormatPressure(Train.HUDLocomotiveBrakeCylinderPSI, PressureUnit.PSI, MainPressureUnit, true), BailOff ? " BailOff" : "");
                 }
-                    
+
                 // Fraction not found so display BC                
             }
             else
@@ -3365,7 +3365,7 @@ namespace Orts.Simulation.RollingStocks
             Simulator.Confirmer.Confirm(CabControl.CabLight, CabLightOn ? CabSetting.On : CabSetting.Off);
         }
 
-        public void ToggleCabRadio( bool newState)
+        public void ToggleCabRadio(bool newState)
         {
             CabRadioOn = newState;
             if (!OnLineCabRadio)
@@ -3607,7 +3607,7 @@ namespace Orts.Simulation.RollingStocks
                 case Event.CompressorOn: { CompressorIsOn = true; break; }
                 case Event.CompressorOff: { CompressorIsOn = false; break; }
                 case Event.VacuumExhausterOn: { VacuumExhausterIsOn = true; break; }
-                case Event.VacuumExhausterOff : { VacuumExhausterIsOn = false; break; }
+                case Event.VacuumExhausterOff: { VacuumExhausterIsOn = false; break; }
 
                 case Event._ResetWheelSlip: { LocomotiveAxle.Reset(Simulator.GameTime, SpeedMpS); ThrottleController.SetValue(0.0f); break; }
                 case Event.TrainBrakePressureDecrease:
@@ -3629,9 +3629,9 @@ namespace Orts.Simulation.RollingStocks
         }
 
         //used by remote train locomotives
- /*       public virtual void RemoteUpdate()
-        {
-        }*/
+        /*       public virtual void RemoteUpdate()
+               {
+               }*/
 
         public virtual float GetDataOf(CabViewControl cvc)
         {
@@ -3702,14 +3702,14 @@ namespace Orts.Simulation.RollingStocks
                         break;
                     }
 
-                 case CABViewControlTypes.ORTS_WATER_SCOOP:
+                case CABViewControlTypes.ORTS_WATER_SCOOP:
                     data = WaterScoopDown ? 1 : 0;
                     break;
 
                 case CABViewControlTypes.STEAM_HEAT:
                     data = SteamHeatController.CurrentValue;
                     break;
-                
+
                 case CABViewControlTypes.AMMETER: // Current not modelled yet to ammeter shows tractive effort until then.
                 case CABViewControlTypes.AMMETER_ABS:
                     {
@@ -3807,25 +3807,25 @@ namespace Orts.Simulation.RollingStocks
                                 if (ThrottlePercent > 0)
                                 {
                                     data = (data / MaxForceN) * MaxCurrentA;
-                                 }
+                                }
                                 if (DynamicBrakePercent > 0)
                                 {
                                     data = (DynamicBrakeForceN / MaxDynamicBrakeForceN) * DynamicBrakeMaxCurrentA;
                                 }
                                 data = Math.Abs(data);
                                 break;
-                    
+
                             case CABViewControlUnits.NEWTONS:
                                 break;
-                    
+
                             case CABViewControlUnits.KILO_NEWTONS:
                                 data = data / 1000.0f;
                                 break;
-                    
+
                             case CABViewControlUnits.KILO_LBS:
                                 data = data / 4448.22162f;
                                 break;
-                        }                   
+                        }
                         if (direction == 1 && !(cvc is CVCGauge))
                             data = -data;
                         break;
@@ -3926,7 +3926,7 @@ namespace Orts.Simulation.RollingStocks
                 case CABViewControlTypes.THROTTLE_DISPLAY:
                 case CABViewControlTypes.CPH_DISPLAY:
                     {
-                        data = Train.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING? ThrottlePercent / 100f : LocalThrottlePercent / 100f;
+                        data = Train.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING ? ThrottlePercent / 100f : LocalThrottlePercent / 100f;
                         break;
                     }
                 case CABViewControlTypes.ENGINE_BRAKE:
@@ -4163,7 +4163,7 @@ namespace Orts.Simulation.RollingStocks
                                         dieselLoco.DieselEngines[0].EngineStatus == DieselEngine.Status.Starting) ? 1 : 0;
                                     break;
                                 }
-                             }
+                            }
                         }
                         break;
                     }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -750,7 +750,8 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(boilervolume": BoilerVolumeFT3 = stf.ReadFloatBlock(STFReader.UNITS.VolumeDefaultFT3, null); break;
                 case "engine(maxboilerpressure": MaxBoilerPressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, null); break;
                 case "engine(ortsmaxsuperheattemperature": MaxSuperheatRefTempF = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;  // New input and conversion units to be added for temperature
-                case "engine(ortsmaxindicatedhorsepower": MaxIndicatedHorsePowerHP = stf.ReadFloatBlock(STFReader.UNITS.Power, null);
+                case "engine(ortsmaxindicatedhorsepower":
+                    MaxIndicatedHorsePowerHP = stf.ReadFloatBlock(STFReader.UNITS.Power, null);
                     MaxIndicatedHorsePowerHP = W.ToHp(MaxIndicatedHorsePowerHP);  // Convert input to HP for use internally in this module
                     break;
                 case "engine(vacuumbrakeslargeejectorusagerate": EjectorLargeSteamConsumptionLbpS = pS.FrompH(stf.ReadFloatBlock(STFReader.UNITS.MassRateDefaultLBpH, null)); break;
@@ -6368,11 +6369,11 @@ namespace Orts.Simulation.RollingStocks
             }
 
             return status.ToString();
-        } 
+        }
 
-// Gear Box
+        // Gear Box
 
-public void SteamStartGearBoxIncrease()
+        public void SteamStartGearBoxIncrease()
         {
             if (IsSelectGeared)
             {
@@ -7113,7 +7114,7 @@ public void SteamStartGearBoxIncrease()
             if (type == (uint)PickupType.FuelCoal && MaxTenderCoalMassKG != 0)
                 FuelController.SetStepSize(matchPickup.PickupCapacity.FeedRateKGpS / MSTSNotchController.StandardBoost / MaxTenderCoalMassKG);
             else if (type == (uint)PickupType.FuelWater && MaxLocoTenderWaterMassKG != 0)
-                WaterController.SetStepSize(matchPickup.PickupCapacity.FeedRateKGpS / MSTSNotchController.StandardBoost / MaxLocoTenderWaterMassKG); 
+                WaterController.SetStepSize(matchPickup.PickupCapacity.FeedRateKGpS / MSTSNotchController.StandardBoost / MaxLocoTenderWaterMassKG);
         }
 
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -235,7 +235,7 @@ namespace Orts.Simulation.RollingStocks
         {
             stf.MustMatch("(");
             string s;
-            
+
             while ((s = stf.ReadItem()) != ")")
             {
                 var data = new ParticleEmitterData(stf);
@@ -439,8 +439,8 @@ namespace Orts.Simulation.RollingStocks
                 else
                 {
                     LoadEmptyMassKg = MassKG;
-                }  
-                
+                }
+
                 if (FreightAnimations.EmptyORTSDavis_A > 0)
                 {
                     LoadEmptyORTSDavis_A = FreightAnimations.EmptyORTSDavis_A;
@@ -602,7 +602,7 @@ namespace Orts.Simulation.RollingStocks
                     else
                     {
                         LoadFullMassKg = MassKG;
-                    } 
+                    }
 
                     if (FreightAnimations.FullPhysicsContinuousOne.FullORTSDavis_A > 0)
                     {
@@ -679,30 +679,30 @@ namespace Orts.Simulation.RollingStocks
                 }
 
                 if (!FreightAnimations.MSTSFreightAnimEnabled) FreightShapeFileName = null;
-                    if (FreightAnimations.WagonEmptyWeight != -1)
+                if (FreightAnimations.WagonEmptyWeight != -1)
+                {
+
+                    MassKG = FreightAnimations.WagonEmptyWeight + FreightAnimations.FreightWeight + FreightAnimations.StaticFreightWeight;
+
+                    if (FreightAnimations.StaticFreightAnimationsPresent) // If it is static freight animation, set wagon physics to full wagon value
                     {
+                        // Update brake parameters   
+                        MaxBrakeForceN = LoadFullMaxBrakeForceN;
+                        MaxHandbrakeForceN = LoadFullMaxHandbrakeForceN;
 
-                        MassKG = FreightAnimations.WagonEmptyWeight + FreightAnimations.FreightWeight + FreightAnimations.StaticFreightWeight;
+                        // Update friction related parameters
+                        DavisAN = LoadFullORTSDavis_A;
+                        DavisBNSpM = LoadFullORTSDavis_B;
+                        DavisCNSSpMM = LoadFullORTSDavis_C;
+                        DavisDragConstant = LoadFullDavisDragConstant;
+                        WagonFrontalAreaM2 = LoadFullWagonFrontalAreaM2;
 
-                        if (FreightAnimations.StaticFreightAnimationsPresent) // If it is static freight animation, set wagon physics to full wagon value
-                        {
-                            // Update brake parameters   
-                            MaxBrakeForceN = LoadFullMaxBrakeForceN;
-                            MaxHandbrakeForceN = LoadFullMaxHandbrakeForceN;
-
-                            // Update friction related parameters
-                            DavisAN = LoadFullORTSDavis_A;
-                            DavisBNSpM = LoadFullORTSDavis_B;
-                            DavisCNSSpMM = LoadFullORTSDavis_C;
-                            DavisDragConstant = LoadFullDavisDragConstant;
-                            WagonFrontalAreaM2 = LoadFullWagonFrontalAreaM2;
-
-                            // Update CoG related parameters
-                            CentreOfGravityM.Y = LoadFullCentreOfGravityM_Y;
-
-                        }
+                        // Update CoG related parameters
+                        CentreOfGravityM.Y = LoadFullCentreOfGravityM_Y;
 
                     }
+
+                }
                 if (FreightAnimations.LoadedOne != null) // If it is a Continuouos freight animation, set freight wagon parameters to FullatStart
                 {
                     WeightLoadController.CurrentValue = FreightAnimations.LoadedOne.LoadPerCent / 100;
@@ -719,15 +719,15 @@ namespace Orts.Simulation.RollingStocks
                     DavisBNSpM = ((LoadFullORTSDavis_B - LoadEmptyORTSDavis_B) * TempMassDiffRatio) + LoadEmptyORTSDavis_B;
                     DavisCNSSpMM = ((LoadFullORTSDavis_C - LoadEmptyORTSDavis_C) * TempMassDiffRatio) + LoadEmptyORTSDavis_C;
 
-                    if (LoadEmptyDavisDragConstant > LoadFullDavisDragConstant ) // Due to wind turbulence empty drag might be higher then loaded drag, and therefore both scenarios need to be covered.
+                    if (LoadEmptyDavisDragConstant > LoadFullDavisDragConstant) // Due to wind turbulence empty drag might be higher then loaded drag, and therefore both scenarios need to be covered.
                     {
-                        DavisDragConstant = LoadEmptyDavisDragConstant -   ((LoadEmptyDavisDragConstant - LoadFullDavisDragConstant) * TempMassDiffRatio);
+                        DavisDragConstant = LoadEmptyDavisDragConstant - ((LoadEmptyDavisDragConstant - LoadFullDavisDragConstant) * TempMassDiffRatio);
                     }
                     else
                     {
                         DavisDragConstant = ((LoadFullDavisDragConstant - LoadEmptyDavisDragConstant) * TempMassDiffRatio) + LoadEmptyDavisDragConstant;
                     }
-                    
+
                     WagonFrontalAreaM2 = ((LoadFullWagonFrontalAreaM2 - LoadEmptyWagonFrontalAreaM2) * TempMassDiffRatio) + LoadEmptyWagonFrontalAreaM2;
 
                     // Update CoG related parameters
@@ -944,7 +944,7 @@ namespace Orts.Simulation.RollingStocks
                     break;
                 case "wagon(coupling(spring(ortsslack":
                     stf.MustMatch("(");
-                     // IsAdvancedCoupler = true; // If this parameter is present in WAG file then treat coupler as advanced ones.  Temporarily disabled for v1.3 release
+                    // IsAdvancedCoupler = true; // If this parameter is present in WAG file then treat coupler as advanced ones.  Temporarily disabled for v1.3 release
                     Couplers[Couplers.Count - 1].SetSlack(stf.ReadFloat(STFReader.UNITS.Distance, null), stf.ReadFloat(STFReader.UNITS.Distance, null));
                     stf.SkipRestOfBlock();
                     break;
@@ -1142,7 +1142,7 @@ namespace Orts.Simulation.RollingStocks
                     // If freight animations not used or else wagon is a tender or locomotive, use the "MSTS" type IntakePoints if present in WAG / ENG file
 
                     if (copyIntakePoint.LinkedFreightAnim == null)
-               //     if (copyIntakePoint.LinkedFreightAnim == null || WagonType == WagonTypes.Engine || WagonType == WagonTypes.Tender || AuxWagonType == "AuxiliaryTender")
+                        //     if (copyIntakePoint.LinkedFreightAnim == null || WagonType == WagonTypes.Engine || WagonType == WagonTypes.Tender || AuxWagonType == "AuxiliaryTender")
                         IntakePointList.Add(new IntakePoint(copyIntakePoint));
                 }
             }
@@ -1356,7 +1356,7 @@ namespace Orts.Simulation.RollingStocks
                 // Test to see if coupler forces have been exceeded, and coupler has broken. Exceeding this limit will break the coupler
                 if (IsPlayerTrain) // Only break couplers on player trains
                 {
-                    if (-CouplerForceU > coupler.Break2N )  // break couplers if forces exceeded
+                    if (-CouplerForceU > coupler.Break2N)  // break couplers if forces exceeded
                     {
                         CouplerExceedBreakLimit = true;
                     }
@@ -1372,7 +1372,7 @@ namespace Orts.Simulation.RollingStocks
             }
 
             Pantographs.Update(elapsedClockSeconds);
-            
+
             MSTSBrakeSystem.Update(elapsedClockSeconds);
 
             // Updates freight load animations when defined in WAG file - Locomotive and Tender load animation are done independently in UpdateTenderLoad() & UpdateLocomotiveLoadPhysics()
@@ -1388,13 +1388,13 @@ namespace Orts.Simulation.RollingStocks
                         if (WeightLoadController.UpdateValue != 0.0)
                             Simulator.Confirmer.UpdateWithPerCent(CabControl.FreightLoad,
                                 CabSetting.Increase, WeightLoadController.CurrentValue * 100);
-                    // Update wagon parameters sensitive to wagon mass change
-                    // Calculate the difference ratio, ie how full the wagon is. This value allows the relevant value to be scaled from the empty mass to the full mass of the wagon
+                        // Update wagon parameters sensitive to wagon mass change
+                        // Calculate the difference ratio, ie how full the wagon is. This value allows the relevant value to be scaled from the empty mass to the full mass of the wagon
                         TempMassDiffRatio = WeightLoadController.CurrentValue;
-                   // Update brake parameters
+                        // Update brake parameters
                         MaxBrakeForceN = ((LoadFullMaxBrakeForceN - LoadEmptyMaxBrakeForceN) * TempMassDiffRatio) + LoadEmptyMaxBrakeForceN;
                         MaxHandbrakeForceN = ((LoadFullMaxHandbrakeForceN - LoadEmptyMaxHandbrakeForceN) * TempMassDiffRatio) + LoadEmptyMaxHandbrakeForceN;
-                  // Update friction related parameters
+                        // Update friction related parameters
                         DavisAN = ((LoadFullORTSDavis_A - LoadEmptyORTSDavis_A) * TempMassDiffRatio) + LoadEmptyORTSDavis_A;
                         DavisBNSpM = ((LoadFullORTSDavis_B - LoadEmptyORTSDavis_B) * TempMassDiffRatio) + LoadEmptyORTSDavis_B;
                         DavisCNSSpMM = ((LoadFullORTSDavis_C - LoadEmptyORTSDavis_C) * TempMassDiffRatio) + LoadEmptyORTSDavis_C;
@@ -1430,7 +1430,7 @@ namespace Orts.Simulation.RollingStocks
             }
         }
 
-       private void UpdateLocomotiveLoadPhysics()
+        private void UpdateLocomotiveLoadPhysics()
         {
             // This section updates the weight and physics of the locomotive
             if (FreightAnimations != null && FreightAnimations.ContinuousFreightAnimationsPresent) // make sure that a freight animation INCLUDE File has been defined, and it contains "continuous" animation data.
@@ -1462,7 +1462,7 @@ namespace Orts.Simulation.RollingStocks
                         {
                             MassKG = LoadEmptyMassKg + Kg.FromLb(SteamLocomotiveIdentification.BoilerMassLB) + SteamLocomotiveIdentification.FireMassKG;
                             MassKG = MathHelper.Clamp(MassKG, LoadEmptyMassKg, LoadFullMassKg); // Clamp Mass to between the empty and full wagon values        
-                        // Adjust drive wheel weight
+                                                                                                // Adjust drive wheel weight
                             SteamLocomotiveIdentification.DrvWheelWeightKg = (MassKG / InitialMassKG) * SteamLocomotiveIdentification.InitialDrvWheelWeightKg;
                         }
 
@@ -1496,7 +1496,7 @@ namespace Orts.Simulation.RollingStocks
                 else if (this is MSTSDieselLocomotive)
                 // If diesel locomotive
                 {
-                   // set a process to pass relevant locomotive parameters from locomotive file to this wagon file
+                    // set a process to pass relevant locomotive parameters from locomotive file to this wagon file
                     var LocoIndex = 0;
                     for (var i = 0; i < Train.Cars.Count; i++) // test each car to find the where the Diesel locomotive is in the consist
                         if (Train.Cars[i] == this)  // If this car is a Diesel locomotive then set loco index
@@ -1535,7 +1535,7 @@ namespace Orts.Simulation.RollingStocks
 
                         // Update CoG related parameters
                         CentreOfGravityM.Y = ((LoadFullCentreOfGravityM_Y - LoadEmptyCentreOfGravityM_Y) * TempMassDiffRatio) + LoadEmptyCentreOfGravityM_Y;
-                        
+
                     }
                 }
             }
@@ -1879,7 +1879,7 @@ namespace Orts.Simulation.RollingStocks
 
                     // Determine the running resistance due to wheel bearing temperature
                     float WheelBearingTemperatureResistanceFactor = 0;
-                    
+
                     // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
                     // bearing. Assume that resisnce will increase by 30% as temperature drops below 0 DegC.
                     // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
@@ -1909,7 +1909,7 @@ namespace Orts.Simulation.RollingStocks
                     {
                         WheelBearingTemperatureResistanceFactor = 2.0f;
                     }
-                    
+
                     FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * DavisCNSSpMM); // for normal speed operation
 
                     // if this car is a locomotive, but not the lead one then recalculate the resistance with lower value as drag will not be as high on trailing locomotives
@@ -1974,7 +1974,7 @@ namespace Orts.Simulation.RollingStocks
             // Keep track of Activity details if an activity, setup random wagon, and start time for hotbox
             if (Simulator.ActivityRun != null)
             {
-                if (ActivityElapsedDurationS<HotBoxStartTimeS)
+                if (ActivityElapsedDurationS < HotBoxStartTimeS)
                 {
                     ActivityElapsedDurationS += elapsedClockSeconds;
                 }
@@ -1984,29 +1984,29 @@ namespace Orts.Simulation.RollingStocks
                 {
                     // Activity randomizatrion needs to be active in Options menu, and HotBox will not be applied to a locomotive or tender.
                     if (Simulator.Settings.ActRandomizationLevel > 0 && WagonType != WagonTypes.Engine && WagonType != WagonTypes.Tender)
-                    {                        
+                    {
                         var HotboxRandom = Simulator.Random.Next(100) / Simulator.Settings.ActRandomizationLevel;
                         float PerCentRandom = 0.66f; // Set so that random time is always in first 66% of activity duration
                         var RawHotBoxTimeRandomS = Simulator.Random.Next(Train.ActivityDurationS);
                         if (!Train.HotBoxSetOnTrain) // only allow one hot box to be set per train 
                         {
-                            if (HotboxRandom< 10)
+                            if (HotboxRandom < 10)
                             {
                                 HotBoxActivated = true;
                                 Train.HotBoxSetOnTrain = true;
-                                HotBoxStartTimeS = PerCentRandom* RawHotBoxTimeRandomS;
+                                HotBoxStartTimeS = PerCentRandom * RawHotBoxTimeRandomS;
 
                                 Trace.TraceInformation("Hotbox Bearing Activated on CarID {0}. Hotbox to start from {1:F1} minutes into activity", CarID, S.ToM(HotBoxStartTimeS));
                             }
                         }
 
-                                            
+
                     }
                 }
 
                 HotBoxHasBeenInitialized = true; // Only allow to loop once at first pass
             }
-            
+
 
             float BearingSpeedMaximumTemperatureDegC = 0;
             float MaximumNormalBearingTemperatureDegC = 90.0f;
@@ -2041,11 +2041,11 @@ namespace Orts.Simulation.RollingStocks
 
             if (elapsedClockSeconds > 0) // Prevents zero values resetting temperature
             {
-                
+
                 // Keep track of wheel bearing temperature until activtaion time reached
-                if (ActivityElapsedDurationS<HotBoxStartTimeS) 
+                if (ActivityElapsedDurationS < HotBoxStartTimeS)
                 {
-                   InitialHotBoxRiseTemperatureDegS = WheelBearingTemperatureDegC;
+                    InitialHotBoxRiseTemperatureDegS = WheelBearingTemperatureDegC;
                 }
 
                 // Calculate Hot box bearing temperature
@@ -2061,7 +2061,7 @@ namespace Orts.Simulation.RollingStocks
                     HotBoxTemperatureRiseTimeS += elapsedClockSeconds;
 
                     // Calculate predicted bearing temperature based upon elapsed time
-                    WheelBearingTemperatureDegC = MaximumHotBoxBearingTemperatureDegC + (InitialHotBoxRiseTemperatureDegS - MaximumHotBoxBearingTemperatureDegC) * (float) (Math.Exp(HotBoxKConst* HotBoxTemperatureRiseTimeS));
+                    WheelBearingTemperatureDegC = MaximumHotBoxBearingTemperatureDegC + (InitialHotBoxRiseTemperatureDegS - MaximumHotBoxBearingTemperatureDegC) * (float)(Math.Exp(HotBoxKConst * HotBoxTemperatureRiseTimeS));
 
                     // Reset temperature decline values in preparation for next cylce
                     WheelBearingTemperatureDeclineTimeS = 0;
@@ -2074,12 +2074,12 @@ namespace Orts.Simulation.RollingStocks
                     // Calculate maximum bearing temperature based on current speed using approximated linear graph y = 0.25x + 55
                     const float MConst = 0.25f;
                     const float BConst = 55;
-                    BearingSpeedMaximumTemperatureDegC = MConst* AbsSpeedMpS + BConst;
+                    BearingSpeedMaximumTemperatureDegC = MConst * AbsSpeedMpS + BConst;
 
                     WheelBearingTemperatureRiseTimeS += elapsedClockSeconds;
 
                     // Calculate predicted bearing temperature based upon elapsed time
-                    WheelBearingTemperatureDegC = MaximumNormalBearingTemperatureDegC + (InitialWheelBearingRiseTemperatureDegC - MaximumNormalBearingTemperatureDegC) * (float) (Math.Exp(HeatingKConst* WheelBearingTemperatureRiseTimeS));
+                    WheelBearingTemperatureDegC = MaximumNormalBearingTemperatureDegC + (InitialWheelBearingRiseTemperatureDegC - MaximumNormalBearingTemperatureDegC) * (float)(Math.Exp(HeatingKConst * WheelBearingTemperatureRiseTimeS));
 
                     // Cap bearing temperature depending upon speed
                     if (WheelBearingTemperatureDegC > BearingSpeedMaximumTemperatureDegC)
@@ -2098,7 +2098,7 @@ namespace Orts.Simulation.RollingStocks
                     if (WheelBearingTemperatureDegC > CarOutsideTempC)
                     {
                         WheelBearingTemperatureDeclineTimeS += elapsedClockSeconds;
-                        WheelBearingTemperatureDegC = CarOutsideTempC + (InitialWheelBearingDeclineTemperatureDegC - CarOutsideTempC) * (float) (Math.Exp(CoolingKConst* WheelBearingTemperatureDeclineTimeS));
+                        WheelBearingTemperatureDegC = CarOutsideTempC + (InitialWheelBearingDeclineTemperatureDegC - CarOutsideTempC) * (float)(Math.Exp(CoolingKConst * WheelBearingTemperatureDeclineTimeS));
                     }
 
                     WheelBearingTemperatureRiseTimeS = 0;
@@ -2108,7 +2108,7 @@ namespace Orts.Simulation.RollingStocks
 
                 WheelBearingTemperatureRiseTimeS = 0;
                 InitialWheelBearingRiseTemperatureDegC = WheelBearingTemperatureDegC;
-                
+
                 // Turn off Hotbox sounds
                 SignalEvent(Event.HotBoxBearingOff);
                 HotBoxSoundActivated = false;
@@ -2182,14 +2182,14 @@ namespace Orts.Simulation.RollingStocks
                     {
                         WagonDirectionDeg -= 360;
                     }
-                }                   
+                }
 
                 // If a westerly direction (ie -ve) convert to an angle between 0 and 360
                 if (WagonDirectionDeg < 0)
                     WagonDirectionDeg += 360;
 
                 float TrainSpeedMpS = Math.Abs(SpeedMpS);
-                
+
                 // Find angle between wind and direction of train
                 if (Train.PhysicsWindDirectionDeg > WagonDirectionDeg)
                     WagonResultantWindComponentDeg = Train.PhysicsWindDirectionDeg - WagonDirectionDeg;
@@ -2286,7 +2286,7 @@ namespace Orts.Simulation.RollingStocks
 
                 }
 
-                    WindForceN = LateralWindResistanceForceN + WindDragResistanceForceN;
+                WindForceN = LateralWindResistanceForceN + WindDragResistanceForceN;
 
             }
             else
@@ -2315,7 +2315,7 @@ namespace Orts.Simulation.RollingStocks
                         Trace.TraceInformation("Tender @ position {0} does not have a locomotive associated with. Check that it is preceeded by a steam locomotive.", CarID);
                     }
 
-                    MassKG = FreightAnimations.WagonEmptyWeight + TendersSteamLocomotive.TenderCoalMassKG + Kg.FromLb( (TendersSteamLocomotive.CurrentLocoTenderWaterVolumeUKG * WaterLBpUKG));
+                    MassKG = FreightAnimations.WagonEmptyWeight + TendersSteamLocomotive.TenderCoalMassKG + Kg.FromLb((TendersSteamLocomotive.CurrentLocoTenderWaterVolumeUKG * WaterLBpUKG));
                     MassKG = MathHelper.Clamp(MassKG, LoadEmptyMassKg, LoadFullMassKg); // Clamp Mass to between the empty and full wagon values   
 
                     // Update wagon parameters sensitive to wagon mass change
@@ -2684,22 +2684,22 @@ namespace Orts.Simulation.RollingStocks
                 TendersSteamLocomotive = null;
         }
 
-         /// <summary>
+        /// <summary>
         /// This function checks each steam locomotive to see if it has a tender attached.
         /// </summary>
         public void ConfirmSteamLocomotiveTender()
         {
-            
+
             // Check each steam locomotive to see if it has a tender attached.
-            if (this is MSTSSteamLocomotive )
+            if (this is MSTSSteamLocomotive)
             {
 
                 if (Train == null || Train.Cars == null)
                 {
                     SteamLocomotiveTender = null;
-                     return;
+                    return;
                 }
-                else if(Train.Cars.Count == 1) // If car count is equal to 1, then there must be no tender attached
+                else if (Train.Cars.Count == 1) // If car count is equal to 1, then there must be no tender attached
                 {
                     SteamLocomotiveTender = Train.Cars[0] as MSTSSteamLocomotive;
                     SteamLocomotiveTender.HasTenderCoupled = false;
@@ -2764,15 +2764,15 @@ namespace Orts.Simulation.RollingStocks
             }
 
             // If a "normal" tender is connected then the steam locomotive will be two cars away.
-                      
+
             if (!AuxTenderFound)
             {
-            
+
                 if (tenderIndex > 0 && Train.Cars[tenderIndex - 2] is MSTSSteamLocomotive)
                 {
                     AuxTendersSteamLocomotive = Train.Cars[tenderIndex - 2] as MSTSSteamLocomotive;
                 }
-                
+
                 if (tenderIndex < Train.Cars.Count - 2 && Train.Cars[tenderIndex + 2] is MSTSSteamLocomotive)
                 {
                     AuxTendersSteamLocomotive = Train.Cars[tenderIndex + 2] as MSTSSteamLocomotive;
@@ -2804,17 +2804,17 @@ namespace Orts.Simulation.RollingStocks
                 float zerolength;
                 if (Coupler != null)
                 {
-                   zerolength = Coupler.CouplerSlackAM;
+                    zerolength = Coupler.CouplerSlackAM;
                 }
                 else
                 {
-                   zerolength = base.GetCouplerZeroLengthM();
+                    zerolength = base.GetCouplerZeroLengthM();
                 }
 
                 // Ensure zerolength doesn't go higher then 0.15
                 if (zerolength > 0.5)
                 {
-                   zerolength = 0.5f;
+                    zerolength = 0.5f;
                 }
 
                 return zerolength;
@@ -2822,8 +2822,8 @@ namespace Orts.Simulation.RollingStocks
             }
             else
             {
-               return Coupler != null ? Coupler.R0X : base.GetCouplerZeroLengthM();
-            } 
+                return Coupler != null ? Coupler.R0X : base.GetCouplerZeroLengthM();
+            }
 
         }
 
@@ -2838,16 +2838,16 @@ namespace Orts.Simulation.RollingStocks
             {
                 return base.GetCouplerStiffness1NpM();
             }
-            return Coupler.Rigid? 10 * Coupler.Stiffness1NpM : Coupler.Stiffness1NpM;
+            return Coupler.Rigid ? 10 * Coupler.Stiffness1NpM : Coupler.Stiffness1NpM;
         }
- 
+
         public override float GetCouplerStiffness2NpM()
         {
             if (Coupler == null)
             {
                 return base.GetCouplerStiffness2NpM();
             }
-            return Coupler.Rigid? 10 * Coupler.Stiffness1NpM : Coupler.Stiffness2NpM;
+            return Coupler.Rigid ? 10 * Coupler.Stiffness1NpM : Coupler.Stiffness2NpM;
         }
 
         public override float GetCouplerDamping1NMpS()
@@ -2890,7 +2890,7 @@ namespace Orts.Simulation.RollingStocks
         {
             if (Coupler == null)
             {
-                 return base.GetCouplerRigidIndication();   // If no coupler defined
+                return base.GetCouplerRigidIndication();   // If no coupler defined
             }
             return Coupler.Rigid ? 1 : 2; // Return whether coupler Rigid or Flexible
         }
@@ -3001,7 +3001,7 @@ namespace Orts.Simulation.RollingStocks
         public override float GetUserBrakeShoeFrictionFactor()
         {
             var frictionfraction = 0.0f;
-            if ( BrakeShoeFrictionFactor == null)
+            if (BrakeShoeFrictionFactor == null)
             {
                 frictionfraction = 0.0f;
             }
@@ -3009,7 +3009,7 @@ namespace Orts.Simulation.RollingStocks
             {
                 frictionfraction = BrakeShoeFrictionFactor[MpS.ToKpH(AbsSpeedMpS)];
             }
-            
+
             return frictionfraction;
         }
 
@@ -3030,10 +3030,10 @@ namespace Orts.Simulation.RollingStocks
             }
 
             return frictionfraction;
-        }       
-      
-        
-        
+        }
+
+
+
         /// <summary>
         /// Starts a continuous increase in controlled value.
         /// </summary>
@@ -3057,7 +3057,7 @@ namespace Orts.Simulation.RollingStocks
             }
             if (!unload)
             {
-                controller.SetStepSize(matchPickup.PickupCapacity.FeedRateKGpS/ MSTSNotchController.StandardBoost / FreightAnimations.LoadedOne.FreightWeightWhenFull);
+                controller.SetStepSize(matchPickup.PickupCapacity.FeedRateKGpS / MSTSNotchController.StandardBoost / FreightAnimations.LoadedOne.FreightWeightWhenFull);
                 Simulator.Confirmer.Message(ConfirmLevel.Information, Simulator.Catalog.GetString("Starting refill"));
                 controller.StartIncrease(controller.MaximumValue);
             }
@@ -3148,8 +3148,8 @@ namespace Orts.Simulation.RollingStocks
         }
         public void SetR0(float a, float b)
         {
-                R0X = a;
-                R0Y = b;
+            R0X = a;
+            R0Y = b;
             if (a == 0)
                 R0Diff = b / 2 * Stiffness2NpM / (Stiffness1NpM + Stiffness2NpM);
             else
@@ -3159,7 +3159,7 @@ namespace Orts.Simulation.RollingStocks
             // Ensure R0Diff stays within "reasonable limits"
             if (R0Diff < 0.001)
                 R0Diff = 0.001f;
-            else if (R0Diff > 0.1) 
+            else if (R0Diff > 0.1)
                 R0Diff = 0.1f;
 
         }
@@ -3174,7 +3174,7 @@ namespace Orts.Simulation.RollingStocks
 
         public void SetDamping(float a, float b)
         {
-            if (a + b< 0)
+            if (a + b < 0)
                 return;
 
             Damping1NMps = a;
@@ -3198,7 +3198,7 @@ namespace Orts.Simulation.RollingStocks
             Break1N = a;
 
             // Check if b = 0, as some stock has a zero value, set a default
-            if ( b == 0)
+            if (b == 0)
             {
                 Break2N = 2e7f;
             }
@@ -3206,7 +3206,7 @@ namespace Orts.Simulation.RollingStocks
             {
                 Break2N = b;
             }
-            
+
         }
 
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -83,7 +83,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         {
             Car = car;
             // taking into account very short (fake) cars to prevent NaNs in brake line pressures
-            BrakePipeVolumeM3 = (0.032f * 0.032f * (float)Math.PI / 4f) * Math.Max ( 5.0f, (1 + car.CarLengthM)); // Using DN32 (1-1/4") pipe
+            BrakePipeVolumeM3 = (0.032f * 0.032f * (float)Math.PI / 4f) * Math.Max(5.0f, (1 + car.CarLengthM)); // Using DN32 (1-1/4") pipe
             DebugType = "1P";
 
             // Force graduated releasable brakes. Workaround for MSTS with bugs preventing to set eng/wag files correctly for this.
@@ -124,7 +124,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             string s = string.Format(
                 " BC {0}",
                 FormatStrings.FormatPressure(CylPressurePSI, PressureUnit.PSI, units[BrakeSystemComponent.BrakeCylinder], true));
-                s += string.Format(" BP {0}", FormatStrings.FormatPressure(BrakeLine1PressurePSI, PressureUnit.PSI, units[BrakeSystemComponent.BrakePipe], true));
+            s += string.Format(" BP {0}", FormatStrings.FormatPressure(BrakeLine1PressurePSI, PressureUnit.PSI, units[BrakeSystemComponent.BrakePipe], true));
             return s;
         }
 
@@ -138,7 +138,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             );
 
             s += string.Format(
-                " BP {0}",                
+                " BP {0}",
                 FormatStrings.FormatPressure(BrakeLine1PressurePSI, PressureUnit.PSI, units[BrakeSystemComponent.BrakePipe], true)
             );
             if (lastCarBrakeSystem != null && lastCarBrakeSystem != this)
@@ -230,7 +230,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 case "wagon(emergencyreschargingrate": EmergResChargingRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null); break;
                 case "wagon(emergencyresvolumemultiplier": EmergAuxVolumeRatio = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;
                 case "wagon(emergencyrescapacity": EmergResVolumeM3 = Me3.FromFt3(stf.ReadFloatBlock(STFReader.UNITS.VolumeDefaultFT3, null)); break;
-                
+
                 // OpenRails specific parameters
                 case "wagon(brakepipevolume": BrakePipeVolumeM3 = Me3.FromFt3(stf.ReadFloatBlock(STFReader.UNITS.VolumeDefaultFT3, null)); break;
             }
@@ -284,7 +284,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         {
             // reducing size of Emergency Reservoir for short (fake) cars
             if (Car.Simulator.Settings.CorrectQuestionableBrakingParams && Car.CarLengthM <= 1)
-            EmergResVolumeM3 = Math.Min (0.02f, EmergResVolumeM3);
+                EmergResVolumeM3 = Math.Min(0.02f, EmergResVolumeM3);
             BrakeLine1PressurePSI = Car.Train.EqualReservoirPressurePSIorInHg;
             BrakeLine2PressurePSI = Car.Train.BrakeLine2PressurePSI;
             BrakeLine3PressurePSI = 0;
@@ -299,7 +299,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             HandbrakePercent = handbrakeOn & (Car as MSTSWagon).HandBrakePresent ? 100 : 0;
             SetRetainer(RetainerSetting.Exhaust);
             MSTSLocomotive loco = Car as MSTSLocomotive;
-            if (loco != null) 
+            if (loco != null)
             {
                 loco.MainResPressurePSI = loco.MaxMainResPressurePSI;
             }
@@ -308,14 +308,14 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 AuxBrakeLineVolumeRatio = EmergResVolumeM3 / EmergAuxVolumeRatio / BrakePipeVolumeM3;
             else
                 AuxBrakeLineVolumeRatio = 3.1f;
-                     
+
             CylVolumeM3 = EmergResVolumeM3 / EmergAuxVolumeRatio / AuxCylVolumeRatio;
         }
 
         /// <summary>
         /// Used when initial speed > 0
         /// </summary>
-        public override void InitializeMoving ()
+        public override void InitializeMoving()
         {
             var emergResPressurePSI = EmergResPressurePSI;
             Initialize(false, 0, FullServPressurePSI, true);
@@ -415,26 +415,26 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 }
 
                 if ((Car as MSTSWagon).EmergencyReservoirPresent)
-				{
+                {
                     if (!(Car as MSTSWagon).DistributorPresent && AuxResPressurePSI < EmergResPressurePSI && AuxResPressurePSI < BrakeLine1PressurePSI)
-					{
-						float dp = elapsedClockSeconds * EmergResChargingRatePSIpS;
-						if (EmergResPressurePSI - dp < AuxResPressurePSI + dp * EmergAuxVolumeRatio)
-							dp = (EmergResPressurePSI - AuxResPressurePSI) / (1 + EmergAuxVolumeRatio);
-						if (BrakeLine1PressurePSI < AuxResPressurePSI + dp * EmergAuxVolumeRatio)
-							dp = (BrakeLine1PressurePSI - AuxResPressurePSI) / EmergAuxVolumeRatio;
-						EmergResPressurePSI -= dp;
-						AuxResPressurePSI += dp * EmergAuxVolumeRatio;
-					}
-					if (AuxResPressurePSI > EmergResPressurePSI)
-					{
-						float dp = elapsedClockSeconds * EmergResChargingRatePSIpS;
-						if (EmergResPressurePSI + dp > AuxResPressurePSI - dp * EmergAuxVolumeRatio)
-							dp = (AuxResPressurePSI - EmergResPressurePSI) / (1 + EmergAuxVolumeRatio);
-						EmergResPressurePSI += dp;
-						AuxResPressurePSI -= dp * EmergAuxVolumeRatio;
-					}
-				}
+                    {
+                        float dp = elapsedClockSeconds * EmergResChargingRatePSIpS;
+                        if (EmergResPressurePSI - dp < AuxResPressurePSI + dp * EmergAuxVolumeRatio)
+                            dp = (EmergResPressurePSI - AuxResPressurePSI) / (1 + EmergAuxVolumeRatio);
+                        if (BrakeLine1PressurePSI < AuxResPressurePSI + dp * EmergAuxVolumeRatio)
+                            dp = (BrakeLine1PressurePSI - AuxResPressurePSI) / EmergAuxVolumeRatio;
+                        EmergResPressurePSI -= dp;
+                        AuxResPressurePSI += dp * EmergAuxVolumeRatio;
+                    }
+                    if (AuxResPressurePSI > EmergResPressurePSI)
+                    {
+                        float dp = elapsedClockSeconds * EmergResChargingRatePSIpS;
+                        if (EmergResPressurePSI + dp > AuxResPressurePSI - dp * EmergAuxVolumeRatio)
+                            dp = (AuxResPressurePSI - EmergResPressurePSI) / (1 + EmergAuxVolumeRatio);
+                        EmergResPressurePSI += dp;
+                        AuxResPressurePSI -= dp * EmergAuxVolumeRatio;
+                    }
+                }
                 if (AuxResPressurePSI < BrakeLine1PressurePSI && (!TwoPipes || NoMRPAuxResCharging || BrakeLine2PressurePSI < BrakeLine1PressurePSI) && !BleedOffValveOpen)
                 {
                     float dp = elapsedClockSeconds * MaxAuxilaryChargingRatePSIpS; // Change in pressure for train brake pipe.
@@ -480,24 +480,24 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             else
                 CylPressurePSI = AutoCylPressurePSI;
 
-          // Record HUD display values for brake cylinders depending upon whether they are wagons or locomotives/tenders (which are subject to their own engine brakes)   
+            // Record HUD display values for brake cylinders depending upon whether they are wagons or locomotives/tenders (which are subject to their own engine brakes)   
             if (Car.WagonType == MSTSWagon.WagonTypes.Engine || Car.WagonType == MSTSWagon.WagonTypes.Tender)
             {
-                 Car.Train.HUDLocomotiveBrakeCylinderPSI = CylPressurePSI;
+                Car.Train.HUDLocomotiveBrakeCylinderPSI = CylPressurePSI;
             }
             else
             {
-               // Record the Brake Cylinder pressure in first wagon, as EOT is also captured elsewhere, and this will provide the two extremeties of the train
-               // Identifies the first wagon based upon the previously identified UiD 
+                // Record the Brake Cylinder pressure in first wagon, as EOT is also captured elsewhere, and this will provide the two extremeties of the train
+                // Identifies the first wagon based upon the previously identified UiD 
                 if (Car.UiD == Car.Train.FirstCarUiD)
-               {
-                   Car.Train.HUDWagonBrakeCylinderPSI = CylPressurePSI;
-               }
-                
+                {
+                    Car.Train.HUDWagonBrakeCylinderPSI = CylPressurePSI;
+                }
+
             }
 
             // If wagons are not attached to the locomotive, then set wagon BC pressure to same as locomotive in the Train brake line
-            if (!Car.Train.WagonsAttached &&  (Car.WagonType == MSTSWagon.WagonTypes.Engine || Car.WagonType == MSTSWagon.WagonTypes.Tender) ) 
+            if (!Car.Train.WagonsAttached && (Car.WagonType == MSTSWagon.WagonTypes.Engine || Car.WagonType == MSTSWagon.WagonTypes.Tender))
             {
                 Car.Train.HUDWagonBrakeCylinderPSI = CylPressurePSI;
             }
@@ -509,7 +509,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 if (f < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
                     f = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
             }
-            else f = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2); 
+            else f = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
             Car.BrakeRetardForceN = f * Car.BrakeShoeRetardCoefficientFrictionAdjFactor; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding to excessive brake force
             {
@@ -524,7 +524,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             if (SoundTriggerCounter >= 0.5f)
             {
                 SoundTriggerCounter = 0f;
-                if ( Math.Abs(AutoCylPressurePSI - prevCylPressurePSI) > 0.1f) //(AutoCylPressurePSI != prevCylPressurePSI)
+                if (Math.Abs(AutoCylPressurePSI - prevCylPressurePSI) > 0.1f) //(AutoCylPressurePSI != prevCylPressurePSI)
                 {
                     if (!TrainBrakePressureChanging)
                     {
@@ -542,7 +542,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     Car.SignalEvent(Event.TrainBrakePressureStoppedChanging);
                 }
 
-                if ( Math.Abs(BrakeLine1PressurePSI - prevBrakePipePressurePSI) > 0.1f /*BrakeLine1PressurePSI > prevBrakePipePressurePSI*/)
+                if (Math.Abs(BrakeLine1PressurePSI - prevBrakePipePressurePSI) > 0.1f /*BrakeLine1PressurePSI > prevBrakePipePressurePSI*/)
                 {
                     if (!BrakePipePressureChanging)
                     {
@@ -573,7 +573,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         protected static void PropagateBrakeLinePressures(float elapsedClockSeconds, TrainCar trainCar, bool twoPipes)
         {
             // Brake pressures are calculated on the lead locomotive first, and then propogated along each wagon in the consist.
-            
+
             var train = trainCar.Train;
             var lead = trainCar as MSTSLocomotive;
             var brakePipeTimeFactorS = lead == null ? 0.0015f : lead.BrakePipeTimeFactorS;
@@ -602,19 +602,19 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
                     if (lead != null)
                     {
-                            // Allow for leaking train air brakepipe
-                            if (lead.BrakeSystem.BrakeLine1PressurePSI - TrainPipeLeakLossPSI > 0 && lead.TrainBrakePipeLeakPSIorInHgpS != 0) // if train brake pipe has pressure in it, ensure result will not be negative if loss is subtracted
-                            {
-                                lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipeLeakLossPSI;
-                            }
+                        // Allow for leaking train air brakepipe
+                        if (lead.BrakeSystem.BrakeLine1PressurePSI - TrainPipeLeakLossPSI > 0 && lead.TrainBrakePipeLeakPSIorInHgpS != 0) // if train brake pipe has pressure in it, ensure result will not be negative if loss is subtracted
+                        {
+                            lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipeLeakLossPSI;
+                        }
 
-                            // Charge train brake pipe - adjust main reservoir pressure, and lead brake pressure line to maintain brake pipe equal to equalising resevoir pressure - release brakes
+                        // Charge train brake pipe - adjust main reservoir pressure, and lead brake pressure line to maintain brake pipe equal to equalising resevoir pressure - release brakes
                         if (lead.BrakeSystem.BrakeLine1PressurePSI < train.EqualReservoirPressurePSIorInHg)
                         {
                             // Calculate change in brake pipe pressure between equalising reservoir and lead brake pipe
                             float PressureDiffEqualToPipePSI = TrainPipeTimeVariationS * lead.BrakePipeChargingRatePSIorInHgpS; // default condition - if EQ Res is higher then Brake Pipe Pressure
 
-                            if (lead.BrakeSystem.BrakeLine1PressurePSI + PressureDiffEqualToPipePSI > train.EqualReservoirPressurePSIorInHg) 
+                            if (lead.BrakeSystem.BrakeLine1PressurePSI + PressureDiffEqualToPipePSI > train.EqualReservoirPressurePSIorInHg)
                                 PressureDiffEqualToPipePSI = train.EqualReservoirPressurePSIorInHg - lead.BrakeSystem.BrakeLine1PressurePSI;
 
                             if (lead.BrakeSystem.BrakeLine1PressurePSI + PressureDiffEqualToPipePSI > lead.MainResPressurePSI)
@@ -641,7 +641,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                                     lead.BrakeSystem.BrakeLine1PressurePSI += PressureDiffEqualToPipePSI;  // Increase brake pipe pressure to cover loss
                                     lead.MainResPressurePSI = lead.MainResPressurePSI - (PressureDiffEqualToPipePSI * lead.BrakeSystem.BrakePipeVolumeM3 / lead.MainResVolumeM3);   // Decrease main reservoir pressure
                                 }
-                                    // else in LAP psoition brake pipe is isolated, and thus brake pipe pressure decreases, but reservoir remains at same pressure
+                                // else in LAP psoition brake pipe is isolated, and thus brake pipe pressure decreases, but reservoir remains at same pressure
                             }
                         }
                         // reduce pressure in lead brake line if brake pipe pressure is above equalising pressure - apply brakes
@@ -654,7 +654,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
                         train.LeadPipePressurePSI = lead.BrakeSystem.BrakeLine1PressurePSI;  // Keep a record of current train pipe pressure in lead locomotive
                     }
-                    
+
                     // Propogate lead brake line pressure from lead locomotive along the train to each car
                     TrainCar car0 = train.Cars[0];
                     float p0 = car0.BrakeSystem.BrakeLine1PressurePSI;
@@ -668,7 +668,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     Trace.TraceInformation("Main Resevoir {0} Compressor running {1}", lead.MainResPressurePSI, lead.CompressorIsOn);
 
 #endif
-                    foreach (TrainCar car in train.Cars)               
+                    foreach (TrainCar car in train.Cars)
                     {
                         train.TotalTrainBrakePipeVolumeM3 += car.BrakeSystem.BrakePipeVolumeM3; // Calculate total brake pipe volume of train
 
@@ -676,7 +676,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         if (car == train.Cars[0] || car.BrakeSystem.FrontBrakeHoseConnected && car.BrakeSystem.AngleCockAOpen && car0.BrakeSystem.AngleCockBOpen)
                         {
 
-                            float TrainPipePressureDiffPropogationPSI = Math.Min (TrainPipeTimeVariationS * (p1 - p0) / brakePipeTimeFactorS, p1 - p0);
+                            float TrainPipePressureDiffPropogationPSI = Math.Min(TrainPipeTimeVariationS * (p1 - p0) / brakePipeTimeFactorS, p1 - p0);
                             // Appears to work on the principle of pressure equalisation, ie trailing car pressure will drop by fraction of total volume determined by lead car.
 
                             // TODO - Confirm logic - it appears to allow for air flow to coupled car by reducing (increasing) preceeding car brake pipe - this allows time for the train to "recharge".
@@ -686,13 +686,13 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                                 car0.BrakeSystem.BrakeLine1PressurePSI += TrainPipePressureDiffPropogationPSI * car.BrakeSystem.BrakePipeVolumeM3 / (brakePipeVolumeM30 + car.BrakeSystem.BrakePipeVolumeM3);
                                 car0.BrakeSystem.BrakeLine1PressurePSI = MathHelper.Clamp(car0.BrakeSystem.BrakeLine1PressurePSI, 0.001f, lead.TrainBrakeController.MaxPressurePSI); // Prevent Lead locomotive pipe pressure increasing above the value calculated above
                             }
-                           else
+                            else
                             {
                                 car.BrakeSystem.BrakeLine1PressurePSI -= TrainPipePressureDiffPropogationPSI * brakePipeVolumeM30 / (brakePipeVolumeM30 + car.BrakeSystem.BrakePipeVolumeM3);
                                 car0.BrakeSystem.BrakeLine1PressurePSI += TrainPipePressureDiffPropogationPSI * car.BrakeSystem.BrakePipeVolumeM3 / (brakePipeVolumeM30 + car.BrakeSystem.BrakePipeVolumeM3);
-                            }                      
+                            }
                         }
-                        
+
                         if (!car.BrakeSystem.FrontBrakeHoseConnected)  // Car front brake hose not connected
                         {
                             if (car.BrakeSystem.AngleCockAOpen) //  AND Front brake cock opened
@@ -776,7 +776,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         if (p > 1000)
                             p -= 1000;
                         var prevState = lead.EngineBrakeState;
-                        if (p < train.BrakeLine3PressurePSI && p < lead.MainResPressurePSI )  // Apply the engine brake as the pressure decreases
+                        if (p < train.BrakeLine3PressurePSI && p < lead.MainResPressurePSI)  // Apply the engine brake as the pressure decreases
                         {
                             float dp = elapsedClockSeconds * lead.EngineBrakeApplyRatePSIpS / (last - first + 1);
                             if (p + dp > train.BrakeLine3PressurePSI)
@@ -902,7 +902,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         public override bool IsBraking()
         {
             if (AutoCylPressurePSI > MaxCylPressurePSI * 0.3)
-            return true;
+                return true;
             return false;
         }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirTwinPipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirTwinPipe.cs
@@ -31,7 +31,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
         public override void UpdateTripleValveState(float controlPressurePSI)
         {
-            if (controlPressurePSI < AutoCylPressurePSI - (TripleValveState != ValveState.Release ? 2.2f : 0f) 
+            if (controlPressurePSI < AutoCylPressurePSI - (TripleValveState != ValveState.Release ? 2.2f : 0f)
                 || controlPressurePSI < 2.2f) // The latter is a UIC regulation (0.15 bar)
                 TripleValveState = ValveState.Release;
             else if (!BailOffOn && controlPressurePSI > AutoCylPressurePSI + (TripleValveState != ValveState.Apply ? 2.2f : 0f))

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/SingleTransferPipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/SingleTransferPipe.cs
@@ -101,15 +101,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     s += string.Format(" Handbrake {0:F0}%", HandbrakePercent);
                 return s;
             }
-            
+
         }
 
         // This overides the information for each individual wagon in the extended HUD  
-       public override string[] GetDebugStatus(Dictionary<BrakeSystemComponent, PressureUnit> units)
+        public override string[] GetDebugStatus(Dictionary<BrakeSystemComponent, PressureUnit> units)
         {
             // display differently depending upon whether vacuum or air braked system
             if (Car.CarBrakeSystemType == "vacuum_piped")
-            {       
+            {
 
                 return new string[] {
                 DebugType,
@@ -125,7 +125,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             else  // air braked by default
             {
 
-            return new string[] {
+                return new string[] {
                 DebugType,
                 string.Empty,
                 FormatStrings.FormatPressure(BrakeLine1PressurePSI, PressureUnit.PSI, units[BrakeSystemComponent.BrakePipe], true),
@@ -141,7 +141,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 BleedOffValveOpen ? Simulator.Catalog.GetString("Open") : string.Empty,
                 };
 
-           }
+            }
         }
 
         public override float GetCylPressurePSI()
@@ -157,7 +157,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         public override void Update(float elapsedClockSeconds)
         {
             BleedOffValveOpen = false;
-            Car.BrakeRetardForceN = ( Car.MaxHandbrakeForceN * HandbrakePercent / 100) * Car.BrakeShoeRetardCoefficientFrictionAdjFactor; // calculates value of force applied to wheel, independent of wheel skid
+            Car.BrakeRetardForceN = (Car.MaxHandbrakeForceN * HandbrakePercent / 100) * Car.BrakeShoeRetardCoefficientFrictionAdjFactor; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding to excessive brake force
             {
                 Car.BrakeForceN = (Car.MaxHandbrakeForceN * HandbrakePercent / 100) * Car.SkidFriction;   // if excessive brakeforce, wheel skids, and loses adhesion
@@ -166,7 +166,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             {
                 Car.BrakeForceN = (Car.MaxHandbrakeForceN * HandbrakePercent / 100) * Car.BrakeShoeCoefficientFrictionAdjFactor; // In advanced adhesion model brake shoe coefficient varies with speed, in simple model constant force applied as per value in WAG file, will vary with wheel skid.
             }
-        
+
         }
     }
 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
@@ -81,7 +81,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             VacResVolM3 = thiscopy.VacResVolM3;
             HasDirectAdmissionValue = thiscopy.HasDirectAdmissionValue;
         }
-         
+
         // return vacuum reservior pressure adjusted for piston movement
         float VacResPressureAdjPSIA()
         {
@@ -100,7 +100,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         {
             string s;
             // display depending upon whether an EQ reservoir fitted
-            if ( Car.Train.EQEquippedVacLoco)
+            if (Car.Train.EQEquippedVacLoco)
             {
                 s = string.Format(" EQ {0}", FormatStrings.FormatPressure(Vac.FromPress(Vac.ToPress(Car.Train.EqualReservoirPressurePSIorInHg)), PressureUnit.InHg, PressureUnit.InHg, true));
                 s += string.Format(" V {0}", FormatStrings.FormatPressure(Vac.FromPress(BrakeLine1PressurePSI), PressureUnit.InHg, PressureUnit.InHg, true));
@@ -151,7 +151,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         {
             return NumBrakeCylinders;
         }
-        
+
 
         public override float GetVacResPressurePSI()
         {
@@ -165,8 +165,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 case "wagon(brakecylinderpressureformaxbrakebrakeforce": MaxForcePressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultInHg, null); break;
                 case "wagon(maxreleaserate": MaxReleaseRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultInHgpS, null); break;
                 case "wagon(maxapplicationrate": MaxApplicationRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultInHgpS, null); break;
-                case "wagon(ortsdirectadmissionvalve": DirectAdmissionValve = stf.ReadFloatBlock(STFReader.UNITS.None, null);
-                    if(DirectAdmissionValve == 1.0f)
+                case "wagon(ortsdirectadmissionvalve":
+                    DirectAdmissionValve = stf.ReadFloatBlock(STFReader.UNITS.None, null);
+                    if (DirectAdmissionValve == 1.0f)
                     {
                         HasDirectAdmissionValue = true;
                     }
@@ -178,7 +179,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 // OpenRails specific parameters
                 case "wagon(brakepipevolume": BrakePipeVolumeM3 = Me3.FromFt3(stf.ReadFloatBlock(STFReader.UNITS.VolumeDefaultFT3, null)); break;
                 case "wagon(ortsauxilaryrescapacity": VacResVolM3 = Me3.FromFt3(stf.ReadFloatBlock(STFReader.UNITS.VolumeDefaultFT3, null)); break;
-                case "wagon(ortsbrakecylindersize": float BrakeCylSizeM = stf.ReadFloatBlock(STFReader.UNITS.Distance, null);
+                case "wagon(ortsbrakecylindersize":
+                    float BrakeCylSizeM = stf.ReadFloatBlock(STFReader.UNITS.Distance, null);
                     BrakeCylVolM3 = Me3.FromIn3((float)((Me.ToIn(BrakeCylSizeM) / 2) * (Me.ToIn(BrakeCylSizeM) / 2) * 4.5 * Math.PI)); // Calculate brake cylinder volume based upon size of BC, 4.5" of piston travel
                     break;
                 case "wagon(ortsnumberbrakecylinders": NumBrakeCylinders = stf.ReadIntBlock(null); break;
@@ -226,13 +228,13 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
             BrakeLine1PressurePSI = Vac.ToPress(Car.Train.EqualReservoirPressurePSIorInHg);
             BrakeLine2PressurePSI = 0;
-//            BrakeLine3PressurePSI = V2P(Car.Train.EqualReservoirPressurePSIorInHg);
-/*            if (Car.Train.AITrainBrakePercent == 0)
-            {
-                CylPressurePSIA = 0;
-                Car.BrakeForceN = 0;
-            }
-            else */
+            //            BrakeLine3PressurePSI = V2P(Car.Train.EqualReservoirPressurePSIorInHg);
+            /*            if (Car.Train.AITrainBrakePercent == 0)
+                        {
+                            CylPressurePSIA = 0;
+                            Car.BrakeForceN = 0;
+                        }
+                        else */
             CylPressurePSIA = Vac.ToPress(Car.Train.EqualReservoirPressurePSIorInHg);
             VacResPressurePSIA = Vac.ToPress(Car.Train.EqualReservoirPressurePSIorInHg);
             HandbrakePercent = 0;
@@ -252,16 +254,16 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             {
                 LeadLoco = true;
             }
-                       
+
             // Brake information is updated for each vehicle
 
             //            if (BrakeLine3PressurePSI > 3.0 && BrakeLine3PressurePSI < OneAtmospherePSI) // To be confirmed
-            if (BrakeLine3PressurePSI > 3.0 ) // To be confirmed
-                {
-                    CylPressurePSIA = BrakeLine3PressurePSI;
-                }
+            if (BrakeLine3PressurePSI > 3.0) // To be confirmed
+            {
+                CylPressurePSIA = BrakeLine3PressurePSI;
+            }
             else
-                { 
+            {
                 if (BrakeLine1PressurePSI < VacResPressurePSIA)
                 {
                     float dp = elapsedClockSeconds * MaxApplicationRatePSIpS * BrakeCylVolM3 / VacResVolM3;
@@ -270,11 +272,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         dp = (VacResPressurePSIA - BrakeLine1PressurePSI) / (1 + vr);
                     VacResPressurePSIA -= dp;
 
-                  if (LeadLoco == false)
+                    if (LeadLoco == false)
                     {
                         BrakeLine1PressurePSI += dp * vr; // don't adjust the BP pressure if this is the lead locomotive
                     }
-                    
+
                     CylPressurePSIA = VacResPressurePSIA;
                 }
                 else if (BrakeLine1PressurePSI < CylPressurePSIA) // Increase BP pressure, hence vacuum brakes are being released
@@ -366,7 +368,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     Car.SignalEvent(Event.TrainBrakePressureStoppedChanging);
                 }
 
-                if ( Math.Abs(BrakeLine1PressurePSI-prevBrakePipePressurePSI)> 0.05f /*BrakeLine1PressurePSI > prevBrakePipePressurePSI*/)
+                if (Math.Abs(BrakeLine1PressurePSI - prevBrakePipePressurePSI) > 0.05f /*BrakeLine1PressurePSI > prevBrakePipePressurePSI*/)
                 {
                     if (!BrakePipePressureChanging)
                     {
@@ -410,7 +412,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             // The resulting air pressures are then converted to a respective vacuum value where - 14.5psi (atmospheric pressure) = 0 InHg, and approx 4.185psi = 21 InHg.
             // Brakes are applied when vaccum is destroyed, ie 0 InHg, Brakes released when vacuum established ie 21 or 25 InHg
             float DesiredPipeVacuum = Vac.ToPress(train.EqualReservoirPressurePSIorInHg);
-            float SmallEjectorChargingRateInHgpS = lead == null ? 10.0f : (lead.SmallEjectorBrakePipeChargingRatePSIorInHgpS ); // Set value for small ejector to operate - fraction set in steam locomotive
+            float SmallEjectorChargingRateInHgpS = lead == null ? 10.0f : (lead.SmallEjectorBrakePipeChargingRatePSIorInHgpS); // Set value for small ejector to operate - fraction set in steam locomotive
             float LargeEjectorChargingRateInHgpS = lead == null ? 10.0f : (lead.LargeEjectorBrakePipeChargingRatePSIorInHgpS); // Set value for large ejector to operate - fraction set in steam locomotive
             float MaxVacuumPipeLevelPSI = lead == null ? Bar.ToPSI(Bar.FromInHg(21)) : lead.TrainBrakeController.MaxPressurePSI;
             float TrainPipeLeakLossPSI = lead == null ? 0.0f : (lead.TrainBrakePipeLeakPSIorInHgpS);
@@ -448,7 +450,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
             train.EQEquippedVacLoco = lead == null ? false : lead.VacuumBrakeEQFitted;
 
-           foreach (TrainCar car in train.Cars)
+            foreach (TrainCar car in train.Cars)
             {
 
                 // Calculate train brake system volumes
@@ -482,7 +484,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             float nStepsFraction;
             nStepsFraction = (Me3.FromFt3(200.0f) / train.TotalTrainBrakeSystemVolumeM3);
             float nStepsWhole = (elapsedClockSeconds * nStepsFraction) / brakePipeTimeFactorS + 1;
-            nSteps = (int)( nStepsWhole);
+            nSteps = (int)(nStepsWhole);
             float TrainPipeTimeVariationS = elapsedClockSeconds / nSteps;
 
             // Calculate adjusted values based upon the train brake system volume
@@ -566,9 +568,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
             }
 
-                // For each iterative step, calculate lead locomotive pressures, and propagate them along the train
-                // Train brake pipe volume will be calculated, and used to vary timing response parameters, thus simulating variations in train length
-                for (int i = 0; i < nSteps; i++)
+            // For each iterative step, calculate lead locomotive pressures, and propagate them along the train
+            // Train brake pipe volume will be calculated, and used to vary timing response parameters, thus simulating variations in train length
+            for (int i = 0; i < nSteps; i++)
             {
                 // Calculate train pipe pressure at lead locomotive.
                 if (lead != null)
@@ -578,19 +580,19 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     // locking the system into the Running position.
                     if (lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.Running && DesiredPipeVacuum == lead.BrakeSystem.BrakeLine1PressurePSI && !lead.BrakeSystem.ControllerRunningLock)
                     {
-                      lead.BrakeSystem.ControllerRunningLock = true;
+                        lead.BrakeSystem.ControllerRunningLock = true;
                     }
                     else if (lead.TrainBrakeController.TrainBrakeControllerState != ControllerState.Running) // Only reset lock when moved to another controller position
                     {
-                    lead.BrakeSystem.ControllerRunningLock = false;
+                        lead.BrakeSystem.ControllerRunningLock = false;
                     }
 
-                 /*  // For testing purposes
-                       Trace.TraceInformation("Brake Test - Volume {0} Release Rate {1} Charging Rate {2}", train.TotalTrainBrakeSystemVolumeM3, ReleaseNetBPLossGainPSI, lead.BrakePipeChargingRatePSIorInHgpS);
-                       Trace.TraceInformation("Large Ejector Raw {0} Large Ejector (VB) {1} Ad Large Ejector {2}", lead.LargeEjectorBrakePipeChargingRatePSIorInHgpS, LargeEjectorChargingRateInHgpS, AdjLargeEjectorChargingRateInHgpS);
-                       Trace.TraceInformation("Small Ejector Raw {0} Small Ejector (VB) {1} Ad Small Ejector {2}", lead.SmallEjectorBrakePipeChargingRatePSIorInHgpS, SmallEjectorChargingRateInHgpS, AdjSmallEjectorChargingRateInHgpS);
-                       Trace.TraceInformation("Pipe Loss - Raw {0} Adj {1}", lead.TrainBrakePipeLeakPSIorInHgpS, AdjTrainPipeLeakLossPSI);
-                 */
+                    /*  // For testing purposes
+                          Trace.TraceInformation("Brake Test - Volume {0} Release Rate {1} Charging Rate {2}", train.TotalTrainBrakeSystemVolumeM3, ReleaseNetBPLossGainPSI, lead.BrakePipeChargingRatePSIorInHgpS);
+                          Trace.TraceInformation("Large Ejector Raw {0} Large Ejector (VB) {1} Ad Large Ejector {2}", lead.LargeEjectorBrakePipeChargingRatePSIorInHgpS, LargeEjectorChargingRateInHgpS, AdjLargeEjectorChargingRateInHgpS);
+                          Trace.TraceInformation("Small Ejector Raw {0} Small Ejector (VB) {1} Ad Small Ejector {2}", lead.SmallEjectorBrakePipeChargingRatePSIorInHgpS, SmallEjectorChargingRateInHgpS, AdjSmallEjectorChargingRateInHgpS);
+                          Trace.TraceInformation("Pipe Loss - Raw {0} Adj {1}", lead.TrainBrakePipeLeakPSIorInHgpS, AdjTrainPipeLeakLossPSI);
+                    */
 
                     // Adjust brake pipe pressure according to various brake controls. Two modes are considered
                     //  - EQ where brake system is fitted with EQ reservoir, and lead locomotive uses the equalising pressure to set brake pipe
@@ -608,7 +610,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                                 lead.BrakeSystem.BrakeLine1PressurePSI = OneAtmospherePSI;
                         }
 
-                        else if (lead.BrakeSystem.BrakeLine1PressurePSI < DesiredPipeVacuum) 
+                        else if (lead.BrakeSystem.BrakeLine1PressurePSI < DesiredPipeVacuum)
                         {
                             // Vacuum Pipe is < Desired value - increase brake pipe pressure (decrease vacuum value) - PSI goes from approx 4.189 to 14.5 - applying brakes
                             lead.BrakeSystem.BrakeLine1PressurePSI *= (1 + TrainPipeTimeVariationS / AdjBrakeServiceTimeFactorS);
@@ -634,26 +636,26 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                             {
                                 TrainPipePressureDiffPSI = lead.VacuumMainResVacuumPSIAorInHg - lead.BrakeSystem.BrakeLine1PressurePSI;
                             }
-                                
+
 
                             if (TrainPipePressureDiffPSI < 0 || lead.VacuumMainResVacuumPSIAorInHg > lead.BrakeSystem.BrakeLine1PressurePSI)
                                 TrainPipePressureDiffPSI = 0;
 
                             // Adjust brake pipe pressure based upon pressure differential
-                                 // If pipe leakage and brake control valve is in LAP position then pipe is connected to main reservoir and maintained at equalising pressure from reservoir
-                                // All other brake states will have the brake pipe connected to the main reservoir, and therefore leakage will be compenstaed by air from main reservoir
-                                // Modern self lap brakes will maintain pipe pressure using air from main reservoir
+                            // If pipe leakage and brake control valve is in LAP position then pipe is connected to main reservoir and maintained at equalising pressure from reservoir
+                            // All other brake states will have the brake pipe connected to the main reservoir, and therefore leakage will be compenstaed by air from main reservoir
+                            // Modern self lap brakes will maintain pipe pressure using air from main reservoir
 
-                           if (lead.TrainBrakeController.TrainBrakeControllerState != ControllerState.Lap)
+                            if (lead.TrainBrakeController.TrainBrakeControllerState != ControllerState.Lap)
                             {
-                                    lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipePressureDiffPSI;  // Increase brake pipe pressure to cover loss
+                                lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipePressureDiffPSI;  // Increase brake pipe pressure to cover loss
                                 float VolDiffM3 = (train.TotalTrainBrakeSystemVolumeM3 / lead.VacuumBrakesMainResVolumeM3);
                                 lead.VacuumMainResVacuumPSIAorInHg += TrainPipePressureDiffPSI * VolDiffM3;
                                 if (lead.VacuumMainResVacuumPSIAorInHg > OneAtmospherePSI)
                                     lead.VacuumMainResVacuumPSIAorInHg = OneAtmospherePSI; // Ensure Main Res does not go negative
                             }
-                                // else in LAP psoition brake pipe is isolated, and thus brake pipe pressure decreases, but reservoir remains at same pressure
-                            
+                            // else in LAP psoition brake pipe is isolated, and thus brake pipe pressure decreases, but reservoir remains at same pressure
+
                         }
                     }
 
@@ -677,28 +679,28 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         // If no leakage, ie not in Running position, adjust the train pipe up and down as appropriate.
                         // Brake Controller is in Emergency position - fast increase brake pipe pressure (decrease vacuum value) - PSI goes from approx 4.189 to 14.5 - applying brakes
                         else if (lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.Emergency)
-                            {
-                                lead.BrakeSystem.BrakeLine1PressurePSI *= (1 + TrainPipeTimeVariationS / AdjBrakeEmergencyTimeFactorS);
+                        {
+                            lead.BrakeSystem.BrakeLine1PressurePSI *= (1 + TrainPipeTimeVariationS / AdjBrakeEmergencyTimeFactorS);
 
-                                if (lead.BrakeSystem.BrakeLine1PressurePSI > OneAtmospherePSI)
-                                    lead.BrakeSystem.BrakeLine1PressurePSI = OneAtmospherePSI;
-                            }
+                            if (lead.BrakeSystem.BrakeLine1PressurePSI > OneAtmospherePSI)
+                                lead.BrakeSystem.BrakeLine1PressurePSI = OneAtmospherePSI;
+                        }
 
 
-                            // Brake Controller is in Apply position - increase brake pipe pressure (decrease vacuum value) - PSI goes from approx 4.189 to 14.5 - applying brakes
-                            else if (lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.Apply)
-                            {
-                                    lead.BrakeSystem.BrakeLine1PressurePSI *= (1 + TrainPipeTimeVariationS / AdjBrakeServiceTimeFactorS);
-                                    if (lead.BrakeSystem.BrakeLine1PressurePSI > OneAtmospherePSI)
-                                        lead.BrakeSystem.BrakeLine1PressurePSI = OneAtmospherePSI;
-                            }
+                        // Brake Controller is in Apply position - increase brake pipe pressure (decrease vacuum value) - PSI goes from approx 4.189 to 14.5 - applying brakes
+                        else if (lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.Apply)
+                        {
+                            lead.BrakeSystem.BrakeLine1PressurePSI *= (1 + TrainPipeTimeVariationS / AdjBrakeServiceTimeFactorS);
+                            if (lead.BrakeSystem.BrakeLine1PressurePSI > OneAtmospherePSI)
+                                lead.BrakeSystem.BrakeLine1PressurePSI = OneAtmospherePSI;
+                        }
 
-                            // Brake Controller is in Release position - decrease brake pipe value pressure - PSI goes from 14.5 to 4.189 - releasing brakes
-                            else if (lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.Release)
-                            {
+                        // Brake Controller is in Release position - decrease brake pipe value pressure - PSI goes from 14.5 to 4.189 - releasing brakes
+                        else if (lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.Release)
+                        {
                             float TrainPipePressureDiffPSI = TrainPipeTimeVariationS * ReleaseNetBPLossGainPSI;
-                                lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipePressureDiffPSI;
-                            }
+                            lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipePressureDiffPSI;
+                        }
 
                         // Brake Controller is in Fast Release position - decrease brake pipe value pressure - PSI goes from 14.5 to 4.189 - releasing brakes
                         else if (lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.FullQuickRelease)
@@ -706,38 +708,38 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                             float TrainPipePressureDiffPSI = TrainPipeTimeVariationS * QuickReleaseNetBPLossGainPSI;
                             lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipePressureDiffPSI;
                         }
-                        
+
                         // Brake Controller is in Lap position - increase brake pipe pressure (decrease vacuum value) - PSI goes from approx 4.189 to 14.5 due to leakage - applying brakes
                         else if (lead.TrainBrakePipeLeakPSIorInHgpS != 0 && (lead.BrakeSystem.BrakeLine1PressurePSI + (TrainPipeTimeVariationS * TrainPipeLeakLossPSI)) < OneAtmospherePSI && lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.Lap)
-                            {
-                                lead.BrakeSystem.BrakeLine1PressurePSI += TrainPipeTimeVariationS * TrainPipeLeakLossPSI; // Pipe pressure will increase (ie vacuum is destroyed) due to leakage, no compensation as BP is isolated from everything
-                            }
+                        {
+                            lead.BrakeSystem.BrakeLine1PressurePSI += TrainPipeTimeVariationS * TrainPipeLeakLossPSI; // Pipe pressure will increase (ie vacuum is destroyed) due to leakage, no compensation as BP is isolated from everything
+                        }
 
-                            else if (lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.VacContServ)
-                            {
+                        else if (lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.VacContServ)
+                        {
                             // Vac Cont Service allows the brake to be moved continuously between the ON and OFF position. Once stationary the brake will be held at the level set
                             // Simulates turning steam onto the ejector, and adjusting the rate to get desired outcome out of ejector
 
-                                if (lead.BrakeSystem.BrakeLine1PressurePSI < DesiredPipeVacuum)
-                                {
+                            if (lead.BrakeSystem.BrakeLine1PressurePSI < DesiredPipeVacuum)
+                            {
                                 // Vacuum Pipe is < Desired value - increase brake pipe pressure (decrease vacuum value) - PSI goes from approx 4.189 to 14.5 - applying brakes
-                                  lead.BrakeSystem.BrakeLine1PressurePSI *= (1 + TrainPipeTimeVariationS / AdjBrakeServiceTimeFactorS);
-                                    if (lead.BrakeSystem.BrakeLine1PressurePSI > OneAtmospherePSI)
-                                        lead.BrakeSystem.BrakeLine1PressurePSI = OneAtmospherePSI;
-                                }
-                                else
-                                {
-                                    if (lead.BrakeSystem.BrakeLine1PressurePSI > DesiredPipeVacuum)
-                                    {
-                                        // Vacuum Pipe is > Desired value - decrease brake pipe value pressure - PSI goes from 14.5 to 4.189 - releasing brakes
-                                        float TrainPipePressureDiffPSI = TrainPipeTimeVariationS * ReleaseNetBPLossGainPSI;
-                                        if (lead.BrakeSystem.BrakeLine1PressurePSI - TrainPipePressureDiffPSI < DesiredPipeVacuum)
-                                            TrainPipePressureDiffPSI = lead.BrakeSystem.BrakeLine1PressurePSI - DesiredPipeVacuum;
-                                        lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipePressureDiffPSI;
-
-                                    }
-                                 }
+                                lead.BrakeSystem.BrakeLine1PressurePSI *= (1 + TrainPipeTimeVariationS / AdjBrakeServiceTimeFactorS);
+                                if (lead.BrakeSystem.BrakeLine1PressurePSI > OneAtmospherePSI)
+                                    lead.BrakeSystem.BrakeLine1PressurePSI = OneAtmospherePSI;
                             }
+                            else
+                            {
+                                if (lead.BrakeSystem.BrakeLine1PressurePSI > DesiredPipeVacuum)
+                                {
+                                    // Vacuum Pipe is > Desired value - decrease brake pipe value pressure - PSI goes from 14.5 to 4.189 - releasing brakes
+                                    float TrainPipePressureDiffPSI = TrainPipeTimeVariationS * ReleaseNetBPLossGainPSI;
+                                    if (lead.BrakeSystem.BrakeLine1PressurePSI - TrainPipePressureDiffPSI < DesiredPipeVacuum)
+                                        TrainPipePressureDiffPSI = lead.BrakeSystem.BrakeLine1PressurePSI - DesiredPipeVacuum;
+                                    lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipePressureDiffPSI;
+
+                                }
+                            }
+                        }
                     }
                     // Keep brake line within relevant limits - ie between 21 or 25 InHg and Atmospheric pressure.
                     lead.BrakeSystem.BrakeLine1PressurePSI = MathHelper.Clamp(lead.BrakeSystem.BrakeLine1PressurePSI, OneAtmospherePSI - MaxVacuumPipeLevelPSI, OneAtmospherePSI);
@@ -746,7 +748,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 // Propogate lead brake line pressure from lead locomotive along the train to each car
                 TrainCar car0 = train.Cars[0];
 
-                float  p0 = car0.BrakeSystem.BrakeLine1PressurePSI;
+                float p0 = car0.BrakeSystem.BrakeLine1PressurePSI;
                 p0 = MathHelper.Clamp(p0, OneAtmospherePSI - MaxVacuumPipeLevelPSI, OneAtmospherePSI);
                 float Car0brakePipeVolumeM3 = car0.BrakeSystem.BrakePipeVolumeM3;
                 float Car0brakeCylVolumeM3 = car0.BrakeSystem.GetCylVolumeM3();
@@ -775,9 +777,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     // If the vehicle has a brake cylinder fitted then calculate the car brake system volume ( brake cylinder and BP). 
                     //This value is used later to average the pressure during propogation along the train.
 
-                        Car0BrakeSytemVolumeM30 = Car0brakePipeVolumeM3 / (Car0brakePipeVolumeM3 + car.BrakeSystem.BrakePipeVolumeM3);
+                    Car0BrakeSytemVolumeM30 = Car0brakePipeVolumeM3 / (Car0brakePipeVolumeM3 + car.BrakeSystem.BrakePipeVolumeM3);
 
-                        CarBrakeSytemVolumeM3 = CarbrakePipeVolumeM3 / (Car0brakePipeVolumeM3 + car.BrakeSystem.BrakePipeVolumeM3);
+                    CarBrakeSytemVolumeM3 = CarbrakePipeVolumeM3 / (Car0brakePipeVolumeM3 + car.BrakeSystem.BrakePipeVolumeM3);
 
                     float p1 = car.BrakeSystem.BrakeLine1PressurePSI;
                     p1 = MathHelper.Clamp(p1, OneAtmospherePSI - MaxVacuumPipeLevelPSI, OneAtmospherePSI);
@@ -830,8 +832,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                             {
                                 // Start propagating pressure along train BP by averaging pressure across each car down the train
                                 if ((car0 == lead) && train.TrainBPIntact) // For the car after the locomotive, only decrease the car itself, and not the locomotive. 
-                                    // If previous car BP pressure is increased then the total proagation time is increased, as there is a "fight" between the lead BP pressure, 
-                                    // and the propagation BP pressure as it evens out along the train
+                                                                           // If previous car BP pressure is increased then the total proagation time is increased, as there is a "fight" between the lead BP pressure, 
+                                                                           // and the propagation BP pressure as it evens out along the train
                                 {
                                     car.BrakeSystem.BrakeLine1PressurePSI -= TrainPipePressureDiffPropogationPSI * Car0BrakeSytemVolumeM30;
                                     car.BrakeSystem.BrakeLine1PressurePSI = MathHelper.Clamp(car.BrakeSystem.BrakeLine1PressurePSI, OneAtmospherePSI - MaxVacuumPipeLevelPSI, OneAtmospherePSI);
@@ -876,15 +878,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         }
                     }
 
-                        // The following section adjusts the brake pipe pressure if the BP is disconnected or broken, eg when shunting, etc. 
-                        // If it has broken then brake pipe pressure will rise (vacuum goes to 0 InHg), and brakes will apply
-                   if (!car.BrakeSystem.FrontBrakeHoseConnected) // Brake pipe broken
+                    // The following section adjusts the brake pipe pressure if the BP is disconnected or broken, eg when shunting, etc. 
+                    // If it has broken then brake pipe pressure will rise (vacuum goes to 0 InHg), and brakes will apply
+                    if (!car.BrakeSystem.FrontBrakeHoseConnected) // Brake pipe broken
                     {
                         if (car.BrakeSystem.AngleCockAOpen)  //  AND Front brake cock opened
                         {
 
                             // release vacuum pressure if train brake pipe is "open". Make sure that we stay within bound
-                            if ( (car.BrakeSystem.BrakeLine1PressurePSI + (TrainPipeTimeVariationS * (p1) / AdjbrakePipeTimeFactorS)) > OneAtmospherePSI)
+                            if ((car.BrakeSystem.BrakeLine1PressurePSI + (TrainPipeTimeVariationS * (p1) / AdjbrakePipeTimeFactorS)) > OneAtmospherePSI)
                             {
                                 car.BrakeSystem.BrakeLine1PressurePSI = OneAtmospherePSI;
                             }
@@ -895,7 +897,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         }
 
                         if (car0.BrakeSystem.AngleCockBOpen && car != car0)  //  AND Rear cock of wagon opened, and car is not the previous wagon
-                            // appears to be the case when a locomotive (steam?) connects to the rear of the train.
+                                                                             // appears to be the case when a locomotive (steam?) connects to the rear of the train.
                         {
 
                             // release vacuum pressure if train brake pipe is "open". Make sure that we stay within bound
@@ -912,7 +914,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         }
                         car.BrakeSystem.CarBPIntact = false;
                     }
-                   else
+                    else
                     {
                         car.BrakeSystem.CarBPIntact = true;
                     }
@@ -921,7 +923,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     // If positioned at front of train
                     if (car0.BrakeSystem.AngleCockAOpen && car == train.Cars[0])
                     {
-             //           Trace.TraceInformation("Front Car (A) - Carid {0} Car BP {1} Time Factor {2} Variation {3} p1 {4}", car.CarID, car.BrakeSystem.BrakeLine1PressurePSI, AdjbrakePipeTimeFactorS, TrainPipeTimeVariationS, p1);
+                        //           Trace.TraceInformation("Front Car (A) - Carid {0} Car BP {1} Time Factor {2} Variation {3} p1 {4}", car.CarID, car.BrakeSystem.BrakeLine1PressurePSI, AdjbrakePipeTimeFactorS, TrainPipeTimeVariationS, p1);
 
                         // release vacuum pressure if train brake pipe is "open". Make sure that we stay within bound
                         if ((car0.BrakeSystem.BrakeLine1PressurePSI + (TrainPipeTimeVariationS * (p0) / AdjbrakePipeTimeFactorS)) > OneAtmospherePSI)
@@ -943,14 +945,14 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
                     // This monitors the last car in the train, and if the valve is open then BP pressure will be maintained at atmospheric (eg brakes in applied state)
                     // When valve is closed then pressure will be able to drop, and return to normal
-                    if (car == train.Cars[train.Cars.Count - 1] && car.BrakeSystem.AngleCockBOpen)  
+                    if (car == train.Cars[train.Cars.Count - 1] && car.BrakeSystem.AngleCockBOpen)
                     {
                         // Test to make sure that BP pressure stays within reasonable bounds
                         if (AdjbrakePipeTimeFactorS == 0)
                         {
                             car.BrakeSystem.BrakeLine1PressurePSI = p1;
                         }
-                         else if (  (car.BrakeSystem.BrakeLine1PressurePSI + (TrainPipeTimeVariationS * (p1) / AdjbrakePipeTimeFactorS)) > OneAtmospherePSI)
+                        else if ((car.BrakeSystem.BrakeLine1PressurePSI + (TrainPipeTimeVariationS * (p1) / AdjbrakePipeTimeFactorS)) > OneAtmospherePSI)
                         {
                             car.BrakeSystem.BrakeLine1PressurePSI = OneAtmospherePSI;
                         }
@@ -997,83 +999,83 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
             // **************  Engine Brake *************
             // Propagate engine brake pipe (#3) data
-            
-            int first = -1;
-                int last = -1;
 
-                train.FindLeadLocomotives(ref first, ref last);
-                int continuousFromInclusive = 0;
-                int continuousToExclusive = train.Cars.Count;
+            int first = -1;
+            int last = -1;
+
+            train.FindLeadLocomotives(ref first, ref last);
+            int continuousFromInclusive = 0;
+            int continuousToExclusive = train.Cars.Count;
 
             for (int i = 0; i < train.Cars.Count; i++)
             {
 
                 if (lead != null)
-                  {
-
-                // Next section forces wagons not condidered to be locomotives or tenders out of this calculation and thus their Brakeline3 values set to zero. This used above to identify which BC to change
-                BrakeSystem brakeSystem = train.Cars[i].BrakeSystem;
-                if (lead.EngineBrakeFitted)
                 {
 
-                    if (i < first && (!train.Cars[i + 1].BrakeSystem.FrontBrakeHoseConnected || !brakeSystem.AngleCockBOpen || !train.Cars[i + 1].BrakeSystem.AngleCockAOpen))
+                    // Next section forces wagons not condidered to be locomotives or tenders out of this calculation and thus their Brakeline3 values set to zero. This used above to identify which BC to change
+                    BrakeSystem brakeSystem = train.Cars[i].BrakeSystem;
+                    if (lead.EngineBrakeFitted)
                     {
-                        if (continuousFromInclusive < i + 1)
+
+                        if (i < first && (!train.Cars[i + 1].BrakeSystem.FrontBrakeHoseConnected || !brakeSystem.AngleCockBOpen || !train.Cars[i + 1].BrakeSystem.AngleCockAOpen))
                         {
-                            continuousFromInclusive = i + 1;
+                            if (continuousFromInclusive < i + 1)
+                            {
+                                continuousFromInclusive = i + 1;
+                                brakeSystem.BrakeLine3PressurePSI = 0;
+                            }
+                            continue;
+                        }
+                        if (i > last && i > 0 && (!brakeSystem.FrontBrakeHoseConnected || !brakeSystem.AngleCockAOpen || !train.Cars[i - 1].BrakeSystem.AngleCockBOpen))
+                        {
+                            if (continuousToExclusive > i)
+                                continuousToExclusive = i;
+                            brakeSystem.BrakeLine3PressurePSI = 0;
+                            continue;
+                        }
+
+                        // Collect and propagate engine brake pipe (3) data
+                        // This appears to be calculating the engine brake cylinder pressure???
+                        if (i < first || i > last) // This loop rarely used as the above exclusion and inclusion process excludes non-locomotive cars
+                        {
                             brakeSystem.BrakeLine3PressurePSI = 0;
                         }
-                        continue;
-                    }
-                    if (i > last && i > 0 && (!brakeSystem.FrontBrakeHoseConnected || !brakeSystem.AngleCockAOpen || !train.Cars[i - 1].BrakeSystem.AngleCockBOpen))
-                    {
-                        if (continuousToExclusive > i)
-                            continuousToExclusive = i;
-                        brakeSystem.BrakeLine3PressurePSI = 0;
-                        continue;
-                    }
+                        else
+                        {
 
-                    // Collect and propagate engine brake pipe (3) data
-                    // This appears to be calculating the engine brake cylinder pressure???
-                    if (i < first || i > last) // This loop rarely used as the above exclusion and inclusion process excludes non-locomotive cars
-                    {
-                        brakeSystem.BrakeLine3PressurePSI = 0;
+                            // Engine Brake Controller is in Apply position - increase brake pipe pressure (decrease vacuum value) - PSI goes from approx 4.189 to 14.5 - applying brakes
+                            if (lead.EngineBrakeController.TrainBrakeControllerState == ControllerState.Apply)
+                            {
+                                brakeSystem.BrakeLine3PressurePSI += elapsedClockSeconds * lead.EngineBrakeController.ApplyRatePSIpS;
+                                if (brakeSystem.BrakeLine3PressurePSI > OneAtmospherePSI)
+                                    brakeSystem.BrakeLine3PressurePSI = OneAtmospherePSI;
+                            }
+
+                            // Engine Brake Controller is in Apply position - increase brake pipe pressure (decrease vacuum value) - PSI goes from approx 4.189 to 14.5 - applying brakes
+                            if (lead.EngineBrakeController.TrainBrakeControllerState == ControllerState.Emergency)
+                            {
+                                brakeSystem.BrakeLine3PressurePSI += elapsedClockSeconds * lead.EngineBrakeController.EmergencyRatePSIpS;
+                                if (brakeSystem.BrakeLine3PressurePSI > OneAtmospherePSI)
+                                    brakeSystem.BrakeLine3PressurePSI = OneAtmospherePSI;
+                            }
+
+                            // Engine Brake Controller is in Release position - decrease brake pipe value pressure - PSI goes from 14.5 to 4.189 - releasing brakes
+                            else if (lead.EngineBrakeController.TrainBrakeControllerState == ControllerState.Release)
+                            {
+                                float EnginePipePressureDiffPSI = elapsedClockSeconds * lead.EngineBrakeController.ReleaseRatePSIpS;
+                                brakeSystem.BrakeLine3PressurePSI -= EnginePipePressureDiffPSI;
+                                if (brakeSystem.BrakeLine3PressurePSI < OneAtmospherePSI - MaxVacuumPipeLevelPSI)
+                                    brakeSystem.BrakeLine3PressurePSI = OneAtmospherePSI - MaxVacuumPipeLevelPSI;
+                            }
+
+                        }
                     }
                     else
                     {
-
-                        // Engine Brake Controller is in Apply position - increase brake pipe pressure (decrease vacuum value) - PSI goes from approx 4.189 to 14.5 - applying brakes
-                        if (lead.EngineBrakeController.TrainBrakeControllerState == ControllerState.Apply)
-                        {
-                            brakeSystem.BrakeLine3PressurePSI += elapsedClockSeconds * lead.EngineBrakeController.ApplyRatePSIpS;
-                            if (brakeSystem.BrakeLine3PressurePSI > OneAtmospherePSI)
-                                brakeSystem.BrakeLine3PressurePSI = OneAtmospherePSI;
-                        }
-
-                        // Engine Brake Controller is in Apply position - increase brake pipe pressure (decrease vacuum value) - PSI goes from approx 4.189 to 14.5 - applying brakes
-                        if (lead.EngineBrakeController.TrainBrakeControllerState == ControllerState.Emergency)
-                        {
-                            brakeSystem.BrakeLine3PressurePSI += elapsedClockSeconds * lead.EngineBrakeController.EmergencyRatePSIpS;
-                            if (brakeSystem.BrakeLine3PressurePSI > OneAtmospherePSI)
-                                brakeSystem.BrakeLine3PressurePSI = OneAtmospherePSI;
-                        }
-
-                        // Engine Brake Controller is in Release position - decrease brake pipe value pressure - PSI goes from 14.5 to 4.189 - releasing brakes
-                        else if (lead.EngineBrakeController.TrainBrakeControllerState == ControllerState.Release)
-                        {
-                            float EnginePipePressureDiffPSI = elapsedClockSeconds * lead.EngineBrakeController.ReleaseRatePSIpS;
-                            brakeSystem.BrakeLine3PressurePSI -= EnginePipePressureDiffPSI;
-                            if (brakeSystem.BrakeLine3PressurePSI < OneAtmospherePSI - MaxVacuumPipeLevelPSI)
-                                brakeSystem.BrakeLine3PressurePSI = OneAtmospherePSI - MaxVacuumPipeLevelPSI;
-                        }
-
+                        brakeSystem.BrakeLine3PressurePSI = 0; // Set engine brake line to zero if no engine brake fitted
                     }
                 }
-                else
-                {
-                    brakeSystem.BrakeLine3PressurePSI = 0; // Set engine brake line to zero if no engine brake fitted
-                }
-              }
             }
 
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
@@ -196,7 +196,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                     break;
 
                 case "engine(trainbrakescontrollermaxreleaserate":
-                case "engine(enginebrakescontrollermaxreleaserate":    
+                case "engine(enginebrakescontrollermaxreleaserate":
                     ReleaseRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null);
                     break;
 
@@ -392,7 +392,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             SignalEvent(BrakeControllerEvent.StartIncrease, target);
         }
 
-        public void StartDecrease(float? target , bool toZero = false)
+        public void StartDecrease(float? target, bool toZero = false)
         {
             if (toZero) SignalEvent(BrakeControllerEvent.StartDecreaseToZero, target);
             else SignalEvent(BrakeControllerEvent.StartDecrease, target);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/ControllerFactory.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/ControllerFactory.cs
@@ -20,8 +20,8 @@ using System.IO;
 namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
 {
     public enum ControllerTypes
-    {        
-        MSTSNotchController = 1,        
+    {
+        MSTSNotchController = 1,
         BrakeController
     }
 
@@ -35,13 +35,13 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 controller.Save(outf);
         }
 
-		public static void Restore(IController controller, BinaryReader inf)
+        public static void Restore(IController controller, BinaryReader inf)
         {
             if (!inf.ReadBoolean())
                 return;
 
             switch ((ControllerTypes)inf.ReadInt32())
-            {                
+            {
                 case ControllerTypes.MSTSNotchController:
                     if (controller == null)
                         controller = new MSTSNotchController();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
@@ -27,7 +27,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
      * has specific methods to update brake status.
      * 
      */
-    public class MSTSBrakeController: BrakeController
+    public class MSTSBrakeController : BrakeController
     {
         public MSTSNotchController NotchController;
 
@@ -119,7 +119,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                             break;
                         case ControllerState.Lap:
                             // Lap position applies min service reduction when first selected, and previous contoller position was Running, then no change in pressure occurs 
-                            if (PreviousNotchPosition.Type == ControllerState.Running) 
+                            if (PreviousNotchPosition.Type == ControllerState.Running)
                             {
                                 pressureBar -= MinReductionBar();
                                 epState = -1;
@@ -182,7 +182,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 pressureBar = (MaxPressureBar() - FullServReductionBar()) * CurrentValue();
             }
             else
-            {                
+            {
                 float x = NotchController.GetNotchFraction();
                 switch (notch.Type)
                 {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSNotchController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSNotchController.cs
@@ -23,7 +23,8 @@ using System.IO;
 
 namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
 {
-    public class MSTSNotch {
+    public class MSTSNotch
+    {
         public float Value;
         public bool Smooth;
         public ControllerState Type;
@@ -110,7 +111,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
      * The user need to press the key multiple times to update this controller.
      * 
      */
-    public class MSTSNotchController: IController
+    public class MSTSNotchController : IController
     {
         public float CurrentValue { get; set; }
         public float IntermediateValue;
@@ -221,7 +222,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
 
         private float GetNotchBoost()
         {
-            return (ToZero && ((CurrentNotch >= 0 && Notches[CurrentNotch].Smooth) || Notches.Count == 0 || 
+            return (ToZero && ((CurrentNotch >= 0 && Notches[CurrentNotch].Smooth) || Notches.Count == 0 ||
                 IntermediateValue - CurrentValue > StepSize) ? FastBoost : StandardBoost);
         }
 
@@ -246,7 +247,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             if (CurrentNotch >= 0 && !Notches[CurrentNotch].Smooth)
                 CurrentValue = Notches[CurrentNotch].Value;
 
-            var change = CurrentNotch > oldNotch || CurrentValue > OldValue + 0.1f || CurrentValue == 1 && OldValue < 1 
+            var change = CurrentNotch > oldNotch || CurrentValue > OldValue + 0.1f || CurrentValue == 1 && OldValue < 1
                 ? 1 : CurrentNotch < oldNotch || CurrentValue < OldValue - 0.1f || CurrentValue == 0 && OldValue > 0 ? -1 : 0;
             if (change != 0)
                 OldValue = CurrentValue;
@@ -268,7 +269,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                     MSTSNotch notch = Notches[CurrentNotch];
                     if (CurrentNotch > 0 && v < notch.Value)
                     {
-                        MSTSNotch prev = Notches[CurrentNotch-1];
+                        MSTSNotch prev = Notches[CurrentNotch - 1];
                         if (!notch.Smooth && !prev.Smooth && v - prev.Value > .45 * (notch.Value - prev.Value))
                             break;
                         CurrentNotch--;
@@ -298,7 +299,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             return 100 * CurrentValue;
         }
 
-        public void StartIncrease( float? target ) {
+        public void StartIncrease(float? target)
+        {
             controllerTarget = target;
             ToZero = false;
             StartIncrease();
@@ -314,20 +316,20 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 ++CurrentNotch;
                 IntermediateValue = CurrentValue = Notches[CurrentNotch].Value;
             }
-		}
+        }
 
         public void StopIncrease()
         {
             UpdateValue = 0;
         }
 
-        public void StartDecrease( float? target, bool toZero = false)
+        public void StartDecrease(float? target, bool toZero = false)
         {
             controllerTarget = target;
             ToZero = toZero;
             StartDecrease();
         }
-        
+
         public void StartDecrease()
         {
             UpdateValue = -1;
@@ -361,12 +363,13 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
         /// <summary>
         /// If a target has been set, then stop once it's reached and also cancel the target.
         /// </summary>
-        public void CheckControllerTargetAchieved() {
-            if( controllerTarget != null )
+        public void CheckControllerTargetAchieved()
+        {
+            if (controllerTarget != null)
             {
-                if( UpdateValue > 0.0 )
+                if (UpdateValue > 0.0)
                 {
-                    if( CurrentValue >= controllerTarget )
+                    if (CurrentValue >= controllerTarget)
                     {
                         StopIncrease();
                         controllerTarget = null;
@@ -374,7 +377,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 }
                 else
                 {
-                    if( CurrentValue <= controllerTarget )
+                    if (CurrentValue <= controllerTarget)
                     {
                         StopDecrease();
                         controllerTarget = null;
@@ -405,7 +408,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                     CurrentNotch++;
                 }
                 //decreasing, again check if the current notch has changed
-                else if((direction < 0) && (CurrentNotch > 0) && (IntermediateValue < Notches[CurrentNotch].Value))
+                else if ((direction < 0) && (CurrentNotch > 0) && (IntermediateValue < Notches[CurrentNotch].Value))
                 {
                     CurrentNotch--;
                 }
@@ -489,25 +492,25 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
         }
 
         protected virtual void SaveData(BinaryWriter outf)
-        {            
-            outf.Write(CurrentValue);            
+        {
+            outf.Write(CurrentValue);
             outf.Write(MinimumValue);
             outf.Write(MaximumValue);
             outf.Write(StepSize);
-            outf.Write(CurrentNotch);            
+            outf.Write(CurrentNotch);
             outf.Write(Notches.Count);
-            
-            foreach(MSTSNotch notch in Notches)
+
+            foreach (MSTSNotch notch in Notches)
             {
-                notch.Save(outf);                
-            }            
+                notch.Save(outf);
+            }
         }
 
         public virtual void Restore(BinaryReader inf)
         {
             Notches.Clear();
 
-            IntermediateValue = CurrentValue = inf.ReadSingle();            
+            IntermediateValue = CurrentValue = inf.ReadSingle();
             MinimumValue = inf.ReadSingle();
             MaximumValue = inf.ReadSingle();
             StepSize = inf.ReadSingle();
@@ -520,7 +523,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             for (int i = 0; i < count; ++i)
             {
                 Notches.Add(new MSTSNotch(inf));
-            }           
+            }
         }
 
         public MSTSNotch GetCurrentNotch()
@@ -542,12 +545,12 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             }
         }
 
-        public void SetStepSize ( float stepSize)
+        public void SetStepSize(float stepSize)
         {
             StepSize = stepSize;
         }
 
-        public void Normalize (float ratio)
+        public void Normalize(float ratio)
         {
             for (int i = 0; i < Notches.Count; i++)
                 Notches[i].Value /= ratio;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/FreightAnimations.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/FreightAnimations.cs
@@ -45,7 +45,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
         public float LoadingStartDelay = 0;
         public float UnloadingStartDelay = 0;
         public bool IsGondola = false;
- 
+
         // additions to manage consequences of variable weight on friction and brake forces
         public float EmptyORTSDavis_A = -9999;
         public float EmptyORTSDavis_B = -9999;
@@ -62,7 +62,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
         {
             stf.MustMatch("(");
             bool empty = true;
-              stf.ParseBlock(new[] {
+            stf.ParseBlock(new[] {
                 new STFReader.TokenProcessor("mstsfreightanimenabled", ()=>{ MSTSFreightAnimEnabled = stf.ReadBoolBlock(true);}),
                 new STFReader.TokenProcessor("wagonemptyweight", ()=>{ WagonEmptyWeight = stf.ReadFloatBlock(STFReader.UNITS.Mass, -1); }),
                 new STFReader.TokenProcessor("loadingstartdelay", ()=>{ UnloadingStartDelay = stf.ReadFloatBlock(STFReader.UNITS.None, 0); }),
@@ -153,7 +153,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             {
                 if (freightAnim is FreightAnimationContinuous)
                 {
-                    if ((freightAnim as FreightAnimationContinuous).LinkedIntakePoint !=  null )
+                    if ((freightAnim as FreightAnimationContinuous).LinkedIntakePoint != null)
                     {
                         if ((freightAnim as FreightAnimationContinuous).LinkedIntakePoint.Type == FreightType)
                         {
@@ -179,7 +179,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 {
                     Animations.Add(new FreightAnimationContinuous(freightAnim as FreightAnimationContinuous, wagon));
                     if ((Animations.Last() as FreightAnimationContinuous).FullAtStart) LoadedOne = Animations.Last() as FreightAnimationContinuous;
-                    
+
                 }
                 else if (freightAnim is FreightAnimationStatic)
                 {
@@ -292,7 +292,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             FullORTSDavisDragConstant = freightAnimContin.FullORTSDavisDragConstant;
             FullMaxBrakeForceN = freightAnimContin.FullMaxBrakeForceN;
             FullMaxHandbrakeForceN = freightAnimContin.FullMaxHandbrakeForceN;
-            FullCentreOfGravityM_Y = freightAnimContin.FullCentreOfGravityM_Y;          
+            FullCentreOfGravityM_Y = freightAnimContin.FullCentreOfGravityM_Y;
         }
     }
 
@@ -336,11 +336,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             {
                 var typeString = stf.ReadStringBlock(null);
                 switch (typeString)
-	            {
+                {
                     default:
                         SubType = FreightAnimationStatic.Type.DEFAULT;
                         break;
-	            }
+                }
             }),
             new STFReader.TokenProcessor("shape", ()=>{ ShapeFileName = stf.ReadStringBlock(null); }),
             new STFReader.TokenProcessor("freightweight", ()=>{ FreightWeight = stf.ReadFloatBlock(STFReader.UNITS.Mass, 0); }),
@@ -432,11 +432,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 {
                         var typeString = stf.ReadStringBlock(null);
                         switch (typeString)
-	                    {
+                        {
                             default:
                                 SubType = FreightAnimationDiscrete.Type.DEFAULT;
                                 break;
-	                    }
+                        }
                 }),
                 new STFReader.TokenProcessor("shape", ()=>{ ShapeFileName = stf.ReadStringBlock(null); }),
                 new STFReader.TokenProcessor("offset", ()=>{

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/AbstractPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/AbstractPowerSupply.cs
@@ -105,7 +105,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public float PowerOnDelayS { get; private set; }
         public float AuxPowerOnDelayS { get; private set; }
-        
+
         public AbstractPowerSupply(MSTSLocomotive locomotive)
         {
             Locomotive = locomotive;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/CircuitBreaker.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/CircuitBreaker.cs
@@ -112,7 +112,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             {
                 if (ScriptName != null)
                 {
-                    switch(ScriptName)
+                    switch (ScriptName)
                     {
                         case "Automatic":
                             Script = new AutomaticCircuitBreaker() as CircuitBreaker;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
@@ -116,7 +116,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     DEList[i].Parse(stf, loco);
                     DEList[i].Initialize(true);
                 }
-                
+
                 if ((!DEList[i].IsInitialized))
                 {
                     STFException.TraceWarning(stf, "Diesel engine model has some errors - loading MSTS format");
@@ -158,7 +158,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     DEList[i].InitFromMSTS((MSTSDieselLocomotive)Locomotive);
                     DEList[i].Initialize(true);
                 }
-                
+
             }
             foreach (DieselEngine de in DEList)
                 de.Restore(inf);
@@ -228,7 +228,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             }
         }
 
-         /// <summary>
+        /// <summary>
         /// Maximum rail output power for all locomotives
         /// </summary>
         public float MaximumRailOutputPowerW
@@ -295,7 +295,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 float temp = 0;
                 foreach (DieselEngine de in DEList)
                 {
-                    if(de.GearBox != null)
+                    if (de.GearBox != null)
                         temp += (de.DemandedThrottlePercent * 0.01f * de.GearBox.MotiveForceN);
                 }
                 return temp;
@@ -363,7 +363,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             get
             {
                 int num = 0;
-                foreach(DieselEngine eng in DEList)
+                foreach (DieselEngine eng in DEList)
                 {
                     if (eng.EngineStatus == DieselEngine.Status.Running)
                         num++;
@@ -442,31 +442,31 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public enum SettingsFlags
         {
-            IdleRPM              = 0x0001,
-            MaxRPM               = 0x0002,
-            StartingRPM          = 0x0004,
-            StartingConfirmRPM   = 0x0008,
-            ChangeUpRPMpS        = 0x0010,
-            ChangeDownRPMpS      = 0x0020,
+            IdleRPM = 0x0001,
+            MaxRPM = 0x0002,
+            StartingRPM = 0x0004,
+            StartingConfirmRPM = 0x0008,
+            ChangeUpRPMpS = 0x0010,
+            ChangeDownRPMpS = 0x0020,
             RateOfChangeUpRPMpSS = 0x0040,
             RateOfChangeDownRPMpSS = 0x0080,
-            MaximalPowerW        = 0x0100,
-            IdleExhaust          = 0x0200,
-            MaxExhaust           = 0x0400,
-            ExhaustDynamics      = 0x0800,
-            ExhaustColor         = 0x1000,
+            MaximalPowerW = 0x0100,
+            IdleExhaust = 0x0200,
+            MaxExhaust = 0x0400,
+            ExhaustDynamics = 0x0800,
+            ExhaustColor = 0x1000,
             ExhaustTransientColor = 0x2000,
-            DieselPowerTab       = 0x4000,
+            DieselPowerTab = 0x4000,
             DieselConsumptionTab = 0x8000,
-            ThrottleRPMTab       = 0x10000,
-            DieselTorqueTab      = 0x20000,
-            MinOilPressure       = 0x40000,
-            MaxOilPressure       = 0x80000,
-            MaxTemperature       = 0x100000,
-            Cooling              = 0x200000,
-            TempTimeConstant     = 0x400000,
-            OptTemperature       = 0x800000,
-            IdleTemperature      = 0x1000000
+            ThrottleRPMTab = 0x10000,
+            DieselTorqueTab = 0x20000,
+            MinOilPressure = 0x40000,
+            MaxOilPressure = 0x80000,
+            MaxTemperature = 0x100000,
+            Cooling = 0x200000,
+            TempTimeConstant = 0x400000,
+            OptTemperature = 0x800000,
+            IdleTemperature = 0x1000000
         }
 
         public DieselEngine()
@@ -575,7 +575,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         /// <summary>
         /// The RPM controller tries to reach this value
         /// </summary>
-        public float DemandedRPM;           
+        public float DemandedRPM;
         float demandedThrottlePercent;
         /// <summary>
         /// Demanded throttle percent, usually token from parent locomotive
@@ -617,7 +617,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         /// Current power available to the rail
         /// </summary>
         public float CurrentDieselOutputPowerW;
-         /// <summary>
+        /// <summary>
         /// Maximum power available to the rail
         /// </summary>
         public float MaximumRailOutputPowerW;
@@ -661,7 +661,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         /// Engine output torque table - Torque vs. RPM
         /// </summary>
         public Interpolator DieselTorqueTab;
-         /// <summary>
+        /// <summary>
         /// Current exhaust number of particles
         /// </summary>
         public float ExhaustParticles = 10.0f;
@@ -684,10 +684,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public Color ExhaustCompressorBlownColor = Color.Gray;
 
-        public float InitialMagnitude = 1.5f;        
+        public float InitialMagnitude = 1.5f;
         public float MaxMagnitude = 1.5f;
         public float MagnitudeRange;
-        public float ExhaustMagnitude = 1.5f;   
+        public float ExhaustMagnitude = 1.5f;
 
         public float InitialExhaust = 0.7f;
         public float MaxExhaust = 2.8f;
@@ -703,7 +703,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         {
             get
             {
-                float k = (DieselMaxOilPressurePSI - DieselMinOilPressurePSI)/(MaxRPM - IdleRPM);
+                float k = (DieselMaxOilPressurePSI - DieselMinOilPressurePSI) / (MaxRPM - IdleRPM);
                 float q = DieselMaxOilPressurePSI - k * MaxRPM;
                 float res = k * RealRPM + q - dieseloilfailurePSI;
                 if (res < 0f)
@@ -759,7 +759,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         {
             get
             {
-                return (CurrentDieselOutputPowerW <= 0f ? 0f : (OutputPowerW * 100f / CurrentDieselOutputPowerW)) ;
+                return (CurrentDieselOutputPowerW <= 0f ? 0f : (OutputPowerW * 100f / CurrentDieselOutputPowerW));
             }
         }
         /// <summary>
@@ -784,28 +784,28 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 switch (lowercasetoken)
                 {
                     case "idlerpm": IdleRPM = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.IdleRPM; break;
-                    case "maxrpm":          MaxRPM = stf.ReadFloatBlock(STFReader.UNITS.None, 0);initLevel |= SettingsFlags.MaxRPM; break;
+                    case "maxrpm": MaxRPM = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.MaxRPM; break;
                     case "startingrpm": StartingRPM = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.StartingRPM; break;
                     case "startingconfirmrpm": StartingConfirmationRPM = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.StartingConfirmRPM; break;
                     case "changeuprpmps": ChangeUpRPMpS = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.ChangeUpRPMpS; break;
                     case "changedownrpmps": ChangeDownRPMpS = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.ChangeDownRPMpS; break;
-                    case "rateofchangeuprpmpss": RateOfChangeUpRPMpSS = stf.ReadFloatBlock(STFReader.UNITS.None, 0);initLevel |= SettingsFlags.RateOfChangeUpRPMpSS; break;
-                    case "rateofchangedownrpmpss": RateOfChangeDownRPMpSS = stf.ReadFloatBlock(STFReader.UNITS.None, 0);initLevel |= SettingsFlags.RateOfChangeDownRPMpSS; break;
-                    case "maximalpower":   MaximumDieselPowerW = stf.ReadFloatBlock(STFReader.UNITS.Power, 0);initLevel |= SettingsFlags.MaximalPowerW; break;
-                    case "idleexhaust":     InitialExhaust = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.IdleExhaust; break;
-                    case "maxexhaust":      MaxExhaust = stf.ReadFloatBlock(STFReader.UNITS.None, 0);initLevel |= SettingsFlags.MaxExhaust; break;
+                    case "rateofchangeuprpmpss": RateOfChangeUpRPMpSS = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.RateOfChangeUpRPMpSS; break;
+                    case "rateofchangedownrpmpss": RateOfChangeDownRPMpSS = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.RateOfChangeDownRPMpSS; break;
+                    case "maximalpower": MaximumDieselPowerW = stf.ReadFloatBlock(STFReader.UNITS.Power, 0); initLevel |= SettingsFlags.MaximalPowerW; break;
+                    case "idleexhaust": InitialExhaust = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.IdleExhaust; break;
+                    case "maxexhaust": MaxExhaust = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.MaxExhaust; break;
                     case "exhaustdynamics": ExhaustAccelIncrease = stf.ReadFloatBlock(STFReader.UNITS.None, 0); initLevel |= SettingsFlags.ExhaustDynamics; break;
                     case "exhaustdynamicsdown": ExhaustDecelReduction = stf.ReadFloatBlock(STFReader.UNITS.None, null); initLevel |= SettingsFlags.ExhaustDynamics; break;
-                    case "exhaustcolor":    ExhaustSteadyColor.PackedValue = stf.ReadHexBlock(Color.Gray.PackedValue); initLevel |= SettingsFlags.ExhaustColor; break;
-                    case "exhausttransientcolor": ExhaustTransientColor.PackedValue = stf.ReadHexBlock(Color.Black.PackedValue);initLevel |= SettingsFlags.ExhaustTransientColor; break;
-                    case "dieselpowertab": DieselPowerTab = new Interpolator(stf);initLevel |= SettingsFlags.DieselPowerTab; break;
-                    case "dieselconsumptiontab": DieselConsumptionTab = new Interpolator(stf);initLevel |= SettingsFlags.DieselConsumptionTab; break;
+                    case "exhaustcolor": ExhaustSteadyColor.PackedValue = stf.ReadHexBlock(Color.Gray.PackedValue); initLevel |= SettingsFlags.ExhaustColor; break;
+                    case "exhausttransientcolor": ExhaustTransientColor.PackedValue = stf.ReadHexBlock(Color.Black.PackedValue); initLevel |= SettingsFlags.ExhaustTransientColor; break;
+                    case "dieselpowertab": DieselPowerTab = new Interpolator(stf); initLevel |= SettingsFlags.DieselPowerTab; break;
+                    case "dieselconsumptiontab": DieselConsumptionTab = new Interpolator(stf); initLevel |= SettingsFlags.DieselConsumptionTab; break;
                     case "throttlerpmtab": ThrottleRPMTab = new Interpolator(stf); initLevel |= SettingsFlags.ThrottleRPMTab; break;
                     case "dieseltorquetab": DieselTorqueTab = new Interpolator(stf); initLevel |= SettingsFlags.DieselTorqueTab; break;
                     case "minoilpressure": DieselMinOilPressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, 40f); initLevel |= SettingsFlags.MinOilPressure; break;
                     case "maxoilpressure": DieselMaxOilPressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, 120f); initLevel |= SettingsFlags.MaxOilPressure; break;
                     case "maxtemperature": DieselMaxTemperatureDeg = stf.ReadFloatBlock(STFReader.UNITS.TemperatureDifference, 100f); initLevel |= SettingsFlags.MaxTemperature; break;
-                    case "cooling": EngineCooling = (Cooling)stf.ReadIntBlock((int)Cooling.Proportional); initLevel |= SettingsFlags.Cooling; break ; //ReadInt changed to ReadIntBlock
+                    case "cooling": EngineCooling = (Cooling)stf.ReadIntBlock((int)Cooling.Proportional); initLevel |= SettingsFlags.Cooling; break; //ReadInt changed to ReadIntBlock
                     case "temptimeconstant": DieselTempTimeConstantSec = stf.ReadFloatBlock(STFReader.UNITS.Time, 720f); initLevel |= SettingsFlags.TempTimeConstant; break;
                     case "opttemperature": DieselOptimalTemperatureDegC = stf.ReadFloatBlock(STFReader.UNITS.TemperatureDifference, 95f); initLevel |= SettingsFlags.OptTemperature; break;
                     case "idletemperature": DieselIdleTemperatureDegC = stf.ReadFloatBlock(STFReader.UNITS.TemperatureDifference, 75f); initLevel |= SettingsFlags.IdleTemperature; break;
@@ -861,7 +861,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     GearBox.ClutchPercent = (RealRPM - GearBox.ShaftRPM) / RealRPM * 100f;
                 else
                     GearBox.ClutchPercent = 100f;
-                
+
                 if (GearBox.CurrentGear != null)
                 {
                     if (GearBox.IsClutchOn)
@@ -869,7 +869,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 }
             }
 
-            if ( RealRPM == IdleRPM )
+            if (RealRPM == IdleRPM)
             {
                 ExhaustParticles = InitialExhaust;
                 ExhaustMagnitude = InitialMagnitude;
@@ -878,11 +878,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             if (RealRPM < DemandedRPM)
             {
                 dRPM = (float)Math.Min(Math.Sqrt(2 * RateOfChangeUpRPMpSS * (DemandedRPM - RealRPM)), ChangeUpRPMpS);
-                if ( dRPM > 1.0f ) //The forumula above generates a floating point error that we have to compensate for so we can't actually test for zero.
+                if (dRPM > 1.0f) //The forumula above generates a floating point error that we have to compensate for so we can't actually test for zero.
                 {
-                    ExhaustParticles = (InitialExhaust + ((ExhaustRange * (RealRPM - IdleRPM) / RPMRange ))) * ExhaustAccelIncrease;
+                    ExhaustParticles = (InitialExhaust + ((ExhaustRange * (RealRPM - IdleRPM) / RPMRange))) * ExhaustAccelIncrease;
                     ExhaustMagnitude = (InitialMagnitude + ((MagnitudeRange * (RealRPM - IdleRPM) / RPMRange))) * ExhaustAccelIncrease;
-                    ExhaustColor = ExhaustTransientColor; 
+                    ExhaustColor = ExhaustTransientColor;
                 }
                 else
                 {
@@ -893,13 +893,13 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 }
             }
             else if (RealRPM > (DemandedRPM))
-                {
-                    dRPM = (float)Math.Max(-Math.Sqrt(2 * RateOfChangeDownRPMpSS * (RealRPM - DemandedRPM)), -ChangeDownRPMpS);
-                    ExhaustParticles = (InitialExhaust + ((ExhaustRange * (RealRPM - IdleRPM) / RPMRange))) * ExhaustDecelReduction;
-                    ExhaustMagnitude = (InitialMagnitude + ((MagnitudeRange * (RealRPM - IdleRPM) / RPMRange))) * ExhaustDecelReduction;
-                    ExhaustColor = ExhaustDecelColor;
+            {
+                dRPM = (float)Math.Max(-Math.Sqrt(2 * RateOfChangeDownRPMpSS * (RealRPM - DemandedRPM)), -ChangeDownRPMpS);
+                ExhaustParticles = (InitialExhaust + ((ExhaustRange * (RealRPM - IdleRPM) / RPMRange))) * ExhaustDecelReduction;
+                ExhaustMagnitude = (InitialMagnitude + ((MagnitudeRange * (RealRPM - IdleRPM) / RPMRange))) * ExhaustDecelReduction;
+                ExhaustColor = ExhaustDecelColor;
 
-                }
+            }
 
             if ((OutputPowerW > (1.1f * CurrentDieselOutputPowerW)) && (EngineStatus == Status.Running))
                 dRPM = (CurrentDieselOutputPowerW - OutputPowerW) / MaximumDieselPowerW * 0.01f * RateOfChangeDownRPMpSS;
@@ -914,7 +914,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 CurrentRailOutputPowerW = (RealRPM - IdleRPM) / (MaxRPM - IdleRPM) * MaximumRailOutputPowerW * (1 - locomotive.PowerReduction);
                 CurrentRailOutputPowerW = CurrentRailOutputPowerW < 0f ? 0f : CurrentRailOutputPowerW;
             }
-             else
+            else
             {
                 CurrentDieselOutputPowerW = (RealRPM - IdleRPM) / (MaxRPM - IdleRPM) * MaximumDieselPowerW * (1 - locomotive.PowerReduction);
             }
@@ -943,7 +943,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             {
                 if (DieselConsumptionTab != null)
                 {
-                         DieselFlowLps = DieselConsumptionTab[RealRPM] / 3600.0f;
+                    DieselFlowLps = DieselConsumptionTab[RealRPM] / 3600.0f;
                 }
                 else
                 {
@@ -965,7 +965,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             }
 
             DieselTemperatureDeg += elapsedClockSeconds * (DieselMaxTemperatureDeg - DieselTemperatureDeg) / DieselTempTimeConstantSec;
-            switch(EngineCooling)
+            switch (EngineCooling)
             {
                 case Cooling.NoCooling:
                     DieselTemperatureDeg += elapsedClockSeconds * (LoadPercent * 0.01f * (95f - 60f) + 60f - DieselTemperatureDeg) / DieselTempTimeConstantSec;
@@ -976,12 +976,12 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     DieselTempCoolingRunning = true;
                     break;
                 case Cooling.Hysteresis:
-                    if(DieselTemperatureDeg > DieselMaxTemperatureDeg)
+                    if (DieselTemperatureDeg > DieselMaxTemperatureDeg)
                         DieselTempCoolingRunning = true;
-                    if(DieselTemperatureDeg < (DieselMaxTemperatureDeg - DieselTempCoolingHyst))
+                    if (DieselTemperatureDeg < (DieselMaxTemperatureDeg - DieselTempCoolingHyst))
                         DieselTempCoolingRunning = false;
 
-                    if(DieselTempCoolingRunning)
+                    if (DieselTempCoolingRunning)
                         DieselTemperatureDeg += elapsedClockSeconds * (DieselMaxTemperatureDeg - DieselTemperatureDeg) / DieselTempTimeConstantSec;
                     else
                         DieselTemperatureDeg -= elapsedClockSeconds * (DieselMaxTemperatureDeg - 2f * DieselTempCoolingHyst - DieselTemperatureDeg) / DieselTempTimeConstantSec;
@@ -992,7 +992,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     cooling = cooling < 0f ? 0 : cooling;
                     if (DieselTemperatureDeg >= (80f))
                         DieselTempCoolingRunning = true;
-                    if(DieselTemperatureDeg < (80f - DieselTempCoolingHyst))
+                    if (DieselTemperatureDeg < (80f - DieselTempCoolingHyst))
                         DieselTempCoolingRunning = false;
 
                     if (!DieselTempCoolingRunning)
@@ -1003,7 +1003,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                         DieselTemperatureDeg = DieselMaxTemperatureDeg - DieselTempCoolingHyst;
                     break;
             }
-            if(DieselTemperatureDeg < 40f)
+            if (DieselTemperatureDeg < 40f)
                 DieselTemperatureDeg = 40f;
 
             if (GearBox != null)
@@ -1069,7 +1069,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             OutputPowerW = inf.ReadSingle();
             DieselTemperatureDeg = inf.ReadSingle();
 
-            Boolean gearSaved    = inf.ReadBoolean();  // read boolean which indicates gear data was saved
+            Boolean gearSaved = inf.ReadBoolean();  // read boolean which indicates gear data was saved
 
             if (((MSTSDieselLocomotive)locomotive).GearBox != null)
             {
@@ -1107,7 +1107,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public void InitFromMSTS(MSTSDieselLocomotive loco)
         {
-            if((initLevel & SettingsFlags.IdleRPM) == 0) IdleRPM = loco.IdleRPM;
+            if ((initLevel & SettingsFlags.IdleRPM) == 0) IdleRPM = loco.IdleRPM;
             if ((initLevel & SettingsFlags.MaxRPM) == 0) MaxRPM = loco.MaxRPM;
             InitialMagnitude = loco.InitialMagnitude;
             MaxMagnitude = loco.MaxMagnitude;
@@ -1136,9 +1136,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             if ((initLevel & SettingsFlags.MaxTemperature) == 0) DieselMaxTemperatureDeg = loco.DieselMaxTemperatureDeg;
             if ((initLevel & SettingsFlags.Cooling) == 0) EngineCooling = loco.DieselEngineCooling;
             if ((initLevel & SettingsFlags.TempTimeConstant) == 0) DieselTempTimeConstantSec = 720f;
-            if ((initLevel & SettingsFlags.DieselConsumptionTab) == 0) 
+            if ((initLevel & SettingsFlags.DieselConsumptionTab) == 0)
                 DieselConsumptionTab = new Interpolator(new float[] { loco.IdleRPM, loco.MaxRPM }, new float[] { loco.DieselUsedPerHourAtIdleL, loco.DieselUsedPerHourAtMaxPowerL });
-            if ((initLevel & SettingsFlags.ThrottleRPMTab) == 0) 
+            if ((initLevel & SettingsFlags.ThrottleRPMTab) == 0)
                 ThrottleRPMTab = new Interpolator(new float[] { 0, 100 }, new float[] { loco.IdleRPM, loco.MaxRPM });
 
             if (((initLevel & SettingsFlags.DieselTorqueTab) == 0) && ((initLevel & SettingsFlags.DieselPowerTab) == 0))
@@ -1183,7 +1183,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     power[i] = DieselPowerTab[rpm[i]] * rpm[i] * 2f * 3.1415f / 60f;
                 }
             }
-            
+
             InitialExhaust = loco.InitialExhaust;
             MaxExhaust = loco.MaxExhaust;
             locomotive = loco;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricPowerSupply.cs
@@ -42,7 +42,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             }
         }
 
-        public float LineVoltageV {
+        public float LineVoltageV
+        {
             get
             {
                 return (float)Simulator.TRK.Tr_RouteFile.MaxLineVoltage;
@@ -88,7 +89,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         {
             ScriptName = other.ScriptName;
 
-            base.Copy(other);            
+            base.Copy(other);
             CircuitBreaker.Copy(other.CircuitBreaker);
         }
 
@@ -198,7 +199,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         {
             PantographFilter = new IIRFilter(IIRFilter.FilterTypes.Butterworth, 1, IIRFilter.HzToRad(0.7f), 0.001f);
             VoltageFilter = new IIRFilter(IIRFilter.FilterTypes.Butterworth, 1, IIRFilter.HzToRad(0.7f), 0.001f);
-            
+
             PowerOnTimer = new Timer(this);
             PowerOnTimer.Setup(PowerOnDelayS());
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/Pantograph.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/Pantograph.cs
@@ -191,7 +191,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         public PantographState State { get; private set; }
         public float DelayS { get; private set; }
         public float TimeS { get; private set; }
-        public bool CommandUp {
+        public bool CommandUp
+        {
             get
             {
                 bool value;
@@ -254,7 +255,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public void Restore(BinaryReader inf)
         {
-            State = (PantographState) Enum.Parse(typeof(PantographState), inf.ReadString());
+            State = (PantographState)Enum.Parse(typeof(PantographState), inf.ReadString());
             DelayS = inf.ReadSingle();
             TimeS = inf.ReadSingle();
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
@@ -119,7 +119,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             set
             {
                 motor = value;
-                switch(driveType)
+                switch (driveType)
                 {
                     case AxleDriveType.NotDriven:
                         break;
@@ -187,7 +187,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                         break;
                 }
             }
-            get 
+            get
             {
                 return inertiaKgm2;
             }
@@ -364,7 +364,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         {
             get
             {
-                if (Math.Abs(SlipSpeedMpS) > WheelSlipThresholdMpS) 
+                if (Math.Abs(SlipSpeedMpS) > WheelSlipThresholdMpS)
                     return true;
                 else
                     return false;
@@ -385,12 +385,12 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             {
                 if (AdhesionK == 0.0f)
                     AdhesionK = 1.0f;
-                float A = 2.0f*AdhesionK*AdhesionConditions*AdhesionConditions;
-                float B = AdhesionConditions*AdhesionConditions;
-                float C = AdhesionK*AdhesionK;
-                float a = -2.0f*A*B;
-                float b = A*B;
-                float c = A*C;
+                float A = 2.0f * AdhesionK * AdhesionConditions * AdhesionConditions;
+                float B = AdhesionConditions * AdhesionConditions;
+                float C = AdhesionK * AdhesionK;
+                float a = -2.0f * A * B;
+                float b = A * B;
+                float c = A * C;
                 return ((-b - (float)Math.Sqrt(b * b - 4.0f * a * c)) / (2.0f * a));
             }
         }
@@ -414,7 +414,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                 }
                 if (SlipSpeedMpS < 0.0f)
                 {
-                    if ((SlipSpeedPercent < ( -SlipWarningTresholdPercent)))
+                    if ((SlipSpeedPercent < (-SlipWarningTresholdPercent)))
                         return true;
                     else
                         return false;
@@ -740,7 +740,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         /// <returns>Relative force transmitted to the rail</returns>
         public float SlipCharacteristics(float slipSpeed, float speed, float K, float conditions, float Adhesion2)
         {
-            speed = Math.Abs(3.6f*speed);
+            speed = Math.Abs(3.6f * speed);
             float umax = (CurtiusKnifflerA / (speed + CurtiusKnifflerB) + CurtiusKnifflerC);// *Adhesion2 / 0.331455f; // Curtius - Kniffler equation
             umax *= conditions;
             if (K == 0.0)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/ElectricMotor.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/ElectricMotor.cs
@@ -42,7 +42,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             }
             get
             {
-                return inertiaKgm2; 
+                return inertiaKgm2;
             }
         }
 
@@ -115,7 +115,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             //revolutionsRad += timeSpan / inertiaKgm2 * (developedTorqueNm + loadTorqueNm + (revolutionsRad == 0.0 ? 0.0 : frictionTorqueNm));
             //if (revolutionsRad < 0.0)
             //    revolutionsRad = 0.0;
-            temperatureK = tempIntegrator.Integrate(timeSpan, 1.0f/(SpecificHeatCapacityJ_kg_C * WeightKg)*((powerLossesW - CoolingPowerW) / (ThermalCoeffJ_m2sC * SurfaceM) - temperatureK));
+            temperatureK = tempIntegrator.Integrate(timeSpan, 1.0f / (SpecificHeatCapacityJ_kg_C * WeightKg) * ((powerLossesW - CoolingPowerW) / (ThermalCoeffJ_m2sC * SurfaceM) - temperatureK));
 
         }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/GearBox.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/GearBox.cs
@@ -127,7 +127,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         {
             get
             {
-                if ((currentGearIndex >= 0)&&(currentGearIndex < NumOfGears))
+                if ((currentGearIndex >= 0) && (currentGearIndex < NumOfGears))
                     return Gears[currentGearIndex];
                 else
                     return null;
@@ -135,23 +135,23 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         }
 
         public int CurrentGearIndex { get { return currentGearIndex; } }
-        public Gear NextGear 
+        public Gear NextGear
         {
             get
             {
-                if ((nextGearIndex >= 0)&&(nextGearIndex < NumOfGears))
+                if ((nextGearIndex >= 0) && (nextGearIndex < NumOfGears))
                     return Gears[nextGearIndex];
                 else
                     return null;
             }
             set
             {
-                switch(GearBoxOperation)
+                switch (GearBoxOperation)
                 {
                     case GearBoxOperation.Manual:
                     case GearBoxOperation.Semiautomatic:
                         int temp = 0;
-                        if(value == null)
+                        if (value == null)
                             nextGearIndex = -1;
                         else
                         {
@@ -185,8 +185,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             {
                 if (!gearedUp)
                 {
-                    if(++nextGearIndex >= Gears.Count)
-                        nextGearIndex =  (Gears.Count - 1);
+                    if (++nextGearIndex >= Gears.Count)
+                        nextGearIndex = (Gears.Count - 1);
                     else
                         gearedUp = true;
                 }
@@ -202,8 +202,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             {
                 if (!gearedDown)
                 {
-                    if(--nextGearIndex <= 0)
-                        nextGearIndex =  0;
+                    if (--nextGearIndex <= 0)
+                        nextGearIndex = 0;
                     else
                         gearedDown = true;
                 }
@@ -240,25 +240,25 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         int currentGearIndex = -1;
         int nextGearIndex = -1;
 
-        public float CurrentSpeedMpS 
+        public float CurrentSpeedMpS
         {
             get
             {
-                if(DieselEngine.locomotive.Direction == Direction.Reverse)
+                if (DieselEngine.locomotive.Direction == Direction.Reverse)
                     return -(DieselEngine.locomotive.SpeedMpS);
                 else
                     return (DieselEngine.locomotive.SpeedMpS);
             }
         }
 
-        public float ShaftRPM 
+        public float ShaftRPM
         {
             get
             {
                 if (CurrentGear == null)
                     return DieselEngine.RealRPM;
                 else
-                    return CurrentSpeedMpS / CurrentGear.Ratio; 
+                    return CurrentSpeedMpS / CurrentGear.Ratio;
             }
         }
 
@@ -269,24 +269,27 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                 if (CurrentGear == null)
                     return false;
                 else
-                    return ((DieselEngine.RealRPM / DieselEngine.MaxRPM * 100f) > CurrentGear.OverspeedPercentage); 
-            } 
+                    return ((DieselEngine.RealRPM / DieselEngine.MaxRPM * 100f) > CurrentGear.OverspeedPercentage);
+            }
         }
 
-        public bool IsOverspeedWarning 
+        public bool IsOverspeedWarning
         {
             get
             {
                 if (CurrentGear == null)
                     return false;
                 else
-                    return ((DieselEngine.RealRPM / DieselEngine.MaxRPM * 100f) > 100f); 
+                    return ((DieselEngine.RealRPM / DieselEngine.MaxRPM * 100f) > 100f);
             }
         }
 
         float clutch;
-        public float ClutchPercent { set { clutch = (value > 100.0f ? 100f : (value < -100f ? -100f : value)) / 100f; }
-            get { return clutch * 100f; } }
+        public float ClutchPercent
+        {
+            set { clutch = (value > 100.0f ? 100f : (value < -100f ? -100f : value)) / 100f; }
+            get { return clutch * 100f; }
+        }
 
         public bool AutoClutch = true;
 
@@ -311,7 +314,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                         float motiveForceN = DieselEngine.DieselTorqueTab[DieselEngine.RealRPM] * DieselEngine.DemandedThrottlePercent / DieselEngine.DieselTorqueTab.MaxY() * 0.01f * CurrentGear.MaxTractiveForceN;
                         if (CurrentSpeedMpS > 0)
                         {
-                            if (motiveForceN > (DieselEngine.CurrentDieselOutputPowerW/ CurrentSpeedMpS))
+                            if (motiveForceN > (DieselEngine.CurrentDieselOutputPowerW / CurrentSpeedMpS))
                                 motiveForceN = DieselEngine.CurrentDieselOutputPowerW / CurrentSpeedMpS;
                         }
                         return motiveForceN;
@@ -333,9 +336,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
 
             CopyFromMSTSParams(DieselEngine);
 
-        }      
+        }
 
-        
+
 
         public void Parse(string lowercasetoken, STFReader stf)
         {
@@ -365,14 +368,14 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             outf.Write(clutch);
         }
 
-        public void InitializeMoving ()
+        public void InitializeMoving()
         {
             for (int iGear = 0; iGear < Gears.Count; iGear++)
             {
                 if (Gears[iGear].MaxSpeedMpS < CurrentSpeedMpS) continue;
                 else currentGearIndex = nextGearIndex = iGear;
                 break;
-             } 
+            }
 
             gearedUp = false;
             gearedDown = false;
@@ -383,7 +386,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
 
         public bool IsInitialized { get { return mstsParams.IsInitialized; } }
 
-        public void UseLocoGearBox (DieselEngine dieselEngine)
+        public void UseLocoGearBox(DieselEngine dieselEngine)
         {
             DieselEngine = dieselEngine;
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/SeriesMotor.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/SeriesMotor.cs
@@ -21,7 +21,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
     public class SeriesMotor : ElectricMotor
     {
         float armatureResistanceOhms;
-        public float ArmatureResistanceOhms 
+        public float ArmatureResistanceOhms
         {
             set
             {
@@ -166,11 +166,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             else
             {
                 fieldCurrentA = 0.0f;
-            }          
+            }
 
             UpdateField();
             backEMFvoltageV = RevolutionsRad * fieldWb;
-            developedTorqueNm = fieldWb * armatureCurrentA -(frictionTorqueNm * revolutionsRad /NominalRevolutionsRad * revolutionsRad/NominalRevolutionsRad);
+            developedTorqueNm = fieldWb * armatureCurrentA - (frictionTorqueNm * revolutionsRad / NominalRevolutionsRad * revolutionsRad / NominalRevolutionsRad);
 
             powerLossesW = ArmatureResistanceOhms * armatureCurrentA * armatureCurrentA +
                            FieldResistanceOhms * fieldCurrentA * fieldCurrentA;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -124,7 +124,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
 
         public bool AlerterButtonPressed { get; private set; }
         public bool PowerAuthorization { get; private set; }
-        public bool CircuitBreakerClosingOrder { get; private set;  }
+        public bool CircuitBreakerClosingOrder { get; private set; }
         public bool CircuitBreakerOpeningOrder { get; private set; }
         public bool TractionAuthorization { get; private set; }
 
@@ -276,7 +276,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 if (Locomotive.TrainBrakeController.TCSFullServiceBraking != value)
                 {
                     Locomotive.TrainBrakeController.TCSFullServiceBraking = value;
-                    
+
                     //Debrief Eval
                     if (value && Locomotive.IsPlayerTrain && !ldbfevalfullbrakeabove16kmh && Math.Abs(Locomotive.SpeedMpS) > 4.44444)
                     {
@@ -286,7 +286,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                         train.DbfEvalValueChanged = true;//Debrief eval
                     }
                     if (!value)
-                       ldbfevalfullbrakeabove16kmh = false;
+                        ldbfevalfullbrakeabove16kmh = false;
                 }
             };
             Script.SetEmergencyBrake = (value) =>
@@ -684,7 +684,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
         float VigilanceAlarmTimeoutS;
         float CurrentSpeedLimitMpS;
         float NextSpeedLimitMpS;
-       
+
         MonitoringStatus Status;
 
         public ScriptedTrainControlSystem.MonitoringDevice VigilanceMonitor;
@@ -814,7 +814,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 CurrentSpeedLimitMpS = TrainSpeedLimitMpS();
 
             // TODO: NextSignalSpeedLimitMpS(0) should return 0 if the signal is at stop; cause seems to be updateSpeedInfo() within Train.cs
-            NextSpeedLimitMpS = NextSignalAspect(0) != Aspect.Stop ? (NextSignalSpeedLimitMpS(0) > 0 && NextSignalSpeedLimitMpS(0) < TrainSpeedLimitMpS() ? NextSignalSpeedLimitMpS(0) : TrainSpeedLimitMpS() ) : 0;
+            NextSpeedLimitMpS = NextSignalAspect(0) != Aspect.Stop ? (NextSignalSpeedLimitMpS(0) > 0 && NextSignalSpeedLimitMpS(0) < TrainSpeedLimitMpS() ? NextSignalSpeedLimitMpS(0) : TrainSpeedLimitMpS()) : 0;
 
             SetCurrentSpeedLimitMpS(CurrentSpeedLimitMpS);
             SetNextSpeedLimitMpS(NextSpeedLimitMpS);
@@ -822,7 +822,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
 
         public override void HandleEvent(TCSEvent evt, string message)
         {
-            switch(evt)
+            switch (evt)
             {
                 case TCSEvent.AlerterPressed:
                 case TCSEvent.AlerterReleased:
@@ -842,7 +842,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                                 VigilanceMonitorState = MonitorState.StandBy;
                                 break;
 
-                            // case VigilanceState.Emergency: do nothing
+                                // case VigilanceState.Emergency: do nothing
                         }
                     }
                     break;
@@ -954,12 +954,12 @@ namespace Orts.Simulation.RollingStocks.SubSystems
         void UpdateSpeedControl()
         {
             var interventionSpeedMpS = CurrentSpeedLimitMpS + MpS.FromKpH(5.0f); // Default margin : 5 km/h
-            
+
             if (OverspeedMonitor.TriggerOnTrackOverspeed)
             {
                 interventionSpeedMpS = CurrentSpeedLimitMpS + OverspeedMonitor.TriggerOnTrackOverspeedMarginMpS;
             }
-            
+
             SetInterventionSpeedLimitMpS(interventionSpeedMpS);
 
             switch (OverspeedMonitorState)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -104,7 +104,7 @@ namespace Orts.Simulation.RollingStocks
         static float dbfmaxsafecurvespeedmps;//Debrief eval
         public static int DbfEvalTrainOverturned;//Debrief eval
         public bool ldbfevaltrainoverturned = false;
-                                        
+
         // original consist of which car was part (used in timetable for couple/uncouple options)
         public string OrgConsist = string.Empty;
 
@@ -363,7 +363,7 @@ namespace Orts.Simulation.RollingStocks
         public float TotalWagonLateralDerailForceN;
         public float LateralWindForceN;
         public float WagonFrontCouplerAngleRad;
-//        public float WagonVerticalForceN; // Vertical force of wagon/car - essentially determined by the weight
+        //        public float WagonVerticalForceN; // Vertical force of wagon/car - essentially determined by the weight
 
         public bool BuffForceExceeded;
 
@@ -487,7 +487,7 @@ namespace Orts.Simulation.RollingStocks
             CurveResistanceDependent = Simulator.Settings.CurveResistanceDependent;
             CurveSpeedDependent = Simulator.Settings.CurveSpeedDependent;
             TunnelResistanceDependent = Simulator.Settings.TunnelResistanceDependent;
-            
+
             //CurveForceFilter.Initialize();
             // Initialize tunnel resistance values
 
@@ -592,7 +592,7 @@ namespace Orts.Simulation.RollingStocks
                 InitializeCarTemperatures();
                 AmbientTemperatureInitialised = true;
             }
-            
+
             // Update temperature variation for height of car above sea level
             // Typically in clear conditions there is a 9.8 DegC variation for every 1000m (1km) rise, in snow/rain there is approx 5.5 DegC variation for every 1000m (1km) rise
             float TemperatureHeightVariationDegC = 0;
@@ -607,9 +607,9 @@ namespace Orts.Simulation.RollingStocks
             {
                 TemperatureHeightVariationDegC = Me.ToKiloM(CarHeightAboveSeaLevelM) * DryLapseTemperatureC;
             }
-            
+
             TemperatureHeightVariationDegC = MathHelper.Clamp(TemperatureHeightVariationDegC, 0.00f, 30.0f);
-            
+
             CarOutsideTempC = InitialCarOutsideTempC - TemperatureHeightVariationDegC;
 
             // gravity force, M32 is up component of forward vector
@@ -665,9 +665,9 @@ namespace Orts.Simulation.RollingStocks
             double longitude = 0;
 
             new Orts.Common.WorldLatLon().ConvertWTC(WorldPosition.TileX, WorldPosition.TileZ, WorldPosition.Location, ref latitude, ref longitude);
-            
+
             float LatitudeDeg = MathHelper.ToDegrees((float)latitude);
-                      
+
 
             // Sets outside temperature dependent upon the season
             if (Simulator.Season == SeasonType.Winter)
@@ -754,14 +754,14 @@ namespace Orts.Simulation.RollingStocks
 
                 if (this is MSTSDieselLocomotive || this is MSTSElectricLocomotive)
                 {
-                   if (WheelSlip && ThrottlePercent < 0.1f && BrakeRetardForceN > 25.0) // If advanced adhesion model indicates wheel slip, then check other conditiond (throttle and brake force) to determine whether it is a wheel slip or brake skid
+                    if (WheelSlip && ThrottlePercent < 0.1f && BrakeRetardForceN > 25.0) // If advanced adhesion model indicates wheel slip, then check other conditiond (throttle and brake force) to determine whether it is a wheel slip or brake skid
                     {
-                       BrakeSkid = true;  // set brake skid flag true
-                    } 
-                   else
-                   {
-                       BrakeSkid = false;
-                   }
+                        BrakeSkid = true;  // set brake skid flag true
+                    }
+                    else
+                    {
+                        BrakeSkid = false;
+                    }
                 }
 
                 else if (!(this is MSTSDieselLocomotive) || !(this is MSTSElectricLocomotive))
@@ -797,7 +797,7 @@ namespace Orts.Simulation.RollingStocks
                         {
                             BrakeSkid = false; 	// wagon wheel is not slipping
                         }
-                        
+
                     }
                     else
                     {
@@ -892,9 +892,9 @@ namespace Orts.Simulation.RollingStocks
 
                 float HeatLossTransmissionWpT = HeatLossTransRoofWpT + HeatLossTransTotalSidesWpT + HeatLossTransFloorWpT;
 
-               // Heat loss due to train movement and air flow, based upon convection heat transfer information - http://www.engineeringtoolbox.com/convective-heat-transfer-d_430.html
-               // The formula on this page ( hc = 10.45 - v + 10v1/2), where v = m/s. This formula is used to develop a multiplication factor with train speed.
-               // Curve is only valid from 2.5m/s
+                // Heat loss due to train movement and air flow, based upon convection heat transfer information - http://www.engineeringtoolbox.com/convective-heat-transfer-d_430.html
+                // The formula on this page ( hc = 10.45 - v + 10v1/2), where v = m/s. This formula is used to develop a multiplication factor with train speed.
+                // Curve is only valid from 2.5m/s
 
                 float LowSpeedMpS = 2.0f;
                 float ConvHeatTxfLowSpeed = 10.45f - LowSpeedMpS + (10.0f * (float)Math.Pow(LowSpeedMpS, 0.5));
@@ -902,11 +902,11 @@ namespace Orts.Simulation.RollingStocks
                 float ConvFactor = ConvHeatTxSpeed / ConvHeatTxfLowSpeed;
 
                 // TO DO - CHeck this out further - allow full range of values?
-               // ConvFactor = MathHelper.Clamp(ConvFactor, 1.0f, 1.6f); // Keep Conv Factor ratio within bounds - should not exceed 1.6.
+                // ConvFactor = MathHelper.Clamp(ConvFactor, 1.0f, 1.6f); // Keep Conv Factor ratio within bounds - should not exceed 1.6.
 
                 ConvFactor = MathHelper.Clamp(ConvFactor, 1.0f, 1.0f); // Keep Conv Factor ratio within bounds - should not exceed 1.6.
 
-               // Adjust transmission heat loss due to speed of train - loss increases as the apparent wind speed across carriages increases
+                // Adjust transmission heat loss due to speed of train - loss increases as the apparent wind speed across carriages increases
                 HeatLossTransmissionWpT *= ConvFactor;
 
 
@@ -920,7 +920,7 @@ namespace Orts.Simulation.RollingStocks
                 float HeatLossInfiltrationWpT = SpecificHeatCapacityJpKgpK * AirDensityKgpM3 * NumAirShiftspSec * CarHeatVolumeM3 * (CarriageHeatTempC - CarOutsideTempC);
 
                 CarHeatLossWpT = HeatLossTransmissionWpT + HeatLossInfiltrationWpT;
-                
+
                 // ++++++++++++++++++++++++
                 // Calculate steam pipe surface area
                 float CompartmentSteamPipeRadiusM = Me.FromIn(2.0f) / 2.0f;  // Assume the steam pipes in the compartments have diameter of 2" (50mm)
@@ -1050,14 +1050,14 @@ namespace Orts.Simulation.RollingStocks
 
             foreach (var w in WheelAxles)
             {
- //               Trace.TraceInformation("Car ID {0} Length {1} Bogie {2} Offset {3} MAtrix {4}", CarID, CarLengthM,  w.BogieIndex, w.OffsetM, w.BogieMatrix);
+                //               Trace.TraceInformation("Car ID {0} Length {1} Bogie {2} Offset {3} MAtrix {4}", CarID, CarLengthM,  w.BogieIndex, w.OffsetM, w.BogieMatrix);
 
             }
 
             // Calculate the vertival force on the wheel of the car, to determine whether wagon derails or not
             WagonVerticalDerailForceN = MassKG * GravitationalAccelerationMpS2 * Train.WagonCoefficientFriction;
 
- 
+
 
             // Calculate coupler angle when travelling around curve
 
@@ -1081,9 +1081,9 @@ namespace Orts.Simulation.RollingStocks
 
                 float AngleBetweenCarbodies = CouplerAlphaAngleRad + CouplerBetaAngleRad + 2.0f * CouplerGammaAngleRad;
 
-                WagonFrontCouplerAngleRad = (BogieCentresAdjVehiclesM* (CouplerGammaAngleRad + CouplerAlphaAngleRad) - OverhangCarI1M* AngleBetweenCarbodies) / CouplerDistanceM;
+                WagonFrontCouplerAngleRad = (BogieCentresAdjVehiclesM * (CouplerGammaAngleRad + CouplerAlphaAngleRad) - OverhangCarI1M * AngleBetweenCarbodies) / CouplerDistanceM;
 
-          //      Trace.TraceInformation("Centre {0} Gamma {1} Alpha {2} Between {3} CouplerDist {4}", BogieCentresAdjVehiclesM, CouplerGammaAngleRad, CouplerAlphaAngleRad, AngleBetweenCarbodies, CouplerDistanceM);
+                //      Trace.TraceInformation("Centre {0} Gamma {1} Alpha {2} Between {3} CouplerDist {4}", BogieCentresAdjVehiclesM, CouplerGammaAngleRad, CouplerAlphaAngleRad, AngleBetweenCarbodies, CouplerDistanceM);
             }
             else
             {
@@ -1131,8 +1131,8 @@ namespace Orts.Simulation.RollingStocks
 
                 if (CurrentCurveRadius > 0)  // only check curve speed if it is a curve
                 {
-                    float SpeedToleranceMpS =  Me.FromMi( pS.FrompH(2.5f));  // Set bandwidth tolerance for resetting notifications
-                    
+                    float SpeedToleranceMpS = Me.FromMi(pS.FrompH(2.5f));  // Set bandwidth tolerance for resetting notifications
+
                     // If super elevation set in Route (TRK) file
                     if (Simulator.TRK.Tr_RouteFile.SuperElevationHgtpRadiusM != null)
                     {
@@ -1231,7 +1231,7 @@ namespace Orts.Simulation.RollingStocks
 
                     if (CurveSpeedDependent)
                     {
-                        
+
                         // This section not required any more???????????
                         // This section tests for the durability value of the consist. Durability value will non-zero if read from consist files. 
                         // Timetable mode does not read consistent durability values for consists, and therefore value will be zero at this time. 
@@ -1256,11 +1256,11 @@ namespace Orts.Simulation.RollingStocks
                                 {
                                     if (Train.IsFreight)
                                     {
-                                        Simulator.Confirmer.Message(ConfirmLevel.Warning, Simulator.Catalog.GetString("You are travelling too fast for this curve. Slow down, your freight car " + CarID + " may be damaged. The recommended speed for this curve is " + FormatStrings.FormatSpeedDisplay(MaxSafeCurveSpeedMps, IsMetric) ));
+                                        Simulator.Confirmer.Message(ConfirmLevel.Warning, Simulator.Catalog.GetString("You are travelling too fast for this curve. Slow down, your freight car " + CarID + " may be damaged. The recommended speed for this curve is " + FormatStrings.FormatSpeedDisplay(MaxSafeCurveSpeedMps, IsMetric)));
                                     }
                                     else
                                     {
-                                        Simulator.Confirmer.Message(ConfirmLevel.Warning, Simulator.Catalog.GetString("You are travelling too fast for this curve. Slow down, your passengers in car " + CarID + " are feeling uncomfortable. The recommended speed for this curve is " + FormatStrings.FormatSpeedDisplay(MaxSafeCurveSpeedMps, IsMetric) ));
+                                        Simulator.Confirmer.Message(ConfirmLevel.Warning, Simulator.Catalog.GetString("You are travelling too fast for this curve. Slow down, your passengers in car " + CarID + " are feeling uncomfortable. The recommended speed for this curve is " + FormatStrings.FormatSpeedDisplay(MaxSafeCurveSpeedMps, IsMetric)));
                                     }
 
                                     if (dbfmaxsafecurvespeedmps != MaxSafeCurveSpeedMps)//Debrief eval
@@ -1274,7 +1274,7 @@ namespace Orts.Simulation.RollingStocks
 
                             }
                         }
-                        else if ( s < MaxSafeCurveSpeedMps - SpeedToleranceMpS)  // Reset notification once spped drops
+                        else if (s < MaxSafeCurveSpeedMps - SpeedToleranceMpS)  // Reset notification once spped drops
                         {
                             if (IsMaxSafeCurveSpeed)
                             {
@@ -1308,7 +1308,7 @@ namespace Orts.Simulation.RollingStocks
                             }
 
                         }
-                        else if ( s < CriticalMaxSpeedMpS - SpeedToleranceMpS) // Reset notification once speed drops
+                        else if (s < CriticalMaxSpeedMpS - SpeedToleranceMpS) // Reset notification once speed drops
                         {
                             if (IsCriticalMaxSpeed)
                             {
@@ -1330,27 +1330,27 @@ namespace Orts.Simulation.RollingStocks
                         // Code is disabled until a bteer way is determined to work out whether track piees are superelevated or not.
 
                         // if speed doesn't reach minimum speed required around the curve then set notification
-                       // Breaking of brake hose will not apply to TT mode or AI trains or if on a curve less then 150m to cover operation in shunting yards, where track would mostly have no superelevation
-//                        if (s < CriticalMinSpeedMpS && Train.GetType() != typeof(AITrain) && Train.GetType() != typeof(TTTrain) && CurrentCurveRadius > 150 ) 
-//                       {
-//                            if (!IsCriticalMinSpeed)
-//                            {
-//                                IsCriticalMinSpeed = true; // set flag for IsCriticalSpeed not reached
-//
-//                                if (Train.IsPlayerDriven && !Simulator.TimetableMode)  // Warning messages will only apply if this is player train and not running in TT mode
-//                                {
-//                                      Simulator.Confirmer.Message(ConfirmLevel.Warning, Simulator.Catalog.GetString("You were travelling too slow for this curve, and Car " + CarID + "may topple over."));
-//                                }
-//                            }
-//
-//                        }
-//                        else if (s > CriticalMinSpeedMpS + SpeedToleranceMpS) // Reset notification once speed increases
-//                        {
-//                            if (IsCriticalMinSpeed)
-//                            {
-//                                IsCriticalMinSpeed = false; // reset flag for IsCriticalSpeed reached - if speed on curve decreases
-//                            }
-//                        }
+                        // Breaking of brake hose will not apply to TT mode or AI trains or if on a curve less then 150m to cover operation in shunting yards, where track would mostly have no superelevation
+                        //                        if (s < CriticalMinSpeedMpS && Train.GetType() != typeof(AITrain) && Train.GetType() != typeof(TTTrain) && CurrentCurveRadius > 150 ) 
+                        //                       {
+                        //                            if (!IsCriticalMinSpeed)
+                        //                            {
+                        //                                IsCriticalMinSpeed = true; // set flag for IsCriticalSpeed not reached
+                        //
+                        //                                if (Train.IsPlayerDriven && !Simulator.TimetableMode)  // Warning messages will only apply if this is player train and not running in TT mode
+                        //                                {
+                        //                                      Simulator.Confirmer.Message(ConfirmLevel.Warning, Simulator.Catalog.GetString("You were travelling too slow for this curve, and Car " + CarID + "may topple over."));
+                        //                                }
+                        //                            }
+                        //
+                        //                        }
+                        //                        else if (s > CriticalMinSpeedMpS + SpeedToleranceMpS) // Reset notification once speed increases
+                        //                        {
+                        //                            if (IsCriticalMinSpeed)
+                        //                            {
+                        //                                IsCriticalMinSpeed = false; // reset flag for IsCriticalSpeed reached - if speed on curve decreases
+                        //                            }
+                        //                        }
 
 #if DEBUG_CURVE_SPEED
                    Trace.TraceInformation("================================== TrainCar.cs - DEBUG_CURVE_SPEED ==============================================================");
@@ -1374,7 +1374,7 @@ namespace Orts.Simulation.RollingStocks
 
         #endregion
 
-    
+
         #region Calculate friction force in curves
 
         /// <summary>
@@ -1393,7 +1393,7 @@ namespace Orts.Simulation.RollingStocks
                     if (RigidWheelBaseM == 0)   // Calculate default values if no value in Wag File
                     {
 
-                        
+
                         float Axles = WheelAxles.Count;
                         float Bogies = Parts.Count - 1;
                         float BogieSize = Axles / Bogies;
@@ -1690,7 +1690,7 @@ namespace Orts.Simulation.RollingStocks
         {
             return 0.012f;
         }
-        
+
         public virtual float GetMaximumCouplerSlack2M()
         {
             return 0.12f;
@@ -2086,7 +2086,7 @@ namespace Orts.Simulation.RollingStocks
             WorldPosition.XNAMatrix = m;
             WorldPosition.TileX = tileX;
             WorldPosition.TileZ = tileZ;
-            
+
             UpdatedTraveler(traveler, elapsedTimeS, distance, speed);
 
             // calculate truck angles
@@ -2141,7 +2141,7 @@ namespace Orts.Simulation.RollingStocks
         #endregion
 
         #region Super-elevation
-        void UpdateSuperElevation(Traveller traveler,  float elapsedTimeS)
+        void UpdateSuperElevation(Traveller traveler, float elapsedTimeS)
         {
             if (Simulator.Settings.UseSuperElevation == 0)
                 return;

--- a/Source/Orts.Simulation/Simulation/Signalling/SIGSCRfile.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/SIGSCRfile.cs
@@ -1525,14 +1525,14 @@ namespace Orts.Simulation.Signalling
                     }
                 }
 
-  // AND or OR indication (to link previous and next part)
+                // AND or OR indication (to link previous and next part)
 
                 else if (thisCond is SignalScripts.SCRAndOr)
                 {
                     condstring = (SignalScripts.SCRAndOr)thisCond;
                 }
 
-  // subcondition
+                // subcondition
 
                 else
                 {
@@ -1659,7 +1659,7 @@ namespace Orts.Simulation.Signalling
 #endif
             }
 
-  // process second term
+            // process second term
 
             else
             {

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -171,7 +171,7 @@ namespace Orts.Simulation.Signalling
             // Process trough information
             //
 
-            ProcessTroughs();         
+            ProcessTroughs();
 
             //
             // Print all info (DEBUG only)
@@ -275,7 +275,7 @@ namespace Orts.Simulation.Signalling
                                 Trace.TraceInformation("Signal " + thisSignal.thisRef +
                                     " ; TC : " + thisSignal.TCReference +
                                     " ; NextTC : " + thisSignal.TCNextTC +
-                                    " ; TN : " + thisSignal.trackNode + 
+                                    " ; TN : " + thisSignal.trackNode +
                                     " ; TDB (0) : " + thisSignal.SignalHeads[0].TDBIndex);
                             }
 
@@ -532,7 +532,7 @@ namespace Orts.Simulation.Signalling
                             }
                         }
                     }
-                    else  if (worldObject.GetType() == typeof(PlatformObj))
+                    else if (worldObject.GetType() == typeof(PlatformObj))
                     {
                         var thisWorldObj = worldObject as PlatformObj;
                         if (!PlatformSidesList.ContainsKey(thisWorldObj.trItemIDList[0].dbID)) PlatformSidesList.Add(thisWorldObj.trItemIDList[0].dbID, thisWorldObj.PlatformData);
@@ -934,7 +934,7 @@ namespace Orts.Simulation.Signalling
         /// </summary>
 
         private void ScanSection(TrItem[] TrItems, TrackNode[] trackNodes, int index,
-                               TrackSectionsFile tsectiondat, TrackDatabaseFile tdbfile, Dictionary<int, int> platformList, List <Milepost> milepostList)
+                               TrackSectionsFile tsectiondat, TrackDatabaseFile tdbfile, Dictionary<int, int> platformList, List<Milepost> milepostList)
         {
             int lastSignal = -1;                // Index to last signal found in path; -1 if none
             int lastMilepost = -1;                // Index to last milepost found in path; -1 if none
@@ -971,7 +971,7 @@ namespace Orts.Simulation.Signalling
                             }
                         }
 
-        // Track Item is speedpost - check if really limit
+                        // Track Item is speedpost - check if really limit
                         else if (TrItems[TDBRef].ItemType == TrItem.trItemType.trSPEEDPOST)
                         {
                             SpeedPostItem speedItem = (SpeedPostItem)TrItems[TDBRef];
@@ -1181,7 +1181,7 @@ namespace Orts.Simulation.Signalling
             milepost.TrItemId = (uint)TDBRef;
             milepost.MilepostValue = speedItem.SpeedInd;
             MilepostList.Add(milepost);
- 
+
 #if DEBUG_PRINT
             File.AppendAllText(@"C:\temp\speedpost.txt",
 				String.Format("\nMilepost placed : at : {0} {1}:{2} {3}. String: {4}\n",
@@ -2129,7 +2129,7 @@ namespace Orts.Simulation.Signalling
                 if (speedItem.SigObj >= 0)
                 {
                     if (!speedItem.IsMilePost)
-                    { 
+                    {
                         SignalObject thisSpeedpost = SignalObjects[speedItem.SigObj];
                         float speedpostDistance = thisSpeedpost.DistanceTo(TDBTrav);
                         if (thisSpeedpost.direction == 1)
@@ -2245,7 +2245,7 @@ namespace Orts.Simulation.Signalling
                 addIndex.Add(thisNode);
 
                 List<TrackCircuitSignalItem> sectionSignals =
-                         thisSection.CircuitItems.TrackCircuitSignals[0] [(int)MstsSignalFunction.NORMAL].TrackCircuitItem;
+                         thisSection.CircuitItems.TrackCircuitSignals[0][(int)MstsSignalFunction.NORMAL].TrackCircuitItem;
 
                 while (sectionSignals.Count > 0)
                 {
@@ -2262,7 +2262,7 @@ namespace Orts.Simulation.Signalling
                     addIndex.Add(newIndex);
 
                     // restore list (link is lost as item is replaced)
-                    sectionSignals = thisSection.CircuitItems.TrackCircuitSignals[0] [(int)MstsSignalFunction.NORMAL].TrackCircuitItem;
+                    sectionSignals = thisSection.CircuitItems.TrackCircuitSignals[0][(int)MstsSignalFunction.NORMAL].TrackCircuitItem;
                 }
             }
 
@@ -2283,7 +2283,7 @@ namespace Orts.Simulation.Signalling
                     {
 
                         List<TrackCircuitSignalItem> sectionSignals =
-                           thisSection.CircuitItems.TrackCircuitSignals[1] [(int)MstsSignalFunction.NORMAL].TrackCircuitItem;
+                           thisSection.CircuitItems.TrackCircuitSignals[1][(int)MstsSignalFunction.NORMAL].TrackCircuitItem;
 
                         if (sectionSignals.Count > 0)
                         {
@@ -2300,10 +2300,10 @@ namespace Orts.Simulation.Signalling
                             thisSection.EndSignals[1] = thisSignal.SignalRef;
 
                             // restore list (link is lost as item is replaced)
-                            sectionSignals = thisSection.CircuitItems.TrackCircuitSignals[1] [(int)MstsSignalFunction.NORMAL].TrackCircuitItem;
+                            sectionSignals = thisSection.CircuitItems.TrackCircuitSignals[1][(int)MstsSignalFunction.NORMAL].TrackCircuitItem;
                         }
                     }
-                    thisIndex = thisSection.CircuitItems.TrackCircuitSignals[1] [(int)MstsSignalFunction.NORMAL].TrackCircuitItem.Count > 0 ? thisIndex : newIndex;
+                    thisIndex = thisSection.CircuitItems.TrackCircuitSignals[1][(int)MstsSignalFunction.NORMAL].TrackCircuitItem.Count > 0 ? thisIndex : newIndex;
                 }
             }
 
@@ -3061,7 +3061,7 @@ namespace Orts.Simulation.Signalling
                     thisMilepost.TCOffset = thisItem.MilepostLocation[0];
                 }
             }
-            
+
         }
 
         //================================================================================================//
@@ -3265,7 +3265,7 @@ namespace Orts.Simulation.Signalling
             if (thisTrain.Train.LoopSection >= 0)
             {
                 thisSection = TrackCircuitList[thisTrain.Train.LoopSection];
-                
+
                 // test if train is really occupying this section
                 Train.TCSubpathRoute tempRoute = BuildTempRoute(thisTrain.Train, thisTrain.Train.PresentPosition[1].TCSectionIndex, thisTrain.Train.PresentPosition[1].TCOffset,
                     thisTrain.Train.PresentPosition[1].TCDirection, thisTrain.Train.Length, true, true, false);
@@ -3350,7 +3350,7 @@ namespace Orts.Simulation.Signalling
                     {
                         lastRouteIndex = routeIndex - 1;
                     }
-                    
+
                     if (thisTrain.Train.CheckTrain)
                     {
                         if (lastRouteIndex >= 0)
@@ -3514,7 +3514,7 @@ namespace Orts.Simulation.Signalling
 
             // if not cleared to max distance or looped, determine reason
 
-            if (!furthestRouteCleared && lastRouteIndex > 0 && routePart[lastRouteIndex].TCSectionIndex >= 0  && endAuthority != Train.END_AUTHORITY.LOOP)
+            if (!furthestRouteCleared && lastRouteIndex > 0 && routePart[lastRouteIndex].TCSectionIndex >= 0 && endAuthority != Train.END_AUTHORITY.LOOP)
             {
 
                 thisElement = routePart[lastRouteIndex];
@@ -4051,7 +4051,7 @@ namespace Orts.Simulation.Signalling
                         break;
 
                     case TrackCircuitSection.TrackCircuitType.Junction:
-//                        if (checkReenterOriginalRoute && foundItems.Count > 2)
+                        //                        if (checkReenterOriginalRoute && foundItems.Count > 2)
                         if (checkReenterOriginalRoute)
                         {
                             Train.TCSubpathRoute originalSubpath = thisTrain.TCRoute.TCRouteSubpaths[thisTrain.TCRoute.OriginalSubpath];
@@ -4217,7 +4217,7 @@ namespace Orts.Simulation.Signalling
                     refIndex = 1;
                 }
 
-        // create new platform details
+                // create new platform details
 
                 else
                 {
@@ -4270,7 +4270,7 @@ namespace Orts.Simulation.Signalling
                     thisDetails.TCSectionIndex.Add(TCSectionIndex);
                 }
 
-        // if second entry, test if equal - if not, build list
+                // if second entry, test if equal - if not, build list
 
                 else
                 {
@@ -4329,7 +4329,7 @@ namespace Orts.Simulation.Signalling
                     thisDetails.Name = String.Copy(thisPlatform.Station);
                     thisDetails.MinWaitingTime = thisPlatform.PlatformMinWaitingTime;
                     thisDetails.NumPassengersWaiting = (int)thisPlatform.PlatformNumPassengersWaiting;
-                 }
+                }
                 else if (!splitPlatform)
                 {
                     thisDetails.Length = Math.Abs(thisDetails.nodeOffset[1] - thisDetails.nodeOffset[0]);
@@ -6252,7 +6252,7 @@ namespace Orts.Simulation.Signalling
             CircuitState.TrainOccupy.Add(thisTrain, direction);
             CircuitState.Forced = false;
             thisTrain.Train.OccupiedTrack.Add(this);
-	    
+
             // clear all reservations
             CircuitState.TrainReserved = null;
             CircuitState.SignalReserved = -1;
@@ -6985,7 +6985,7 @@ namespace Orts.Simulation.Signalling
         /// <summary>
         /// Test only if section reserved to train
         /// </summary>
-        
+
         public bool CheckReserved(Train.TrainRouted thisTrain)
         {
             var reserved = false;
@@ -7643,7 +7643,7 @@ namespace Orts.Simulation.Signalling
         {
             MilepostRef = thisRef;
             MilepostLocation[0] = thisLocation0;
-            MilepostLocation[1] = thisLocation1; 
+            MilepostLocation[1] = thisLocation1;
         }
     }
 
@@ -7722,7 +7722,7 @@ namespace Orts.Simulation.Signalling
         //================================================================================================//
         /// <summary>
         /// Check if it contains specified train
-	/// Routed
+        /// Routed
         /// </summary>
 
         public bool ContainsTrain(Train.TrainRouted thisTrain)
@@ -7734,7 +7734,7 @@ namespace Orts.Simulation.Signalling
         //================================================================================================//
         /// <summary>
         /// Check if it contains specified train
-	/// Unrouted
+        /// Unrouted
         /// </summary>
 
         public bool ContainsTrain(Train thisTrain)
@@ -7746,7 +7746,7 @@ namespace Orts.Simulation.Signalling
         //================================================================================================//
         /// <summary>
         /// Check if it contains specified train and return train direction
-	/// Routed
+        /// Routed
         /// </summary>
 
         public Dictionary<bool, int> ContainsTrainDirected(Train.TrainRouted thisTrain)
@@ -7758,7 +7758,7 @@ namespace Orts.Simulation.Signalling
         //================================================================================================//
         /// <summary>
         /// Check if it contains specified train and return train direction
-	/// Unrouted
+        /// Unrouted
         /// </summary>
 
         public Dictionary<bool, int> ContainsTrainDirected(Train thisTrain)
@@ -7796,7 +7796,7 @@ namespace Orts.Simulation.Signalling
         //================================================================================================//
         /// <summary>
         /// Remove train from list
-	/// Routed
+        /// Routed
         /// </summary>
 
         public void RemoveTrain(Train.TrainRouted thisTrain)
@@ -7822,7 +7822,7 @@ namespace Orts.Simulation.Signalling
     {
         //================================================================================================//
         /// <summary>
-	/// Peek top train from queue
+        /// Peek top train from queue
         /// </summary>
 
         public Train PeekTrain()
@@ -7834,7 +7834,7 @@ namespace Orts.Simulation.Signalling
 
         //================================================================================================//
         /// <summary>
-	/// Check if queue contains routed train
+        /// Check if queue contains routed train
         /// </summary>
 
         public bool ContainsTrain(Train.TrainRouted thisTrain)
@@ -8112,7 +8112,7 @@ namespace Orts.Simulation.Signalling
         //================================================================================================//
         /// <summary>
         /// Get list of trains occupying track
-	/// Check based on direction
+        /// Check based on direction
         /// </summary>
 
         public List<Train.TrainRouted> TrainsOccupying(int reqDirection)
@@ -8949,14 +8949,14 @@ namespace Orts.Simulation.Signalling
         /// opp_sig_mr
         /// </summary>
 
-	/// normal version
+        /// normal version
         public MstsSignalAspect opp_sig_mr(int fn_type)
         {
             int signalFound = SONextSignalOpp(fn_type);
             return (signalFound >= 0 ? signalObjects[signalFound].this_sig_mr(fn_type) : MstsSignalAspect.STOP);
         }//opp_sig_mr
 
-	/// debug version
+        /// debug version
         public MstsSignalAspect opp_sig_mr(int fn_type, ref SignalObject foundSignal)
         {
             int signalFound = SONextSignalOpp(fn_type);
@@ -8969,14 +8969,14 @@ namespace Orts.Simulation.Signalling
         /// opp_sig_lr
         /// </summary>
 
-	/// normal version
+        /// normal version
         public MstsSignalAspect opp_sig_lr(int fn_type)
         {
             int signalFound = SONextSignalOpp(fn_type);
             return (signalFound >= 0 ? signalObjects[signalFound].this_sig_lr(fn_type) : MstsSignalAspect.STOP);
         }//opp_sig_lr
 
-	/// debug version
+        /// debug version
         public MstsSignalAspect opp_sig_lr(int fn_type, ref SignalObject foundSignal)
         {
             int signalFound = SONextSignalOpp(fn_type);
@@ -9663,7 +9663,7 @@ namespace Orts.Simulation.Signalling
                 signalFound = SONextSignalNormal(TCReference);   // other types of signals (sigfound not used)
             }
 
-        // for other signals : move to next TC (signal would have been default if within same section)
+            // for other signals : move to next TC (signal would have been default if within same section)
 
             else
             {
@@ -9745,7 +9745,7 @@ namespace Orts.Simulation.Signalling
 
                     if (nextSectionIndex >= 0)
                     {
-                        for (int iSection = nextSectionIndex+1; iSection <= (refSignal.signalRoute.Count - 1) && signalFound < 0; iSection++)
+                        for (int iSection = nextSectionIndex + 1; iSection <= (refSignal.signalRoute.Count - 1) && signalFound < 0; iSection++)
                         {
                             thisSection = signalRef.TrackCircuitList[refSignal.signalRoute[iSection].TCSectionIndex];
                             direction = refSignal.signalRoute[iSection].Direction;
@@ -9894,7 +9894,7 @@ namespace Orts.Simulation.Signalling
 
                 // check if required type of signal is along this section
 
-                if (fntype == (int) MstsSignalFunction.NORMAL)
+                if (fntype == (int)MstsSignalFunction.NORMAL)
                 {
                     signalFound = thisSection.EndSignals[direction] != null ? thisSection.EndSignals[direction].thisRef : -1;
                 }
@@ -9979,7 +9979,7 @@ namespace Orts.Simulation.Signalling
                     }
                 }
 
-        // fixed route - check route and update
+                // fixed route - check route and update
 
                 else if (hasFixedRoute)
                 {
@@ -9994,7 +9994,7 @@ namespace Orts.Simulation.Signalling
 
                 }
 
-        // no route - perform update only
+                // no route - perform update only
 
                 else
                 {
@@ -10003,7 +10003,7 @@ namespace Orts.Simulation.Signalling
 
             }
 
-        // check blockstate for other signals
+            // check blockstate for other signals
 
             else
             {
@@ -10399,49 +10399,49 @@ namespace Orts.Simulation.Signalling
 
             // find section in route part which follows signal
 
-                signalRoute.Clear();
+            signalRoute.Clear();
 
-                int firstIndex = -1;
-                if (lastSignal != null)
-                {
-                    firstIndex = lastSignal.thisTrainRouteIndex;
-                }
-                if (firstIndex < 0)
-                {
-                    firstIndex = thisTrain.Train.PresentPosition[thisTrain.TrainRouteDirectionIndex].RouteListIndex;
-                }
+            int firstIndex = -1;
+            if (lastSignal != null)
+            {
+                firstIndex = lastSignal.thisTrainRouteIndex;
+            }
+            if (firstIndex < 0)
+            {
+                firstIndex = thisTrain.Train.PresentPosition[thisTrain.TrainRouteDirectionIndex].RouteListIndex;
+            }
 
-                if (firstIndex >= 0)
+            if (firstIndex >= 0)
+            {
+                for (int iNode = firstIndex;
+                         iNode < RoutePart.Count && foundFirstSection < 0;
+                         iNode++)
                 {
-                    for (int iNode = firstIndex;
-                             iNode < RoutePart.Count && foundFirstSection < 0;
-                             iNode++)
+                    Train.TCRouteElement thisElement = RoutePart[iNode];
+                    if (thisElement.TCSectionIndex == TCNextTC)
                     {
-                        Train.TCRouteElement thisElement = RoutePart[iNode];
-                        if (thisElement.TCSectionIndex == TCNextTC)
-                        {
-                            foundFirstSection = iNode;
-                            thisTrainRouteIndex = iNode;
-                        }
+                        foundFirstSection = iNode;
+                        thisTrainRouteIndex = iNode;
                     }
                 }
+            }
 
-                if (foundFirstSection < 0)
+            if (foundFirstSection < 0)
+            {
+                enabledTrain = null;
+
+                // if signal on holding list, set hold state
+                if (thisTrain.Train.HoldingSignals.Contains(thisRef) && holdState == HoldState.None)
                 {
-                    enabledTrain = null;
-
-                    // if signal on holding list, set hold state
-                    if (thisTrain.Train.HoldingSignals.Contains(thisRef) && holdState == HoldState.None)
-                    {
-                        holdState = HoldState.StationStop;
-                    }
-                    return false;
+                    holdState = HoldState.StationStop;
                 }
+                return false;
+            }
 
             // copy sections upto next normal signal
             // check for loop
 
-                List<int> sectionsInRoute = new List<int>();
+            List<int> sectionsInRoute = new List<int>();
 
             for (int iNode = foundFirstSection; iNode < RoutePart.Count && foundLastSection < 0; iNode++)
             {
@@ -10725,7 +10725,7 @@ namespace Orts.Simulation.Signalling
                     enabledTrain.Train.ClaimState = false;
                 }
 
-            // reserve partial sections if signal clears on occupied track or permission is granted
+                // reserve partial sections if signal clears on occupied track or permission is granted
 
                 else if ((signalState > MstsSignalAspect.STOP || hasPermission == Permission.Granted) &&
                          (internalBlockState != InternalBlockstate.Reserved && internalBlockState < InternalBlockstate.ReservedOther))
@@ -10784,7 +10784,7 @@ namespace Orts.Simulation.Signalling
                     enabledTrain.Train.ClaimState = false;
                 }
 
-            // if claim allowed - reserve free sections and claim all other if first signal ahead of train
+                // if claim allowed - reserve free sections and claim all other if first signal ahead of train
 
                 else if (enabledTrain.Train.ClaimState && internalBlockState != InternalBlockstate.Reserved &&
                          enabledTrain.Train.NextSignalObject[0] != null && enabledTrain.Train.NextSignalObject[0].thisRef == thisRef)
@@ -10985,7 +10985,7 @@ namespace Orts.Simulation.Signalling
                 }
             }
 
-        // otherwise follow sections upto first non-set switch or next signal
+            // otherwise follow sections upto first non-set switch or next signal
             else
             {
                 int thisTC = TCReference;
@@ -11037,7 +11037,7 @@ namespace Orts.Simulation.Signalling
                         thisSection = null;
                     }
 
-        // get next section if active link is set
+                    // get next section if active link is set
 
                     else
                     {
@@ -12010,7 +12010,7 @@ namespace Orts.Simulation.Signalling
 
         public bool CheckTimingTrigger(int reqTiming, string dumpfile)
         {
-            int foundDelta = (int) (signalRef.Simulator.GameTime - TimingTriggerValue);
+            int foundDelta = (int)(signalRef.Simulator.GameTime - TimingTriggerValue);
             bool triggerExceeded = foundDelta > reqTiming;
 
             if (!String.IsNullOrEmpty(dumpfile))
@@ -12674,7 +12674,7 @@ namespace Orts.Simulation.Signalling
 
             float passSpeed = speedItem.IsPassenger ? speedMpS : -1;
             float freightSpeed = speedItem.IsFreight ? speedMpS : -1;
-            ObjectSpeedInfo speedinfo = new ObjectSpeedInfo(passSpeed, freightSpeed, false, false, speedItem is TempSpeedPostItem? (speedMpS == 999f? 2 : 1) : 0);
+            ObjectSpeedInfo speedinfo = new ObjectSpeedInfo(passSpeed, freightSpeed, false, false, speedItem is TempSpeedPostItem ? (speedMpS == 999f ? 2 : 1) : 0);
             speed_info[(int)state] = speedinfo;
         }
 
@@ -12700,7 +12700,7 @@ namespace Orts.Simulation.Signalling
                 foreach (SignalAspect thisAspect in signalType.Aspects)
                 {
                     int arrindex = (int)thisAspect.Aspect;
-                    speed_info[arrindex] = new ObjectSpeedInfo(thisAspect.SpeedMpS, thisAspect.SpeedMpS, thisAspect.Asap, thisAspect.Reset, thisAspect.NoSpeedReduction? 1 : 0);
+                    speed_info[arrindex] = new ObjectSpeedInfo(thisAspect.SpeedMpS, thisAspect.SpeedMpS, thisAspect.Asap, thisAspect.Reset, thisAspect.NoSpeedReduction ? 1 : 0);
                 }
 
                 // set normal subtype
@@ -12746,7 +12746,7 @@ namespace Orts.Simulation.Signalling
         //================================================================================================//
         /// <summary>
         ///  Set of methods called per signal head from signal script processing
-	///  All methods link through to the main method set for signal objec
+        ///  All methods link through to the main method set for signal objec
         /// </summary>
 
         public MstsSignalAspect next_sig_mr(int sigFN)
@@ -13409,7 +13409,7 @@ namespace Orts.Simulation.Signalling
         public int speed_flag;
         public int speed_reset;
         // for signals: if = 1 no speed reduction; for speedposts: if = 0 standard; = 1 start of temp speedreduction post; = 2 end of temp speed reduction post
-        public int speed_noSpeedReductionOrIsTempSpeedReduction; 
+        public int speed_noSpeedReductionOrIsTempSpeedReduction;
         public float actual_speed;                   // set active by TRAIN
 
         public bool processed;                       // for AI trains, set active by TRAIN
@@ -13547,7 +13547,7 @@ namespace Orts.Simulation.Signalling
             Name = String.Copy(orgDetails.Name);
             MinWaitingTime = orgDetails.MinWaitingTime;
             NumPassengersWaiting = orgDetails.NumPassengersWaiting;
-            PlatformSide [0] = orgDetails.PlatformSide[0];
+            PlatformSide[0] = orgDetails.PlatformSide[0];
             PlatformSide[1] = orgDetails.PlatformSide[1];
         }
     }

--- a/Source/Orts.Simulation/Simulation/Simulator.cs
+++ b/Source/Orts.Simulation/Simulation/Simulator.cs
@@ -526,10 +526,10 @@ namespace Orts.Simulation
             }
             if (MovingTables != null && MovingTables.Count >= 0)
                 foreach (var movingTable in MovingTables) movingTable.Restore(inf, this);
-/*
-            if (Turntables != null && Turntables.Count >= 0)
-                foreach (var turntable in Turntables) turntable.ReInitTrainPositions();
-*/
+            /*
+                        if (Turntables != null && Turntables.Count >= 0)
+                            foreach (var turntable in Turntables) turntable.ReInitTrainPositions();
+            */
             ActivityRun = Orts.Simulation.Activity.Restore(inf, this, ActivityRun);
             Signals.RestoreTrains(Trains);  // restore links to trains
             Signals.Update(true);           // update all signals once to set proper stat
@@ -1772,7 +1772,7 @@ namespace Orts.Simulation
                     if (playerTrain != null)
                     {
                         if (playerTrain.ControlMode == Train.TRAIN_CONTROL.MANUAL) TrainSwitcher.SuspendOldPlayer = true; // force suspend state to avoid disappearing of train;
-                        if (TrainSwitcher.SuspendOldPlayer && 
+                        if (TrainSwitcher.SuspendOldPlayer &&
                             (playerTrain.SpeedMpS < -0.025 || playerTrain.SpeedMpS > 0.025 || playerTrain.PresentPosition[0].TCOffset != playerTrain.PreviousPosition[0].TCOffset))
                         {
                             Confirmer.Message(ConfirmLevel.Warning, Catalog.GetString("Train can't be suspended with speed not equal 0"));
@@ -1989,10 +1989,10 @@ namespace Orts.Simulation
                 }
             }
             if (trainToRestart == null)
-                Trace.TraceWarning("Train {0} to restart not found", restartWaitingTrain.WaitingTrainToRestart);            
+                Trace.TraceWarning("Train {0} to restart not found", restartWaitingTrain.WaitingTrainToRestart);
         }
 
- 
+
 
         /// <summary>
         /// Derive log-file name from route path and activity name

--- a/Source/Orts.Simulation/Simulation/Timetables/PoolInfo.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/PoolInfo.cs
@@ -75,13 +75,13 @@ namespace Orts.Simulation.Timetables
                     switch (poolInfo.Strings[lineindex][0].ToLower().Trim())
                     {
                         // skip comment
-                        case "#comment" :
+                        case "#comment":
                             lineindex++;
                             break;
-                         
+
                         // process name
                         // do not increase lineindex as that is done in called method
-                        case "#name" :
+                        case "#name":
                             TimetablePool newPool = new TimetablePool(poolInfo, ref lineindex, simulator);
                             // store if valid pool
                             if (!String.IsNullOrEmpty(newPool.PoolName))
@@ -97,7 +97,7 @@ namespace Orts.Simulation.Timetables
                             }
                             break;
 
-                        default :
+                        default:
                             if (!String.IsNullOrEmpty(poolInfo.Strings[lineindex][0]))
                             {
                                 Trace.TraceInformation("Invalid definition in file " + filePath + " at line " + lineindex + " : " +

--- a/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
@@ -1504,7 +1504,7 @@ namespace Orts.Simulation.Timetables
                                             {
                                                 TTTrain.TransferTrainDetails.Add(-1, newList); // set key to -1 to work out reference later
                                             }
-                                        } 
+                                        }
                                         break;
 
                                     case "activate":
@@ -1811,7 +1811,7 @@ namespace Orts.Simulation.Timetables
                                 break;
 
                             // activated : set activated flag
-                            case "activated" :
+                            case "activated":
                                 activationRequired = true;
                                 break;
 
@@ -1907,7 +1907,7 @@ namespace Orts.Simulation.Timetables
                 if (activationRequired && !String.IsNullOrEmpty(createFromPool))
                 {
                     activationRequired = false;
-                    Trace.TraceInformation("Trigger activation not allowed when starting from pool, trigger activation reset for train {0}", TTTrain.Name);                  
+                    Trace.TraceInformation("Trigger activation not allowed when starting from pool, trigger activation reset for train {0}", TTTrain.Name);
                 }
 
             }
@@ -2548,7 +2548,7 @@ namespace Orts.Simulation.Timetables
                         newStop.Commands = new List<TTTrainCommands>();
                     }
 
-                    newStop.Commands.Add(new TTTrainCommands(String.Concat("stoptime=",stationDetails.actMinStopTime.Value.ToString().Trim())));
+                    newStop.Commands.Add(new TTTrainCommands(String.Concat("stoptime=", stationDetails.actMinStopTime.Value.ToString().Trim())));
                 }
 
                 // process restrict to signal
@@ -3357,7 +3357,7 @@ namespace Orts.Simulation.Timetables
 
                     // create station stop info
                     validStop = actTrain.CreateStationStop(actPlatformID, arrivalTime, departureTime, arrivalDT, departureDT, AITrain.clearingDistanceM,
-                        AITrain.minStopDistanceM, terminal, actMinStopTime,keepClearFront, keepClearRear, forcePosition, closeupSignal, closeup, restrictPlatformToSignal, extendPlatformToSignal, endStop);
+                        AITrain.minStopDistanceM, terminal, actMinStopTime, keepClearFront, keepClearRear, forcePosition, closeupSignal, closeup, restrictPlatformToSignal, extendPlatformToSignal, endStop);
 
                     // override holdstate using stop info - but only if exit signal is defined
 

--- a/Source/Orts.Simulation/Simulation/Timetables/TTPool.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTPool.cs
@@ -41,12 +41,12 @@ namespace Orts.Simulation.Timetables
     /// </summary>
     public class Poolholder
     {
-        public Dictionary<string,TimetablePool> Pools;
+        public Dictionary<string, TimetablePool> Pools;
 
         /// <summary>
         /// loader for timetable mode
         /// </summary>
-        public Poolholder (Simulator simulatorref, string[] arguments, CancellationToken cancellation)
+        public Poolholder(Simulator simulatorref, string[] arguments, CancellationToken cancellation)
         {
             PoolInfo TTPool = new PoolInfo(simulatorref);
             Pools = TTPool.ProcessPools(arguments, cancellation);
@@ -65,7 +65,7 @@ namespace Orts.Simulation.Timetables
         /// <summary>
         /// loader for restore
         /// </summary>
-        public Poolholder (BinaryReader inf, Simulator simulatorref)
+        public Poolholder(BinaryReader inf, Simulator simulatorref)
         {
             int nopools = inf.ReadInt32();
             if (nopools < 0)
@@ -89,7 +89,7 @@ namespace Orts.Simulation.Timetables
         /// Save
         /// </summary>
         /// <param name="outf"></param>
-        public void Save (BinaryWriter outf)
+        public void Save(BinaryWriter outf)
         {
             if (Pools == null)
             {
@@ -715,12 +715,12 @@ namespace Orts.Simulation.Timetables
                                 newRoute.Add(newElement);
                             }
                         }
-                    // add elements from storage
+                        // add elements from storage
                         for (int iElement = thisStorage.StoragePath.Count - 1; iElement >= 0; iElement--)
                         {
                             if (newRoute.GetRouteIndex(thisStorage.StoragePath[iElement].TCSectionIndex, 0) < 0)
                             {
-                                Train.TCRouteElement newElement = new Train.TCRouteElement (thisStorage.StoragePath[iElement]);
+                                Train.TCRouteElement newElement = new Train.TCRouteElement(thisStorage.StoragePath[iElement]);
                                 newElement.Direction = newElement.Direction == 1 ? 0 : 1;
                                 newRoute.Add(newElement);
                             }
@@ -778,11 +778,11 @@ namespace Orts.Simulation.Timetables
                 train.PresentPosition[1].TCDirection, train.Length, true, true, false);
             train.OccupiedTrack.Clear();
 
-            foreach(Train.TCRouteElement thisElement in tempRoute)
+            foreach (Train.TCRouteElement thisElement in tempRoute)
             {
                 train.OccupiedTrack.Add(train.signalRef.TrackCircuitList[thisElement.TCSectionIndex]);
             }
-            
+
             train.ClearActiveSectionItems();
         }
 
@@ -881,7 +881,7 @@ namespace Orts.Simulation.Timetables
 
                 if (ForceCreation)
                 {
-                    Trace.TraceInformation("Train request : " + train.Name + " from pool " + PoolName + 
+                    Trace.TraceInformation("Train request : " + train.Name + " from pool " + PoolName +
                         " : no engines available in pool, engine is created, at " + moveTimeA.ToString("HH:mm:ss") + "\n");
 #if DEBUG_POOLINFO
                     sob = new StringBuilder();
@@ -892,7 +892,7 @@ namespace Orts.Simulation.Timetables
                 }
                 else
                 {
-                    Trace.TraceInformation("Train request : " + train.Name + " from pool " + PoolName + 
+                    Trace.TraceInformation("Train request : " + train.Name + " from pool " + PoolName +
                         " : no engines available in pool, engine is not created , at " + moveTimeA.ToString("HH:mm:ss") + "\n");
 #if DEBUG_POOLINFO
                     sob = new StringBuilder();
@@ -1101,7 +1101,7 @@ namespace Orts.Simulation.Timetables
                     train.OrgAINumber = train.Number;
                     train.Number = 0;
                     train.LeadLocomotiveIndex = selectedTrain.LeadLocomotiveIndex;
-                    for (int carid = 0; carid < train.Cars.Count; carid++ )
+                    for (int carid = 0; carid < train.Cars.Count; carid++)
                     {
                         train.Cars[carid].CarID = selectedTrain.Cars[carid].CarID;
                     }

--- a/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
@@ -458,7 +458,7 @@ namespace Orts.Simulation.Timetables
             }
 
             int totalNeedTrainTransfer = inf.ReadInt32();
-            NeedTrainTransfer = new Dictionary<int,int>();
+            NeedTrainTransfer = new Dictionary<int, int>();
 
             for (int iNeedTransferList = 0; iNeedTransferList < totalNeedTrainTransfer; iNeedTransferList++)
             {
@@ -760,7 +760,7 @@ namespace Orts.Simulation.Timetables
             }
 
             outf.Write(NeedTrainTransfer.Count);
-            foreach (KeyValuePair<int,int> thisNeedTransfer in NeedTrainTransfer)
+            foreach (KeyValuePair<int, int> thisNeedTransfer in NeedTrainTransfer)
             {
                 outf.Write(thisNeedTransfer.Key);
                 outf.Write(thisNeedTransfer.Value);
@@ -904,7 +904,7 @@ namespace Orts.Simulation.Timetables
                 {
                     StationStop newStop = CalculateStationStop(signalRef.PlatformDetailsList[altPlatformIndex].PlatformReference[0],
                         orgStop.ArrivalTime, orgStop.DepartTime, orgStop.arrivalDT, orgStop.departureDT, clearingDistanceM, minStopDistanceM,
-                        orgStop.Terminal, orgStop.ActualMinStopTime, orgStop.KeepClearFront, orgStop.KeepClearRear, orgStop.ForcePosition, 
+                        orgStop.Terminal, orgStop.ActualMinStopTime, orgStop.KeepClearFront, orgStop.KeepClearRear, orgStop.ForcePosition,
                         orgStop.CloseupSignal, orgStop.Closeup, orgStop.RestrictPlatformToSignal, orgStop.ExtendPlatformToSignal, orgStop.EndStop);
 
 #if DEBUG_REPORTS
@@ -1272,7 +1272,7 @@ namespace Orts.Simulation.Timetables
         /// <\summary>
 
         public StationStop CalculateStationStop(int platformStartID, int arrivalTime, int departTime, DateTime arrivalDT, DateTime departureDT, float clearingDistanceM,
-            float minStopDistance, bool terminal, int? actMinStopTime, float? keepClearFront, float? keepClearRear, bool forcePosition, bool closeupSignal, 
+            float minStopDistance, bool terminal, int? actMinStopTime, float? keepClearFront, float? keepClearRear, bool forcePosition, bool closeupSignal,
             bool closeup, bool restrictPlatformToSignal, bool extendPlatformToSignal, bool endStop)
         {
             int platformIndex;
@@ -1329,7 +1329,7 @@ namespace Orts.Simulation.Timetables
                 // determine end stop position depending on direction
 
                 StationStop dummyStop = CalculateStationStopPosition(thisRoute, routeIndex, thisPlatform, activeSubroute,
-                    keepClearFront, keepClearRear, forcePosition, closeupSignal, closeup, restrictPlatformToSignal, extendPlatformToSignal, 
+                    keepClearFront, keepClearRear, forcePosition, closeupSignal, closeup, restrictPlatformToSignal, extendPlatformToSignal,
                     terminal, platformIndex);
 
                 // build and add station stop
@@ -1381,7 +1381,7 @@ namespace Orts.Simulation.Timetables
         /// <param name="platformIndex"></param>
         /// <returns></returns>
         public StationStop CalculateStationStopPosition(TCSubpathRoute thisRoute, int routeIndex, PlatformDetails thisPlatform, int activeSubroute,
-            float? keepClearFront, float? keepClearRear, bool forcePosition, bool closeupSignal, bool closeup, 
+            float? keepClearFront, float? keepClearRear, bool forcePosition, bool closeupSignal, bool closeup,
             bool restrictPlatformToSignal, bool ExtendPlatformToSignal, bool terminal, int platformIndex)
         {
             StationStop dummyStop = new StationStop();
@@ -1721,7 +1721,7 @@ namespace Orts.Simulation.Timetables
                 TrackCircuitSection followingSection = signalRef.TrackCircuitList[endSectionIndex];
                 float remLength = followingSection.Length - endOffset;
 
-                for (int iSection = lastRouteIndex + 1; iSection < thisRoute.Count; iSection++ )
+                for (int iSection = lastRouteIndex + 1; iSection < thisRoute.Count; iSection++)
                 {
                     followingSection = signalRef.TrackCircuitList[thisRoute[iSection].TCSectionIndex];
                     remLength += followingSection.Length;
@@ -1971,7 +1971,7 @@ namespace Orts.Simulation.Timetables
         /// <param name="endStop"></param>
         /// <returns></returns>
         public bool CreateStationStop(int platformStartID, int arrivalTime, int departTime, DateTime arrivalDT, DateTime departureDT, float clearingDistanceM,
-            float minStopDistanceM, bool terminal, int? actMinStopTime, float? keepClearFront, float? keepClearRear, bool forcePosition, bool closeupSignal, 
+            float minStopDistanceM, bool terminal, int? actMinStopTime, float? keepClearFront, float? keepClearRear, bool forcePosition, bool closeupSignal,
             bool closeup, bool restrictPlatformToSignal, bool extendPlatformToSignal, bool endStop)
         {
             StationStop thisStation = CalculateStationStop(platformStartID, arrivalTime, departTime, arrivalDT, departureDT, clearingDistanceM,
@@ -2170,7 +2170,7 @@ namespace Orts.Simulation.Timetables
             {
                 atStation = true;
             }
-           
+
             return (atStation);
         }
 
@@ -2303,7 +2303,7 @@ namespace Orts.Simulation.Timetables
                 PlatformDetails thisPlatform = actualStation.PlatformItem;
 
                 StationStop newStop = CalculateStationStopPosition(TCRoute.TCRouteSubpaths[actualStation.SubrouteIndex], actualStation.RouteIndex, actualStation.PlatformItem,
-                    actualStation.SubrouteIndex, actualStation.KeepClearFront, actualStation.KeepClearRear, actualStation.ForcePosition, 
+                    actualStation.SubrouteIndex, actualStation.KeepClearFront, actualStation.KeepClearRear, actualStation.ForcePosition,
                     actualStation.CloseupSignal, actualStation.Closeup, actualStation.RestrictPlatformToSignal, actualStation.ExtendPlatformToSignal,
                     actualStation.Terminal, actualStation.PlatformReference);
 
@@ -2833,7 +2833,7 @@ namespace Orts.Simulation.Timetables
             {
                 return; // station stop required - reversal not valid
             }
-            
+
             if (nextActionInfo != null && nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.REVERSAL)
             {
                 return; // other reversal still active - reversal not valid
@@ -3085,7 +3085,7 @@ namespace Orts.Simulation.Timetables
 
             }
 
-     // Other node mode : check distance ahead (path may have cleared)
+            // Other node mode : check distance ahead (path may have cleared)
 
             else if (ControlMode == TRAIN_CONTROL.AUTO_NODE)
             {
@@ -3105,7 +3105,7 @@ namespace Orts.Simulation.Timetables
                 }
             }
 
-    // signal node : check state of signal
+            // signal node : check state of signal
 
             else if (ControlMode == TRAIN_CONTROL.AUTO_SIGNAL)
             {
@@ -3261,7 +3261,7 @@ namespace Orts.Simulation.Timetables
                     {
                         File.AppendAllText(@"C:\temp\checktrain.txt", "Train " +
                                 Number.ToString() + " , forced to BRAKING from invalid stop (now at " +
-                            //                                FormatStrings.FormatDistance(PresentPosition[0].DistanceTravelledM, true) + ")\n");
+                                //                                FormatStrings.FormatDistance(PresentPosition[0].DistanceTravelledM, true) + ")\n");
                                 PresentPosition[0].DistanceTravelledM.ToString() + ")\n");
                     }
                 }
@@ -3348,7 +3348,7 @@ namespace Orts.Simulation.Timetables
                     TTAnalysisUpdateStationState1(presentTime, thisStation);
 #endif
 
-                    // set reference arrival for any waiting connections
+                // set reference arrival for any waiting connections
                 if (thisStation.ConnectionsWaiting.Count > 0)
                 {
                     foreach (int otherTrainNumber in thisStation.ConnectionsWaiting)
@@ -3849,7 +3849,7 @@ namespace Orts.Simulation.Timetables
                 }
             }
 
-                // check if speedlimit on signal is cleared
+            // check if speedlimit on signal is cleared
 
             else if (nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.SPEED_SIGNAL)
             {
@@ -3874,8 +3874,8 @@ namespace Orts.Simulation.Timetables
                               nextActionInfo.ActiveItem.ObjectDetails.thisRef.ToString() + " : speed : " +
                               FormatStrings.FormatSpeed(nextActionInfo.ActiveItem.actual_speed, true) + " >= limit : " +
                               FormatStrings.FormatSpeed(AllowedMaxSpeedMpS, true) + " at " +
-                            //FormatStrings.FormatDistance(nextActionInfo.ActivateDistanceM, true) + " (now at " +
-                            //FormatStrings.FormatDistance(PresentPosition[0].DistanceTravelledM, true) + " - " +
+                              //FormatStrings.FormatDistance(nextActionInfo.ActivateDistanceM, true) + " (now at " +
+                              //FormatStrings.FormatDistance(PresentPosition[0].DistanceTravelledM, true) + " - " +
                               nextActionInfo.ActivateDistanceM.ToString() + " (now at " +
                               PresentPosition[0].DistanceTravelledM.ToString() + " - " +
                               FormatStrings.FormatSpeed(SpeedMpS, true) + ")\n");
@@ -3907,7 +3907,7 @@ namespace Orts.Simulation.Timetables
                 }
             }
 
-        // check if STOP signal cleared
+            // check if STOP signal cleared
 
             else if (nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.SIGNAL_ASPECT_STOP)
             {
@@ -3929,8 +3929,8 @@ namespace Orts.Simulation.Timetables
                         File.AppendAllText(@"C:\temp\checktrain.txt", "Train " +
                               Number.ToString() + " : signal " +
                               nextActionInfo.ActiveItem.ObjectDetails.thisRef.ToString() + " at " +
-                            //FormatStrings.FormatDistance(nextActionInfo.ActivateDistanceM, true) + " cleared (now at " +
-                            //FormatStrings.FormatDistance(PresentPosition[0].DistanceTravelledM, true) + " - " +
+                              //FormatStrings.FormatDistance(nextActionInfo.ActivateDistanceM, true) + " cleared (now at " +
+                              //FormatStrings.FormatDistance(PresentPosition[0].DistanceTravelledM, true) + " - " +
                               nextActionInfo.ActivateDistanceM.ToString() + " cleared (now at " +
                               PresentPosition[0].DistanceTravelledM.ToString() + " - " +
                               FormatStrings.FormatSpeed(SpeedMpS, true) + ")\n");
@@ -3956,8 +3956,8 @@ namespace Orts.Simulation.Timetables
                             File.AppendAllText(@"C:\temp\checktrain.txt",
                               Number.ToString() + " : signal " +
                               nextActionInfo.ActiveItem.ObjectDetails.thisRef.ToString() + " at " +
-                                //FormatStrings.FormatDistance(nextActionInfo.ActivateDistanceM, true) + " cleared (now at " +
-                                //FormatStrings.FormatDistance(PresentPosition[0].DistanceTravelledM, true) + " - " +
+                              //FormatStrings.FormatDistance(nextActionInfo.ActivateDistanceM, true) + " cleared (now at " +
+                              //FormatStrings.FormatDistance(PresentPosition[0].DistanceTravelledM, true) + " - " +
                               nextActionInfo.ActivateDistanceM.ToString() + " cleared (now at " +
                               PresentPosition[0].DistanceTravelledM.ToString() + " - " +
                               FormatStrings.FormatSpeed(SpeedMpS, true) + ")\n");
@@ -3966,7 +3966,7 @@ namespace Orts.Simulation.Timetables
                 }
             }
 
-        // check if RESTRICTED signal cleared
+            // check if RESTRICTED signal cleared
 
             else if (nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.SIGNAL_ASPECT_RESTRICTED)
             {
@@ -3988,8 +3988,8 @@ namespace Orts.Simulation.Timetables
                         File.AppendAllText(@"C:\temp\checktrain.txt",
                           Number.ToString() + " : signal " +
                           nextActionInfo.ActiveItem.ObjectDetails.thisRef.ToString() + " at " +
-                            //FormatStrings.FormatDistance(nextActionInfo.ActivateDistanceM, true) + " cleared (now at " +
-                            //FormatStrings.FormatDistance(PresentPosition[0].DistanceTravelledM, true) + " - " +
+                          //FormatStrings.FormatDistance(nextActionInfo.ActivateDistanceM, true) + " cleared (now at " +
+                          //FormatStrings.FormatDistance(PresentPosition[0].DistanceTravelledM, true) + " - " +
                           nextActionInfo.ActivateDistanceM.ToString() + " cleared (now at " +
                           PresentPosition[0].DistanceTravelledM.ToString() + " - " +
                           FormatStrings.FormatSpeed(SpeedMpS, true) + ")\n");
@@ -3997,7 +3997,7 @@ namespace Orts.Simulation.Timetables
                 }
             }
 
-    // check if END_AUTHORITY extended
+            // check if END_AUTHORITY extended
 
             else if (nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.END_OF_AUTHORITY)
             {
@@ -4146,7 +4146,7 @@ namespace Orts.Simulation.Timetables
                             }
                         }
 
-                    // perform slow approach to stop
+                        // perform slow approach to stop
                         else if (distanceToGoM > 0)
                         {
                             if (AITrainBrakePercent < 50)
@@ -4188,7 +4188,7 @@ namespace Orts.Simulation.Timetables
                     }
                 }
 
-        // check if approaching reversal point
+                // check if approaching reversal point
 
                 else if (nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.REVERSAL)
                 {
@@ -4730,7 +4730,7 @@ namespace Orts.Simulation.Timetables
                 File.AppendAllText(@"C:\temp\checktrain.txt",
                                         "Update Train Ahead - now at : " +
                                         PresentPosition[0].TCSectionIndex.ToString() + " " +
-                    //                                        FormatStrings.FormatDistance(PresentPosition[0].TCOffset, true) +
+                                        //                                        FormatStrings.FormatDistance(PresentPosition[0].TCOffset, true) +
                                         PresentPosition[0].TCOffset.ToString() +
                                         " ; speed : " + FormatStrings.FormatSpeed(SpeedMpS, true) + "\n");
             }
@@ -4836,11 +4836,11 @@ namespace Orts.Simulation.Timetables
                             File.AppendAllText(@"C:\temp\checktrain.txt",
                                                     "Other train : " + OtherTrain.Number.ToString() + " at : " +
                                                     OtherTrain.PresentPosition[0].TCSectionIndex.ToString() + " " +
-                                //                                                    FormatStrings.FormatDistance(OtherTrain.PresentPosition[0].TCOffset, true) +
+                                                    //                                                    FormatStrings.FormatDistance(OtherTrain.PresentPosition[0].TCOffset, true) +
                                                     OtherTrain.PresentPosition[0].TCOffset.ToString() +
                                                     " ; speed : " + FormatStrings.FormatSpeed(OtherTrain.SpeedMpS, true) + "\n");
                             File.AppendAllText(@"C:\temp\checktrain.txt",
-                                //                                                            "DistAhd: " + FormatStrings.FormatDistance(DistanceToEndNodeAuthorityM[0], true) + "\n");
+                                                            //                                                            "DistAhd: " + FormatStrings.FormatDistance(DistanceToEndNodeAuthorityM[0], true) + "\n");
                                                             "DistAhd: " + DistanceToEndNodeAuthorityM[0].ToString() + "\n");
                         }
 
@@ -5269,7 +5269,7 @@ namespace Orts.Simulation.Timetables
             {
                 if (CheckTrain)
                 {
-                    File.AppendAllText(@"C:\temp\checktrain.txt","Section : > AllowedMaxSpeedMps \n");
+                    File.AppendAllText(@"C:\temp\checktrain.txt", "Section : > AllowedMaxSpeedMps \n");
                 }
 
                 if (AITrainThrottlePercent > 0)
@@ -6857,7 +6857,7 @@ namespace Orts.Simulation.Timetables
                     transferTrain = true;
                     trainTransferIndex = otherTrain.Number;
                 }
-                
+
                 // if found, no need to look any further
                 if (transferTrain)
                 {
@@ -7916,7 +7916,7 @@ namespace Orts.Simulation.Timetables
                         // if same direction and atStart not set also use next section as start for common section search
                         // if same direction and atStart is set use first section as start for common section search as train is to wait in this section
                         lastIndex++;
-                        if (!sameDirection || !atStart)  
+                        if (!sameDirection || !atStart)
                         {
                             thisTrainStartRouteIndex = lastIndex;
                         }
@@ -11009,7 +11009,7 @@ namespace Orts.Simulation.Timetables
 
                 case DetachInfo.DetachUnitsInfo.consists:
                     bool inConsist = false;
-                    
+
                     // check if front must be detached
                     if (detachConsist.Contains(Cars[0].OrgConsist))
                     {
@@ -12122,7 +12122,7 @@ namespace Orts.Simulation.Timetables
             formedTrain.AI = train.AI;
 
             trainList.Add(formedTrain);
-            return(formedTrain.Number);
+            return (formedTrain.Number);
         }
 
         //================================================================================================//
@@ -12763,7 +12763,7 @@ namespace Orts.Simulation.Timetables
         /// <param name="leadingPower"></param>
         /// <param name="trailingPower"></param>
         /// <param name="units"></param>
-        public DetachInfo(bool atStart, bool atEnd, bool atStation, int sectionIndex, bool leadingPower, bool allLeadingPower, bool trailingPower, bool allTrailingPower, 
+        public DetachInfo(bool atStart, bool atEnd, bool atStation, int sectionIndex, bool leadingPower, bool allLeadingPower, bool trailingPower, bool allTrailingPower,
             bool onlyPower, bool nonPower, int units, int? time, int formedTrain, bool reverseTrain)
         {
             if (atStart)
@@ -13169,7 +13169,7 @@ namespace Orts.Simulation.Timetables
                     // create dummy train - train will be removed but timetable can continue
                     newTrain = new TTTrain(train.AI.Simulator, train);
                     newTrain.AI = train.AI;  // set AT as Simulator.AI does not exist in prerun mode
-                    newTrain.ValidRoute[0] = train.signalRef.BuildTempRoute(newTrain, train.PresentPosition[0].TCSectionIndex, 
+                    newTrain.ValidRoute[0] = train.signalRef.BuildTempRoute(newTrain, train.PresentPosition[0].TCSectionIndex,
                         train.PresentPosition[0].TCOffset, train.PresentPosition[0].TCDirection, train.Length, true, true, false);
                     train.PresentPosition[0].CopyTo(ref newTrain.PresentPosition[0]);
                     train.PresentPosition[1].CopyTo(ref newTrain.PresentPosition[1]);
@@ -13354,7 +13354,7 @@ namespace Orts.Simulation.Timetables
                 }
             }
 
-            return(true);
+            return (true);
         }
 
         //================================================================================================//
@@ -13953,12 +13953,12 @@ namespace Orts.Simulation.Timetables
             {
                 switch (thisCommand.CommandQualifiers[0].QualifierName)
                 {
-                    case "static" :
+                    case "static":
                         PickUpStatic = true;
                         StationPlatformReference = stationPlatformReference;
                         break;
 
-                    default :
+                    default:
                         Trace.TraceInformation("Train : {0} : unknown pickup qualifier : {1}", thisTrain.Name, thisCommand.CommandQualifiers[0].QualifierName);
                         break;
                 }
@@ -14156,12 +14156,12 @@ namespace Orts.Simulation.Timetables
                 switch (thisCommand.CommandQualifiers[0].QualifierName)
                 {
                     // static is allowed, will be inserted with key -99
-                    case "static" :
+                    case "static":
                         TransferTrain = -99;
                         break;
 
                     // other qualifiers processed below
-                    default :
+                    default:
                         break;
                 }
             }
@@ -14294,7 +14294,7 @@ namespace Orts.Simulation.Timetables
         /// <param name="inf"></param>
         public TransferInfo(BinaryReader inf)
         {
-            TypeOfTransfer = (TransferType) inf.ReadInt32();
+            TypeOfTransfer = (TransferType)inf.ReadInt32();
             TransferUnitsInfo = (DetachInfo.DetachUnitsInfo)inf.ReadInt32();
             TransferUnitCount = inf.ReadInt32();
 
@@ -14678,7 +14678,7 @@ namespace Orts.Simulation.Timetables
                     transferTrain = playerTrain;
                     trainFound = true;
                 }
-            }          
+            }
 
             // issue warning if train not found
             if (!trainFound)

--- a/Source/Orts.Simulation/Simulation/Transfertables.cs
+++ b/Source/Orts.Simulation/Simulation/Transfertables.cs
@@ -37,7 +37,7 @@ namespace Orts.Simulation
     /// 
 
 
- 
+
     public class Transfertable : MovingTable
     {
         public float Width;
@@ -53,17 +53,17 @@ namespace Orts.Simulation
 
         public Signals signalRef { get; protected set; }
 
-        public Transfertable(STFReader stf, Simulator simulator): base(stf, simulator)
+        public Transfertable(STFReader stf, Simulator simulator) : base(stf, simulator)
         {
             signalRef = Simulator.Signals;
             string animation;
             WorldPosition.XNAMatrix.M44 = 100000000; //WorlPosition not yet defined, will be loaded when loading related tile
             stf.MustMatch("(");
-              stf.ParseBlock(new[] {
+            stf.ParseBlock(new[] {
                 new STFReader.TokenProcessor("wfile", ()=>{
                     WFile = stf.ReadStringBlock(null);
                     WorldPosition.TileX = int.Parse(WFile.Substring(1, 7));
-                    WorldPosition.TileZ = int.Parse(WFile.Substring(8, 7));                
+                    WorldPosition.TileZ = int.Parse(WFile.Substring(8, 7));
                 }),
                 new STFReader.TokenProcessor("uid", ()=>{ UID = stf.ReadIntBlock(-1); }),
                 new STFReader.TokenProcessor("animation", ()=>{ animation = stf.ReadStringBlock(null);
@@ -249,7 +249,7 @@ namespace Orts.Simulation
             {
                 // Preparing for transfer
                 var train = TrainsOnMovingTable[0].Train;
-                if (Math.Abs(train.SpeedMpS) > 0.1 || (train.LeadLocomotiveIndex != -1 && (train.LeadLocomotive.ThrottlePercent >= 1 || !(train.LeadLocomotive.Direction == Direction.N 
+                if (Math.Abs(train.SpeedMpS) > 0.1 || (train.LeadLocomotiveIndex != -1 && (train.LeadLocomotive.ThrottlePercent >= 1 || !(train.LeadLocomotive.Direction == Direction.N
                  || Math.Abs(train.MUReverserPercent) <= 1))) || (train.ControlMode != Train.TRAIN_CONTROL.MANUAL && train.ControlMode != Train.TRAIN_CONTROL.TURNTABLE &&
                  train.ControlMode != Train.TRAIN_CONTROL.EXPLORER && train.ControlMode != Train.TRAIN_CONTROL.UNDEFINED))
                 {
@@ -280,13 +280,13 @@ namespace Orts.Simulation
                     RelativeRearTravellerXNALocation = Vector3.Transform(XNALocation, invAnimationXNAMatrix);
                     train.ControlMode = Train.TRAIN_CONTROL.TURNTABLE;
                 }
-                Simulator.Confirmer.Information (Simulator.Catalog.GetStringFmt("Transfertable starting transferring train"));
+                Simulator.Confirmer.Information(Simulator.Catalog.GetStringFmt("Transfertable starting transferring train"));
                 // Computing position of cars relative to center of transfertable
 
-             }
-             Forward = isForward;
-             Reverse = !isForward;
-             Continuous = true;
+            }
+            Forward = isForward;
+            Reverse = !isForward;
+            Continuous = true;
         }
 
         public void ComputeCenter(WorldPosition worldPosition)
@@ -345,12 +345,12 @@ namespace Orts.Simulation
                             Connected = true;
                             Forward = false;
                             ConnectedTrackEnd = ConnectedTarget;
-                            Simulator.Confirmer.Information (Simulator.Catalog.GetStringFmt("Transfertable connected"));
+                            Simulator.Confirmer.Information(Simulator.Catalog.GetStringFmt("Transfertable connected"));
                             GoToTarget = true;
                             TargetX = Offsets[ConnectedTarget];
                         }
                     }
-                 }
+                }
                 else if (Reverse)
                 {
                     Connected = false;
@@ -377,7 +377,7 @@ namespace Orts.Simulation
         public void TargetExactlyReached()
         {
             Traveller.TravellerDirection direction = Traveller.TravellerDirection.Forward;
-            direction = SaveConnected ^ !MyTrackNodesOrientation[ConnectedTrackEnd]? direction : (direction == Traveller.TravellerDirection.Forward ? Traveller.TravellerDirection.Backward : Traveller.TravellerDirection.Forward);
+            direction = SaveConnected ^ !MyTrackNodesOrientation[ConnectedTrackEnd] ? direction : (direction == Traveller.TravellerDirection.Forward ? Traveller.TravellerDirection.Backward : Traveller.TravellerDirection.Forward);
             GoToTarget = false;
             if (TrainsOnMovingTable.Count == 1)
             {
@@ -397,7 +397,7 @@ namespace Orts.Simulation
             if ((Connected) && MyTrVectorSectionsIndex[ConnectedTrackEnd] != -1 && MyTrackNodesIndex[ConnectedTrackEnd] != -1 &&
                 (MyTrackNodesIndex[ConnectedTrackEnd] == train.FrontTDBTraveller.TN.Index || MyTrackNodesIndex[ConnectedTrackEnd] == train.RearTDBTraveller.TN.Index))
             {
-            return true;
+                return true;
             }
             return false;
         }
@@ -406,7 +406,7 @@ namespace Orts.Simulation
         /// PerformUpdateActions: actions to be performed at every animation step
         /// </summary>
         /// 
-        public void PerformUpdateActions ( Matrix absAnimationMatrix, WorldPosition worldPosition )
+        public void PerformUpdateActions(Matrix absAnimationMatrix, WorldPosition worldPosition)
         {
             TransferTrain(absAnimationMatrix);
             if (GoToTarget && TrainsOnMovingTable.Count == 1 && TrainsOnMovingTable[0].Train.ControlMode == Train.TRAIN_CONTROL.TURNTABLE)

--- a/Source/Orts.Simulation/Simulation/Traveller.cs
+++ b/Source/Orts.Simulation/Simulation/Traveller.cs
@@ -292,7 +292,7 @@ namespace Orts.Simulation
                     {
                         throw new MissingTrackNodeException();
                     }
-                    
+
                 }
 
                 // Figure out which end of the track node is closest and use that.

--- a/Source/Orts.Simulation/Simulation/Turntables.cs
+++ b/Source/Orts.Simulation/Simulation/Turntables.cs
@@ -100,7 +100,7 @@ namespace Orts.Simulation
         {
             outf.Write(Continuous);
             outf.Write(GoToTarget);
-            outf.Write(ConnectedTrackEnd); 
+            outf.Write(ConnectedTrackEnd);
             SaveVector(outf, RelativeFrontTravellerXNALocation);
             SaveVector(outf, RelativeRearTravellerXNALocation);
             SaveVector(outf, FinalFrontTravellerXNALocation);
@@ -117,7 +117,7 @@ namespace Orts.Simulation
             outf.Write(vector.Z);
         }
 
-                /// <summary>
+        /// <summary>
         /// Restores the general variable parameters
         /// Called from within the Simulator class.
         /// </summary>
@@ -263,7 +263,7 @@ namespace Orts.Simulation
         }
 
 
-        public virtual void StartContinuous (bool isClockwise)
+        public virtual void StartContinuous(bool isClockwise)
         {
 
         }
@@ -328,11 +328,11 @@ namespace Orts.Simulation
             string animation;
             WorldPosition.XNAMatrix.M44 = 100000000; //WorlPosition not yet defined, will be loaded when loading related tile
             stf.MustMatch("(");
-              stf.ParseBlock(new[] {
+            stf.ParseBlock(new[] {
                 new STFReader.TokenProcessor("wfile", ()=>{
                     WFile = stf.ReadStringBlock(null);
                     WorldPosition.TileX = int.Parse(WFile.Substring(1, 7));
-                    WorldPosition.TileZ = int.Parse(WFile.Substring(8, 7));                
+                    WorldPosition.TileZ = int.Parse(WFile.Substring(8, 7));
                 }),
                 new STFReader.TokenProcessor("uid", ()=>{ UID = stf.ReadIntBlock(-1); }),
                 new STFReader.TokenProcessor("animation", ()=>{ animation = stf.ReadStringBlock(null);
@@ -354,17 +354,17 @@ namespace Orts.Simulation
         /// </summary>
         public override void Save(BinaryWriter outf)
         {
-        base.Save(outf);
-        outf.Write(Clockwise);
-        outf.Write(Counterclockwise);
-        outf.Write(YAngle);
-        outf.Write(ForwardConnected);
-        outf.Write(RearConnected);
-        outf.Write(SaveForwardConnected);
-        outf.Write(SaveRearConnected);
-        outf.Write(ForwardConnectedTarget);
-        outf.Write(RearConnectedTarget);
-        outf.Write(TargetY);
+            base.Save(outf);
+            outf.Write(Clockwise);
+            outf.Write(Counterclockwise);
+            outf.Write(YAngle);
+            outf.Write(ForwardConnected);
+            outf.Write(RearConnected);
+            outf.Write(SaveForwardConnected);
+            outf.Write(SaveRearConnected);
+            outf.Write(ForwardConnectedTarget);
+            outf.Write(RearConnectedTarget);
+            outf.Write(TargetY);
         }
 
 
@@ -425,7 +425,7 @@ namespace Orts.Simulation
             }
         }
 
-         /// <summary>
+        /// <summary>
         /// Computes the nearest turntable exit in the actual direction
         /// Returns the Y angle to be compared.
         /// </summary>
@@ -561,7 +561,7 @@ namespace Orts.Simulation
             {
                 // Preparing for rotation
                 var train = TrainsOnMovingTable[0].Train;
-                if (Math.Abs(train.SpeedMpS) > 0.1 || (train.LeadLocomotiveIndex != -1 && (train.LeadLocomotive.ThrottlePercent >= 1 || !(train.LeadLocomotive.Direction == Direction.N 
+                if (Math.Abs(train.SpeedMpS) > 0.1 || (train.LeadLocomotiveIndex != -1 && (train.LeadLocomotive.ThrottlePercent >= 1 || !(train.LeadLocomotive.Direction == Direction.N
                  || Math.Abs(train.MUReverserPercent) <= 1))) || (train.ControlMode != Train.TRAIN_CONTROL.MANUAL && train.ControlMode != Train.TRAIN_CONTROL.TURNTABLE &&
                  train.ControlMode != Train.TRAIN_CONTROL.EXPLORER && train.ControlMode != Train.TRAIN_CONTROL.UNDEFINED))
                 {
@@ -593,13 +593,13 @@ namespace Orts.Simulation
                     RelativeRearTravellerXNALocation = Vector3.Transform(XNALocation, invAnimationXNAMatrix);
                     train.ControlMode = Train.TRAIN_CONTROL.TURNTABLE;
                 }
-                Simulator.Confirmer.Information (Simulator.Catalog.GetStringFmt("Turntable starting rotation with train"));
+                Simulator.Confirmer.Information(Simulator.Catalog.GetStringFmt("Turntable starting rotation with train"));
                 // Computing position of cars relative to center of platform
 
-             }
-             Clockwise = isClockwise;
-             Counterclockwise = !isClockwise;
-             Continuous = true;
+            }
+            Clockwise = isClockwise;
+            Counterclockwise = !isClockwise;
+            Continuous = true;
         }
 
         public void ComputeCenter(WorldPosition worldPosition)
@@ -658,7 +658,7 @@ namespace Orts.Simulation
                             ForwardConnected = true;
                             Clockwise = false;
                             ConnectedTrackEnd = ForwardConnectedTarget;
-                            Simulator.Confirmer.Information (Simulator.Catalog.GetStringFmt("Turntable forward connected"));
+                            Simulator.Confirmer.Information(Simulator.Catalog.GetStringFmt("Turntable forward connected"));
                             GoToTarget = true;
                             TargetY = -Angles[ForwardConnectedTarget];
                         }
@@ -715,7 +715,7 @@ namespace Orts.Simulation
         public void TargetExactlyReached()
         {
             Traveller.TravellerDirection direction = ForwardConnected ? Traveller.TravellerDirection.Forward : Traveller.TravellerDirection.Backward;
-            direction = SaveForwardConnected ^ !MyTrackNodesOrientation[ConnectedTrackEnd]? direction : (direction == Traveller.TravellerDirection.Forward ? Traveller.TravellerDirection.Backward : Traveller.TravellerDirection.Forward);
+            direction = SaveForwardConnected ^ !MyTrackNodesOrientation[ConnectedTrackEnd] ? direction : (direction == Traveller.TravellerDirection.Forward ? Traveller.TravellerDirection.Backward : Traveller.TravellerDirection.Forward);
             GoToTarget = false;
             if (TrainsOnMovingTable.Count == 1)
             {
@@ -736,20 +736,20 @@ namespace Orts.Simulation
             if ((ForwardConnected || RearConnected) && MyTrVectorSectionsIndex[ConnectedTrackEnd] != -1 && MyTrackNodesIndex[ConnectedTrackEnd] != -1 &&
                 (MyTrackNodesIndex[ConnectedTrackEnd] == train.FrontTDBTraveller.TN.Index || MyTrackNodesIndex[ConnectedTrackEnd] == train.RearTDBTraveller.TN.Index))
             {
-            direction = ForwardConnected ? Traveller.TravellerDirection.Forward : Traveller.TravellerDirection.Backward;
-            return true;
+                direction = ForwardConnected ? Traveller.TravellerDirection.Forward : Traveller.TravellerDirection.Backward;
+                return true;
             }
             direction = Traveller.TravellerDirection.Forward;
             return false;
         }
 
- 
+
 
         /// <summary>
         /// PerformUpdateActions: actions to be performed at every animation step
         /// </summary>
         /// 
-        public void PerformUpdateActions ( Matrix absAnimationMatrix)
+        public void PerformUpdateActions(Matrix absAnimationMatrix)
         {
             RotateTrain(absAnimationMatrix);
             if (GoToTarget && TrainsOnMovingTable.Count == 1 && TrainsOnMovingTable[0].Train.ControlMode == Train.TRAIN_CONTROL.TURNTABLE)
@@ -767,7 +767,7 @@ namespace Orts.Simulation
         public bool BackOnBoard;
         public Simulator Simulator;
 
-        public TrainOnMovingTable (Train train, Simulator simulator)
+        public TrainOnMovingTable(Train train, Simulator simulator)
         {
             Train = train;
             Simulator = simulator;
@@ -778,7 +778,7 @@ namespace Orts.Simulation
             Simulator = simulator;
         }
 
-        public void Save (BinaryWriter outf)
+        public void Save(BinaryWriter outf)
         {
             outf.Write(Train.Number);
             outf.Write(FrontOnBoard);
@@ -792,7 +792,7 @@ namespace Orts.Simulation
             BackOnBoard = inf.ReadBoolean();
         }
 
-        public void SetFrontState (bool frontOnBoard)
+        public void SetFrontState(bool frontOnBoard)
         {
             FrontOnBoard = frontOnBoard;
         }

--- a/Source/Orts.Simulation/Simulation/Weather.cs
+++ b/Source/Orts.Simulation/Simulation/Weather.cs
@@ -38,18 +38,18 @@ namespace Orts.Simulation
 
         // Overcast factor: 0.0 = almost no clouds; 0.1 = wispy clouds; 1.0 = total overcast.
         public float OvercastFactor;
-        
+
         // Pricipitation intensity in particles per second per meter^2 (PPSPM2).
         public float PricipitationIntensityPPSPM2;
-        
+
         // Fog/visibility distance. Ranges from 10m (can't see anything), 5km (medium), 20km (clear) to 100km (clear arctic).
         public float FogDistance;
-        
+
         // Precipitation liquidity; =1 for rain, =0 for snow; intermediate values possible with dynamic weather;
         public float PrecipitationLiquidity;
         public float CalculatedWindDirection;
         public Vector2 WindSpeedMpS = new Vector2();
-        public float WindSpeed {get { return WindSpeedMpS.Length(); } }
+        public float WindSpeed { get { return WindSpeedMpS.Length(); } }
         //        public float WindDirection { get { return (float)Math.Atan2(WindSpeedMpS.X, WindSpeedMpS.Y); } }
         public float WindDirection { get { return CalculatedWindDirection; } }
     }

--- a/Source/RunActivity/Viewer3D/ALSoundHelper.cs
+++ b/Source/RunActivity/Viewer3D/ALSoundHelper.cs
@@ -160,7 +160,7 @@ namespace Orts.Viewer3D
         {
             return (bufferID != 0 && BufferIDs.Any(value => bufferID == value));
         }
-        
+
         public bool isLast(int soundSourceID)
         {
             if (_isSingle)
@@ -249,7 +249,7 @@ namespace Orts.Viewer3D
                 }
             if (bid == -1)
                 return false;
-            
+
             int len = (int)(CheckFactor * pitch);
             if (BufferLens[bid] < len)
                 return true;
@@ -995,7 +995,7 @@ namespace Orts.Viewer3D
                     for (int i = 1; i < 5; i++)
                     {
 
-                       prev = SoundQueue[(QueueHeader - i) % QUEUELENGHT];
+                        prev = SoundQueue[(QueueHeader - i) % QUEUELENGHT];
 
                         prevMode = prev.PlayMode;
 
@@ -1107,7 +1107,7 @@ namespace Orts.Viewer3D
             if (h >= QueueTail)
             {
                 int i;
-                for (i = h-1; i >= QueueTail; i--)
+                for (i = h - 1; i >= QueueTail; i--)
                 {
                     SoundQueue[i % QUEUELENGHT].PlayState = PlayState.NOP;
                 }
@@ -1151,7 +1151,7 @@ namespace Orts.Viewer3D
         public void Stop()
         {
             OpenAL.alSourceStop(SoundSourceID);
-            OpenAL.alSourcei(SoundSourceID, OpenAL.AL_BUFFER, OpenAL.AL_NONE); 
+            OpenAL.alSourcei(SoundSourceID, OpenAL.AL_BUFFER, OpenAL.AL_NONE);
             SkipProcessed();
             isPlaying = false;
         }
@@ -1236,7 +1236,7 @@ namespace Orts.Viewer3D
 
             if (SoundQueue[QueueTail % QUEUELENGHT].PlayState != PlayState.NOP)
             {
-                retval[3] = String.Format("{0} {1}{2}", 
+                retval[3] = String.Format("{0} {1}{2}",
                     SoundQueue[QueueTail % QUEUELENGHT].PlayState,
                     SoundQueue[QueueTail % QUEUELENGHT].PlayMode,
                     SoundQueue[QueueTail % QUEUELENGHT].SoftLoopPoints && SoundQueue[QueueTail % QUEUELENGHT].PlayMode == PlayMode.LoopRelease ? "Soft" : "");

--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -804,7 +804,7 @@ namespace Orts.Viewer3D
                 if (carIndex < Viewer.SelectedTrain.Cars.Count)
                     attachedCar = Viewer.SelectedTrain.Cars[carIndex];
                 else if (Viewer.SelectedTrain.Cars.Count > 0)
-                    attachedCar = Viewer.SelectedTrain.Cars[Viewer.SelectedTrain.Cars.Count -1];
+                    attachedCar = Viewer.SelectedTrain.Cars[Viewer.SelectedTrain.Cars.Count - 1];
             }
             attachedLocation.X = inf.ReadSingle();
             attachedLocation.Y = inf.ReadSingle();
@@ -1251,7 +1251,7 @@ namespace Orts.Viewer3D
             {
                 var ZIncrM = -BrowseSpeedMpS * elapsedTime.ClockSeconds;
                 ZDistanceM += ZIncrM;
-                if (-ZDistanceM >= attachedCar.Train.Length - (trainCars.First().CarLengthM  + trainCars.Last().CarLengthM) * 0.5f)
+                if (-ZDistanceM >= attachedCar.Train.Length - (trainCars.First().CarLengthM + trainCars.Last().CarLengthM) * 0.5f)
                 {
                     ZIncrM = -attachedCar.Train.Length + (trainCars.First().CarLengthM + trainCars.Last().CarLengthM) * 0.5f - (ZDistanceM - ZIncrM);
                     ZDistanceM = -attachedCar.Train.Length + (trainCars.First().CarLengthM + trainCars.Last().CarLengthM) * 0.5f;
@@ -1286,7 +1286,7 @@ namespace Orts.Viewer3D
             else browsedTraveller.Move(elapsedTime.ClockSeconds * attachedCar.Train.SpeedMpS);
         }
 
-        protected void ComputeCarOffsets( TrackingCamera camera)
+        protected void ComputeCarOffsets(TrackingCamera camera)
         {
             var trainCars = camera.GetCameraCars();
             camera.HighWagonOffsetLimit = trainCars.First().CarLengthM * 0.5f;
@@ -1387,7 +1387,7 @@ namespace Orts.Viewer3D
                 HighWagonOffsetLimit += attachedCar.CarLengthM;
                 ZDistanceM = LowWagonOffsetLimit + attachedCar.CarLengthM * 0.5f;
             }
- //           LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
+            //           LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
         }
 
         public override void PreviousCar()
@@ -1404,7 +1404,7 @@ namespace Orts.Viewer3D
                 LowWagonOffsetLimit -= attachedCar.CarLengthM;
                 ZDistanceM = LowWagonOffsetLimit + attachedCar.CarLengthM * 0.5f;
             }
- //           LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
+            //           LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
         }
 
         public override void FirstCar()
@@ -1416,7 +1416,7 @@ namespace Orts.Viewer3D
             ZDistanceM = 0;
             HighWagonOffsetLimit = attachedCar.CarLengthM * 0.5f;
             LowWagonOffsetLimit = -attachedCar.CarLengthM * 0.5f;
-//            LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
+            //            LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
         }
 
         public override void LastCar()
@@ -1429,7 +1429,7 @@ namespace Orts.Viewer3D
             ZDistanceM = -attachedCar.Train.Length + (trainCars.First().CarLengthM + trainCars.Last().CarLengthM) * 0.5f;
             LowWagonOffsetLimit = -attachedCar.Train.Length + trainCars.First().CarLengthM * 0.5f;
             HighWagonOffsetLimit = LowWagonOffsetLimit + attachedCar.CarLengthM;
-//            LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
+            //            LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
         }
 
         public void ToggleBrowseBackwards()
@@ -1439,7 +1439,7 @@ namespace Orts.Viewer3D
             {
                 if (!BrowseMode)
                 {
-//                    LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
+                    //                    LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
                     browsedTraveller = new Traveller(attachedCar.Train.FrontTDBTraveller);
                     browsedTraveller.Move(-attachedCar.CarLengthM * 0.5f + ZDistanceM);
                     BrowseDistance = attachedCar.CarLengthM * 0.5f;
@@ -1456,18 +1456,18 @@ namespace Orts.Viewer3D
             {
                 if (!BrowseMode)
                 {
-//                    LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
+                    //                    LookedAtPosition = new WorldPosition(attachedCar.WorldPosition);
                     browsedTraveller = new Traveller(attachedCar.Train.RearTDBTraveller);
                     var trainCars = GetCameraCars();
                     browsedTraveller.Move((attachedCar.CarLengthM - trainCars.First().CarLengthM - trainCars.Last().CarLengthM) * 0.5f + attachedCar.Train.Length + ZDistanceM);
                     BrowseDistance = attachedCar.CarLengthM * 0.5f;
                     BrowseMode = true;
                 }
-            }          
+            }
             BrowseBackwards = false;
         }
     }
-    
+
     public abstract class NonTrackingCamera : AttachedCamera
     {
         public NonTrackingCamera(Viewer viewer)
@@ -1797,7 +1797,7 @@ namespace Orts.Viewer3D
             if (UserInput.IsPressed(UserCommand.CameraChangePassengerViewPoint))
                 new CameraChangePassengerViewPointCommand(Viewer.Log);
         }
-        
+
         public void SwitchSideCameraCar(TrainCar car)
         {
             attachedLocation.X = -attachedLocation.X;
@@ -2018,13 +2018,13 @@ namespace Orts.Viewer3D
             if (Viewer.Settings.Cab2DStretch == 0 && Viewer.CabExceedsDisplayHorizontally <= 0)
             {
                 // We must modify FOV to get correct lookout
-                    FieldOfView = MathHelper.ToDegrees((float)(2 * Math.Atan((float)Viewer.DisplaySize.Y / Viewer.DisplaySize.X / Viewer.CabTextureInverseRatio * Math.Tan(MathHelper.ToRadians(Viewer.Settings.ViewingFOV / 2)))));
-                    RotationRatio = (float)(0.962314f * 2 * Math.Tan(MathHelper.ToRadians(FieldOfView / 2)) / Viewer.DisplaySize.Y);
+                FieldOfView = MathHelper.ToDegrees((float)(2 * Math.Atan((float)Viewer.DisplaySize.Y / Viewer.DisplaySize.X / Viewer.CabTextureInverseRatio * Math.Tan(MathHelper.ToRadians(Viewer.Settings.ViewingFOV / 2)))));
+                RotationRatio = (float)(0.962314f * 2 * Math.Tan(MathHelper.ToRadians(FieldOfView / 2)) / Viewer.DisplaySize.Y);
             }
             else if (Viewer.CabExceedsDisplayHorizontally > 0)
             {
-                    var halfFOVHorizontalRadians = (float)(Math.Atan((float)Viewer.DisplaySize.X / Viewer.DisplaySize.Y * Math.Tan(MathHelper.ToRadians(Viewer.Settings.ViewingFOV / 2))));
-                    RotationRatioHorizontal = (float)(0.962314f * 2 * Viewer.DisplaySize.X / Viewer.DisplaySize.Y * Math.Tan(MathHelper.ToRadians(Viewer.Settings.ViewingFOV / 2)) / Viewer.DisplaySize.X);
+                var halfFOVHorizontalRadians = (float)(Math.Atan((float)Viewer.DisplaySize.X / Viewer.DisplaySize.Y * Math.Tan(MathHelper.ToRadians(Viewer.Settings.ViewingFOV / 2))));
+                RotationRatioHorizontal = (float)(0.962314f * 2 * Viewer.DisplaySize.X / Viewer.DisplaySize.Y * Math.Tan(MathHelper.ToRadians(Viewer.Settings.ViewingFOV / 2)) / Viewer.DisplaySize.X);
             }
             InitialiseRotation(attachedCar);
         }
@@ -2125,7 +2125,7 @@ namespace Orts.Viewer3D
         /// and pans the image left/right to reveal details at the sides of the cab.
         /// The external view also moves sidewards by a similar amount.
         /// </summary>
-        void ScrollRight (bool right, float speed)
+        void ScrollRight(bool right, float speed)
         {
             int min = 0;
             int max = Viewer.CabWidthPixels - Viewer.DisplaySize.X; // -ve value
@@ -2293,7 +2293,7 @@ namespace Orts.Viewer3D
         public override void Update(ElapsedTime elapsedTime)
         {
             bool trainForwards;
-            var train = PrepUpdate( out trainForwards);
+            var train = PrepUpdate(out trainForwards);
 
             // Train is close enough if the last car we used is part of the same train and still close enough.
             var trainClose = (LastCheckCar != null) && (LastCheckCar.Train == train) && (WorldLocation.GetDistance2D(LastCheckCar.WorldPosition.WorldLocation, cameraLocation).Length() < MaximumDistance);
@@ -2328,7 +2328,7 @@ namespace Orts.Viewer3D
             UpdateListener();
         }
 
-        protected Train PrepUpdate (out bool trainForwards)
+        protected Train PrepUpdate(out bool trainForwards)
         {
             var train = attachedCar.Train;
 
@@ -2348,7 +2348,7 @@ namespace Orts.Viewer3D
         }
 
 
-        protected WorldLocation GoToNewLocation ( ref Traveller tdb, Train train, bool trainForwards)
+        protected WorldLocation GoToNewLocation(ref Traveller tdb, Train train, bool trainForwards)
         {
             tdb.Move(MaximumDistance * 0.75f);
             var newLocation = tdb.WorldLocation;
@@ -2658,7 +2658,7 @@ namespace Orts.Viewer3D
                 {
                     tdb = trainForwards ? new Traveller(train.FrontTDBTraveller) : new Traveller(train.RearTDBTraveller, Traveller.TravellerDirection.Backward); // return to standard
                     newLocation = GoToNewLocation(ref tdb, train, trainForwards);
-                 }
+                }
 
                 if (newLocation != WorldLocation.None && !trainClose)
                 {

--- a/Source/RunActivity/Viewer3D/Commands.cs
+++ b/Source/RunActivity/Viewer3D/Commands.cs
@@ -27,11 +27,11 @@ namespace Orts.Viewer3D
 {
     [Serializable()]
     public abstract class ActivityCommand : PausedCommand
-        {
+    {
         public static ActivityWindow Receiver { get; set; }
         string EventNameLabel;
 
-        public ActivityCommand( CommandLog log, string eventNameLabel, double pauseDurationS )
+        public ActivityCommand(CommandLog log, string eventNameLabel, double pauseDurationS)
             : base(log, pauseDurationS)
         {
             EventNameLabel = eventNameLabel;
@@ -61,7 +61,7 @@ namespace Orts.Viewer3D
         public override void Redo()
         {
             if (Receiver == null) return;
-            Receiver.ImmediateRefill(); 
+            Receiver.ImmediateRefill();
             // Report();
         }
     }
@@ -106,7 +106,7 @@ namespace Orts.Viewer3D
             Receiver.ChangeCab();
             // Report();
         }
-        }
+    }
 
     [Serializable()]
     public sealed class ToggleSwitchAheadCommand : Command
@@ -124,7 +124,7 @@ namespace Orts.Viewer3D
             Receiver.ToggleSwitchAhead();
             // Report();
         }
-        }
+    }
 
     [Serializable()]
     public sealed class ToggleSwitchBehindCommand : Command
@@ -142,14 +142,14 @@ namespace Orts.Viewer3D
             Receiver.ToggleSwitchBehind();
             // Report();
         }
-        }
+    }
 
     [Serializable()]
     public sealed class ToggleAnySwitchCommand : IndexCommand
-        {
+    {
         public static Viewer Receiver { get; set; }
 
-        public ToggleAnySwitchCommand( CommandLog log, int index )
+        public ToggleAnySwitchCommand(CommandLog log, int index)
             : base(log, index)
         {
             Redo();
@@ -168,7 +168,7 @@ namespace Orts.Viewer3D
         public static Viewer Receiver { get; set; }
         int CarPosition;    // 0 for head of train
 
-        public UncoupleCommand( CommandLog log, int carPosition ) 
+        public UncoupleCommand(CommandLog log, int carPosition)
             : base(log)
         {
             CarPosition = carPosition;
@@ -177,7 +177,7 @@ namespace Orts.Viewer3D
 
         public override void Redo()
         {
-            Receiver.UncoupleBehind( CarPosition );
+            Receiver.UncoupleBehind(CarPosition);
             // Report();
         }
 
@@ -208,7 +208,7 @@ namespace Orts.Viewer3D
     [Serializable()]
     public sealed class ResumeActivityCommand : ActivityCommand
     {
-        public ResumeActivityCommand( CommandLog log, string eventNameLabel, double pauseDurationS )
+        public ResumeActivityCommand(CommandLog log, string eventNameLabel, double pauseDurationS)
             : base(log, eventNameLabel, pauseDurationS)
         {
             Redo();
@@ -224,12 +224,12 @@ namespace Orts.Viewer3D
     [Serializable()]
     public sealed class CloseAndResumeActivityCommand : ActivityCommand
     {
-        public CloseAndResumeActivityCommand( CommandLog log, string eventNameLabel, double pauseDurationS )
+        public CloseAndResumeActivityCommand(CommandLog log, string eventNameLabel, double pauseDurationS)
             : base(log, eventNameLabel, pauseDurationS)
         {
             Redo();
         }
-    
+
         public override void Redo()
         {
             Receiver.CloseBox();
@@ -256,7 +256,7 @@ namespace Orts.Viewer3D
     [Serializable()]
     public sealed class QuitActivityCommand : ActivityCommand
     {
-        public QuitActivityCommand( CommandLog log, string eventNameLabel, double pauseDurationS )
+        public QuitActivityCommand(CommandLog log, string eventNameLabel, double pauseDurationS)
             : base(log, eventNameLabel, pauseDurationS)
         {
             Redo();
@@ -268,13 +268,13 @@ namespace Orts.Viewer3D
             // Report();
         }
     }
-    
+
     [Serializable()]
     public abstract class UseCameraCommand : CameraCommand
     {
         public static Viewer Receiver { get; set; }
 
-        public UseCameraCommand( CommandLog log )
+        public UseCameraCommand(CommandLog log)
             : base(log)
         {
         }
@@ -284,7 +284,7 @@ namespace Orts.Viewer3D
     public sealed class UseCabCameraCommand : UseCameraCommand
     {
 
-        public UseCabCameraCommand( CommandLog log ) 
+        public UseCabCameraCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -297,28 +297,28 @@ namespace Orts.Viewer3D
         }
     }
 
-	[Serializable()]
-	public sealed class Use3DCabCameraCommand : UseCameraCommand
-	{
+    [Serializable()]
+    public sealed class Use3DCabCameraCommand : UseCameraCommand
+    {
 
-		public Use3DCabCameraCommand(CommandLog log)
-			: base(log)
-		{
-			Redo();
-		}
+        public Use3DCabCameraCommand(CommandLog log)
+            : base(log)
+        {
+            Redo();
+        }
 
-		public override void Redo()
-		{
-			Receiver.ThreeDimCabCamera.Activate();
-			// Report();
-		}
-	}
-	
-	[Serializable()]
+        public override void Redo()
+        {
+            Receiver.ThreeDimCabCamera.Activate();
+            // Report();
+        }
+    }
+
+    [Serializable()]
     public sealed class UseFrontCameraCommand : UseCameraCommand
     {
 
-        public UseFrontCameraCommand( CommandLog log )
+        public UseFrontCameraCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -335,7 +335,7 @@ namespace Orts.Viewer3D
     public sealed class UseBackCameraCommand : UseCameraCommand
     {
 
-        public UseBackCameraCommand( CommandLog log )
+        public UseBackCameraCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -352,7 +352,7 @@ namespace Orts.Viewer3D
     public sealed class UseHeadOutForwardCameraCommand : UseCameraCommand
     {
 
-        public UseHeadOutForwardCameraCommand( CommandLog log )
+        public UseHeadOutForwardCameraCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -388,7 +388,7 @@ namespace Orts.Viewer3D
             Receiver.FreeRoamCamera.Activate();
         }
     }
-    
+
     [Serializable()]
     public sealed class UsePreviousFreeRoamCameraCommand : UseCameraCommand
     {
@@ -404,12 +404,12 @@ namespace Orts.Viewer3D
             Receiver.ChangeToPreviousFreeRoamCamera();
         }
     }
-    
+
     [Serializable()]
     public sealed class UseHeadOutBackCameraCommand : UseCameraCommand
     {
 
-        public UseHeadOutBackCameraCommand( CommandLog log )
+        public UseHeadOutBackCameraCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -426,7 +426,7 @@ namespace Orts.Viewer3D
     public sealed class UseBrakemanCameraCommand : UseCameraCommand
     {
 
-        public UseBrakemanCameraCommand( CommandLog log )
+        public UseBrakemanCameraCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -443,7 +443,7 @@ namespace Orts.Viewer3D
     public sealed class UsePassengerCameraCommand : UseCameraCommand
     {
 
-        public UsePassengerCameraCommand( CommandLog log )
+        public UsePassengerCameraCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -460,7 +460,7 @@ namespace Orts.Viewer3D
     public sealed class UseTracksideCameraCommand : UseCameraCommand
     {
 
-        public UseTracksideCameraCommand( CommandLog log )
+        public UseTracksideCameraCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -496,7 +496,7 @@ namespace Orts.Viewer3D
         public static Viewer Receiver { get; set; }
         protected double EndTime;
 
-        public MoveCameraCommand( CommandLog log, double startTime, double endTime )
+        public MoveCameraCommand(CommandLog log, double startTime, double endTime)
             : base(log)
         {
             Time = startTime;
@@ -505,7 +505,7 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            return base.ToString() + " - " + String.Format( "{0}", FormatStrings.FormatPreciseTime( EndTime ) );
+            return base.ToString() + " - " + String.Format("{0}", FormatStrings.FormatPreciseTime(EndTime));
         }
     }
 
@@ -514,7 +514,7 @@ namespace Orts.Viewer3D
     {
         float RotationXRadians;
 
-        public CameraRotateUpDownCommand( CommandLog log, double startTime, double endTime, float rx )
+        public CameraRotateUpDownCommand(CommandLog log, double startTime, double endTime, float rx)
             : base(log, startTime, endTime)
         {
             RotationXRadians = rx;
@@ -534,7 +534,7 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            return base.ToString() + String.Format( ", {0}", RotationXRadians );
+            return base.ToString() + String.Format(", {0}", RotationXRadians);
         }
     }
 
@@ -543,7 +543,7 @@ namespace Orts.Viewer3D
     {
         float RotationYRadians;
 
-        public CameraRotateLeftRightCommand( CommandLog log, double startTime, double endTime, float ry )
+        public CameraRotateLeftRightCommand(CommandLog log, double startTime, double endTime, float ry)
             : base(log, startTime, endTime)
         {
             RotationYRadians = ry;
@@ -563,7 +563,7 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            return base.ToString() + String.Format( ", {0}", RotationYRadians );
+            return base.ToString() + String.Format(", {0}", RotationYRadians);
         }
     }
 
@@ -576,7 +576,7 @@ namespace Orts.Viewer3D
         float RotationXRadians;
         float RotationYRadians;
 
-        public CameraMouseRotateCommand( CommandLog log, double startTime, double endTime, float rx, float ry )
+        public CameraMouseRotateCommand(CommandLog log, double startTime, double endTime, float rx, float ry)
             : base(log, startTime, endTime)
         {
             RotationXRadians = rx;
@@ -598,7 +598,7 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            return base.ToString() + String.Format( ", {0} {1} {2}", EndTime, RotationXRadians, RotationYRadians );
+            return base.ToString() + String.Format(", {0} {1} {2}", EndTime, RotationXRadians, RotationYRadians);
         }
     }
 
@@ -607,7 +607,7 @@ namespace Orts.Viewer3D
     {
         float XRadians;
 
-        public CameraXCommand( CommandLog log, double startTime, double endTime, float xr )
+        public CameraXCommand(CommandLog log, double startTime, double endTime, float xr)
             : base(log, startTime, endTime)
         {
             XRadians = xr;
@@ -627,7 +627,7 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            return base.ToString() + String.Format( ", {0}", XRadians );
+            return base.ToString() + String.Format(", {0}", XRadians);
         }
     }
 
@@ -636,7 +636,7 @@ namespace Orts.Viewer3D
     {
         float YRadians;
 
-        public CameraYCommand( CommandLog log, double startTime, double endTime, float yr )
+        public CameraYCommand(CommandLog log, double startTime, double endTime, float yr)
             : base(log, startTime, endTime)
         {
             YRadians = yr;
@@ -656,7 +656,7 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            return base.ToString() + String.Format( ", {0}", YRadians );
+            return base.ToString() + String.Format(", {0}", YRadians);
         }
     }
 
@@ -665,7 +665,7 @@ namespace Orts.Viewer3D
     {
         float ZRadians;
 
-        public CameraZCommand( CommandLog log, double startTime, double endTime, float zr )
+        public CameraZCommand(CommandLog log, double startTime, double endTime, float zr)
             : base(log, startTime, endTime)
         {
             ZRadians = zr;
@@ -684,45 +684,45 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            return base.ToString() + String.Format( ", {0}", ZRadians );
+            return base.ToString() + String.Format(", {0}", ZRadians);
         }
     }
 
-	[Serializable()]
-	public sealed class CameraMoveXYZCommand : MoveCameraCommand
-	{
-		float X, Y, Z;
+    [Serializable()]
+    public sealed class CameraMoveXYZCommand : MoveCameraCommand
+    {
+        float X, Y, Z;
 
         public CameraMoveXYZCommand(CommandLog log, double startTime, double endTime, float xr, float yr, float zr)
-			: base(log, startTime, endTime)
-		{
-			X = xr; Y = yr; Z = zr;
-			Redo();
-		}
+            : base(log, startTime, endTime)
+        {
+            X = xr; Y = yr; Z = zr;
+            Redo();
+        }
 
-		public override void Redo()
-		{
-			if (Receiver.Camera is ThreeDimCabCamera)
-			{
-				var c = Receiver.Camera as ThreeDimCabCamera;
-				c.MoveCameraXYZ(X, Y, Z);
-				c.EndTime = EndTime;
-			}
-			// Report();
-		}
+        public override void Redo()
+        {
+            if (Receiver.Camera is ThreeDimCabCamera)
+            {
+                var c = Receiver.Camera as ThreeDimCabCamera;
+                c.MoveCameraXYZ(X, Y, Z);
+                c.EndTime = EndTime;
+            }
+            // Report();
+        }
 
-		public override string ToString()
-		{
-			return base.ToString() + String.Format(", {0}", X);
-		}
-	}
+        public override string ToString()
+        {
+            return base.ToString() + String.Format(", {0}", X);
+        }
+    }
 
-	[Serializable()]
+    [Serializable()]
     public sealed class TrackingCameraXCommand : MoveCameraCommand
     {
         float PositionXRadians;
 
-        public TrackingCameraXCommand( CommandLog log, double startTime, double endTime, float rx )
+        public TrackingCameraXCommand(CommandLog log, double startTime, double endTime, float rx)
             : base(log, startTime, endTime)
         {
             PositionXRadians = rx;
@@ -742,7 +742,7 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            return base.ToString() + String.Format( ", {0}", PositionXRadians );
+            return base.ToString() + String.Format(", {0}", PositionXRadians);
         }
     }
 
@@ -751,7 +751,7 @@ namespace Orts.Viewer3D
     {
         float PositionYRadians;
 
-        public TrackingCameraYCommand( CommandLog log, double startTime, double endTime, float ry )
+        public TrackingCameraYCommand(CommandLog log, double startTime, double endTime, float ry)
             : base(log, startTime, endTime)
         {
             PositionYRadians = ry;
@@ -771,7 +771,7 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            return base.ToString() + String.Format( ", {0}", PositionYRadians );
+            return base.ToString() + String.Format(", {0}", PositionYRadians);
         }
     }
 
@@ -780,7 +780,7 @@ namespace Orts.Viewer3D
     {
         float PositionDistanceMetres;
 
-        public TrackingCameraZCommand( CommandLog log, double startTime, double endTime, float d )
+        public TrackingCameraZCommand(CommandLog log, double startTime, double endTime, float d)
             : base(log, startTime, endTime)
         {
             PositionDistanceMetres = d;
@@ -800,7 +800,7 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            return base.ToString() + String.Format( ", {0}", PositionDistanceMetres );
+            return base.ToString() + String.Format(", {0}", PositionDistanceMetres);
         }
     }
 
@@ -808,7 +808,7 @@ namespace Orts.Viewer3D
     public sealed class NextCarCommand : UseCameraCommand
     {
 
-        public NextCarCommand( CommandLog log )
+        public NextCarCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -829,7 +829,7 @@ namespace Orts.Viewer3D
     public sealed class PreviousCarCommand : UseCameraCommand
     {
 
-        public PreviousCarCommand( CommandLog log )
+        public PreviousCarCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -850,7 +850,7 @@ namespace Orts.Viewer3D
     public sealed class FirstCarCommand : UseCameraCommand
     {
 
-        public FirstCarCommand( CommandLog log )
+        public FirstCarCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -871,7 +871,7 @@ namespace Orts.Viewer3D
     public sealed class LastCarCommand : UseCameraCommand
     {
 
-        public LastCarCommand( CommandLog log )
+        public LastCarCommand(CommandLog log)
             : base(log)
         {
             Redo();
@@ -947,7 +947,7 @@ namespace Orts.Viewer3D
         }
     }
 
-   [Serializable()]
+    [Serializable()]
     public sealed class ToggleBrowseForwardsCommand : UseCameraCommand
     {
 

--- a/Source/RunActivity/Viewer3D/DDSLib.cs
+++ b/Source/RunActivity/Viewer3D/DDSLib.cs
@@ -756,10 +756,10 @@ namespace Orts.Viewer3D
             }
         }
 
-        #if WINDOWS
+#if WINDOWS
         [ThreadStatic]
         private static byte[] mipData;
-        #else
+#else
 
         static DDSLib()
         {
@@ -797,7 +797,7 @@ namespace Orts.Viewer3D
             }
         }
 
-        #endif
+#endif
 
         //try to evaluate the xna compatible surface for the present data
         private static SurfaceFormat SurfaceFormatFromLoadFormat(LoadSurfaceFormat loadSurfaceFormat, FourCC compressionFormat, uint pixelFlags, int rgbBitCount)
@@ -814,28 +814,28 @@ namespace Orts.Viewer3D
                         return SurfaceFormat.Dxt5;
                     case 0:
                         if (rgbBitCount == 8)
-                    {
-                        return SurfaceFormat.Alpha8;
-                    }
-
-                    if (rgbBitCount == 16)
-                    {
-                        if (HasAlphaTest(pixelFlags))
                         {
-                            return SurfaceFormat.Bgr565;
+                            return SurfaceFormat.Alpha8;
                         }
-                        else
+
+                        if (rgbBitCount == 16)
                         {
-                            return SurfaceFormat.Bgra4444;
+                            if (HasAlphaTest(pixelFlags))
+                            {
+                                return SurfaceFormat.Bgr565;
+                            }
+                            else
+                            {
+                                return SurfaceFormat.Bgra4444;
+                            }
                         }
-                    }
 
-                    if (rgbBitCount == 32 || rgbBitCount == 24)
-                    {
-                        return SurfaceFormat.Color;
-                    }
+                        if (rgbBitCount == 32 || rgbBitCount == 24)
+                        {
+                            return SurfaceFormat.Color;
+                        }
 
-                    break;
+                        break;
                     default:
                         throw new Exception("Unsuported format");
                 }
@@ -908,7 +908,7 @@ namespace Orts.Viewer3D
 
             if (tx.Format != surfaceFormat)
             {
-                throw new Exception("Can't generate a " +surfaceFormat.ToString()+" surface.");
+                throw new Exception("Can't generate a " + surfaceFormat.ToString() + " surface.");
             }
 
             return tx;
@@ -1359,17 +1359,17 @@ namespace Orts.Viewer3D
                 case SurfaceFormat.Dxt3:
                 case SurfaceFormat.Dxt5:
                     pixelWidth = 0;
-                break;
+                    break;
 
                 case SurfaceFormat.Vector4:
                     pixelWidth = 16;
-                break;
+                    break;
 
                 case SurfaceFormat.Rgba64:
                 case SurfaceFormat.HalfVector4:
-                case SurfaceFormat.Vector2 :
+                case SurfaceFormat.Vector2:
                     pixelWidth = 8;
-                break;
+                    break;
 
                 case SurfaceFormat.Rg32:
                 case SurfaceFormat.Rgba1010102:
@@ -1378,7 +1378,7 @@ namespace Orts.Viewer3D
                 case SurfaceFormat.Single:
                 case SurfaceFormat.Color:
                     pixelWidth = 4;
-                break;
+                    break;
 
                 case SurfaceFormat.NormalizedByte2:
                 case SurfaceFormat.HalfSingle:
@@ -1386,11 +1386,11 @@ namespace Orts.Viewer3D
                 case SurfaceFormat.Bgra4444:
                 case SurfaceFormat.Bgr565:
                     pixelWidth = 2;
-                break;
+                    break;
 
                 case SurfaceFormat.Alpha8:
                     pixelWidth = 1;
-                break;
+                    break;
                 default:
                     throw new Exception(((Texture2D)texture).Format + " has no save as DDS support.");
             }
@@ -1471,7 +1471,7 @@ namespace Orts.Viewer3D
                         fourCC = 0x35545844;
                     }
                     return;
-                #if COLOR_SAVE_TO_ARGB
+#if COLOR_SAVE_TO_ARGB
                 case SurfaceFormat.Color:
                     flags = 0x41;
                     rgbBitCount = 32;
@@ -1481,7 +1481,7 @@ namespace Orts.Viewer3D
                     bBitMask = 0xff;
                     aBitMask = 0xff000000;
                     return;
-                #else
+#else
                 case SurfaceFormat.Color:
                     flags = 0x41;
                     rgbBitCount = 32;
@@ -1491,7 +1491,7 @@ namespace Orts.Viewer3D
                     bBitMask = 0xff0000;
                     aBitMask = 0xff000000;
                     return;
-                #endif
+#endif
 
                 //case DDS_FORMAT_X8R8G8B8:
                 //    flags = 0x40;
@@ -1633,7 +1633,7 @@ namespace Orts.Viewer3D
                     aBitMask = 0;
                     break;
 
-                case SurfaceFormat.NormalizedByte2 :
+                case SurfaceFormat.NormalizedByte2:
                     flags = 4;
                     fourCC = 117;
                     rgbBitCount = 16;
@@ -1716,19 +1716,19 @@ namespace Orts.Viewer3D
                 }
 
 
-                #if COLOR_SAVE_TO_ARGB
+#if COLOR_SAVE_TO_ARGB
                 if (((Texture2D)texture).Format == SurfaceFormat.Color)
+                {
+                    byte g, b;
+                    for (int k = 0; k < size - 3; k += 4)
                     {
-                        byte g, b;
-                        for (int k = 0; k < size - 3; k += 4)
-                        {
-                            g = data[k];
-                            b = data[k + 2];
-                            data[k] = b;
-                            data[k + 2] = g;
-                        }
+                        g = data[k];
+                        b = data[k + 2];
+                        data[k] = b;
+                        data[k + 2] = g;
                     }
-                #endif
+                }
+#endif
 
                 writer.Write(data, 0, size);
                 //for (int j = 0; j < size; j++)
@@ -1741,7 +1741,7 @@ namespace Orts.Viewer3D
         }
 
         //Write texture data to stream if the texture is a 2d texture the face is ignored.
-        private static void WriteTexture(BinaryWriter writer, CubeMapFace face, Texture texture, int mipLevel,int depth, int width, int height, bool isCompressed, FourCC fourCC, int rgbBitCount)
+        private static void WriteTexture(BinaryWriter writer, CubeMapFace face, Texture texture, int mipLevel, int depth, int width, int height, bool isCompressed, FourCC fourCC, int rgbBitCount)
         {
             int size = MipMapSizeInBytes(mipLevel, width, height, isCompressed, fourCC, rgbBitCount);
             byte[] data = mipData;
@@ -1764,23 +1764,23 @@ namespace Orts.Viewer3D
                 int localWidth = MipMapSize(mipLevel, width);
                 int localHeight = MipMapSize(mipLevel, height);
 
-                tex.GetData<byte>(mipLevel, 0, 0,localWidth, localHeight, depth, depth+1, data, 0, size);
+                tex.GetData<byte>(mipLevel, 0, 0, localWidth, localHeight, depth, depth + 1, data, 0, size);
             }
 
 
-            #if COLOR_SAVE_TO_ARGB
+#if COLOR_SAVE_TO_ARGB
             if (((Texture2D)texture).Format == SurfaceFormat.Color)
+            {
+                byte g, b;
+                for (int k = 0; k < size - 3; k += 4)
                 {
-                    byte g, b;
-                    for (int k = 0; k < size - 3; k += 4)
-                    {
-                        g = data[k];
-                        b = data[k + 2];
-                        data[k] = b;
-                        data[k + 2] = g;
-                    }
+                    g = data[k];
+                    b = data[k + 2];
+                    data[k] = b;
+                    data[k + 2] = g;
                 }
-            #endif
+            }
+#endif
 
             writer.Write(data, 0, size);
             //for (int j = 0; j < size; j++)
@@ -1846,7 +1846,7 @@ namespace Orts.Viewer3D
                 dwHeaderFlags |= DDSD_LINEARSIZE;
             }
 
-            if(texture.LevelCount > 1 && saveMipMaps)
+            if (texture.LevelCount > 1 && saveMipMaps)
             {
                 dwHeaderFlags |= DDSD_MIPMAPCOUNT;
             }
@@ -1861,7 +1861,7 @@ namespace Orts.Viewer3D
             int Width = 1;
             int Height = 1;
 
-            if(textureAs2D != null)
+            if (textureAs2D != null)
             {
                 Width = textureAs2D.Width;
                 Height = textureAs2D.Height;
@@ -1934,26 +1934,26 @@ namespace Orts.Viewer3D
             GenerateDdspf(((Texture2D)texture).Format, out flags, out rgbBitCount, out rBitMask, out gBitMask, out bBitMask, out aBitMask, out fourCC);
 
             //ddspf
-                //dwSize
-                writer.Write(32);
-                //dwFlags
-                writer.Write(flags);
-                //dwFourCC
-                writer.Write(fourCC);
-                //dwRGBBitCount
-                writer.Write(rgbBitCount);
-                //dwRBitMask;
-                writer.Write(rBitMask);
-                //dwGBitMask;
-                writer.Write(gBitMask);
-                //dwBBitMask;
-                writer.Write(bBitMask);
-                //dwABitMask;
-                writer.Write(aBitMask);
+            //dwSize
+            writer.Write(32);
+            //dwFlags
+            writer.Write(flags);
+            //dwFourCC
+            writer.Write(fourCC);
+            //dwRGBBitCount
+            writer.Write(rgbBitCount);
+            //dwRBitMask;
+            writer.Write(rBitMask);
+            //dwGBitMask;
+            writer.Write(gBitMask);
+            //dwBBitMask;
+            writer.Write(bBitMask);
+            //dwABitMask;
+            writer.Write(aBitMask);
             //ddspf end
 
             uint dwSurfaceFlags = DDSCAPS_TEXTURE;
-            if((texture.LevelCount > 1 && saveMipMaps))
+            if ((texture.LevelCount > 1 && saveMipMaps))
             {
                 dwSurfaceFlags |= DDSCAPS_MIPMAP;
                 dwSurfaceFlags |= DDSCAPS_COMPLEX;
@@ -2030,7 +2030,7 @@ namespace Orts.Viewer3D
         /// <param name="saveMipMaps">Save the complete mip-map chain ?</param>
         /// <param name="texture">The texture that you want to save.</param>
         /// <param name="throwExceptionIfFileExist">Throw an exception if the file exists ?</param>
-        public static void DDSToFile(string fileName, bool saveMipMaps, Texture texture,bool throwExceptionIfFileExist)
+        public static void DDSToFile(string fileName, bool saveMipMaps, Texture texture, bool throwExceptionIfFileExist)
         {
             if (throwExceptionIfFileExist && File.Exists(fileName))
             {
@@ -2044,13 +2044,13 @@ namespace Orts.Viewer3D
                 DDSToStream(fileStream, 0, saveMipMaps, texture);
 
             }
-            catch(Exception x)
+            catch (Exception x)
             {
                 throw x;
             }
             finally
             {
-                if(fileStream != null)
+                if (fileStream != null)
                 {
                     fileStream.Close();
                     fileStream = null;

--- a/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
@@ -50,77 +50,77 @@ namespace Orts.Viewer3D.Debugging
     /// when using Open Rails 
     /// </summary>
     public partial class DispatchViewer : Form
-   {
+    {
 
 
-      #region Data Viewers
-	  //public MessageViewer MessageViewer;
-      #endregion
+        #region Data Viewers
+        //public MessageViewer MessageViewer;
+        #endregion
 
-      /// <summary>
-      /// Reference to the main simulator object.
-      /// </summary>
-      private readonly Simulator simulator;
+        /// <summary>
+        /// Reference to the main simulator object.
+        /// </summary>
+        private readonly Simulator simulator;
 
 
-      private int IM_Width = 720;
-      private int IM_Height = 720;
+        private int IM_Width = 720;
+        private int IM_Height = 720;
 
-	  /// <summary>
-	  /// True when the user is dragging the route view
-	  /// </summary>
-      private bool Dragging;
-	  private WorldPosition worldPos;
-      float xScale = 1; 
-      float yScale = 1; 
+        /// <summary>
+        /// True when the user is dragging the route view
+        /// </summary>
+        private bool Dragging;
+        private WorldPosition worldPos;
+        float xScale = 1;
+        float yScale = 1;
 
-	  string name = "";
-	  List<SwitchWidget> switchItemsDrawn;
-	  List<SignalWidget> signalItemsDrawn;
+        string name = "";
+        List<SwitchWidget> switchItemsDrawn;
+        List<SignalWidget> signalItemsDrawn;
 
-      public SwitchWidget switchPickedItem;
-      public SignalWidget signalPickedItem;
-      public bool switchPickedItemHandled;
-      public double switchPickedTime;
-      public bool signalPickedItemHandled;
-      public double signalPickedTime;
-	  public bool DrawPath = true; //draw train path
-      ImageList imageList1;
-      public List<Train> selectedTrainList;
-	  /// <summary>
-	  /// contains the last position of the mouse
-	  /// </summary>
-	  private System.Drawing.Point LastCursorPosition = new System.Drawing.Point();
-	Pen redPen = new Pen(Color.Red);
-	Pen greenPen = new Pen(Color.Green);
-	Pen orangePen = new Pen(Color.Orange);
-	Pen trainPen = new Pen(Color.DarkGreen);
-	Pen pathPen = new Pen(Color.DeepPink);
-	Pen grayPen = new Pen(Color.Gray);
+        public SwitchWidget switchPickedItem;
+        public SignalWidget signalPickedItem;
+        public bool switchPickedItemHandled;
+        public double switchPickedTime;
+        public bool signalPickedItemHandled;
+        public double signalPickedTime;
+        public bool DrawPath = true; //draw train path
+        ImageList imageList1;
+        public List<Train> selectedTrainList;
+        /// <summary>
+        /// contains the last position of the mouse
+        /// </summary>
+        private System.Drawing.Point LastCursorPosition = new System.Drawing.Point();
+        Pen redPen = new Pen(Color.Red);
+        Pen greenPen = new Pen(Color.Green);
+        Pen orangePen = new Pen(Color.Orange);
+        Pen trainPen = new Pen(Color.DarkGreen);
+        Pen pathPen = new Pen(Color.DeepPink);
+        Pen grayPen = new Pen(Color.Gray);
 
-	   //the train selected by leftclicking the mouse
-	public Train PickedTrain;
+        //the train selected by leftclicking the mouse
+        public Train PickedTrain;
 
-      /// <summary>
-      /// Defines the area to view, in meters.
-      /// </summary>
-      private RectangleF ViewWindow;
+        /// <summary>
+        /// Defines the area to view, in meters.
+        /// </summary>
+        private RectangleF ViewWindow;
 
-      /// <summary>
-      /// Used to periodically check if we should shift the view when the
-      /// user is holding down a "shift view" button.
-      /// </summary>
-      private Timer UITimer;
+        /// <summary>
+        /// Used to periodically check if we should shift the view when the
+        /// user is holding down a "shift view" button.
+        /// </summary>
+        private Timer UITimer;
 
-      bool loaded;
-	  TrackNode[] nodes;
-	  float minX = float.MaxValue;
-	  float minY = float.MaxValue;
+        bool loaded;
+        TrackNode[] nodes;
+        float minX = float.MaxValue;
+        float minY = float.MaxValue;
 
-	  float maxX = float.MinValue;
-	  float maxY = float.MinValue;
+        float maxX = float.MinValue;
+        float maxY = float.MinValue;
 
-	  Viewer Viewer;
+        Viewer Viewer;
         /// <summary>
         /// Creates a new DebugViewerForm.
         /// </summary>
@@ -201,522 +201,524 @@ namespace Orts.Viewer3D.Debugging
         }
 
 
-      public int RedrawCount;
-	  private Font trainFont;
-	  private Font sidingFont;
-	  private SolidBrush trainBrush;
-	  private SolidBrush sidingBrush;
-      private double lastUpdateTime;
+        public int RedrawCount;
+        private Font trainFont;
+        private Font sidingFont;
+        private SolidBrush trainBrush;
+        private SolidBrush sidingBrush;
+        private double lastUpdateTime;
 
-      /// <summary>
-      /// When the user holds down the  "L", "R", "U", "D" buttons,
-      /// shift the view. Avoids the case when the user has to click
-      /// buttons like crazy.
-      /// </summary>
-      /// <param name="sender"></param>
-      /// <param name="e"></param>
-      void UITimer_Tick(object sender, EventArgs e)
-      {
-		  if (Viewer.DebugViewerEnabled == false) { this.Visible = false; firstShow = true; return; }
-		  else this.Visible = true;
+        /// <summary>
+        /// When the user holds down the  "L", "R", "U", "D" buttons,
+        /// shift the view. Avoids the case when the user has to click
+        /// buttons like crazy.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        void UITimer_Tick(object sender, EventArgs e)
+        {
+            if (Viewer.DebugViewerEnabled == false) { this.Visible = false; firstShow = true; return; }
+            else this.Visible = true;
 
-		 if (Program.Simulator.GameTime - lastUpdateTime < 1) return;
-		 lastUpdateTime = Program.Simulator.GameTime;
+            if (Program.Simulator.GameTime - lastUpdateTime < 1) return;
+            lastUpdateTime = Program.Simulator.GameTime;
 
             GenerateView();
-	  }
+        }
 
-	  #region initData
-	  private void InitData()
-	  {
-		  if (!loaded)
-		  {
-			  // do this only once
-			  loaded = true;
-			  //trackSections.DataSource = new List<InterlockingTrack>(simulator.InterlockingSystem.Tracks.Values).ToArray();
-              Localizer.Localize(this, Viewer.Catalog);
-		  }
-
-		  switchItemsDrawn = new List<SwitchWidget>();
-		  signalItemsDrawn = new List<SignalWidget>();
-		  switches = new List<SwitchWidget>();
-		  for (int i = 0; i < nodes.Length; i++)
-		  {
-			  TrackNode currNode = nodes[i];
-
-			  if (currNode != null)
-			  {
-
-				  if (currNode.TrEndNode)
-				  {
-					  //buffers.Add(new PointF(currNode.UiD.TileX * 2048 + currNode.UiD.X, currNode.UiD.TileZ * 2048 + currNode.UiD.Z));
-				  }
-				  else if (currNode.TrVectorNode != null)
-				  {
-
-					  if (currNode.TrVectorNode.TrVectorSections.Length > 1)
-					  {
-						  AddSegments(segments, currNode, currNode.TrVectorNode.TrVectorSections, ref minX, ref minY, ref maxX, ref maxY, simulator);
-					  }
-					  else
-					  {
-						  TrVectorSection s = currNode.TrVectorNode.TrVectorSections[0];
-
-						  foreach (TrPin pin in currNode.TrPins)
-						  {
-
-							  TrackNode connectedNode = nodes[pin.Link];
-
-
-							  //bool occupied = false;
-
-							  //if (simulator.InterlockingSystem.Tracks.ContainsKey(connectedNode))
-							  //{
-							  //occupied = connectedNode   
-							  //}
-
-							  //if (currNode.UiD == null)
-							  //{
-							  dVector A = new dVector(s.TileX, s.X, s.TileZ, + s.Z);
-							  dVector B = new dVector(connectedNode.UiD.TileX, connectedNode.UiD.X, connectedNode.UiD.TileZ, connectedNode.UiD.Z);
-								  segments.Add(new LineSegment(A, B, /*s.InterlockingTrack.IsOccupied*/ false, null));
-							  //}
-						  }
-
-
-					  }
-				  }
-				  else if (currNode.TrJunctionNode != null)
-				  {
-					  foreach (TrPin pin in currNode.TrPins)
-					  {
-						  TrVectorSection item = null;
-						  try
-						  {
-							  if (nodes[pin.Link].TrVectorNode == null || nodes[pin.Link].TrVectorNode.TrVectorSections.Length < 1) continue;
-							  if (pin.Direction == 1) item = nodes[pin.Link].TrVectorNode.TrVectorSections.First();
-							  else item = nodes[pin.Link].TrVectorNode.TrVectorSections.Last();
-						  }
-						  catch { continue; }
-						  dVector A = new dVector(currNode.UiD.TileX, currNode.UiD.X, currNode.UiD.TileZ, + currNode.UiD.Z);
-						  dVector B = new dVector(item.TileX, + item.X, item.TileZ, + item.Z);
-                          var x = dVector.DistanceSqr(A, B);
-						  if (x < 0.1) continue;
-						  segments.Add(new LineSegment(B, A, /*s.InterlockingTrack.IsOccupied*/ false, item));
-					  }
-					  switches.Add(new SwitchWidget(currNode));
-				  }
-			  }
-		  }
-
-          var maxsize = maxX - minX > maxY - minY ? maxX - minX : maxY - minY;
-          maxsize = (int)(maxsize / 100 +1 ) * 100;
-          windowSizeUpDown.Maximum = (decimal)maxsize;
-          Inited = true;
-
-          if (simulator.TDB == null || simulator.TDB.TrackDB == null || simulator.TDB.TrackDB.TrItemTable == null) return;
-
-		  foreach (var item in simulator.TDB.TrackDB.TrItemTable)
-		  {
-			  if (item.ItemType == TrItem.trItemType.trSIGNAL)
-			  {
-				  if (item is SignalItem)
-				  {
-
-					  SignalItem si = item as SignalItem;
-					  
-					  if (si.SigObj >=0  && si.SigObj < simulator.Signals.SignalObjects.Length)
-					  {
-						  SignalObject s = simulator.Signals.SignalObjects[si.SigObj];
-						  if (s != null && s.isSignal && s.isSignalNormal()) signals.Add(new SignalWidget(si, s));
-					  }
-				  }
-
-			  }
-			  if (item.ItemType == TrItem.trItemType.trSIDING || item.ItemType == TrItem.trItemType.trPLATFORM)
-			  {
-				  sidings.Add(new SidingWidget(item));
-			  }
-		  }
-          return;
-	  }
-
-      bool Inited;
-	  List<LineSegment> segments = new List<LineSegment>();
-	  List<SwitchWidget> switches;
-	  //List<PointF> buffers = new List<PointF>();
-	  List<SignalWidget> signals = new List<SignalWidget>();
-	  List<SidingWidget> sidings = new List<SidingWidget>();
-
-	   /// <summary>
-      /// Initialises the picturebox and the image it contains. 
-      /// </summary>
-      public void InitImage()
-      {
-         pictureBox1.Width = IM_Width;
-         pictureBox1.Height = IM_Height;
-
-         if (pictureBox1.Image != null)
-         {
-            pictureBox1.Image.Dispose();
-         }
-
-         pictureBox1.Image = new Bitmap(pictureBox1.Width, pictureBox1.Height);
-		 imageList1 = new ImageList();
-		 this.AvatarView.View = View.LargeIcon;
-		 imageList1.ImageSize = new Size(64, 64);
-		 this.AvatarView.LargeImageList = this.imageList1;
-
-	  }
-
-	  #endregion
-
-	  #region avatar
-      Dictionary<string, Image> avatarList;
-	  public void AddAvatar(string name, string url)
-	  {
-		  if (avatarList == null) avatarList = new Dictionary<string, Image>();
-		  bool FindDefault = false;
-		  try
-		  {
-			  if (Program.Simulator.Settings.ShowAvatar == false) throw new Exception();
-			  FindDefault = true;
-			  var request = WebRequest.Create(url);
-			  using (var response = request.GetResponse())
-			  using (var stream = response.GetResponseStream())
-			  {
-				  Image newImage = Image.FromStream(stream);//Image.FromFile("C:\\test1.png");//
-				  avatarList[name] = newImage;
-
-				  /*using (MemoryStream ms = new MemoryStream())
-				  {
-					  // Convert Image to byte[]
-					  newImage.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
-					  byte[] imageBytes = ms.ToArray();
-
-					  // Convert byte[] to Base64 String
-					  string base64String = Convert.ToBase64String(imageBytes);
-				  }*/
-			  }
-		  }
-		  catch
-		  {
-			  if (FindDefault)
-			  {
-				  byte[] imageBytes = Convert.FromBase64String(imagestring);
-				  MemoryStream ms = new MemoryStream(imageBytes, 0,
-					imageBytes.Length);
-
-				  // Convert byte[] to Image
-				  ms.Write(imageBytes, 0, imageBytes.Length);
-				  Image newImage = Image.FromStream(ms, true);
-				  avatarList[name] = newImage;
-			  }
-			  else
-			  {
-				  avatarList[name] = null;
-			  }
-		  }
-
-
-		  /*
-		  imageList1.Images.Clear();
-		  AvatarView.Items.Clear();
-		  var i = 0;
-		  foreach (var pair in avatarList)
-		  {
-			  if (pair.Value == null) AvatarView.Items.Add(pair.Key);
-			  else
-			  {
-				  AvatarView.Items.Add(pair.Key).ImageIndex = i;
-				  imageList1.Images.Add(pair.Value);
-				  i++;
-			  }
-		  }*/
-	  }
-
-	  int LostCount = 0;//how many players in the lost list (quit)
-	  public void CheckAvatar()
-	  {
-		  if (!MultiPlayer.MPManager.IsMultiPlayer() || MultiPlayer.MPManager.OnlineTrains == null || MultiPlayer.MPManager.OnlineTrains.Players == null) return;
-		  var player = MultiPlayer.MPManager.OnlineTrains.Players;
-		  var username =MultiPlayer.MPManager.GetUserName();
-		  player = player.Concat(MultiPlayer.MPManager.Instance().lostPlayer).ToDictionary(x => x.Key, x => x.Value);
-		  if (avatarList == null) avatarList = new Dictionary<string, Image>();
-		  if (avatarList.Count == player.Count + 1 && LostCount == MultiPlayer.MPManager.Instance().lostPlayer.Count) return;
-
-		  LostCount = MultiPlayer.MPManager.Instance().lostPlayer.Count;
-		  //add myself
-		  if (!avatarList.ContainsKey(username))
-		  {
-			  AddAvatar(username, Program.Simulator.Settings.AvatarURL);
-		  }
-
-		  foreach (var p in player) {
-			  if (avatarList.ContainsKey(p.Key)) continue;
-			  AddAvatar(p.Key, p.Value.url);
-		  }
-
-		  Dictionary<string, Image> tmplist = null;
-		  foreach (var a in avatarList)
-		  {
-			  if (player.ContainsKey(a.Key) || a.Key == username) continue;
-			  if (tmplist == null) tmplist = new Dictionary<string, Image>();
-			  tmplist.Add(a.Key, a.Value);
-		  }
-
-		  if (tmplist != null)
-		  {
-			  foreach (var t in tmplist) avatarList.Remove(t.Key);
-		  }
-		  imageList1.Images.Clear();
-		  AvatarView.Items.Clear();
-		  var i = 0;
-		  if (!Program.Simulator.Settings.ShowAvatar)
-		  {
-			  this.AvatarView.View = View.List;
-			  foreach (var pair in avatarList)
-			  {
-				  if (pair.Key != username) continue;
-				  AvatarView.Items.Add(pair.Key);
-			  }
-			  i = 1;
-			  foreach (var pair in avatarList)
-			  {
-				  if (pair.Key == username) continue;
-				  if (MultiPlayer.MPManager.Instance().aiderList.Contains(pair.Key))
-				  {
-					  AvatarView.Items.Add(pair.Key + " (H)");
-				  }
-				  else if (MultiPlayer.MPManager.Instance().lostPlayer.ContainsKey(pair.Key))
-				  {
-					  AvatarView.Items.Add(pair.Key + " (Q)");
-				  }
-				  else AvatarView.Items.Add(pair.Key);
-				  i++;
-			  }
-		  }
-		  else
-		  {
-			  this.AvatarView.View = View.LargeIcon;
-			  AvatarView.LargeImageList = imageList1;
-			  foreach (var pair in avatarList)
-			  {
-				  if (pair.Key != username) continue;
-
-				  if (pair.Value == null) AvatarView.Items.Add(pair.Key).ImageIndex = -1;
-				  else
-				  {
-					  AvatarView.Items.Add(pair.Key).ImageIndex = 0;
-					  imageList1.Images.Add(pair.Value);
-				  }
-			  }
-
-			  i = 1;
-			  foreach (var pair in avatarList)
-			  {
-				  if (pair.Key == username) continue;
-				  var text = pair.Key;
-				  if (MultiPlayer.MPManager.Instance().aiderList.Contains(pair.Key)) text = pair.Key + " (H)";
-
-				  if (pair.Value == null) AvatarView.Items.Add(name).ImageIndex = -1;
-				  else
-				  {
-					  AvatarView.Items.Add(text).ImageIndex = i;
-					  imageList1.Images.Add(pair.Value);
-					  i++;
-				  }
-			  }
-		  }
-	  }
-
-	  #endregion
-
-	  #region Draw
-	  public bool firstShow = true;
-      public bool followTrain;
-	  float subX, subY;
-      float oldWidth;
-      float oldHeight;
-       //determine locations of buttons and boxes
-      void DetermineLocations()
-      {
-          if (this.Height < 600 || this.Width < 800) return;
-          if (oldHeight != this.Height || oldWidth != label1.Left)//use the label "Res" as anchor point to determine the picture size
-          {
-              oldWidth = label1.Left; oldHeight = this.Height;
-              IM_Width = label1.Left - 20;
-              IM_Height = this.Height - pictureBox1.Top;
-              pictureBox1.Width = IM_Width;
-              pictureBox1.Height = IM_Height;
-              if (pictureBox1.Image != null)
-              {
-                  pictureBox1.Image.Dispose();
-              }
-
-              pictureBox1.Image = new Bitmap(pictureBox1.Width, pictureBox1.Height);
-
-              if (btnAssist.Left - 10 < composeMSG.Right)
-              {
-                  var size = composeMSG.Width;
-                  composeMSG.Left = msgAll.Left = msgSelected.Left = reply2Selected.Left = btnAssist.Left - 10 - size;
-                  MSG.Width = messages.Width = composeMSG.Left - 20;
-              }
-              firstShow = true;
-          }
-      }
-      /// <summary>
-      /// Regenerates the 2D view. At the moment, examines the track network
-      /// each time the view is drawn. Later, the traversal and drawing can be separated.
-      /// </summary>
-      public void GenerateView()
-      {
-
-
-		  if (!Inited) return;
-
-		  if (pictureBox1.Image == null) InitImage();
-          DetermineLocations();
-
-		  if (firstShow)
-		  {
-			  if (!MultiPlayer.MPManager.IsServer())
-			  {
-				  this.chkAllowUserSwitch.Visible = false;
-				  this.chkAllowUserSwitch.Checked = false;
-				  this.rmvButton.Visible = false;
-				  this.btnAssist.Visible = false;
-				  this.btnNormal.Visible = false;
-				  this.msgAll.Text = "MSG to Server";
-			  }
-			  else
-			  {
-				  this.msgAll.Text = "MSG to All";
-			  }
-			  if (MultiPlayer.MPManager.IsServer()) { rmvButton.Visible = true; chkAllowNew.Visible = true; chkAllowUserSwitch.Visible = true; }
-			  else { rmvButton.Visible = false; chkAllowNew.Visible = false; chkAllowUserSwitch.Visible = false; chkBoxPenalty.Visible = false; chkPreferGreen.Visible = false; }
-		  }
-		  if (firstShow || followTrain) {
-			  WorldPosition pos;
-			  //see who should I look at:
-			  //if the player is selected in the avatar list, show the player, otherwise, show the one with the lowest index
-			  if (Program.Simulator.PlayerLocomotive != null) pos = Program.Simulator.PlayerLocomotive.WorldPosition;
-			  else pos = Program.Simulator.Trains[0].Cars[0].WorldPosition;
-			  bool hasSelectedTrain = false;
-			  if (AvatarView.SelectedIndices.Count > 0 && !AvatarView.SelectedIndices.Contains(0))
-			  {
-					  try
-					  {
-						  var i = 10000;
-						  foreach (var index in AvatarView.SelectedIndices)
-						  {
-							  if ((int)index < i) i = (int)index;
-						  }
-						  var name = AvatarView.Items[i].Text.Split(' ')[0].Trim() ;
-						  if (MultiPlayer.MPManager.OnlineTrains.Players.ContainsKey(name))
-						  {
-							  pos = MultiPlayer.MPManager.OnlineTrains.Players[name].Train.Cars[0].WorldPosition;
-						  }
-						  else if (MultiPlayer.MPManager.Instance().lostPlayer.ContainsKey(name))
-						  {
-							  pos = MultiPlayer.MPManager.Instance().lostPlayer[name].Train.Cars[0].WorldPosition;
-						  }
-						  hasSelectedTrain = true;
-					  }
-					  catch { }
-			  }
-			  if (hasSelectedTrain == false && PickedTrain != null && PickedTrain.Cars != null && PickedTrain.Cars.Count > 0)
-			  {
-				  pos = PickedTrain.Cars[0].WorldPosition;
-			  }
-			  var ploc = new PointF(pos.TileX * 2048 + pos.Location.X, pos.TileZ * 2048 + pos.Location.Z);
-			  ViewWindow.X = ploc.X - minX - ViewWindow.Width / 2; ViewWindow.Y = ploc.Y - minY - ViewWindow.Width / 2;
-			  firstShow = false;
-		  }
-
-		  try
-		  {
-			  CheckAvatar();
-		  }
-		  catch {  } //errors for avatar, just ignore
-         using(Graphics g = Graphics.FromImage(pictureBox1.Image))
-         {
-			 subX = minX + ViewWindow.X; subY = minY + ViewWindow.Y;
-            g.Clear(Color.White);
-            
-            xScale = pictureBox1.Width / ViewWindow.Width;
-            yScale = pictureBox1.Height/ ViewWindow.Height;
-
-			PointF[] points = new PointF[3];
-			Pen p = grayPen;
-
-			p.Width = (int) xScale;
-			if (p.Width < 1) p.Width = 1;
-			else if (p.Width > 3) p.Width = 3;
-			greenPen.Width = orangePen.Width = redPen.Width = p.Width; pathPen.Width = 2 * p.Width;
-			trainPen.Width = p.Width*6;
-			var forwardDist = 100 / xScale; if (forwardDist < 5) forwardDist = 5;
-			//if (xScale > 3) p.Width = 3f;
-			//else if (xScale > 2) p.Width = 2f;
-			//else p.Width = 1f;
-			PointF scaledA = new PointF(0, 0);
-			PointF scaledB = new PointF(0, 0);
-			PointF scaledC = new PointF(0, 0);
-
-			foreach (var line in segments)
+        #region initData
+        private void InitData()
+        {
+            if (!loaded)
             {
-
-                scaledA.X = (line.A.TileX * 2048 - subX + (float)line.A.X) * xScale; scaledA.Y = pictureBox1.Height - (line.A.TileZ * 2048 - subY + (float)line.A.Z) * yScale;
-                scaledB.X = (line.B.TileX * 2048 - subX + (float)line.B.X) * xScale; scaledB.Y = pictureBox1.Height - (line.B.TileZ * 2048 - subY + (float)line.B.Z) * yScale;
-
-
-				if ((scaledA.X < 0 && scaledB.X < 0) || (scaledA.X > IM_Width && scaledB.X > IM_Width) || (scaledA.Y > IM_Height && scaledB.Y > IM_Height) || (scaledA.Y < 0 && scaledB.Y < 0)) continue;
-
-
-               //if (highlightTrackSections.Checked)
-               //{
-               //   if (line.Section != null && line.Section.InterlockingTrack == trackSections.SelectedValue)
-               //   {
-               //      p.Width = 5f;
-               //   }
-               //}
-
-			   if (line.isCurved == true)
-			   {
-				   scaledC.X = ((float)line.C.X - subX) * xScale; scaledC.Y = pictureBox1.Height - ((float)line.C.Z - subY) * yScale;
-				   points[0] = scaledA; points[1] = scaledC; points[2] = scaledB;
-				   g.DrawCurve(p, points);
-			   }
-               else g.DrawLine(p, scaledA, scaledB);
-
-               /*if (line.MySection != null)
-               {
-                   g.DrawString(""+line.MySection.StartElev+" "+line.MySection.EndElev, sidingFont, sidingBrush, scaledB);
-               }*/
+                // do this only once
+                loaded = true;
+                //trackSections.DataSource = new List<InterlockingTrack>(simulator.InterlockingSystem.Tracks.Values).ToArray();
+                Localizer.Localize(this, Viewer.Catalog);
             }
-			
-			switchItemsDrawn.Clear();
-			signalItemsDrawn.Clear();
-			 float x, y;
-			 PointF scaledItem = new PointF(0f, 0f);
-			 var width = 6f * p.Width; if (width > 15) width = 15;//not to make it too large
-			 for (var i = 0; i < switches.Count; i++)
-			 {
-				 SwitchWidget sw = switches[i];
 
-				 x = (sw.Location.X - subX) * xScale; y = pictureBox1.Height - (sw.Location.Y - subY) * yScale;
+            switchItemsDrawn = new List<SwitchWidget>();
+            signalItemsDrawn = new List<SignalWidget>();
+            switches = new List<SwitchWidget>();
+            for (int i = 0; i < nodes.Length; i++)
+            {
+                TrackNode currNode = nodes[i];
 
-				 if (x < 0 || x > IM_Width || y > IM_Height || y < 0) continue;
+                if (currNode != null)
+                {
 
-				 scaledItem.X = x; scaledItem.Y = y;
+                    if (currNode.TrEndNode)
+                    {
+                        //buffers.Add(new PointF(currNode.UiD.TileX * 2048 + currNode.UiD.X, currNode.UiD.TileZ * 2048 + currNode.UiD.Z));
+                    }
+                    else if (currNode.TrVectorNode != null)
+                    {
+
+                        if (currNode.TrVectorNode.TrVectorSections.Length > 1)
+                        {
+                            AddSegments(segments, currNode, currNode.TrVectorNode.TrVectorSections, ref minX, ref minY, ref maxX, ref maxY, simulator);
+                        }
+                        else
+                        {
+                            TrVectorSection s = currNode.TrVectorNode.TrVectorSections[0];
+
+                            foreach (TrPin pin in currNode.TrPins)
+                            {
+
+                                TrackNode connectedNode = nodes[pin.Link];
 
 
-				 if (sw.Item.TrJunctionNode.SelectedRoute == sw.main) g.FillEllipse(Brushes.Black, GetRect(scaledItem, width));
-				 else g.FillEllipse(Brushes.Gray, GetRect(scaledItem, width));
+                                //bool occupied = false;
 
-                 //g.DrawString("" + sw.Item.TrJunctionNode.SelectedRoute, trainFont, trainBrush, scaledItem);
+                                //if (simulator.InterlockingSystem.Tracks.ContainsKey(connectedNode))
+                                //{
+                                //occupied = connectedNode   
+                                //}
 
-				 sw.Location2D.X = scaledItem.X; sw.Location2D.Y = scaledItem.Y;
+                                //if (currNode.UiD == null)
+                                //{
+                                dVector A = new dVector(s.TileX, s.X, s.TileZ, +s.Z);
+                                dVector B = new dVector(connectedNode.UiD.TileX, connectedNode.UiD.X, connectedNode.UiD.TileZ, connectedNode.UiD.Z);
+                                segments.Add(new LineSegment(A, B, /*s.InterlockingTrack.IsOccupied*/ false, null));
+                                //}
+                            }
+
+
+                        }
+                    }
+                    else if (currNode.TrJunctionNode != null)
+                    {
+                        foreach (TrPin pin in currNode.TrPins)
+                        {
+                            TrVectorSection item = null;
+                            try
+                            {
+                                if (nodes[pin.Link].TrVectorNode == null || nodes[pin.Link].TrVectorNode.TrVectorSections.Length < 1) continue;
+                                if (pin.Direction == 1) item = nodes[pin.Link].TrVectorNode.TrVectorSections.First();
+                                else item = nodes[pin.Link].TrVectorNode.TrVectorSections.Last();
+                            }
+                            catch { continue; }
+                            dVector A = new dVector(currNode.UiD.TileX, currNode.UiD.X, currNode.UiD.TileZ, +currNode.UiD.Z);
+                            dVector B = new dVector(item.TileX, +item.X, item.TileZ, +item.Z);
+                            var x = dVector.DistanceSqr(A, B);
+                            if (x < 0.1) continue;
+                            segments.Add(new LineSegment(B, A, /*s.InterlockingTrack.IsOccupied*/ false, item));
+                        }
+                        switches.Add(new SwitchWidget(currNode));
+                    }
+                }
+            }
+
+            var maxsize = maxX - minX > maxY - minY ? maxX - minX : maxY - minY;
+            maxsize = (int)(maxsize / 100 + 1) * 100;
+            windowSizeUpDown.Maximum = (decimal)maxsize;
+            Inited = true;
+
+            if (simulator.TDB == null || simulator.TDB.TrackDB == null || simulator.TDB.TrackDB.TrItemTable == null) return;
+
+            foreach (var item in simulator.TDB.TrackDB.TrItemTable)
+            {
+                if (item.ItemType == TrItem.trItemType.trSIGNAL)
+                {
+                    if (item is SignalItem)
+                    {
+
+                        SignalItem si = item as SignalItem;
+
+                        if (si.SigObj >= 0 && si.SigObj < simulator.Signals.SignalObjects.Length)
+                        {
+                            SignalObject s = simulator.Signals.SignalObjects[si.SigObj];
+                            if (s != null && s.isSignal && s.isSignalNormal()) signals.Add(new SignalWidget(si, s));
+                        }
+                    }
+
+                }
+                if (item.ItemType == TrItem.trItemType.trSIDING || item.ItemType == TrItem.trItemType.trPLATFORM)
+                {
+                    sidings.Add(new SidingWidget(item));
+                }
+            }
+            return;
+        }
+
+        bool Inited;
+        List<LineSegment> segments = new List<LineSegment>();
+        List<SwitchWidget> switches;
+        //List<PointF> buffers = new List<PointF>();
+        List<SignalWidget> signals = new List<SignalWidget>();
+        List<SidingWidget> sidings = new List<SidingWidget>();
+
+        /// <summary>
+        /// Initialises the picturebox and the image it contains. 
+        /// </summary>
+        public void InitImage()
+        {
+            pictureBox1.Width = IM_Width;
+            pictureBox1.Height = IM_Height;
+
+            if (pictureBox1.Image != null)
+            {
+                pictureBox1.Image.Dispose();
+            }
+
+            pictureBox1.Image = new Bitmap(pictureBox1.Width, pictureBox1.Height);
+            imageList1 = new ImageList();
+            this.AvatarView.View = View.LargeIcon;
+            imageList1.ImageSize = new Size(64, 64);
+            this.AvatarView.LargeImageList = this.imageList1;
+
+        }
+
+        #endregion
+
+        #region avatar
+        Dictionary<string, Image> avatarList;
+        public void AddAvatar(string name, string url)
+        {
+            if (avatarList == null) avatarList = new Dictionary<string, Image>();
+            bool FindDefault = false;
+            try
+            {
+                if (Program.Simulator.Settings.ShowAvatar == false) throw new Exception();
+                FindDefault = true;
+                var request = WebRequest.Create(url);
+                using (var response = request.GetResponse())
+                using (var stream = response.GetResponseStream())
+                {
+                    Image newImage = Image.FromStream(stream);//Image.FromFile("C:\\test1.png");//
+                    avatarList[name] = newImage;
+
+                    /*using (MemoryStream ms = new MemoryStream())
+                    {
+                        // Convert Image to byte[]
+                        newImage.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                        byte[] imageBytes = ms.ToArray();
+
+                        // Convert byte[] to Base64 String
+                        string base64String = Convert.ToBase64String(imageBytes);
+                    }*/
+                }
+            }
+            catch
+            {
+                if (FindDefault)
+                {
+                    byte[] imageBytes = Convert.FromBase64String(imagestring);
+                    MemoryStream ms = new MemoryStream(imageBytes, 0,
+                      imageBytes.Length);
+
+                    // Convert byte[] to Image
+                    ms.Write(imageBytes, 0, imageBytes.Length);
+                    Image newImage = Image.FromStream(ms, true);
+                    avatarList[name] = newImage;
+                }
+                else
+                {
+                    avatarList[name] = null;
+                }
+            }
+
+
+            /*
+            imageList1.Images.Clear();
+            AvatarView.Items.Clear();
+            var i = 0;
+            foreach (var pair in avatarList)
+            {
+                if (pair.Value == null) AvatarView.Items.Add(pair.Key);
+                else
+                {
+                    AvatarView.Items.Add(pair.Key).ImageIndex = i;
+                    imageList1.Images.Add(pair.Value);
+                    i++;
+                }
+            }*/
+        }
+
+        int LostCount = 0;//how many players in the lost list (quit)
+        public void CheckAvatar()
+        {
+            if (!MultiPlayer.MPManager.IsMultiPlayer() || MultiPlayer.MPManager.OnlineTrains == null || MultiPlayer.MPManager.OnlineTrains.Players == null) return;
+            var player = MultiPlayer.MPManager.OnlineTrains.Players;
+            var username = MultiPlayer.MPManager.GetUserName();
+            player = player.Concat(MultiPlayer.MPManager.Instance().lostPlayer).ToDictionary(x => x.Key, x => x.Value);
+            if (avatarList == null) avatarList = new Dictionary<string, Image>();
+            if (avatarList.Count == player.Count + 1 && LostCount == MultiPlayer.MPManager.Instance().lostPlayer.Count) return;
+
+            LostCount = MultiPlayer.MPManager.Instance().lostPlayer.Count;
+            //add myself
+            if (!avatarList.ContainsKey(username))
+            {
+                AddAvatar(username, Program.Simulator.Settings.AvatarURL);
+            }
+
+            foreach (var p in player)
+            {
+                if (avatarList.ContainsKey(p.Key)) continue;
+                AddAvatar(p.Key, p.Value.url);
+            }
+
+            Dictionary<string, Image> tmplist = null;
+            foreach (var a in avatarList)
+            {
+                if (player.ContainsKey(a.Key) || a.Key == username) continue;
+                if (tmplist == null) tmplist = new Dictionary<string, Image>();
+                tmplist.Add(a.Key, a.Value);
+            }
+
+            if (tmplist != null)
+            {
+                foreach (var t in tmplist) avatarList.Remove(t.Key);
+            }
+            imageList1.Images.Clear();
+            AvatarView.Items.Clear();
+            var i = 0;
+            if (!Program.Simulator.Settings.ShowAvatar)
+            {
+                this.AvatarView.View = View.List;
+                foreach (var pair in avatarList)
+                {
+                    if (pair.Key != username) continue;
+                    AvatarView.Items.Add(pair.Key);
+                }
+                i = 1;
+                foreach (var pair in avatarList)
+                {
+                    if (pair.Key == username) continue;
+                    if (MultiPlayer.MPManager.Instance().aiderList.Contains(pair.Key))
+                    {
+                        AvatarView.Items.Add(pair.Key + " (H)");
+                    }
+                    else if (MultiPlayer.MPManager.Instance().lostPlayer.ContainsKey(pair.Key))
+                    {
+                        AvatarView.Items.Add(pair.Key + " (Q)");
+                    }
+                    else AvatarView.Items.Add(pair.Key);
+                    i++;
+                }
+            }
+            else
+            {
+                this.AvatarView.View = View.LargeIcon;
+                AvatarView.LargeImageList = imageList1;
+                foreach (var pair in avatarList)
+                {
+                    if (pair.Key != username) continue;
+
+                    if (pair.Value == null) AvatarView.Items.Add(pair.Key).ImageIndex = -1;
+                    else
+                    {
+                        AvatarView.Items.Add(pair.Key).ImageIndex = 0;
+                        imageList1.Images.Add(pair.Value);
+                    }
+                }
+
+                i = 1;
+                foreach (var pair in avatarList)
+                {
+                    if (pair.Key == username) continue;
+                    var text = pair.Key;
+                    if (MultiPlayer.MPManager.Instance().aiderList.Contains(pair.Key)) text = pair.Key + " (H)";
+
+                    if (pair.Value == null) AvatarView.Items.Add(name).ImageIndex = -1;
+                    else
+                    {
+                        AvatarView.Items.Add(text).ImageIndex = i;
+                        imageList1.Images.Add(pair.Value);
+                        i++;
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Draw
+        public bool firstShow = true;
+        public bool followTrain;
+        float subX, subY;
+        float oldWidth;
+        float oldHeight;
+        //determine locations of buttons and boxes
+        void DetermineLocations()
+        {
+            if (this.Height < 600 || this.Width < 800) return;
+            if (oldHeight != this.Height || oldWidth != label1.Left)//use the label "Res" as anchor point to determine the picture size
+            {
+                oldWidth = label1.Left; oldHeight = this.Height;
+                IM_Width = label1.Left - 20;
+                IM_Height = this.Height - pictureBox1.Top;
+                pictureBox1.Width = IM_Width;
+                pictureBox1.Height = IM_Height;
+                if (pictureBox1.Image != null)
+                {
+                    pictureBox1.Image.Dispose();
+                }
+
+                pictureBox1.Image = new Bitmap(pictureBox1.Width, pictureBox1.Height);
+
+                if (btnAssist.Left - 10 < composeMSG.Right)
+                {
+                    var size = composeMSG.Width;
+                    composeMSG.Left = msgAll.Left = msgSelected.Left = reply2Selected.Left = btnAssist.Left - 10 - size;
+                    MSG.Width = messages.Width = composeMSG.Left - 20;
+                }
+                firstShow = true;
+            }
+        }
+        /// <summary>
+        /// Regenerates the 2D view. At the moment, examines the track network
+        /// each time the view is drawn. Later, the traversal and drawing can be separated.
+        /// </summary>
+        public void GenerateView()
+        {
+
+
+            if (!Inited) return;
+
+            if (pictureBox1.Image == null) InitImage();
+            DetermineLocations();
+
+            if (firstShow)
+            {
+                if (!MultiPlayer.MPManager.IsServer())
+                {
+                    this.chkAllowUserSwitch.Visible = false;
+                    this.chkAllowUserSwitch.Checked = false;
+                    this.rmvButton.Visible = false;
+                    this.btnAssist.Visible = false;
+                    this.btnNormal.Visible = false;
+                    this.msgAll.Text = "MSG to Server";
+                }
+                else
+                {
+                    this.msgAll.Text = "MSG to All";
+                }
+                if (MultiPlayer.MPManager.IsServer()) { rmvButton.Visible = true; chkAllowNew.Visible = true; chkAllowUserSwitch.Visible = true; }
+                else { rmvButton.Visible = false; chkAllowNew.Visible = false; chkAllowUserSwitch.Visible = false; chkBoxPenalty.Visible = false; chkPreferGreen.Visible = false; }
+            }
+            if (firstShow || followTrain)
+            {
+                WorldPosition pos;
+                //see who should I look at:
+                //if the player is selected in the avatar list, show the player, otherwise, show the one with the lowest index
+                if (Program.Simulator.PlayerLocomotive != null) pos = Program.Simulator.PlayerLocomotive.WorldPosition;
+                else pos = Program.Simulator.Trains[0].Cars[0].WorldPosition;
+                bool hasSelectedTrain = false;
+                if (AvatarView.SelectedIndices.Count > 0 && !AvatarView.SelectedIndices.Contains(0))
+                {
+                    try
+                    {
+                        var i = 10000;
+                        foreach (var index in AvatarView.SelectedIndices)
+                        {
+                            if ((int)index < i) i = (int)index;
+                        }
+                        var name = AvatarView.Items[i].Text.Split(' ')[0].Trim();
+                        if (MultiPlayer.MPManager.OnlineTrains.Players.ContainsKey(name))
+                        {
+                            pos = MultiPlayer.MPManager.OnlineTrains.Players[name].Train.Cars[0].WorldPosition;
+                        }
+                        else if (MultiPlayer.MPManager.Instance().lostPlayer.ContainsKey(name))
+                        {
+                            pos = MultiPlayer.MPManager.Instance().lostPlayer[name].Train.Cars[0].WorldPosition;
+                        }
+                        hasSelectedTrain = true;
+                    }
+                    catch { }
+                }
+                if (hasSelectedTrain == false && PickedTrain != null && PickedTrain.Cars != null && PickedTrain.Cars.Count > 0)
+                {
+                    pos = PickedTrain.Cars[0].WorldPosition;
+                }
+                var ploc = new PointF(pos.TileX * 2048 + pos.Location.X, pos.TileZ * 2048 + pos.Location.Z);
+                ViewWindow.X = ploc.X - minX - ViewWindow.Width / 2; ViewWindow.Y = ploc.Y - minY - ViewWindow.Width / 2;
+                firstShow = false;
+            }
+
+            try
+            {
+                CheckAvatar();
+            }
+            catch { } //errors for avatar, just ignore
+            using (Graphics g = Graphics.FromImage(pictureBox1.Image))
+            {
+                subX = minX + ViewWindow.X; subY = minY + ViewWindow.Y;
+                g.Clear(Color.White);
+
+                xScale = pictureBox1.Width / ViewWindow.Width;
+                yScale = pictureBox1.Height / ViewWindow.Height;
+
+                PointF[] points = new PointF[3];
+                Pen p = grayPen;
+
+                p.Width = (int)xScale;
+                if (p.Width < 1) p.Width = 1;
+                else if (p.Width > 3) p.Width = 3;
+                greenPen.Width = orangePen.Width = redPen.Width = p.Width; pathPen.Width = 2 * p.Width;
+                trainPen.Width = p.Width * 6;
+                var forwardDist = 100 / xScale; if (forwardDist < 5) forwardDist = 5;
+                //if (xScale > 3) p.Width = 3f;
+                //else if (xScale > 2) p.Width = 2f;
+                //else p.Width = 1f;
+                PointF scaledA = new PointF(0, 0);
+                PointF scaledB = new PointF(0, 0);
+                PointF scaledC = new PointF(0, 0);
+
+                foreach (var line in segments)
+                {
+
+                    scaledA.X = (line.A.TileX * 2048 - subX + (float)line.A.X) * xScale; scaledA.Y = pictureBox1.Height - (line.A.TileZ * 2048 - subY + (float)line.A.Z) * yScale;
+                    scaledB.X = (line.B.TileX * 2048 - subX + (float)line.B.X) * xScale; scaledB.Y = pictureBox1.Height - (line.B.TileZ * 2048 - subY + (float)line.B.Z) * yScale;
+
+
+                    if ((scaledA.X < 0 && scaledB.X < 0) || (scaledA.X > IM_Width && scaledB.X > IM_Width) || (scaledA.Y > IM_Height && scaledB.Y > IM_Height) || (scaledA.Y < 0 && scaledB.Y < 0)) continue;
+
+
+                    //if (highlightTrackSections.Checked)
+                    //{
+                    //   if (line.Section != null && line.Section.InterlockingTrack == trackSections.SelectedValue)
+                    //   {
+                    //      p.Width = 5f;
+                    //   }
+                    //}
+
+                    if (line.isCurved == true)
+                    {
+                        scaledC.X = ((float)line.C.X - subX) * xScale; scaledC.Y = pictureBox1.Height - ((float)line.C.Z - subY) * yScale;
+                        points[0] = scaledA; points[1] = scaledC; points[2] = scaledB;
+                        g.DrawCurve(p, points);
+                    }
+                    else g.DrawLine(p, scaledA, scaledB);
+
+                    /*if (line.MySection != null)
+                    {
+                        g.DrawString(""+line.MySection.StartElev+" "+line.MySection.EndElev, sidingFont, sidingBrush, scaledB);
+                    }*/
+                }
+
+                switchItemsDrawn.Clear();
+                signalItemsDrawn.Clear();
+                float x, y;
+                PointF scaledItem = new PointF(0f, 0f);
+                var width = 6f * p.Width; if (width > 15) width = 15;//not to make it too large
+                for (var i = 0; i < switches.Count; i++)
+                {
+                    SwitchWidget sw = switches[i];
+
+                    x = (sw.Location.X - subX) * xScale; y = pictureBox1.Height - (sw.Location.Y - subY) * yScale;
+
+                    if (x < 0 || x > IM_Width || y > IM_Height || y < 0) continue;
+
+                    scaledItem.X = x; scaledItem.Y = y;
+
+
+                    if (sw.Item.TrJunctionNode.SelectedRoute == sw.main) g.FillEllipse(Brushes.Black, GetRect(scaledItem, width));
+                    else g.FillEllipse(Brushes.Gray, GetRect(scaledItem, width));
+
+                    //g.DrawString("" + sw.Item.TrJunctionNode.SelectedRoute, trainFont, trainBrush, scaledItem);
+
+                    sw.Location2D.X = scaledItem.X; sw.Location2D.Y = scaledItem.Y;
 #if false
 				 if (sw.main == sw.Item.TrJunctionNode.SelectedRoute)
 				 {
@@ -725,186 +727,186 @@ namespace Orts.Viewer3D.Debugging
 
 				 }
 #endif
-				 switchItemsDrawn.Add(sw);
-			 }
+                    switchItemsDrawn.Add(sw);
+                }
 
-			 foreach (var s in signals)
-			 {
-                 if (float.IsNaN(s.Location.X) || float.IsNaN(s.Location.Y)) continue;
-				 x = (s.Location.X - subX) * xScale; y = pictureBox1.Height - (s.Location.Y - subY) * yScale;
-				 if (x < 0 || x > IM_Width || y > IM_Height || y < 0) continue;
-				 scaledItem.X = x; scaledItem.Y = y;
-				 s.Location2D.X = scaledItem.X; s.Location2D.Y = scaledItem.Y;
-				 if (s.Signal.isSignalNormal())//only show nor
-				 {
-					 var color = Brushes.Green;
-					 var pen = greenPen;
-					 if (s.IsProceed == 0)
-					 {
-					 }
-					 else if (s.IsProceed == 1)
-					 {
-						 color = Brushes.Orange;
-						 pen = orangePen;
-					 }
-					 else
-					 {
-						 color = Brushes.Red;
-						 pen = redPen;
-					 }
-					 g.FillEllipse(color, GetRect(scaledItem, width));
-					 //if (s.Signal.enabledTrain != null) g.DrawString(""+s.Signal.enabledTrain.Train.Number, trainFont, Brushes.Black, scaledItem);
-					 signalItemsDrawn.Add(s);
-					 if (s.hasDir)
-					 {
-						 scaledB.X = (s.Dir.X - subX) * xScale; scaledB.Y = pictureBox1.Height - (s.Dir.Y - subY) * yScale;
-						 g.DrawLine(pen, scaledItem, scaledB);
-					 }
-				 }
-			 }
+                foreach (var s in signals)
+                {
+                    if (float.IsNaN(s.Location.X) || float.IsNaN(s.Location.Y)) continue;
+                    x = (s.Location.X - subX) * xScale; y = pictureBox1.Height - (s.Location.Y - subY) * yScale;
+                    if (x < 0 || x > IM_Width || y > IM_Height || y < 0) continue;
+                    scaledItem.X = x; scaledItem.Y = y;
+                    s.Location2D.X = scaledItem.X; s.Location2D.Y = scaledItem.Y;
+                    if (s.Signal.isSignalNormal())//only show nor
+                    {
+                        var color = Brushes.Green;
+                        var pen = greenPen;
+                        if (s.IsProceed == 0)
+                        {
+                        }
+                        else if (s.IsProceed == 1)
+                        {
+                            color = Brushes.Orange;
+                            pen = orangePen;
+                        }
+                        else
+                        {
+                            color = Brushes.Red;
+                            pen = redPen;
+                        }
+                        g.FillEllipse(color, GetRect(scaledItem, width));
+                        //if (s.Signal.enabledTrain != null) g.DrawString(""+s.Signal.enabledTrain.Train.Number, trainFont, Brushes.Black, scaledItem);
+                        signalItemsDrawn.Add(s);
+                        if (s.hasDir)
+                        {
+                            scaledB.X = (s.Dir.X - subX) * xScale; scaledB.Y = pictureBox1.Height - (s.Dir.Y - subY) * yScale;
+                            g.DrawLine(pen, scaledItem, scaledB);
+                        }
+                    }
+                }
 
-            if (true/*showPlayerTrain.Checked*/)
-            {
+                if (true/*showPlayerTrain.Checked*/)
+                {
 
-				CleanVerticalCells();//clean the drawing area for text of sidings
-				foreach (var s in sidings)
-				{
-					scaledItem.X = (s.Location.X - subX) * xScale;
-					scaledItem.Y = DetermineSidingLocation(scaledItem.X, pictureBox1.Height - (s.Location.Y - subY) * yScale, s.Name);
-					if (scaledItem.Y >= 0f) //if we need to draw the siding names
-					{
+                    CleanVerticalCells();//clean the drawing area for text of sidings
+                    foreach (var s in sidings)
+                    {
+                        scaledItem.X = (s.Location.X - subX) * xScale;
+                        scaledItem.Y = DetermineSidingLocation(scaledItem.X, pictureBox1.Height - (s.Location.Y - subY) * yScale, s.Name);
+                        if (scaledItem.Y >= 0f) //if we need to draw the siding names
+                        {
 
-						g.DrawString(s.Name, sidingFont, sidingBrush, scaledItem);
-					}
-				}
-				var margin = 30 * xScale;//margins to determine if we want to draw a train
-				var margin2 = 5000 * xScale;
+                            g.DrawString(s.Name, sidingFont, sidingBrush, scaledItem);
+                        }
+                    }
+                    var margin = 30 * xScale;//margins to determine if we want to draw a train
+                    var margin2 = 5000 * xScale;
 
-				//variable for drawing train path
-				var mDist = 5000f; var pDist = 50; //segment length when draw path
+                    //variable for drawing train path
+                    var mDist = 5000f; var pDist = 50; //segment length when draw path
 
-				selectedTrainList.Clear();
-				foreach (var t in simulator.Trains) selectedTrainList.Add(t);
+                    selectedTrainList.Clear();
+                    foreach (var t in simulator.Trains) selectedTrainList.Add(t);
 
-				var redTrain = selectedTrainList.Count;
+                    var redTrain = selectedTrainList.Count;
 
-				//choosen trains will be drawn later using blue, so it will overlap on the red lines
-				var chosen = AvatarView.SelectedItems;
-				if (chosen.Count > 0)
-				{
-					for (var i = 0; i < chosen.Count; i++)
-					{
-						var name = chosen[i].Text.Split(' ')[0].Trim(); //filter out (H) in the text
-						var train = MultiPlayer.MPManager.OnlineTrains.findTrain(name);
-						if (train != null) { selectedTrainList.Remove(train); selectedTrainList.Add(train); redTrain--; }
-						//if selected include myself, will show it as blue
-						if (MultiPlayer.MPManager.GetUserName() == name && Program.Simulator.PlayerLocomotive != null)
-						{
-							selectedTrainList.Remove(Program.Simulator.PlayerLocomotive.Train); selectedTrainList.Add(Program.Simulator.PlayerLocomotive.Train);
-							redTrain--;
-						}
+                    //choosen trains will be drawn later using blue, so it will overlap on the red lines
+                    var chosen = AvatarView.SelectedItems;
+                    if (chosen.Count > 0)
+                    {
+                        for (var i = 0; i < chosen.Count; i++)
+                        {
+                            var name = chosen[i].Text.Split(' ')[0].Trim(); //filter out (H) in the text
+                            var train = MultiPlayer.MPManager.OnlineTrains.findTrain(name);
+                            if (train != null) { selectedTrainList.Remove(train); selectedTrainList.Add(train); redTrain--; }
+                            //if selected include myself, will show it as blue
+                            if (MultiPlayer.MPManager.GetUserName() == name && Program.Simulator.PlayerLocomotive != null)
+                            {
+                                selectedTrainList.Remove(Program.Simulator.PlayerLocomotive.Train); selectedTrainList.Add(Program.Simulator.PlayerLocomotive.Train);
+                                redTrain--;
+                            }
 
-					}
-				}
+                        }
+                    }
 
-				//trains selected in the avatar view list will be drawn in blue, others will be drawn in red
-				pathPen.Color = Color.Red;
-				var drawRed = 0;
-				int ValidTrain = selectedTrainList.Count();
-				//add trains quit into the end, will draw them in gray
-				try
-				{
-					foreach (var lost in MultiPlayer.MPManager.Instance().lostPlayer)
-					{
-						if (lost.Value.Train != null && !selectedTrainList.Contains(lost.Value.Train)) selectedTrainList.Add(lost.Value.Train);
-					}
-				}
-				catch { }
-				foreach (Train t in selectedTrainList)
-				{
-					drawRed++;//how many red has been drawn
-					if (drawRed > redTrain) pathPen.Color = Color.Blue; //more than the red should be drawn, thus draw in blue
+                    //trains selected in the avatar view list will be drawn in blue, others will be drawn in red
+                    pathPen.Color = Color.Red;
+                    var drawRed = 0;
+                    int ValidTrain = selectedTrainList.Count();
+                    //add trains quit into the end, will draw them in gray
+                    try
+                    {
+                        foreach (var lost in MultiPlayer.MPManager.Instance().lostPlayer)
+                        {
+                            if (lost.Value.Train != null && !selectedTrainList.Contains(lost.Value.Train)) selectedTrainList.Add(lost.Value.Train);
+                        }
+                    }
+                    catch { }
+                    foreach (Train t in selectedTrainList)
+                    {
+                        drawRed++;//how many red has been drawn
+                        if (drawRed > redTrain) pathPen.Color = Color.Blue; //more than the red should be drawn, thus draw in blue
 
-					name = "";
-					TrainCar firstCar = null;
-					if (t.LeadLocomotive != null)
-					{
-						worldPos = t.LeadLocomotive.WorldPosition;
-						name = t.GetTrainName(t.LeadLocomotive.CarID);
-						firstCar = t.LeadLocomotive;
-					}
-					else if (t.Cars != null && t.Cars.Count > 0)
-					{
-						worldPos = t.Cars[0].WorldPosition;
-						name = t.GetTrainName(t.Cars[0].CarID);
-						if (t.TrainType == Train.TRAINTYPE.AI)
-							name = t.Number.ToString() + ":" +t.Name;
-						firstCar = t.Cars[0];
-					}
-					else continue;
+                        name = "";
+                        TrainCar firstCar = null;
+                        if (t.LeadLocomotive != null)
+                        {
+                            worldPos = t.LeadLocomotive.WorldPosition;
+                            name = t.GetTrainName(t.LeadLocomotive.CarID);
+                            firstCar = t.LeadLocomotive;
+                        }
+                        else if (t.Cars != null && t.Cars.Count > 0)
+                        {
+                            worldPos = t.Cars[0].WorldPosition;
+                            name = t.GetTrainName(t.Cars[0].CarID);
+                            if (t.TrainType == Train.TRAINTYPE.AI)
+                                name = t.Number.ToString() + ":" + t.Name;
+                            firstCar = t.Cars[0];
+                        }
+                        else continue;
 
-					if (xScale < 0.3 || t.FrontTDBTraveller == null || t.RearTDBTraveller == null)
-					{
-						worldPos = firstCar.WorldPosition;
-						scaledItem.X = (worldPos.TileX * 2048 -subX + worldPos.Location.X) * xScale; 
-						scaledItem.Y = pictureBox1.Height - (worldPos.TileZ * 2048 - subY + worldPos.Location.Z) * yScale;
-						if (scaledItem.X < -margin2 || scaledItem.X > IM_Width + margin2 || scaledItem.Y > IM_Height + margin2 || scaledItem.Y < -margin2) continue;
-						if (drawRed > ValidTrain) g.FillRectangle(Brushes.Gray, GetRect(scaledItem, 15f));
-						else
-						{
-							if (t == PickedTrain) g.FillRectangle(Brushes.Red, GetRect(scaledItem, 15f));
-							else g.FillRectangle(Brushes.DarkGreen, GetRect(scaledItem, 15f));
-							scaledItem.Y -= 25;
-							DrawTrainPath(t, subX, subY, pathPen, g, scaledA, scaledB, pDist, mDist);
-						}
-						g.DrawString(name, trainFont, trainBrush, scaledItem);
-						continue;
-					}
-					var loc = t.FrontTDBTraveller.WorldLocation;
-					x = (loc.TileX * 2048 + loc.Location.X - subX) * xScale; y = pictureBox1.Height - (loc.TileZ * 2048 + loc.Location.Z - subY) * yScale;
-					if (x < -margin2 || x > IM_Width + margin2 || y > IM_Height + margin2 || y < -margin2) continue;
-					
-					//train quit will not draw path, others will draw it
-					if (drawRed <= ValidTrain) DrawTrainPath(t, subX, subY, pathPen, g, scaledA, scaledB, pDist, mDist);
-					
-					trainPen.Color = Color.DarkGreen;
-					foreach (var car in t.Cars)
-					{
-						Traveller t1 = new Traveller(t.RearTDBTraveller);
-						worldPos = car.WorldPosition;
-						var dist = t1.DistanceTo(worldPos.WorldLocation.TileX, worldPos.WorldLocation.TileZ, worldPos.WorldLocation.Location.X, worldPos.WorldLocation.Location.Y, worldPos.WorldLocation.Location.Z);
-						if (dist > 0)
-						{
-							t1.Move(dist - 1 + car.CarLengthM / 2);
-							x = (t1.TileX * 2048 + t1.Location.X - subX) * xScale; y = pictureBox1.Height - (t1.TileZ * 2048 + t1.Location.Z - subY) * yScale;
-							//x = (worldPos.TileX * 2048 + worldPos.Location.X - minX - ViewWindow.X) * xScale; y = pictureBox1.Height - (worldPos.TileZ * 2048 + worldPos.Location.Z - minY - ViewWindow.Y) * yScale;
-							if (x < -margin || x > IM_Width + margin || y > IM_Height + margin || y < -margin) continue;
+                        if (xScale < 0.3 || t.FrontTDBTraveller == null || t.RearTDBTraveller == null)
+                        {
+                            worldPos = firstCar.WorldPosition;
+                            scaledItem.X = (worldPos.TileX * 2048 - subX + worldPos.Location.X) * xScale;
+                            scaledItem.Y = pictureBox1.Height - (worldPos.TileZ * 2048 - subY + worldPos.Location.Z) * yScale;
+                            if (scaledItem.X < -margin2 || scaledItem.X > IM_Width + margin2 || scaledItem.Y > IM_Height + margin2 || scaledItem.Y < -margin2) continue;
+                            if (drawRed > ValidTrain) g.FillRectangle(Brushes.Gray, GetRect(scaledItem, 15f));
+                            else
+                            {
+                                if (t == PickedTrain) g.FillRectangle(Brushes.Red, GetRect(scaledItem, 15f));
+                                else g.FillRectangle(Brushes.DarkGreen, GetRect(scaledItem, 15f));
+                                scaledItem.Y -= 25;
+                                DrawTrainPath(t, subX, subY, pathPen, g, scaledA, scaledB, pDist, mDist);
+                            }
+                            g.DrawString(name, trainFont, trainBrush, scaledItem);
+                            continue;
+                        }
+                        var loc = t.FrontTDBTraveller.WorldLocation;
+                        x = (loc.TileX * 2048 + loc.Location.X - subX) * xScale; y = pictureBox1.Height - (loc.TileZ * 2048 + loc.Location.Z - subY) * yScale;
+                        if (x < -margin2 || x > IM_Width + margin2 || y > IM_Height + margin2 || y < -margin2) continue;
 
-							scaledItem.X = x; scaledItem.Y = y;
+                        //train quit will not draw path, others will draw it
+                        if (drawRed <= ValidTrain) DrawTrainPath(t, subX, subY, pathPen, g, scaledA, scaledB, pDist, mDist);
 
-							t1.Move(-car.CarLengthM);
-							x = (t1.TileX * 2048 + t1.Location.X - subX) * xScale; y = pictureBox1.Height - (t1.TileZ * 2048 + t1.Location.Z - subY) * yScale;
-							if (x < -margin || x > IM_Width + margin || y > IM_Height + margin || y < -margin) continue;
+                        trainPen.Color = Color.DarkGreen;
+                        foreach (var car in t.Cars)
+                        {
+                            Traveller t1 = new Traveller(t.RearTDBTraveller);
+                            worldPos = car.WorldPosition;
+                            var dist = t1.DistanceTo(worldPos.WorldLocation.TileX, worldPos.WorldLocation.TileZ, worldPos.WorldLocation.Location.X, worldPos.WorldLocation.Location.Y, worldPos.WorldLocation.Location.Z);
+                            if (dist > 0)
+                            {
+                                t1.Move(dist - 1 + car.CarLengthM / 2);
+                                x = (t1.TileX * 2048 + t1.Location.X - subX) * xScale; y = pictureBox1.Height - (t1.TileZ * 2048 + t1.Location.Z - subY) * yScale;
+                                //x = (worldPos.TileX * 2048 + worldPos.Location.X - minX - ViewWindow.X) * xScale; y = pictureBox1.Height - (worldPos.TileZ * 2048 + worldPos.Location.Z - minY - ViewWindow.Y) * yScale;
+                                if (x < -margin || x > IM_Width + margin || y > IM_Height + margin || y < -margin) continue;
 
-							scaledA.X = x; scaledA.Y = y;
-							
-							//if the train has quit, will draw in gray, if the train is selected by left click of the mouse, will draw it in red
-							if (drawRed > ValidTrain) trainPen.Color = Color.Gray;
-							else if (t == PickedTrain) trainPen.Color = Color.Red;
-							g.DrawLine(trainPen, scaledA, scaledItem);
-							
-							//g.FillEllipse(Brushes.DarkGreen, GetRect(scaledItem, car.Length * xScale));
-						}
-					}
-					worldPos = firstCar.WorldPosition;
-					scaledItem.X = (worldPos.TileX * 2048 -subX + worldPos.Location.X) * xScale; 
-					scaledItem.Y = -25 + pictureBox1.Height - (worldPos.TileZ * 2048 - subY + worldPos.Location.Z) * yScale;
+                                scaledItem.X = x; scaledItem.Y = y;
 
-					g.DrawString(name, trainFont, trainBrush, scaledItem);
+                                t1.Move(-car.CarLengthM);
+                                x = (t1.TileX * 2048 + t1.Location.X - subX) * xScale; y = pictureBox1.Height - (t1.TileZ * 2048 + t1.Location.Z - subY) * yScale;
+                                if (x < -margin || x > IM_Width + margin || y > IM_Height + margin || y < -margin) continue;
 
-				}
-				if (switchPickedItemHandled) switchPickedItem = null;
-				if (signalPickedItemHandled) signalPickedItem = null;
+                                scaledA.X = x; scaledA.Y = y;
+
+                                //if the train has quit, will draw in gray, if the train is selected by left click of the mouse, will draw it in red
+                                if (drawRed > ValidTrain) trainPen.Color = Color.Gray;
+                                else if (t == PickedTrain) trainPen.Color = Color.Red;
+                                g.DrawLine(trainPen, scaledA, scaledItem);
+
+                                //g.FillEllipse(Brushes.DarkGreen, GetRect(scaledItem, car.Length * xScale));
+                            }
+                        }
+                        worldPos = firstCar.WorldPosition;
+                        scaledItem.X = (worldPos.TileX * 2048 - subX + worldPos.Location.X) * xScale;
+                        scaledItem.Y = -25 + pictureBox1.Height - (worldPos.TileZ * 2048 - subY + worldPos.Location.Z) * yScale;
+
+                        g.DrawString(name, trainFont, trainBrush, scaledItem);
+
+                    }
+                    if (switchPickedItemHandled) switchPickedItem = null;
+                    if (signalPickedItemHandled) signalPickedItem = null;
 
 #if false
 				if (switchPickedItem != null /*&& switchPickedItemChanged == true*/ && !switchPickedItemHandled && simulator.GameTime - switchPickedTime < 5)
@@ -940,86 +942,86 @@ namespace Orts.Viewer3D.Debugging
 					}
 				}
 #endif
-			}
+                }
 
-         }
+            }
 
-         pictureBox1.Invalidate();
-      }
+            pictureBox1.Invalidate();
+        }
 
-	  private Vector2[][] alignedTextY;
-	  private int[] alignedTextNum;
-	  private int spacing = 12;
-	  private void CleanVerticalCells()
-	  {
-		  if (alignedTextY == null || alignedTextY.Length != IM_Height / spacing) //first time to put text, or the text height has changed
-		  {
-			  alignedTextY = new Vector2[IM_Height/spacing][];
-			  alignedTextNum = new int[IM_Height/spacing];
-			  for (var i = 0; i < IM_Height / spacing; i++) alignedTextY[i] = new Vector2[4]; //each line has at most 4 sidings
-		  }
-		  for (var i = 0; i < IM_Height / spacing; i++) { alignedTextNum[i] = 0; }
+        private Vector2[][] alignedTextY;
+        private int[] alignedTextNum;
+        private int spacing = 12;
+        private void CleanVerticalCells()
+        {
+            if (alignedTextY == null || alignedTextY.Length != IM_Height / spacing) //first time to put text, or the text height has changed
+            {
+                alignedTextY = new Vector2[IM_Height / spacing][];
+                alignedTextNum = new int[IM_Height / spacing];
+                for (var i = 0; i < IM_Height / spacing; i++) alignedTextY[i] = new Vector2[4]; //each line has at most 4 sidings
+            }
+            for (var i = 0; i < IM_Height / spacing; i++) { alignedTextNum[i] = 0; }
 
-	  }
-	  private float DetermineSidingLocation(float startX, float wantY, string name)
-	  {
-		  //out of drawing area
-		  if (startX < -64 || startX > IM_Width || wantY < -spacing || wantY > IM_Height) return -1f;
+        }
+        private float DetermineSidingLocation(float startX, float wantY, string name)
+        {
+            //out of drawing area
+            if (startX < -64 || startX > IM_Width || wantY < -spacing || wantY > IM_Height) return -1f;
 
-		  int position = (int)(wantY / spacing);//the cell of the text it wants in
-		  if (position > alignedTextY.Length) return wantY;//position is larger than the number of cells
-		  var endX = startX + name.Length*trainFont.Size;
-		  int desiredPosition = position;
-		  while (position < alignedTextY.Length && position >= 0)
-		  {
-			  //if the line contains no text yet, put it there
-			  if (alignedTextNum[position] == 0)
-			  {
-				  alignedTextY[position][alignedTextNum[position]].X = startX;
-				  alignedTextY[position][alignedTextNum[position]].Y = endX;//add info for the text (i.e. start and end location)
-				  alignedTextNum[position]++;
-				  return position * spacing;
-			  }
+            int position = (int)(wantY / spacing);//the cell of the text it wants in
+            if (position > alignedTextY.Length) return wantY;//position is larger than the number of cells
+            var endX = startX + name.Length * trainFont.Size;
+            int desiredPosition = position;
+            while (position < alignedTextY.Length && position >= 0)
+            {
+                //if the line contains no text yet, put it there
+                if (alignedTextNum[position] == 0)
+                {
+                    alignedTextY[position][alignedTextNum[position]].X = startX;
+                    alignedTextY[position][alignedTextNum[position]].Y = endX;//add info for the text (i.e. start and end location)
+                    alignedTextNum[position]++;
+                    return position * spacing;
+                }
 
-			  bool conflict = false;
-			  //check if it is intersect any one in the cell
-			  foreach (Vector2 v in alignedTextY[position])
-			  {
-				  //check conflict with a text, v.x is the start of the text, v.y is the end of the text
-				  if ((startX > v.X && startX < v.Y) || (endX > v.X && endX < v.Y) || (v.X > startX && v.X < endX) || (v.Y > startX && v.Y < endX))
-				  {
-					  conflict = true;
-					  break;
-				  }
-			  }
-			  if (conflict == false) //no conflict
-			  {
-				  if (alignedTextNum[position] >= alignedTextY[position].Length) return -1f;
-				  alignedTextY[position][alignedTextNum[position]].X = startX;
-				  alignedTextY[position][alignedTextNum[position]].Y = endX;//add info for the text (i.e. start and end location)
-				  alignedTextNum[position]++;
-				  return position * spacing;
-			  }
-			  position--;
-			  //cannot move up, then try to move it down
-			  if (position - desiredPosition < -1)
-			  {
-				  position = desiredPosition + 2;
-			  }
-			  //could not find any position up or down, just return negative
-			  if (position == desiredPosition) return -1f;
-		  }
-		  return position * spacing;
-	  }
-	  
-	    const float SignalErrorDistance = 100;
+                bool conflict = false;
+                //check if it is intersect any one in the cell
+                foreach (Vector2 v in alignedTextY[position])
+                {
+                    //check conflict with a text, v.x is the start of the text, v.y is the end of the text
+                    if ((startX > v.X && startX < v.Y) || (endX > v.X && endX < v.Y) || (v.X > startX && v.X < endX) || (v.Y > startX && v.Y < endX))
+                    {
+                        conflict = true;
+                        break;
+                    }
+                }
+                if (conflict == false) //no conflict
+                {
+                    if (alignedTextNum[position] >= alignedTextY[position].Length) return -1f;
+                    alignedTextY[position][alignedTextNum[position]].X = startX;
+                    alignedTextY[position][alignedTextNum[position]].Y = endX;//add info for the text (i.e. start and end location)
+                    alignedTextNum[position]++;
+                    return position * spacing;
+                }
+                position--;
+                //cannot move up, then try to move it down
+                if (position - desiredPosition < -1)
+                {
+                    position = desiredPosition + 2;
+                }
+                //could not find any position up or down, just return negative
+                if (position == desiredPosition) return -1f;
+            }
+            return position * spacing;
+        }
+
+        const float SignalErrorDistance = 100;
         const float SignalWarningDistance = 500;
         const float DisplayDistance = 1000;
         const float DisplaySegmentLength = 10;
         const float MaximumSectionDistance = 10000;
 
-	  Dictionary<int, SignallingDebugWindow.TrackSectionCacheEntry> Cache = new Dictionary<int, SignallingDebugWindow.TrackSectionCacheEntry>();
-	  SignallingDebugWindow.TrackSectionCacheEntry GetCacheEntry(Traveller position)
+        Dictionary<int, SignallingDebugWindow.TrackSectionCacheEntry> Cache = new Dictionary<int, SignallingDebugWindow.TrackSectionCacheEntry>();
+        SignallingDebugWindow.TrackSectionCacheEntry GetCacheEntry(Traveller position)
         {
             SignallingDebugWindow.TrackSectionCacheEntry rv;
             if (Cache.TryGetValue(position.TrackNodeIndex, out rv) && (rv.Direction == position.Direction))
@@ -1052,417 +1054,417 @@ namespace Orts.Viewer3D.Debugging
             return rv;
         }
 
-	   //draw the train path if it is within the window
-		public void DrawTrainPath(Train train, float subX, float subY, Pen pathPen, Graphics g, PointF scaledA, PointF scaledB, float stepDist, float MaximumSectionDistance)
-		{
-			if (DrawPath != true) return;
-			bool ok = false;
-			if (train == Program.Simulator.PlayerLocomotive.Train) ok = true;
-			if (MultiPlayer.MPManager.IsMultiPlayer())
-			{
-				if (MultiPlayer.MPManager.OnlineTrains.findTrain(train)) ok = true;
-			}
-			if (train.FirstCar != null & train.FirstCar.CarID.Contains("AI")) ok = true; //AI train
-			if (Math.Abs(train.SpeedMpS) > 0.001) ok = true;
-			if (ok == false) return;
-
-			var DisplayDistance = MaximumSectionDistance;
-			var position = train.MUDirection != Direction.Reverse ? new Traveller(train.FrontTDBTraveller) : new Traveller(train.RearTDBTraveller, Traveller.TravellerDirection.Backward);
-			var caches = new List<SignallingDebugWindow.TrackSectionCacheEntry>();
-			// Work backwards until we end up on a different track section.
-			var cacheNode = new Traveller(position);
-			cacheNode.ReverseDirection();
-			var initialNodeOffsetCount = 0;
-			while (cacheNode.TrackNodeIndex == position.TrackNodeIndex && cacheNode.NextSection())
-				initialNodeOffsetCount++;
-			// Now do it again, but don't go the last track section (because it is from a different track node).
-			cacheNode = new Traveller(position);
-			cacheNode.ReverseDirection();
-			for (var i = 1; i < initialNodeOffsetCount; i++)
-				cacheNode.NextSection();
-			// Push the location right up to the end of the section.
-			cacheNode.MoveInSection(MaximumSectionDistance);
-			// Now back facing the right way, calculate the distance to the train location.
-			cacheNode.ReverseDirection();
-			var initialNodeOffset = cacheNode.DistanceTo(position.TileX, position.TileZ, position.X, position.Y, position.Z);
-			// Go and collect all the cache entries for the visible range of vector nodes (straights, curves).
-			var totalDistance = 0f;
-			while (!cacheNode.IsEnd && totalDistance - initialNodeOffset < DisplayDistance)
-			{
-				if (cacheNode.IsTrack)
-				{
-					var cache = GetCacheEntry(cacheNode);
-					cache.Age = 0;
-					caches.Add(cache);
-					totalDistance += cache.Length;
-				}
-				var nodeIndex = cacheNode.TrackNodeIndex;
-				while (cacheNode.TrackNodeIndex == nodeIndex && cacheNode.NextSection()) ;
-			}
-
-			var switchErrorDistance = initialNodeOffset + DisplayDistance + SignalWarningDistance;
-			var signalErrorDistance = initialNodeOffset + DisplayDistance + SignalWarningDistance;
-			var currentDistance = 0f;
-			foreach (var cache in caches)
-			{
-				foreach (var obj in cache.Objects)
-				{
-					var objDistance = currentDistance + obj.Distance;
-					if (objDistance < initialNodeOffset)
-						continue;
-
-					var switchObj = obj as SignallingDebugWindow.TrackSectionSwitch;
-					if (switchObj != null)
-					{
-						for (var pin = switchObj.TrackNode.Inpins; pin < switchObj.TrackNode.Inpins + switchObj.TrackNode.Outpins; pin++)
-						{
-							if (switchObj.TrackNode.TrPins[pin].Link == switchObj.NodeIndex)
-							{
-								if (pin - switchObj.TrackNode.Inpins != switchObj.TrackNode.TrJunctionNode.SelectedRoute)
-									switchErrorDistance = objDistance;
-								break;
-							}
-						}
-						if (switchErrorDistance < DisplayDistance)
-							break;
-					}
-
-				}
-				if (switchErrorDistance < DisplayDistance || signalErrorDistance < DisplayDistance)
-					break;
-				currentDistance += cache.Length;
-			}
-
-			var currentPosition = new Traveller(position);
-			currentPosition.Move(-initialNodeOffset);
-			currentDistance = 0;
-
-			foreach (var cache in caches)
-			{
-				var lastObjDistance = 0f;
-				foreach (var obj in cache.Objects)
-				{
-					var objDistance = currentDistance + obj.Distance;
-
-					for (var step = lastObjDistance; step < obj.Distance; step += DisplaySegmentLength)
-					{
-						var stepDistance = currentDistance + step;
-						var stepLength = DisplaySegmentLength > obj.Distance - step ? obj.Distance - step : DisplaySegmentLength;
-						var previousLocation = currentPosition.WorldLocation;
-						currentPosition.Move(stepLength);
-						if (stepDistance + stepLength >= initialNodeOffset && stepDistance <= initialNodeOffset + DisplayDistance)
-						{
-							var currentLocation = currentPosition.WorldLocation;
-							scaledA.X = (previousLocation.TileX * 2048 + previousLocation.Location.X - subX) * xScale; scaledA.Y = pictureBox1.Height - (previousLocation.TileZ * 2048 + previousLocation.Location.Z - subY) * yScale;
-							scaledB.X = (currentLocation.TileX * 2048 + currentLocation.Location.X - subX) * xScale; scaledB.Y = pictureBox1.Height - (currentPosition.TileZ * 2048 + currentPosition.Location.Z - subY) * yScale;
-							g.DrawLine(pathPen, scaledA, scaledB);
-						}
-					}
-					lastObjDistance = obj.Distance;
-
-					if (objDistance >= switchErrorDistance)
-						break;
-				}
-				currentDistance += cache.Length;
-				if (currentDistance >= switchErrorDistance)
-					break;
-
-			}
-
-			currentPosition = new Traveller(position);
-			currentPosition.Move(-initialNodeOffset);
-			currentDistance = 0;
-			foreach (var cache in caches)
-			{
-				var lastObjDistance = 0f;
-				foreach (var obj in cache.Objects)
-				{
-					currentPosition.Move(obj.Distance - lastObjDistance);
-					lastObjDistance = obj.Distance;
-
-					var objDistance = currentDistance + obj.Distance;
-					if (objDistance < initialNodeOffset || objDistance > initialNodeOffset + DisplayDistance)
-						continue;
-
-					var switchObj = obj as SignallingDebugWindow.TrackSectionSwitch;
-					if (switchObj != null)
-					{
-						for (var pin = switchObj.TrackNode.Inpins; pin < switchObj.TrackNode.Inpins + switchObj.TrackNode.Outpins; pin++)
-						{
-							if (switchObj.TrackNode.TrPins[pin].Link == switchObj.NodeIndex && pin - switchObj.TrackNode.Inpins != switchObj.TrackNode.TrJunctionNode.SelectedRoute)
-							{
-								foreach (var sw in switchItemsDrawn)
-								{
-									if (sw.Item.TrJunctionNode == switchObj.TrackNode.TrJunctionNode)
-									{
-										var r = 6 * greenPen.Width;
-										g.DrawLine(pathPen, new PointF(sw.Location2D.X - r, sw.Location2D.Y - r), new PointF(sw.Location2D.X + r, sw.Location2D.Y + r));
-										g.DrawLine(pathPen, new PointF(sw.Location2D.X - r, sw.Location2D.Y + r), new PointF(sw.Location2D.X + r, sw.Location2D.Y - r));
-										break;
-									}
-								}
-							}
-						}
-					}
-
-					if (objDistance >= switchErrorDistance)
-						break;
-				}
-				currentDistance += cache.Length;
-				if (currentDistance >= switchErrorDistance)
-					break;
-			}
-			// Clean up any cache entries who haven't been using for 30 seconds.
-			var oldCaches = Cache.Where(kvp => kvp.Value.Age > 30 * 4).ToArray();
-			foreach (var oldCache in oldCaches)
-				Cache.Remove(oldCache.Key);
-
-		}
-	  #endregion
-
-		/// <summary>
-      /// Generates a rectangle representing a dot being drawn.
-      /// </summary>
-      /// <param name="p">Center point of the dot, in pixels.</param>
-      /// <param name="size">Size of the dot's diameter, in pixels</param>
-      /// <returns></returns>
-      static RectangleF GetRect(PointF p, float size)
-      {
-         return new RectangleF(p.X - size / 2f, p.Y - size / 2f, size, size);
-      }
-
-	  /// <summary>
-      /// Generates line segments from an array of TrVectorSection. Also computes 
-      /// the bounds of the entire route being drawn.
-      /// </summary>
-      /// <param name="segments"></param>
-      /// <param name="items"></param>
-      /// <param name="minX"></param>
-      /// <param name="minY"></param>
-      /// <param name="maxX"></param>
-      /// <param name="maxY"></param>
-      /// <param name="simulator"></param>
-      private static void AddSegments(List<LineSegment> segments, TrackNode node, TrVectorSection[] items,  ref float minX, ref float minY, ref float maxX, ref float maxY, Simulator simulator)
-      {
-
-         bool occupied = false;
-
-
-         //if (simulator.InterlockingSystem.Tracks.ContainsKey(node))
-         //{
-         //   occupied = node.InterlockingTrack.IsOccupied;
-         //}
-
-         double tempX1, tempX2, tempZ1, tempZ2;
-
-         for (int i = 0; i < items.Length - 1; i++)
-         {
-			 dVector A = new dVector(items[i].TileX , items[i].X, items[i].TileZ, items[i].Z);
-			 dVector B = new dVector(items[i + 1].TileX, items[i + 1].X, items[i + 1].TileZ, items[i + 1].Z);
-
-             tempX1 = A.TileX * 2048 + A.X; tempX2 = B.TileX * 2048 + B.X;
-             tempZ1 = A.TileZ * 2048 + A.Z; tempZ2 = B.TileZ * 2048 + B.Z; 
-             CalcBounds(ref maxX, tempX1, true);
-            CalcBounds(ref maxY, tempZ1, true);
-            CalcBounds(ref maxX, tempX2, true);
-            CalcBounds(ref maxY, tempZ2, true);
-
-            CalcBounds(ref minX, tempX1, false);
-            CalcBounds(ref minY, tempZ1, false);
-            CalcBounds(ref minX, tempX2, false);
-            CalcBounds(ref minY, tempZ2, false);
-
-            segments.Add(new LineSegment(A, B, occupied, items[i]));
-         }
-      }
-
-      /// <summary>
-      /// Given a value representing a limit, evaluate if the given value exceeds the current limit.
-      /// If so, expand the limit.
-      /// </summary>
-      /// <param name="limit">The current limit.</param>
-      /// <param name="value">The value to compare the limit to.</param>
-      /// <param name="gt">True when comparison is greater-than. False if less-than.</param>
-      private static void CalcBounds(ref float limit, double v, bool gt)
-      {
-		  float value = (float)v;
-         if (gt)
-         {
-            if (value > limit)
+        //draw the train path if it is within the window
+        public void DrawTrainPath(Train train, float subX, float subY, Pen pathPen, Graphics g, PointF scaledA, PointF scaledB, float stepDist, float MaximumSectionDistance)
+        {
+            if (DrawPath != true) return;
+            bool ok = false;
+            if (train == Program.Simulator.PlayerLocomotive.Train) ok = true;
+            if (MultiPlayer.MPManager.IsMultiPlayer())
             {
-               limit = value;
+                if (MultiPlayer.MPManager.OnlineTrains.findTrain(train)) ok = true;
             }
-         }
-         else
-         {
-            if (value < limit)
+            if (train.FirstCar != null & train.FirstCar.CarID.Contains("AI")) ok = true; //AI train
+            if (Math.Abs(train.SpeedMpS) > 0.001) ok = true;
+            if (ok == false) return;
+
+            var DisplayDistance = MaximumSectionDistance;
+            var position = train.MUDirection != Direction.Reverse ? new Traveller(train.FrontTDBTraveller) : new Traveller(train.RearTDBTraveller, Traveller.TravellerDirection.Backward);
+            var caches = new List<SignallingDebugWindow.TrackSectionCacheEntry>();
+            // Work backwards until we end up on a different track section.
+            var cacheNode = new Traveller(position);
+            cacheNode.ReverseDirection();
+            var initialNodeOffsetCount = 0;
+            while (cacheNode.TrackNodeIndex == position.TrackNodeIndex && cacheNode.NextSection())
+                initialNodeOffsetCount++;
+            // Now do it again, but don't go the last track section (because it is from a different track node).
+            cacheNode = new Traveller(position);
+            cacheNode.ReverseDirection();
+            for (var i = 1; i < initialNodeOffsetCount; i++)
+                cacheNode.NextSection();
+            // Push the location right up to the end of the section.
+            cacheNode.MoveInSection(MaximumSectionDistance);
+            // Now back facing the right way, calculate the distance to the train location.
+            cacheNode.ReverseDirection();
+            var initialNodeOffset = cacheNode.DistanceTo(position.TileX, position.TileZ, position.X, position.Y, position.Z);
+            // Go and collect all the cache entries for the visible range of vector nodes (straights, curves).
+            var totalDistance = 0f;
+            while (!cacheNode.IsEnd && totalDistance - initialNodeOffset < DisplayDistance)
             {
-               limit = value;
+                if (cacheNode.IsTrack)
+                {
+                    var cache = GetCacheEntry(cacheNode);
+                    cache.Age = 0;
+                    caches.Add(cache);
+                    totalDistance += cache.Length;
+                }
+                var nodeIndex = cacheNode.TrackNodeIndex;
+                while (cacheNode.TrackNodeIndex == nodeIndex && cacheNode.NextSection()) ;
             }
-         }
-      }
+
+            var switchErrorDistance = initialNodeOffset + DisplayDistance + SignalWarningDistance;
+            var signalErrorDistance = initialNodeOffset + DisplayDistance + SignalWarningDistance;
+            var currentDistance = 0f;
+            foreach (var cache in caches)
+            {
+                foreach (var obj in cache.Objects)
+                {
+                    var objDistance = currentDistance + obj.Distance;
+                    if (objDistance < initialNodeOffset)
+                        continue;
+
+                    var switchObj = obj as SignallingDebugWindow.TrackSectionSwitch;
+                    if (switchObj != null)
+                    {
+                        for (var pin = switchObj.TrackNode.Inpins; pin < switchObj.TrackNode.Inpins + switchObj.TrackNode.Outpins; pin++)
+                        {
+                            if (switchObj.TrackNode.TrPins[pin].Link == switchObj.NodeIndex)
+                            {
+                                if (pin - switchObj.TrackNode.Inpins != switchObj.TrackNode.TrJunctionNode.SelectedRoute)
+                                    switchErrorDistance = objDistance;
+                                break;
+                            }
+                        }
+                        if (switchErrorDistance < DisplayDistance)
+                            break;
+                    }
+
+                }
+                if (switchErrorDistance < DisplayDistance || signalErrorDistance < DisplayDistance)
+                    break;
+                currentDistance += cache.Length;
+            }
+
+            var currentPosition = new Traveller(position);
+            currentPosition.Move(-initialNodeOffset);
+            currentDistance = 0;
+
+            foreach (var cache in caches)
+            {
+                var lastObjDistance = 0f;
+                foreach (var obj in cache.Objects)
+                {
+                    var objDistance = currentDistance + obj.Distance;
+
+                    for (var step = lastObjDistance; step < obj.Distance; step += DisplaySegmentLength)
+                    {
+                        var stepDistance = currentDistance + step;
+                        var stepLength = DisplaySegmentLength > obj.Distance - step ? obj.Distance - step : DisplaySegmentLength;
+                        var previousLocation = currentPosition.WorldLocation;
+                        currentPosition.Move(stepLength);
+                        if (stepDistance + stepLength >= initialNodeOffset && stepDistance <= initialNodeOffset + DisplayDistance)
+                        {
+                            var currentLocation = currentPosition.WorldLocation;
+                            scaledA.X = (previousLocation.TileX * 2048 + previousLocation.Location.X - subX) * xScale; scaledA.Y = pictureBox1.Height - (previousLocation.TileZ * 2048 + previousLocation.Location.Z - subY) * yScale;
+                            scaledB.X = (currentLocation.TileX * 2048 + currentLocation.Location.X - subX) * xScale; scaledB.Y = pictureBox1.Height - (currentPosition.TileZ * 2048 + currentPosition.Location.Z - subY) * yScale;
+                            g.DrawLine(pathPen, scaledA, scaledB);
+                        }
+                    }
+                    lastObjDistance = obj.Distance;
+
+                    if (objDistance >= switchErrorDistance)
+                        break;
+                }
+                currentDistance += cache.Length;
+                if (currentDistance >= switchErrorDistance)
+                    break;
+
+            }
+
+            currentPosition = new Traveller(position);
+            currentPosition.Move(-initialNodeOffset);
+            currentDistance = 0;
+            foreach (var cache in caches)
+            {
+                var lastObjDistance = 0f;
+                foreach (var obj in cache.Objects)
+                {
+                    currentPosition.Move(obj.Distance - lastObjDistance);
+                    lastObjDistance = obj.Distance;
+
+                    var objDistance = currentDistance + obj.Distance;
+                    if (objDistance < initialNodeOffset || objDistance > initialNodeOffset + DisplayDistance)
+                        continue;
+
+                    var switchObj = obj as SignallingDebugWindow.TrackSectionSwitch;
+                    if (switchObj != null)
+                    {
+                        for (var pin = switchObj.TrackNode.Inpins; pin < switchObj.TrackNode.Inpins + switchObj.TrackNode.Outpins; pin++)
+                        {
+                            if (switchObj.TrackNode.TrPins[pin].Link == switchObj.NodeIndex && pin - switchObj.TrackNode.Inpins != switchObj.TrackNode.TrJunctionNode.SelectedRoute)
+                            {
+                                foreach (var sw in switchItemsDrawn)
+                                {
+                                    if (sw.Item.TrJunctionNode == switchObj.TrackNode.TrJunctionNode)
+                                    {
+                                        var r = 6 * greenPen.Width;
+                                        g.DrawLine(pathPen, new PointF(sw.Location2D.X - r, sw.Location2D.Y - r), new PointF(sw.Location2D.X + r, sw.Location2D.Y + r));
+                                        g.DrawLine(pathPen, new PointF(sw.Location2D.X - r, sw.Location2D.Y + r), new PointF(sw.Location2D.X + r, sw.Location2D.Y - r));
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (objDistance >= switchErrorDistance)
+                        break;
+                }
+                currentDistance += cache.Length;
+                if (currentDistance >= switchErrorDistance)
+                    break;
+            }
+            // Clean up any cache entries who haven't been using for 30 seconds.
+            var oldCaches = Cache.Where(kvp => kvp.Value.Age > 30 * 4).ToArray();
+            foreach (var oldCache in oldCaches)
+                Cache.Remove(oldCache.Key);
+
+        }
+        #endregion
+
+        /// <summary>
+        /// Generates a rectangle representing a dot being drawn.
+        /// </summary>
+        /// <param name="p">Center point of the dot, in pixels.</param>
+        /// <param name="size">Size of the dot's diameter, in pixels</param>
+        /// <returns></returns>
+        static RectangleF GetRect(PointF p, float size)
+        {
+            return new RectangleF(p.X - size / 2f, p.Y - size / 2f, size, size);
+        }
+
+        /// <summary>
+        /// Generates line segments from an array of TrVectorSection. Also computes 
+        /// the bounds of the entire route being drawn.
+        /// </summary>
+        /// <param name="segments"></param>
+        /// <param name="items"></param>
+        /// <param name="minX"></param>
+        /// <param name="minY"></param>
+        /// <param name="maxX"></param>
+        /// <param name="maxY"></param>
+        /// <param name="simulator"></param>
+        private static void AddSegments(List<LineSegment> segments, TrackNode node, TrVectorSection[] items, ref float minX, ref float minY, ref float maxX, ref float maxY, Simulator simulator)
+        {
+
+            bool occupied = false;
 
 
-      private float ScrollSpeedX
-      {
-         get
-         {
-            return ViewWindow.Width * 0.10f;
-         }
-      }
+            //if (simulator.InterlockingSystem.Tracks.ContainsKey(node))
+            //{
+            //   occupied = node.InterlockingTrack.IsOccupied;
+            //}
 
-      private float ScrollSpeedY
-      {
-         get
-         {
-            return ViewWindow.Width * 0.10f;
-         }
-      }
+            double tempX1, tempX2, tempZ1, tempZ2;
 
-      private void refreshButton_Click(object sender, EventArgs e)
-      {
-		  followTrain = false;
-		  firstShow = true;
-         GenerateView();
-      }
+            for (int i = 0; i < items.Length - 1; i++)
+            {
+                dVector A = new dVector(items[i].TileX, items[i].X, items[i].TileZ, items[i].Z);
+                dVector B = new dVector(items[i + 1].TileX, items[i + 1].X, items[i + 1].TileZ, items[i + 1].Z);
 
-      private void ShiftViewUp()
-      {
-         ViewWindow.Offset(0, -ScrollSpeedY);
+                tempX1 = A.TileX * 2048 + A.X; tempX2 = B.TileX * 2048 + B.X;
+                tempZ1 = A.TileZ * 2048 + A.Z; tempZ2 = B.TileZ * 2048 + B.Z;
+                CalcBounds(ref maxX, tempX1, true);
+                CalcBounds(ref maxY, tempZ1, true);
+                CalcBounds(ref maxX, tempX2, true);
+                CalcBounds(ref maxY, tempZ2, true);
 
-         GenerateView();
-      }
-      private void ShiftViewDown()
-      {
-         ViewWindow.Offset(0, ScrollSpeedY);
+                CalcBounds(ref minX, tempX1, false);
+                CalcBounds(ref minY, tempZ1, false);
+                CalcBounds(ref minX, tempX2, false);
+                CalcBounds(ref minY, tempZ2, false);
 
-         GenerateView();
-      }
+                segments.Add(new LineSegment(A, B, occupied, items[i]));
+            }
+        }
 
-      private void ShiftViewRight()
-      {
-         ViewWindow.Offset(ScrollSpeedX, 0);
-
-         GenerateView();
-      }
-
-
-      private void ShiftViewLeft()
-      {
-         ViewWindow.Offset(-ScrollSpeedX, 0);
-
-         GenerateView();
-      }
-
-	  private void rmvButton_Click(object sender, EventArgs e)
-	  {
-		  if (!MultiPlayer.MPManager.IsServer()) return;
-		  AvatarView.SelectedIndices.Remove(0);//remove myself is not possible.
-		  var chosen = AvatarView.SelectedItems;
-		  if (chosen.Count > 0)
-		  {
-			  for (var i =0; i < chosen.Count; i++)
-			  {
-				  var tmp = chosen[i];
-				  var name = (tmp.Text.Split(' '))[0];//the name may have (H) in it, need to filter that out
-				  if (MultiPlayer.MPManager.OnlineTrains.Players.ContainsKey(name))
-				  {
-					  MultiPlayer.MPManager.OnlineTrains.Players[name].status = MultiPlayer.OnlinePlayer.Status.Removed;
-					  MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage(name, "Error", "Sorry the server has removed you")).ToString());
-
-				  }
-			  }
-		  }
-
-	  }
+        /// <summary>
+        /// Given a value representing a limit, evaluate if the given value exceeds the current limit.
+        /// If so, expand the limit.
+        /// </summary>
+        /// <param name="limit">The current limit.</param>
+        /// <param name="value">The value to compare the limit to.</param>
+        /// <param name="gt">True when comparison is greater-than. False if less-than.</param>
+        private static void CalcBounds(ref float limit, double v, bool gt)
+        {
+            float value = (float)v;
+            if (gt)
+            {
+                if (value > limit)
+                {
+                    limit = value;
+                }
+            }
+            else
+            {
+                if (value < limit)
+                {
+                    limit = value;
+                }
+            }
+        }
 
 
+        private float ScrollSpeedX
+        {
+            get
+            {
+                return ViewWindow.Width * 0.10f;
+            }
+        }
 
-      private void windowSizeUpDown_ValueChanged(object sender, EventArgs e)
-      {
-         // this is the center, before increasing the size
-         PointF center = new PointF(ViewWindow.X + ViewWindow.Width / 2f, ViewWindow.Y + ViewWindow.Height / 2f);
+        private float ScrollSpeedY
+        {
+            get
+            {
+                return ViewWindow.Width * 0.10f;
+            }
+        }
+
+        private void refreshButton_Click(object sender, EventArgs e)
+        {
+            followTrain = false;
+            firstShow = true;
+            GenerateView();
+        }
+
+        private void ShiftViewUp()
+        {
+            ViewWindow.Offset(0, -ScrollSpeedY);
+
+            GenerateView();
+        }
+        private void ShiftViewDown()
+        {
+            ViewWindow.Offset(0, ScrollSpeedY);
+
+            GenerateView();
+        }
+
+        private void ShiftViewRight()
+        {
+            ViewWindow.Offset(ScrollSpeedX, 0);
+
+            GenerateView();
+        }
 
 
-         float newSize = (float)windowSizeUpDown.Value;
+        private void ShiftViewLeft()
+        {
+            ViewWindow.Offset(-ScrollSpeedX, 0);
 
-         ViewWindow = new RectangleF(center.X - newSize / 2f, center.Y - newSize / 2f, newSize, newSize);
+            GenerateView();
+        }
+
+        private void rmvButton_Click(object sender, EventArgs e)
+        {
+            if (!MultiPlayer.MPManager.IsServer()) return;
+            AvatarView.SelectedIndices.Remove(0);//remove myself is not possible.
+            var chosen = AvatarView.SelectedItems;
+            if (chosen.Count > 0)
+            {
+                for (var i = 0; i < chosen.Count; i++)
+                {
+                    var tmp = chosen[i];
+                    var name = (tmp.Text.Split(' '))[0];//the name may have (H) in it, need to filter that out
+                    if (MultiPlayer.MPManager.OnlineTrains.Players.ContainsKey(name))
+                    {
+                        MultiPlayer.MPManager.OnlineTrains.Players[name].status = MultiPlayer.OnlinePlayer.Status.Removed;
+                        MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage(name, "Error", "Sorry the server has removed you")).ToString());
+
+                    }
+                }
+            }
+
+        }
 
 
-         GenerateView();
 
-      }
+        private void windowSizeUpDown_ValueChanged(object sender, EventArgs e)
+        {
+            // this is the center, before increasing the size
+            PointF center = new PointF(ViewWindow.X + ViewWindow.Width / 2f, ViewWindow.Y + ViewWindow.Height / 2f);
 
 
-	  protected override void OnMouseWheel(MouseEventArgs e)
-	  {
-		  decimal tempValue = windowSizeUpDown.Value;
-		  if (e.Delta < 0) tempValue /= 0.95m;
-		  else if (e.Delta > 0) tempValue *= 0.95m;
-		  else return;
+            float newSize = (float)windowSizeUpDown.Value;
 
-		  if (tempValue < windowSizeUpDown.Minimum) tempValue = windowSizeUpDown.Minimum;
-		  if (tempValue > windowSizeUpDown.Maximum) tempValue = windowSizeUpDown.Maximum;
-		  windowSizeUpDown.Value = tempValue;
-	  }
+            ViewWindow = new RectangleF(center.X - newSize / 2f, center.Y - newSize / 2f, newSize, newSize);
 
-      private bool Zooming;
-      private bool LeftClick;
-      private bool RightClick;
 
-	  private void pictureBoxMouseDown(object sender, MouseEventArgs e)
-	  {
-		  if (e.Button == MouseButtons.Left) LeftClick = true;
-		  if (e.Button == MouseButtons.Right) RightClick = true;
+            GenerateView();
 
-		  if (LeftClick == true && RightClick == false)
-		  {
-			  if (Dragging == false) Dragging = true;
-		  }
-		  else if (LeftClick == true && RightClick == true)
-		  {
-			  if (Zooming == false) Zooming = true;
-		  }
-		  LastCursorPosition.X = e.X;
-		  LastCursorPosition.Y = e.Y;
-		  //MSG.Enabled = false;
-		  MultiPlayer.MPManager.Instance().ComposingText = false;
-	  }
+        }
 
-	  private void pictureBoxMouseUp(object sender, MouseEventArgs e)
-	  {
-		  if (e.Button == MouseButtons.Left) LeftClick = false;
-		  if (e.Button == MouseButtons.Right) RightClick = false; 
 
-		  if (LeftClick == false)
-		  {
-			  Dragging = false;
-			  Zooming = false;
-		  }
+        protected override void OnMouseWheel(MouseEventArgs e)
+        {
+            decimal tempValue = windowSizeUpDown.Value;
+            if (e.Delta < 0) tempValue /= 0.95m;
+            else if (e.Delta > 0) tempValue *= 0.95m;
+            else return;
 
-          if ((Control.ModifierKeys & Keys.Shift) == Keys.Shift)
-          {
-              PictureMoveAndZoomInOut(e.X, e.Y, 1200);
-          }
-          else if ((Control.ModifierKeys & Keys.Alt) == Keys.Alt)
-          {
-              PictureMoveAndZoomInOut(e.X, e.Y, 30000);
-          }
-          else if ((Control.ModifierKeys & Keys.Control) == Keys.Control)
-          {
-              PictureMoveAndZoomInOut(e.X, e.Y, windowSizeUpDown.Maximum);
-          }
-          else if (LeftClick == false)
-          {
-              if (LastCursorPosition.X == e.X && LastCursorPosition.Y == e.Y)
-              {
-                  var range = 5 * (int)xScale; if (range > 10) range = 10;
-                  var temp = findItemFromMouse(e.X, e.Y, range);
-                  if (temp != null)
-                  {
-                      //GenerateView();
-                      if (temp is SwitchWidget) { switchPickedItem = (SwitchWidget)temp; signalPickedItem = null; HandlePickedSwitch(); }
-                      if (temp is SignalWidget) { signalPickedItem = (SignalWidget)temp; switchPickedItem = null; HandlePickedSignal(); }
+            if (tempValue < windowSizeUpDown.Minimum) tempValue = windowSizeUpDown.Minimum;
+            if (tempValue > windowSizeUpDown.Maximum) tempValue = windowSizeUpDown.Maximum;
+            windowSizeUpDown.Value = tempValue;
+        }
+
+        private bool Zooming;
+        private bool LeftClick;
+        private bool RightClick;
+
+        private void pictureBoxMouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left) LeftClick = true;
+            if (e.Button == MouseButtons.Right) RightClick = true;
+
+            if (LeftClick == true && RightClick == false)
+            {
+                if (Dragging == false) Dragging = true;
+            }
+            else if (LeftClick == true && RightClick == true)
+            {
+                if (Zooming == false) Zooming = true;
+            }
+            LastCursorPosition.X = e.X;
+            LastCursorPosition.Y = e.Y;
+            //MSG.Enabled = false;
+            MultiPlayer.MPManager.Instance().ComposingText = false;
+        }
+
+        private void pictureBoxMouseUp(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left) LeftClick = false;
+            if (e.Button == MouseButtons.Right) RightClick = false;
+
+            if (LeftClick == false)
+            {
+                Dragging = false;
+                Zooming = false;
+            }
+
+            if ((Control.ModifierKeys & Keys.Shift) == Keys.Shift)
+            {
+                PictureMoveAndZoomInOut(e.X, e.Y, 1200);
+            }
+            else if ((Control.ModifierKeys & Keys.Alt) == Keys.Alt)
+            {
+                PictureMoveAndZoomInOut(e.X, e.Y, 30000);
+            }
+            else if ((Control.ModifierKeys & Keys.Control) == Keys.Control)
+            {
+                PictureMoveAndZoomInOut(e.X, e.Y, windowSizeUpDown.Maximum);
+            }
+            else if (LeftClick == false)
+            {
+                if (LastCursorPosition.X == e.X && LastCursorPosition.Y == e.Y)
+                {
+                    var range = 5 * (int)xScale; if (range > 10) range = 10;
+                    var temp = findItemFromMouse(e.X, e.Y, range);
+                    if (temp != null)
+                    {
+                        //GenerateView();
+                        if (temp is SwitchWidget) { switchPickedItem = (SwitchWidget)temp; signalPickedItem = null; HandlePickedSwitch(); }
+                        if (temp is SignalWidget) { signalPickedItem = (SignalWidget)temp; switchPickedItem = null; HandlePickedSignal(); }
 #if false
 					  pictureBox1.ContextMenu.Show(pictureBox1, e.Location);
 					  pictureBox1.ContextMenu.MenuItems[0].Checked = pictureBox1.ContextMenu.MenuItems[1].Checked = false;
@@ -1472,13 +1474,13 @@ namespace Orts.Viewer3D.Debugging
 						  else pictureBox1.ContextMenu.MenuItems[1].Checked = true;
 					  }
 #endif
-                  }
-                  else { switchPickedItem = null; signalPickedItem = null; UnHandleItemPick(); PickedTrain = null; }
-              }
+                    }
+                    else { switchPickedItem = null; signalPickedItem = null; UnHandleItemPick(); PickedTrain = null; }
+                }
 
-          }
+            }
 
-	  }
+        }
 #if false
 	  void switchMainClick(object sender, EventArgs e)
 	  {
@@ -1513,681 +1515,681 @@ namespace Orts.Viewer3D.Debugging
 	  }
 #endif
 
-	  private void UnHandleItemPick()
-	  {
-		  boxSetSignal.Visible = false;
-		  //boxSetSignal.Enabled = false;
-		  //boxSetSwitch.Enabled = false;
-		  boxSetSwitch.Visible = false;
-	  }
-	  private void HandlePickedSignal()
-	  {
-		  if (MultiPlayer.MPManager.IsClient() && !MultiPlayer.MPManager.Instance().AmAider) return;//normal client not server or aider
-		  //boxSetSwitch.Enabled = false;
-		  boxSetSwitch.Visible = false;
-		  if (signalPickedItem == null) return;
-		  var y = LastCursorPosition.Y;
-		  if (LastCursorPosition.Y < 100) y = 100;
-		  if (LastCursorPosition.Y > pictureBox1.Size.Height - 100) y = pictureBox1.Size.Height - 100;
-		  boxSetSignal.Location = new System.Drawing.Point(LastCursorPosition.X + 2, y);
-		  boxSetSignal.Enabled = true;
-		  boxSetSignal.Focus();
-		  boxSetSignal.SelectedIndex = -1;
-		  boxSetSignal.Visible = true;
-		  return;
-	  }
+        private void UnHandleItemPick()
+        {
+            boxSetSignal.Visible = false;
+            //boxSetSignal.Enabled = false;
+            //boxSetSwitch.Enabled = false;
+            boxSetSwitch.Visible = false;
+        }
+        private void HandlePickedSignal()
+        {
+            if (MultiPlayer.MPManager.IsClient() && !MultiPlayer.MPManager.Instance().AmAider) return;//normal client not server or aider
+                                                                                                      //boxSetSwitch.Enabled = false;
+            boxSetSwitch.Visible = false;
+            if (signalPickedItem == null) return;
+            var y = LastCursorPosition.Y;
+            if (LastCursorPosition.Y < 100) y = 100;
+            if (LastCursorPosition.Y > pictureBox1.Size.Height - 100) y = pictureBox1.Size.Height - 100;
+            boxSetSignal.Location = new System.Drawing.Point(LastCursorPosition.X + 2, y);
+            boxSetSignal.Enabled = true;
+            boxSetSignal.Focus();
+            boxSetSignal.SelectedIndex = -1;
+            boxSetSignal.Visible = true;
+            return;
+        }
 
-	  private void HandlePickedSwitch()
-	  {
-		  if (MultiPlayer.MPManager.IsClient() && !MultiPlayer.MPManager.Instance().AmAider) return;//normal client not server
-		  //boxSetSignal.Enabled = false;
-		  boxSetSignal.Visible = false;
-		  if (switchPickedItem == null) return;
-		  var y = LastCursorPosition.Y + 100;
-		  if (y < 140) y = 140;
-		  if (y > pictureBox1.Size.Height + 100) y = pictureBox1.Size.Height + 100;
-		  boxSetSwitch.Location = new System.Drawing.Point(LastCursorPosition.X + 2, y);
-		  boxSetSwitch.Enabled = true;
-		  boxSetSwitch.Focus();
-		  boxSetSwitch.SelectedIndex = -1;
-		  boxSetSwitch.Visible = true;
-		  return;
-	  }
+        private void HandlePickedSwitch()
+        {
+            if (MultiPlayer.MPManager.IsClient() && !MultiPlayer.MPManager.Instance().AmAider) return;//normal client not server
+                                                                                                      //boxSetSignal.Enabled = false;
+            boxSetSignal.Visible = false;
+            if (switchPickedItem == null) return;
+            var y = LastCursorPosition.Y + 100;
+            if (y < 140) y = 140;
+            if (y > pictureBox1.Size.Height + 100) y = pictureBox1.Size.Height + 100;
+            boxSetSwitch.Location = new System.Drawing.Point(LastCursorPosition.X + 2, y);
+            boxSetSwitch.Enabled = true;
+            boxSetSwitch.Focus();
+            boxSetSwitch.SelectedIndex = -1;
+            boxSetSwitch.Visible = true;
+            return;
+        }
 
-	   private ItemWidget findItemFromMouse(int x, int y, int range)
-	  {
-		  if (range < 5) range = 5;
-		  double closest = float.NaN;
-		  ItemWidget closestItem = null;
-		  if (chkPickSwitches.Checked == true)
-		  {
-			  foreach (var item in switchItemsDrawn)
-			  {
-				  //if out of range, continue
-				  if (item.Location2D.X < x - range || item.Location2D.X > x + range
-					 || item.Location2D.Y < y - range || item.Location2D.Y > y + range) continue;
+        private ItemWidget findItemFromMouse(int x, int y, int range)
+        {
+            if (range < 5) range = 5;
+            double closest = float.NaN;
+            ItemWidget closestItem = null;
+            if (chkPickSwitches.Checked == true)
+            {
+                foreach (var item in switchItemsDrawn)
+                {
+                    //if out of range, continue
+                    if (item.Location2D.X < x - range || item.Location2D.X > x + range
+                       || item.Location2D.Y < y - range || item.Location2D.Y > y + range) continue;
 
-				  if (closestItem != null)
-				  {
-					  var dist = Math.Pow(item.Location2D.X - closestItem.Location2D.X, 2) + Math.Pow(item.Location2D.Y - closestItem.Location2D.Y, 2);
-					  if (dist < closest)
-					  {
-						  closest = dist; closestItem = item;
-					  }
-				  }
-				  else closestItem = item;
-			  }
-			  if (closestItem != null) { switchPickedTime = simulator.GameTime; return closestItem; }
-		  }
-		  if (chkPickSignals.Checked == true)
-		  {
-			  foreach (var item in signalItemsDrawn)
-			  {
-				  //if out of range, continue
-				  if (item.Location2D.X < x - range || item.Location2D.X > x + range
-					 || item.Location2D.Y < y - range || item.Location2D.Y > y + range) continue;
+                    if (closestItem != null)
+                    {
+                        var dist = Math.Pow(item.Location2D.X - closestItem.Location2D.X, 2) + Math.Pow(item.Location2D.Y - closestItem.Location2D.Y, 2);
+                        if (dist < closest)
+                        {
+                            closest = dist; closestItem = item;
+                        }
+                    }
+                    else closestItem = item;
+                }
+                if (closestItem != null) { switchPickedTime = simulator.GameTime; return closestItem; }
+            }
+            if (chkPickSignals.Checked == true)
+            {
+                foreach (var item in signalItemsDrawn)
+                {
+                    //if out of range, continue
+                    if (item.Location2D.X < x - range || item.Location2D.X > x + range
+                       || item.Location2D.Y < y - range || item.Location2D.Y > y + range) continue;
 
-				  if (closestItem != null)
-				  {
-					  var dist = Math.Pow(item.Location2D.X - closestItem.Location2D.X, 2) + Math.Pow(item.Location2D.Y - closestItem.Location2D.Y, 2);
-					  if (dist < closest)
-					  {
-						  closest = dist; closestItem = item;
-					  }
-				  }
-				  else closestItem = item;
-			  }
-			  if (closestItem != null) { switchPickedTime = simulator.GameTime; return closestItem; }
-		  }
+                    if (closestItem != null)
+                    {
+                        var dist = Math.Pow(item.Location2D.X - closestItem.Location2D.X, 2) + Math.Pow(item.Location2D.Y - closestItem.Location2D.Y, 2);
+                        if (dist < closest)
+                        {
+                            closest = dist; closestItem = item;
+                        }
+                    }
+                    else closestItem = item;
+                }
+                if (closestItem != null) { switchPickedTime = simulator.GameTime; return closestItem; }
+            }
 
-		   //now check for trains (first car only)
-		  TrainCar firstCar;
-		  PickedTrain = null;  float tX, tY;
-		  closest = 100f;
+            //now check for trains (first car only)
+            TrainCar firstCar;
+            PickedTrain = null; float tX, tY;
+            closest = 100f;
 
-		  foreach (var t in Program.Simulator.Trains)
-		  {
-			  firstCar = null;
-			  if (t.LeadLocomotive != null)
-			  {
-				  worldPos = t.LeadLocomotive.WorldPosition;
-				  firstCar = t.LeadLocomotive;
-			  }
-			  else if (t.Cars != null && t.Cars.Count > 0)
-			  {
-				  worldPos = t.Cars[0].WorldPosition;
-				  firstCar = t.Cars[0];
+            foreach (var t in Program.Simulator.Trains)
+            {
+                firstCar = null;
+                if (t.LeadLocomotive != null)
+                {
+                    worldPos = t.LeadLocomotive.WorldPosition;
+                    firstCar = t.LeadLocomotive;
+                }
+                else if (t.Cars != null && t.Cars.Count > 0)
+                {
+                    worldPos = t.Cars[0].WorldPosition;
+                    firstCar = t.Cars[0];
 
-			  }
-			  else continue;
+                }
+                else continue;
 
-			  worldPos = firstCar.WorldPosition;
-			  tX = (worldPos.TileX * 2048 -subX + worldPos.Location.X) * xScale; 
-			  tY = pictureBox1.Height - (worldPos.TileZ * 2048 -subY + worldPos.Location.Z) * yScale;
-              float xSpeedCorr = Math.Abs(t.SpeedMpS) * xScale * 1.5f;
-              float ySpeedCorr = Math.Abs(t.SpeedMpS) * yScale * 1.5f;
+                worldPos = firstCar.WorldPosition;
+                tX = (worldPos.TileX * 2048 - subX + worldPos.Location.X) * xScale;
+                tY = pictureBox1.Height - (worldPos.TileZ * 2048 - subY + worldPos.Location.Z) * yScale;
+                float xSpeedCorr = Math.Abs(t.SpeedMpS) * xScale * 1.5f;
+                float ySpeedCorr = Math.Abs(t.SpeedMpS) * yScale * 1.5f;
 
-			  if (tX < x - range-xSpeedCorr || tX > x + range+xSpeedCorr || tY < y - range-ySpeedCorr || tY > y + range+ySpeedCorr) continue;
-			  if (PickedTrain == null) PickedTrain = t;
-		  }
-		   //if a train is picked, will clear the avatar list selection
-		  if (PickedTrain != null)
-		  {
-			  AvatarView.SelectedItems.Clear();
-			  return new TrainWidget(PickedTrain);
-		  }
-		  return null;
-	  }
+                if (tX < x - range - xSpeedCorr || tX > x + range + xSpeedCorr || tY < y - range - ySpeedCorr || tY > y + range + ySpeedCorr) continue;
+                if (PickedTrain == null) PickedTrain = t;
+            }
+            //if a train is picked, will clear the avatar list selection
+            if (PickedTrain != null)
+            {
+                AvatarView.SelectedItems.Clear();
+                return new TrainWidget(PickedTrain);
+            }
+            return null;
+        }
 
-	  private void pictureBoxMouseMove(object sender, MouseEventArgs e)
-	  {
-		  if (Dragging&&!Zooming)
-		  {
-			  int diffX = LastCursorPosition.X - e.X;
-			  int diffY = LastCursorPosition.Y - e.Y;
+        private void pictureBoxMouseMove(object sender, MouseEventArgs e)
+        {
+            if (Dragging && !Zooming)
+            {
+                int diffX = LastCursorPosition.X - e.X;
+                int diffY = LastCursorPosition.Y - e.Y;
 
-			  ViewWindow.Offset(diffX * ScrollSpeedX/10, -diffY * ScrollSpeedX/10);
-			  GenerateView();
-		  }
-		  else if (Zooming)
-		  {
-			  decimal tempValue = windowSizeUpDown.Value;
-			  if (LastCursorPosition.Y - e.Y < 0) tempValue /= 0.95m;
-			  else if (LastCursorPosition.Y - e.Y > 0) tempValue *= 0.95m;
+                ViewWindow.Offset(diffX * ScrollSpeedX / 10, -diffY * ScrollSpeedX / 10);
+                GenerateView();
+            }
+            else if (Zooming)
+            {
+                decimal tempValue = windowSizeUpDown.Value;
+                if (LastCursorPosition.Y - e.Y < 0) tempValue /= 0.95m;
+                else if (LastCursorPosition.Y - e.Y > 0) tempValue *= 0.95m;
 
-			  if (tempValue < windowSizeUpDown.Minimum) tempValue = windowSizeUpDown.Minimum;
-			  if (tempValue > windowSizeUpDown.Maximum) tempValue = windowSizeUpDown.Maximum;
-			  windowSizeUpDown.Value = tempValue;
-			  GenerateView();
+                if (tempValue < windowSizeUpDown.Minimum) tempValue = windowSizeUpDown.Minimum;
+                if (tempValue > windowSizeUpDown.Maximum) tempValue = windowSizeUpDown.Maximum;
+                windowSizeUpDown.Value = tempValue;
+                GenerateView();
 
-		  }
-		  LastCursorPosition.X = e.X;
-		  LastCursorPosition.Y = e.Y;
-	  }
+            }
+            LastCursorPosition.X = e.X;
+            LastCursorPosition.Y = e.Y;
+        }
 
-	  public bool addNewMessage(double time, string msg)
-	  {
-		  var count = 0;
-		  while (count < 3)
-		  {
-			  try
-			  {
-				  if (messages.Items.Count > 10)
-				  {
-					  messages.Items.RemoveAt(0);
-				  }
-				  messages.Items.Add(msg);
-				  messages.SelectedIndex = messages.Items.Count - 1;
-				  messages.SelectedIndex = -1;
-				  break;
-			  }
-			  catch { count++; }
-		  }
-		  return true;
-	  }
+        public bool addNewMessage(double time, string msg)
+        {
+            var count = 0;
+            while (count < 3)
+            {
+                try
+                {
+                    if (messages.Items.Count > 10)
+                    {
+                        messages.Items.RemoveAt(0);
+                    }
+                    messages.Items.Add(msg);
+                    messages.SelectedIndex = messages.Items.Count - 1;
+                    messages.SelectedIndex = -1;
+                    break;
+                }
+                catch { count++; }
+            }
+            return true;
+        }
 
-	  private void chkAllowUserSwitch_CheckedChanged(object sender, EventArgs e)
-	  {
-		  MultiPlayer.MPManager.AllowedManualSwitch = chkAllowUserSwitch.Checked;
-          if (chkAllowUserSwitch.Checked == true) { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "SwitchOK", "OK to switch")).ToString()); }
-          else { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "SwitchWarning", "Cannot switch")).ToString()); }
-	  }
+        private void chkAllowUserSwitch_CheckedChanged(object sender, EventArgs e)
+        {
+            MultiPlayer.MPManager.AllowedManualSwitch = chkAllowUserSwitch.Checked;
+            if (chkAllowUserSwitch.Checked == true) { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "SwitchOK", "OK to switch")).ToString()); }
+            else { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "SwitchWarning", "Cannot switch")).ToString()); }
+        }
 
-	  private void chkShowAvatars_CheckedChanged(object sender, EventArgs e)
-	  {
-		  Program.Simulator.Settings.ShowAvatar = chkShowAvatars.Checked;
-		  AvatarView.Items.Clear();
-		  if (avatarList != null) avatarList.Clear();
-		  if (chkShowAvatars.Checked) AvatarView.Font = new Font(FontFamily.GenericSansSerif, 12);
-		  else AvatarView.Font = new Font(FontFamily.GenericSansSerif, 16);
-		  try { CheckAvatar(); }
-		  catch { }
-	  }
-	  
-	  private const int CP_NOCLOSE_BUTTON = 0x200;
-	  protected override CreateParams CreateParams
-	  {
-		  get
-		  {
-			  CreateParams myCp = base.CreateParams;
-			  myCp.ClassStyle = myCp.ClassStyle | CP_NOCLOSE_BUTTON;
-			  return myCp;
-		  }
-	  }
-	  string imagestring = "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAACpJREFUOE9jYBjs4D/QgSBMNhg1ABKAFAUi2aFPNY0Ue4FiA6jmlUFsEABfyg/x8/L8/gAAAABJRU5ErkJggg==";
+        private void chkShowAvatars_CheckedChanged(object sender, EventArgs e)
+        {
+            Program.Simulator.Settings.ShowAvatar = chkShowAvatars.Checked;
+            AvatarView.Items.Clear();
+            if (avatarList != null) avatarList.Clear();
+            if (chkShowAvatars.Checked) AvatarView.Font = new Font(FontFamily.GenericSansSerif, 12);
+            else AvatarView.Font = new Font(FontFamily.GenericSansSerif, 16);
+            try { CheckAvatar(); }
+            catch { }
+        }
 
-	  private void composeMSG_Click(object sender, EventArgs e)
-	  {
-		  MSG.Enabled = true;
-		  MSG.Focus();
-		  MultiPlayer.MPManager.Instance().ComposingText = true;
-		  msgAll.Enabled = true;
-		  if (messages.SelectedItems.Count > 0) msgSelected.Enabled = true;
-		  if (AvatarView.SelectedItems.Count > 0) reply2Selected.Enabled = true;
-	  }
+        private const int CP_NOCLOSE_BUTTON = 0x200;
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                CreateParams myCp = base.CreateParams;
+                myCp.ClassStyle = myCp.ClassStyle | CP_NOCLOSE_BUTTON;
+                return myCp;
+            }
+        }
+        string imagestring = "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAACpJREFUOE9jYBjs4D/QgSBMNhg1ABKAFAUi2aFPNY0Ue4FiA6jmlUFsEABfyg/x8/L8/gAAAABJRU5ErkJggg==";
 
-	  private void msgAll_Click(object sender, EventArgs e)
-	  {
-		  msgDefault();
-	  }
+        private void composeMSG_Click(object sender, EventArgs e)
+        {
+            MSG.Enabled = true;
+            MSG.Focus();
+            MultiPlayer.MPManager.Instance().ComposingText = true;
+            msgAll.Enabled = true;
+            if (messages.SelectedItems.Count > 0) msgSelected.Enabled = true;
+            if (AvatarView.SelectedItems.Count > 0) reply2Selected.Enabled = true;
+        }
 
-	  private void msgDefault()
-	  {
-		  msgAll.Enabled = false;
-		  msgSelected.Enabled = false;
-		  reply2Selected.Enabled = false;
-		  if (!MultiPlayer.MPManager.IsMultiPlayer()) return;
-		  var msg = MSG.Text;
-		  msg = msg.Replace("\r", "");
-		  msg = msg.Replace("\t", "");
-		  MultiPlayer.MPManager.Instance().ComposingText = false;
-		  MSG.Enabled = false;
-		  if (msg != "")
-		  {
-			  if (MultiPlayer.MPManager.IsServer())
-			  {
-				  try
-				  {
-					  var user = "";
-					  foreach (var p in MultiPlayer.MPManager.OnlineTrains.Players)
-					  {
-						  user += p.Key + "\r";
-					  }
-					  user += "0END";
-					  MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
-					  MSG.Text = "";
+        private void msgAll_Click(object sender, EventArgs e)
+        {
+            msgDefault();
+        }
 
-				  }
-				  catch { }
-			  }
-			  else
-			  {
-				  var user = "0Server\r+0END";
-				  MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
-				  MSG.Text = "";
-			  }
-		  }
-	  }
-	  private void replySelected(object sender, EventArgs e)
-	  {
-		  msgAll.Enabled = false;
-		  msgSelected.Enabled = false;
-		  reply2Selected.Enabled = false;
+        private void msgDefault()
+        {
+            msgAll.Enabled = false;
+            msgSelected.Enabled = false;
+            reply2Selected.Enabled = false;
+            if (!MultiPlayer.MPManager.IsMultiPlayer()) return;
+            var msg = MSG.Text;
+            msg = msg.Replace("\r", "");
+            msg = msg.Replace("\t", "");
+            MultiPlayer.MPManager.Instance().ComposingText = false;
+            MSG.Enabled = false;
+            if (msg != "")
+            {
+                if (MultiPlayer.MPManager.IsServer())
+                {
+                    try
+                    {
+                        var user = "";
+                        foreach (var p in MultiPlayer.MPManager.OnlineTrains.Players)
+                        {
+                            user += p.Key + "\r";
+                        }
+                        user += "0END";
+                        MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
+                        MSG.Text = "";
 
-		  if (!MultiPlayer.MPManager.IsMultiPlayer()) return;
-		  var msg = MSG.Text;
-		  msg = msg.Replace("\r", "");
-		  msg = msg.Replace("\t", "");
-		  MultiPlayer.MPManager.Instance().ComposingText = false;
-		  MSG.Text = "";
-		  MSG.Enabled = false;
-		  if (msg == "") return;
-		  var user = "";
-		  if (messages.SelectedItems.Count > 0)
-		  {
-			  var chosen = messages.SelectedItems;
-			  for (var i = 0; i < chosen.Count; i++)
-			  {
-				  var tmp = (string)(chosen[i]);
-				  var index = tmp.IndexOf(':');
-				  if (index < 0) continue;
-				  tmp = tmp.Substring(0, index) + "\r";
-				  if (user.Contains(tmp)) continue;
-				  user += tmp;
-			  }
-			  user += "0END";
-		  }
-		  else return;
-		  MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
+                    }
+                    catch { }
+                }
+                else
+                {
+                    var user = "0Server\r+0END";
+                    MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
+                    MSG.Text = "";
+                }
+            }
+        }
+        private void replySelected(object sender, EventArgs e)
+        {
+            msgAll.Enabled = false;
+            msgSelected.Enabled = false;
+            reply2Selected.Enabled = false;
 
-
-	  }
-
-	  private void MSGLeave(object sender, EventArgs e)
-	  {
-		  //MultiPlayer.MPManager.Instance().ComposingText = false;
-	  }
-
-	  private void MSGEnter(object sender, EventArgs e)
-	  {
-		  //MultiPlayer.MPManager.Instance().ComposingText = true;
-	  }
-
-	  private void DispatcherLeave(object sender, EventArgs e)
-	  {
-		  //MultiPlayer.MPManager.Instance().ComposingText = false;
-	  }
-
-	  private void checkKeys(object sender, PreviewKeyDownEventArgs e)
-	  {
-		  if (e.KeyValue == 13)
-		  {
-			  if (e.KeyValue == 13)
-			  {
-				  var msg = MSG.Text;
-				  msg = msg.Replace("\r", "");
-				  msg = msg.Replace("\t", "");
-				  msg = msg.Replace("\n", "");
-				  MultiPlayer.MPManager.Instance().ComposingText = false;
-				  MSG.Enabled = false;
-				  MSG.Text = "";
-				  if (msg == "") return;
-				  var user = "";
-
-				  if (MultiPlayer.MPManager.IsServer())
-				  {
-					  try
-					  {
-						  foreach (var p in MultiPlayer.MPManager.OnlineTrains.Players)
-						  {
-							  user += p.Key + "\r";
-						  }
-						  user += "0END";
-						  MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
-						  MSG.Text = "";
-
-					  }
-					  catch { }
-				  }
-				  else
-				  {
-					  user = "0Server\r+0END";
-					  MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
-					  MSG.Text = "";
-				  }
-			  }
-		  }
-	  }
-
-	  private void msgSelected_Click(object sender, EventArgs e)
-	  {
-		  msgAll.Enabled = false;
-		  msgSelected.Enabled = false;
-		  reply2Selected.Enabled = false;
-		  MultiPlayer.MPManager.Instance().ComposingText = false;
-		  MSG.Enabled = false;
-
-		  if (!MultiPlayer.MPManager.IsMultiPlayer()) return;
-		  var msg = MSG.Text;
-		  MSG.Text = "";
-		  msg = msg.Replace("\r", "");
-		  msg = msg.Replace("\t", "");
-		  if (msg == "") return;
-		  var user = "";
-		  if (AvatarView.SelectedItems.Count > 0)
-		  {
-			  var chosen = this.AvatarView.SelectedItems;
-			  for (var i = 0; i < chosen.Count; i++)
-			  {
-				  var name = chosen[i].Text.Split(' ')[0]; //text may have (H) in it, so need to filter out
-				  if (name == MultiPlayer.MPManager.GetUserName()) continue;
-				  user += name + "\r";
-			  }
-			  user += "0END";
+            if (!MultiPlayer.MPManager.IsMultiPlayer()) return;
+            var msg = MSG.Text;
+            msg = msg.Replace("\r", "");
+            msg = msg.Replace("\t", "");
+            MultiPlayer.MPManager.Instance().ComposingText = false;
+            MSG.Text = "";
+            MSG.Enabled = false;
+            if (msg == "") return;
+            var user = "";
+            if (messages.SelectedItems.Count > 0)
+            {
+                var chosen = messages.SelectedItems;
+                for (var i = 0; i < chosen.Count; i++)
+                {
+                    var tmp = (string)(chosen[i]);
+                    var index = tmp.IndexOf(':');
+                    if (index < 0) continue;
+                    tmp = tmp.Substring(0, index) + "\r";
+                    if (user.Contains(tmp)) continue;
+                    user += tmp;
+                }
+                user += "0END";
+            }
+            else return;
+            MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
 
 
-		  }
-		  else return;
+        }
 
-		  MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
+        private void MSGLeave(object sender, EventArgs e)
+        {
+            //MultiPlayer.MPManager.Instance().ComposingText = false;
+        }
 
-	  }
+        private void MSGEnter(object sender, EventArgs e)
+        {
+            //MultiPlayer.MPManager.Instance().ComposingText = true;
+        }
 
-	  private void msgSelectedChanged(object sender, EventArgs e)
-	  {
-		  AvatarView.SelectedItems.Clear();
-		  msgSelected.Enabled = false;
-		  if (MSG.Enabled == true) reply2Selected.Enabled = true;
-	  }
+        private void DispatcherLeave(object sender, EventArgs e)
+        {
+            //MultiPlayer.MPManager.Instance().ComposingText = false;
+        }
 
-	  private void AvatarView_SelectedIndexChanged(object sender, EventArgs e)
-	  {
-		  messages.SelectedItems.Clear();
-		  reply2Selected.Enabled = false;
-		  if (MSG.Enabled == true) msgSelected.Enabled = true;
-		  if (AvatarView.SelectedItems.Count <= 0) return;
-		  var name = AvatarView.SelectedItems[0].Text.Split(' ')[0].Trim();
-		  if (name == MultiPlayer.MPManager.GetUserName())
-		  {
-			  if (Program.Simulator.PlayerLocomotive != null) PickedTrain = Program.Simulator.PlayerLocomotive.Train;
-			  else if (Program.Simulator.Trains.Count > 0) PickedTrain = Program.Simulator.Trains[0];
-		  }
-		  else PickedTrain = MultiPlayer.MPManager.OnlineTrains.findTrain(name);
+        private void checkKeys(object sender, PreviewKeyDownEventArgs e)
+        {
+            if (e.KeyValue == 13)
+            {
+                if (e.KeyValue == 13)
+                {
+                    var msg = MSG.Text;
+                    msg = msg.Replace("\r", "");
+                    msg = msg.Replace("\t", "");
+                    msg = msg.Replace("\n", "");
+                    MultiPlayer.MPManager.Instance().ComposingText = false;
+                    MSG.Enabled = false;
+                    MSG.Text = "";
+                    if (msg == "") return;
+                    var user = "";
 
-	  }
+                    if (MultiPlayer.MPManager.IsServer())
+                    {
+                        try
+                        {
+                            foreach (var p in MultiPlayer.MPManager.OnlineTrains.Players)
+                            {
+                                user += p.Key + "\r";
+                            }
+                            user += "0END";
+                            MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
+                            MSG.Text = "";
 
-	  private void chkDrawPathChanged(object sender, EventArgs e)
-	  {
-		  this.DrawPath = chkDrawPath.Checked;
-	  }
+                        }
+                        catch { }
+                    }
+                    else
+                    {
+                        user = "0Server\r+0END";
+                        MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
+                        MSG.Text = "";
+                    }
+                }
+            }
+        }
 
-	  private void boxSetSignalChosen(object sender, EventArgs e)
-	  {
-		  if (signalPickedItem == null)
-		  {
-			  UnHandleItemPick(); return;
-		  }
-		  var signal = signalPickedItem.Signal;
-		  var type = boxSetSignal.SelectedIndex;
-		  if (MultiPlayer.MPManager.Instance().AmAider)
-		  {
-			  MultiPlayer.MPManager.Notify((new MultiPlayer.MSGSignalChange(signal, type)).ToString());
-			  UnHandleItemPick();
-			  return;
-		  }
-		  switch (type)
-		  {
-			  case 0:
-                  signal.clearHoldSignalDispatcher();
-				  break;
-			  case 1:
-                  signal.requestHoldSignalDispatcher(true);
-				  break;
-			  case 2:
-                  signal.holdState = SignalObject.HoldState.ManualApproach;
-                  foreach (var sigHead in signal.SignalHeads)
-                  {
-                      var drawstate1 = sigHead.def_draw_state(MstsSignalAspect.APPROACH_1);
-                      var drawstate2 = sigHead.def_draw_state(MstsSignalAspect.APPROACH_2);
-                      var drawstate3 = sigHead.def_draw_state(MstsSignalAspect.APPROACH_3);
-                      if (drawstate1 > 0) { sigHead.state = MstsSignalAspect.APPROACH_1; }
-                      else if (drawstate2 > 0) { sigHead.state = MstsSignalAspect.APPROACH_2; }
-                      else { sigHead.state = MstsSignalAspect.APPROACH_3; }
-                      sigHead.draw_state = sigHead.def_draw_state(sigHead.state);
-                  }
-				  break;
-			  case 3:
-                  signal.holdState = SignalObject.HoldState.ManualPass;
-                  foreach (var sigHead in signal.SignalHeads)
-                  {
-                      sigHead.SetLeastRestrictiveAspect();
-                      sigHead.draw_state = sigHead.def_draw_state(sigHead.state);
-                  }
-				  break;
-		  }
-		  UnHandleItemPick();
-	  }
+        private void msgSelected_Click(object sender, EventArgs e)
+        {
+            msgAll.Enabled = false;
+            msgSelected.Enabled = false;
+            reply2Selected.Enabled = false;
+            MultiPlayer.MPManager.Instance().ComposingText = false;
+            MSG.Enabled = false;
 
-	  private void boxSetSwitchChosen(object sender, EventArgs e)
-	  {
-		  if (switchPickedItem == null)
-		  {
-			  UnHandleItemPick(); return;
-		  }
-		  var sw = switchPickedItem.Item.TrJunctionNode;
-		  var type = boxSetSwitch.SelectedIndex;
+            if (!MultiPlayer.MPManager.IsMultiPlayer()) return;
+            var msg = MSG.Text;
+            MSG.Text = "";
+            msg = msg.Replace("\r", "");
+            msg = msg.Replace("\t", "");
+            if (msg == "") return;
+            var user = "";
+            if (AvatarView.SelectedItems.Count > 0)
+            {
+                var chosen = this.AvatarView.SelectedItems;
+                for (var i = 0; i < chosen.Count; i++)
+                {
+                    var name = chosen[i].Text.Split(' ')[0]; //text may have (H) in it, so need to filter out
+                    if (name == MultiPlayer.MPManager.GetUserName()) continue;
+                    user += name + "\r";
+                }
+                user += "0END";
 
-		  //aider can send message to the server for a switch
-		  if (MultiPlayer.MPManager.IsMultiPlayer() && MultiPlayer.MPManager.Instance().AmAider)
-		  {
-			  var nextSwitchTrack = sw;
-			  var Selected = 0;
-			  switch (type)
-			  {
-				  case 0:
-					  Selected = (int)switchPickedItem.main;
-					  break;
-				  case 1:
-					  Selected = 1 - (int)switchPickedItem.main;
-					  break;
-			  }
-			  //aider selects and throws the switch, but need to confirm by the dispatcher
-			  MultiPlayer.MPManager.Notify((new MultiPlayer.MSGSwitch(MultiPlayer.MPManager.GetUserName(),
-				  nextSwitchTrack.TN.UiD.WorldTileX, nextSwitchTrack.TN.UiD.WorldTileZ, nextSwitchTrack.TN.UiD.WorldId, Selected, true)).ToString());
-			  Program.Simulator.Confirmer.Information(Viewer.Catalog.GetString("Switching Request Sent to the Server"));
 
-		  }
-		  //server throws the switch immediately
-		  else
-		  {
-			  switch (type)
-			  {
-				  case 0:
-                      Program.Simulator.Signals.RequestSetSwitch(sw.TN, (int)switchPickedItem.main);
-					  //sw.SelectedRoute = (int)switchPickedItem.main;
-					  break;
-				  case 1:
-                      Program.Simulator.Signals.RequestSetSwitch(sw.TN, 1 - (int)switchPickedItem.main);
-                      //sw.SelectedRoute = 1 - (int)switchPickedItem.main;
-					  break;
-			  }
-		  }
-		  UnHandleItemPick();
+            }
+            else return;
 
-	  }
+            MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
 
-	  private void chkAllowNewCheck(object sender, EventArgs e)
-	  {
-		  MultiPlayer.MPManager.Instance().AllowNewPlayer = chkAllowNew.Checked;
-	  }
+        }
 
-	  private void AssistClick(object sender, EventArgs e)
-	  {
-		  AvatarView.SelectedIndices.Remove(0);
-		  if (AvatarView.SelectedIndices.Count > 0)
-		  {
-			  var tmp = AvatarView.SelectedItems[0].Text.Split(' ');
-			  var name = tmp[0].Trim();
-			  if (MultiPlayer.MPManager.Instance().aiderList.Contains(name)) return;
-			  if (MultiPlayer.MPManager.OnlineTrains.Players.ContainsKey(name))
-			  {
-				  MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGAider(name, true)).ToString());
-				  MultiPlayer.MPManager.Instance().aiderList.Add(name);
-			  }
-			  AvatarView.Items.Clear();
-			  if (avatarList != null) avatarList.Clear();
-		  }
-	  }
+        private void msgSelectedChanged(object sender, EventArgs e)
+        {
+            AvatarView.SelectedItems.Clear();
+            msgSelected.Enabled = false;
+            if (MSG.Enabled == true) reply2Selected.Enabled = true;
+        }
 
-	  private void btnNormalClick(object sender, EventArgs e)
-	  {
-		  if (AvatarView.SelectedIndices.Count > 0)
-		  {
-			  var tmp = AvatarView.SelectedItems[0].Text.Split(' ');
-			  var name = tmp[0].Trim();
-			  if (MultiPlayer.MPManager.OnlineTrains.Players.ContainsKey(name))
-			  {
-				  MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGAider(name, false)).ToString());
-				  MultiPlayer.MPManager.Instance().aiderList.Remove(name);
-			  }
-			  AvatarView.Items.Clear();
-			  if (avatarList != null) avatarList.Clear();
-		  }
+        private void AvatarView_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            messages.SelectedItems.Clear();
+            reply2Selected.Enabled = false;
+            if (MSG.Enabled == true) msgSelected.Enabled = true;
+            if (AvatarView.SelectedItems.Count <= 0) return;
+            var name = AvatarView.SelectedItems[0].Text.Split(' ')[0].Trim();
+            if (name == MultiPlayer.MPManager.GetUserName())
+            {
+                if (Program.Simulator.PlayerLocomotive != null) PickedTrain = Program.Simulator.PlayerLocomotive.Train;
+                else if (Program.Simulator.Trains.Count > 0) PickedTrain = Program.Simulator.Trains[0];
+            }
+            else PickedTrain = MultiPlayer.MPManager.OnlineTrains.findTrain(name);
 
-	  }
+        }
 
-	  private void btnFollowClick(object sender, EventArgs e)
-	  {
-		  followTrain = true;
-	  }
+        private void chkDrawPathChanged(object sender, EventArgs e)
+        {
+            this.DrawPath = chkDrawPath.Checked;
+        }
 
-	  private void chkOPenaltyHandle(object sender, EventArgs e)
-	  {
-		  MultiPlayer.MPManager.Instance().CheckSpad = chkBoxPenalty.Checked;
-		  if (this.chkBoxPenalty.Checked == false) { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "OverSpeedOK", "OK to go overspeed and pass stop light")).ToString()); }
-		  else { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "NoOverSpeed", "Penalty for overspeed and passing stop light")).ToString()); }
+        private void boxSetSignalChosen(object sender, EventArgs e)
+        {
+            if (signalPickedItem == null)
+            {
+                UnHandleItemPick(); return;
+            }
+            var signal = signalPickedItem.Signal;
+            var type = boxSetSignal.SelectedIndex;
+            if (MultiPlayer.MPManager.Instance().AmAider)
+            {
+                MultiPlayer.MPManager.Notify((new MultiPlayer.MSGSignalChange(signal, type)).ToString());
+                UnHandleItemPick();
+                return;
+            }
+            switch (type)
+            {
+                case 0:
+                    signal.clearHoldSignalDispatcher();
+                    break;
+                case 1:
+                    signal.requestHoldSignalDispatcher(true);
+                    break;
+                case 2:
+                    signal.holdState = SignalObject.HoldState.ManualApproach;
+                    foreach (var sigHead in signal.SignalHeads)
+                    {
+                        var drawstate1 = sigHead.def_draw_state(MstsSignalAspect.APPROACH_1);
+                        var drawstate2 = sigHead.def_draw_state(MstsSignalAspect.APPROACH_2);
+                        var drawstate3 = sigHead.def_draw_state(MstsSignalAspect.APPROACH_3);
+                        if (drawstate1 > 0) { sigHead.state = MstsSignalAspect.APPROACH_1; }
+                        else if (drawstate2 > 0) { sigHead.state = MstsSignalAspect.APPROACH_2; }
+                        else { sigHead.state = MstsSignalAspect.APPROACH_3; }
+                        sigHead.draw_state = sigHead.def_draw_state(sigHead.state);
+                    }
+                    break;
+                case 3:
+                    signal.holdState = SignalObject.HoldState.ManualPass;
+                    foreach (var sigHead in signal.SignalHeads)
+                    {
+                        sigHead.SetLeastRestrictiveAspect();
+                        sigHead.draw_state = sigHead.def_draw_state(sigHead.state);
+                    }
+                    break;
+            }
+            UnHandleItemPick();
+        }
 
-	  }
+        private void boxSetSwitchChosen(object sender, EventArgs e)
+        {
+            if (switchPickedItem == null)
+            {
+                UnHandleItemPick(); return;
+            }
+            var sw = switchPickedItem.Item.TrJunctionNode;
+            var type = boxSetSwitch.SelectedIndex;
 
-	  private void chkPreferGreenHandle(object sender, EventArgs e)
-	  {
-		  MultiPlayer.MPManager.PreferGreen = chkBoxPenalty.Checked;
+            //aider can send message to the server for a switch
+            if (MultiPlayer.MPManager.IsMultiPlayer() && MultiPlayer.MPManager.Instance().AmAider)
+            {
+                var nextSwitchTrack = sw;
+                var Selected = 0;
+                switch (type)
+                {
+                    case 0:
+                        Selected = (int)switchPickedItem.main;
+                        break;
+                    case 1:
+                        Selected = 1 - (int)switchPickedItem.main;
+                        break;
+                }
+                //aider selects and throws the switch, but need to confirm by the dispatcher
+                MultiPlayer.MPManager.Notify((new MultiPlayer.MSGSwitch(MultiPlayer.MPManager.GetUserName(),
+                    nextSwitchTrack.TN.UiD.WorldTileX, nextSwitchTrack.TN.UiD.WorldTileZ, nextSwitchTrack.TN.UiD.WorldId, Selected, true)).ToString());
+                Program.Simulator.Confirmer.Information(Viewer.Catalog.GetString("Switching Request Sent to the Server"));
 
-	  }
+            }
+            //server throws the switch immediately
+            else
+            {
+                switch (type)
+                {
+                    case 0:
+                        Program.Simulator.Signals.RequestSetSwitch(sw.TN, (int)switchPickedItem.main);
+                        //sw.SelectedRoute = (int)switchPickedItem.main;
+                        break;
+                    case 1:
+                        Program.Simulator.Signals.RequestSetSwitch(sw.TN, 1 - (int)switchPickedItem.main);
+                        //sw.SelectedRoute = 1 - (int)switchPickedItem.main;
+                        break;
+                }
+            }
+            UnHandleItemPick();
 
-      public bool ClickedTrain;
-	  private void btnSeeInGameClick(object sender, EventArgs e)
-	  {
-		  if (PickedTrain != null) ClickedTrain = true;
-		  else ClickedTrain = false;
-	  }
+        }
 
-      private void PictureMoveAndZoomInOut(int x, int y, decimal scale)
-      {
-          int diffX = x -pictureBox1.Width/2;
-          int diffY = y -pictureBox1.Height/2;
-          ViewWindow.Offset(diffX / xScale, -diffY/yScale);
-          if (scale < windowSizeUpDown.Minimum) scale = windowSizeUpDown.Minimum;
-          if (scale > windowSizeUpDown.Maximum) scale = windowSizeUpDown.Maximum;
-          windowSizeUpDown.Value = scale;
-          GenerateView();
-      }
-   }
+        private void chkAllowNewCheck(object sender, EventArgs e)
+        {
+            MultiPlayer.MPManager.Instance().AllowNewPlayer = chkAllowNew.Checked;
+        }
 
-   #region SignalWidget
-   /// <summary>
-   /// Defines a signal being drawn in a 2D view.
-   /// </summary>
-   public class SignalWidget : ItemWidget
-   {
-	   public TrItem Item;
-	   /// <summary>
-	   /// The underlying signal object as referenced by the TrItem.
-	   /// </summary>
-	   public SignalObject Signal;
+        private void AssistClick(object sender, EventArgs e)
+        {
+            AvatarView.SelectedIndices.Remove(0);
+            if (AvatarView.SelectedIndices.Count > 0)
+            {
+                var tmp = AvatarView.SelectedItems[0].Text.Split(' ');
+                var name = tmp[0].Trim();
+                if (MultiPlayer.MPManager.Instance().aiderList.Contains(name)) return;
+                if (MultiPlayer.MPManager.OnlineTrains.Players.ContainsKey(name))
+                {
+                    MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGAider(name, true)).ToString());
+                    MultiPlayer.MPManager.Instance().aiderList.Add(name);
+                }
+                AvatarView.Items.Clear();
+                if (avatarList != null) avatarList.Clear();
+            }
+        }
 
-	   public PointF Dir;
-       public bool hasDir;
-	   /// <summary>
-	   /// For now, returns true if any of the signal heads shows any "clear" aspect.
-	   /// This obviously needs some refinement.
-	   /// </summary>
-	   public int IsProceed
-	   {
-		   get
-		   {
-			   int returnValue = 2;
+        private void btnNormalClick(object sender, EventArgs e)
+        {
+            if (AvatarView.SelectedIndices.Count > 0)
+            {
+                var tmp = AvatarView.SelectedItems[0].Text.Split(' ');
+                var name = tmp[0].Trim();
+                if (MultiPlayer.MPManager.OnlineTrains.Players.ContainsKey(name))
+                {
+                    MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGAider(name, false)).ToString());
+                    MultiPlayer.MPManager.Instance().aiderList.Remove(name);
+                }
+                AvatarView.Items.Clear();
+                if (avatarList != null) avatarList.Clear();
+            }
 
-			   foreach (var head in Signal.SignalHeads)
-			   {
-                   if (head.state == MstsSignalAspect.CLEAR_1 ||
-                       head.state == MstsSignalAspect.CLEAR_2)
-				   {
-					   returnValue = 0;
-				   }
-                   if (head.state == MstsSignalAspect.APPROACH_1 ||
-                       head.state == MstsSignalAspect.APPROACH_2 || head.state == MstsSignalAspect.APPROACH_3)
-				   {
-					   returnValue = 1;
-				   }
-			   }
+        }
 
-			   return returnValue;
-		   }
-	   }
+        private void btnFollowClick(object sender, EventArgs e)
+        {
+            followTrain = true;
+        }
 
-	   /// <summary>
-	   /// 
-	   /// </summary>
-	   /// <param name="item"></param>
-	   /// <param name="signal"></param>
-	   public SignalWidget(SignalItem item, SignalObject signal)
-	   {
-		   Item = item;
-		   Signal = signal;
-		   hasDir = false;
-		   Location.X = item.TileX * 2048 + item.X; Location.Y = item.TileZ * 2048 + item.Z;
-		   try
-		   {
-			   var node = Program.Simulator.TDB.TrackDB.TrackNodes[signal.trackNode];
-			   Vector2 v2;
-			   if (node.TrVectorNode != null) { var ts = node.TrVectorNode.TrVectorSections[0]; v2 = new Vector2(ts.TileX * 2048 + ts.X, ts.TileZ * 2048 + ts.Z); }
-			   else if (node.TrJunctionNode != null) { var ts = node.UiD; v2 = new Vector2(ts.TileX * 2048 + ts.X, ts.TileZ * 2048 + ts.Z); }
-			   else throw new Exception();
-			   var v1 = new Vector2(Location.X, Location.Y); var v3 = v1 - v2; v3.Normalize(); v2 = v1 - Vector2.Multiply(v3, signal.direction == 0 ? 12f : -12f);
-			   Dir.X = v2.X; Dir.Y = v2.Y;
-               v2 = v1 - Vector2.Multiply(v3, signal.direction == 0 ? 1.5f : -1.5f);//shift signal along the dir for 2m, so signals will not be overlapped
-               Location.X = v2.X; Location.Y = v2.Y;
-			   hasDir = true;
-		   }
-		   catch {  }
-	   }
-   }
-   #endregion
+        private void chkOPenaltyHandle(object sender, EventArgs e)
+        {
+            MultiPlayer.MPManager.Instance().CheckSpad = chkBoxPenalty.Checked;
+            if (this.chkBoxPenalty.Checked == false) { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "OverSpeedOK", "OK to go overspeed and pass stop light")).ToString()); }
+            else { MultiPlayer.MPManager.BroadCast((new MultiPlayer.MSGMessage("All", "NoOverSpeed", "Penalty for overspeed and passing stop light")).ToString()); }
 
-   #region SwitchWidget
-   /// <summary>
-   /// Defines a signal being drawn in a 2D view.
-   /// </summary>
-   public class SwitchWidget : ItemWidget
-   {
-	   public TrackNode Item;
-	   public uint main;
+        }
+
+        private void chkPreferGreenHandle(object sender, EventArgs e)
+        {
+            MultiPlayer.MPManager.PreferGreen = chkBoxPenalty.Checked;
+
+        }
+
+        public bool ClickedTrain;
+        private void btnSeeInGameClick(object sender, EventArgs e)
+        {
+            if (PickedTrain != null) ClickedTrain = true;
+            else ClickedTrain = false;
+        }
+
+        private void PictureMoveAndZoomInOut(int x, int y, decimal scale)
+        {
+            int diffX = x - pictureBox1.Width / 2;
+            int diffY = y - pictureBox1.Height / 2;
+            ViewWindow.Offset(diffX / xScale, -diffY / yScale);
+            if (scale < windowSizeUpDown.Minimum) scale = windowSizeUpDown.Minimum;
+            if (scale > windowSizeUpDown.Maximum) scale = windowSizeUpDown.Maximum;
+            windowSizeUpDown.Value = scale;
+            GenerateView();
+        }
+    }
+
+    #region SignalWidget
+    /// <summary>
+    /// Defines a signal being drawn in a 2D view.
+    /// </summary>
+    public class SignalWidget : ItemWidget
+    {
+        public TrItem Item;
+        /// <summary>
+        /// The underlying signal object as referenced by the TrItem.
+        /// </summary>
+        public SignalObject Signal;
+
+        public PointF Dir;
+        public bool hasDir;
+        /// <summary>
+        /// For now, returns true if any of the signal heads shows any "clear" aspect.
+        /// This obviously needs some refinement.
+        /// </summary>
+        public int IsProceed
+        {
+            get
+            {
+                int returnValue = 2;
+
+                foreach (var head in Signal.SignalHeads)
+                {
+                    if (head.state == MstsSignalAspect.CLEAR_1 ||
+                        head.state == MstsSignalAspect.CLEAR_2)
+                    {
+                        returnValue = 0;
+                    }
+                    if (head.state == MstsSignalAspect.APPROACH_1 ||
+                        head.state == MstsSignalAspect.APPROACH_2 || head.state == MstsSignalAspect.APPROACH_3)
+                    {
+                        returnValue = 1;
+                    }
+                }
+
+                return returnValue;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="signal"></param>
+        public SignalWidget(SignalItem item, SignalObject signal)
+        {
+            Item = item;
+            Signal = signal;
+            hasDir = false;
+            Location.X = item.TileX * 2048 + item.X; Location.Y = item.TileZ * 2048 + item.Z;
+            try
+            {
+                var node = Program.Simulator.TDB.TrackDB.TrackNodes[signal.trackNode];
+                Vector2 v2;
+                if (node.TrVectorNode != null) { var ts = node.TrVectorNode.TrVectorSections[0]; v2 = new Vector2(ts.TileX * 2048 + ts.X, ts.TileZ * 2048 + ts.Z); }
+                else if (node.TrJunctionNode != null) { var ts = node.UiD; v2 = new Vector2(ts.TileX * 2048 + ts.X, ts.TileZ * 2048 + ts.Z); }
+                else throw new Exception();
+                var v1 = new Vector2(Location.X, Location.Y); var v3 = v1 - v2; v3.Normalize(); v2 = v1 - Vector2.Multiply(v3, signal.direction == 0 ? 12f : -12f);
+                Dir.X = v2.X; Dir.Y = v2.Y;
+                v2 = v1 - Vector2.Multiply(v3, signal.direction == 0 ? 1.5f : -1.5f);//shift signal along the dir for 2m, so signals will not be overlapped
+                Location.X = v2.X; Location.Y = v2.Y;
+                hasDir = true;
+            }
+            catch { }
+        }
+    }
+    #endregion
+
+    #region SwitchWidget
+    /// <summary>
+    /// Defines a signal being drawn in a 2D view.
+    /// </summary>
+    public class SwitchWidget : ItemWidget
+    {
+        public TrackNode Item;
+        public uint main;
 #if false
 	   public dVector mainEnd;
 #endif
-	   /// <summary>
-	   /// 
-	   /// </summary>
-	   /// <param name="item"></param>
-	   /// <param name="signal"></param>
-	   public SwitchWidget(TrackNode item)
-	   {
-		   Item = item;
-		   var TS = Program.Simulator.TSectionDat.TrackShapes.Get(item.TrJunctionNode.ShapeIndex);  // TSECTION.DAT tells us which is the main route
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="signal"></param>
+        public SwitchWidget(TrackNode item)
+        {
+            Item = item;
+            var TS = Program.Simulator.TSectionDat.TrackShapes.Get(item.TrJunctionNode.ShapeIndex);  // TSECTION.DAT tells us which is the main route
 
-		   if (TS != null) { main = TS.MainRoute;}
-		   else main = 0;
+            if (TS != null) { main = TS.MainRoute; }
+            else main = 0;
 #if false
 		   try
 		   {
@@ -2211,154 +2213,156 @@ namespace Orts.Viewer3D.Debugging
 		   }
 		   catch { mainEnd = null; }
 #endif
-		   Location.X = Item.UiD.TileX * 2048 + Item.UiD.X; Location.Y = Item.UiD.TileZ * 2048 + Item.UiD.Z;
-	   }
-   }
+            Location.X = Item.UiD.TileX * 2048 + Item.UiD.X; Location.Y = Item.UiD.TileZ * 2048 + Item.UiD.Z;
+        }
+    }
 
-   #endregion
+    #endregion
 
-   #region BufferWidget
-   public class BufferWidget : ItemWidget
-   {
-	   public TrackNode Item;
+    #region BufferWidget
+    public class BufferWidget : ItemWidget
+    {
+        public TrackNode Item;
 
-	   /// <summary>
-	   /// 
-	   /// </summary>
-	   /// <param name="item"></param>
-	   /// <param name="signal"></param>
-	   public BufferWidget(TrackNode item)
-	   {
-		   Item = item;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="signal"></param>
+        public BufferWidget(TrackNode item)
+        {
+            Item = item;
 
-		   Location.X = Item.UiD.TileX * 2048 + Item.UiD.X; Location.Y = Item.UiD.TileZ * 2048 + Item.UiD.Z;
-	   }
-   }
-   #endregion
+            Location.X = Item.UiD.TileX * 2048 + Item.UiD.X; Location.Y = Item.UiD.TileZ * 2048 + Item.UiD.Z;
+        }
+    }
+    #endregion
 
-   #region ItemWidget
-   public class ItemWidget
-   {
-	   public PointF Location;
-	   public PointF Location2D;
+    #region ItemWidget
+    public class ItemWidget
+    {
+        public PointF Location;
+        public PointF Location2D;
 
-	   /// <summary>
-	   /// 
-	   /// </summary>
-	   /// <param name="item"></param>
-	   public ItemWidget()
-	   {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="item"></param>
+        public ItemWidget()
+        {
 
-		   Location = new PointF(float.NegativeInfinity, float.NegativeInfinity);
-		   Location2D = new PointF(float.NegativeInfinity, float.NegativeInfinity);
-	   }
+            Location = new PointF(float.NegativeInfinity, float.NegativeInfinity);
+            Location2D = new PointF(float.NegativeInfinity, float.NegativeInfinity);
+        }
 
-   }
-   #endregion
+    }
+    #endregion
 
-   #region TrainWidget
-   public class TrainWidget : ItemWidget
-   {
-	   public Train Train;
+    #region TrainWidget
+    public class TrainWidget : ItemWidget
+    {
+        public Train Train;
 
-	   /// <summary>
-	   /// 
-	   /// </summary>
-	   /// <param name="item"></param>
-	   public TrainWidget(Train t)
-	   {
-		   Train = t;
-	   }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="item"></param>
+        public TrainWidget(Train t)
+        {
+            Train = t;
+        }
 
-   }
-   #endregion
-   #region LineSegment
-   /// <summary>
-   /// Defines a geometric line segment.
-   /// </summary>
-   public class LineSegment
-   {
-	   public dVector A;
-	   public dVector B;
-	   public dVector C;
-	   //public float radius;
-       public bool isCurved;
+    }
+    #endregion
+    #region LineSegment
+    /// <summary>
+    /// Defines a geometric line segment.
+    /// </summary>
+    public class LineSegment
+    {
+        public dVector A;
+        public dVector B;
+        public dVector C;
+        //public float radius;
+        public bool isCurved;
 
-	   public float angle1, angle2;
-	   //public SectionCurve curve = null;
-       //public TrVectorSection MySection;
-	   public LineSegment(dVector A, dVector B, bool Occupied, TrVectorSection Section)
-	   {
-		   this.A = A;
-		   this.B = B;
+        public float angle1, angle2;
+        //public SectionCurve curve = null;
+        //public TrVectorSection MySection;
+        public LineSegment(dVector A, dVector B, bool Occupied, TrVectorSection Section)
+        {
+            this.A = A;
+            this.B = B;
 
-		   isCurved = false; 
-		   if (Section == null) return;
-           //MySection = Section;
-		   uint k = Section.SectionIndex;
-		   TrackSection ts = Program.Simulator.TSectionDat.TrackSections.Get(k);
-		   if (ts != null)
-		   {
-			   if (ts.SectionCurve != null)
-			   {
-				   float diff = (float) (ts.SectionCurve.Radius * (1 - Math.Cos(ts.SectionCurve.Angle * 3.14f / 360)));
-				   if (diff < 3) return; //not need to worry, curve too small
-				   //curve = ts.SectionCurve;
-				   Vector3 v = new Vector3((float)((B.TileX-A.TileX)*2048 + B.X - A.X), 0, (float)((B.TileZ - A.TileZ)*2048 + B.Z - A.Z));
-				   isCurved = true;
-				   Vector3 v2 = Vector3.Cross(Vector3.Up, v); v2.Normalize();
-                   v = v / 2; v.X += A.TileX * 2048 + (float)A.X; v.Z += A.TileZ * 2048 + (float)A.Z;
-				   if (ts.SectionCurve.Angle > 0)
-				   {
-					   v = v2*-diff + v;
-				   }
-				   else v = v2*diff + v;
-				   C = new dVector(0, v.X, 0, v.Z);
-			   }
-		   }
+            isCurved = false;
+            if (Section == null) return;
+            //MySection = Section;
+            uint k = Section.SectionIndex;
+            TrackSection ts = Program.Simulator.TSectionDat.TrackSections.Get(k);
+            if (ts != null)
+            {
+                if (ts.SectionCurve != null)
+                {
+                    float diff = (float)(ts.SectionCurve.Radius * (1 - Math.Cos(ts.SectionCurve.Angle * 3.14f / 360)));
+                    if (diff < 3) return; //not need to worry, curve too small
+                                          //curve = ts.SectionCurve;
+                    Vector3 v = new Vector3((float)((B.TileX - A.TileX) * 2048 + B.X - A.X), 0, (float)((B.TileZ - A.TileZ) * 2048 + B.Z - A.Z));
+                    isCurved = true;
+                    Vector3 v2 = Vector3.Cross(Vector3.Up, v); v2.Normalize();
+                    v = v / 2; v.X += A.TileX * 2048 + (float)A.X; v.Z += A.TileZ * 2048 + (float)A.Z;
+                    if (ts.SectionCurve.Angle > 0)
+                    {
+                        v = v2 * -diff + v;
+                    }
+                    else v = v2 * diff + v;
+                    C = new dVector(0, v.X, 0, v.Z);
+                }
+            }
 
-	   }
-   }
+        }
+    }
 
-   #endregion
+    #endregion
 
-   #region SidingWidget
+    #region SidingWidget
 
-   /// <summary>
-   /// Defines a siding name being drawn in a 2D view.
-   /// </summary>
-   public struct SidingWidget
-   {
-	   public PointF Location;
-	   public string Name;
-	   /// <summary>
-	   /// The underlying track item.
-	   /// </summary>
-	   private TrItem Item;
+    /// <summary>
+    /// Defines a siding name being drawn in a 2D view.
+    /// </summary>
+    public struct SidingWidget
+    {
+        public PointF Location;
+        public string Name;
+        /// <summary>
+        /// The underlying track item.
+        /// </summary>
+        private TrItem Item;
 
-	   /// <summary>
-	   /// 
-	   /// </summary>
-	   /// <param name="item"></param>
-	   /// <param name="signal"></param>
-	   public SidingWidget(TrItem item)
-	   {
-		   Item = item;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="signal"></param>
+        public SidingWidget(TrItem item)
+        {
+            Item = item;
 
-		   Name = item.ItemName;
+            Name = item.ItemName;
 
-		   Location = new PointF(item.TileX * 2048 + item.X, item.TileZ * 2048 + item.Z);
-	   }
-   }
-   #endregion
+            Location = new PointF(item.TileX * 2048 + item.X, item.TileZ * 2048 + item.Z);
+        }
+    }
+    #endregion
 
-   public class dVector
-   {
-       public int TileX, TileZ;
-	   public double X, Z;
-       public dVector(int tilex1, double x1, int tilez1, double z1) { TileX = tilex1; TileZ = tilez1; X = x1; Z = z1; }
-       static public double DistanceSqr(dVector v1, dVector v2) { return Math.Pow((v1.TileX - v2.TileX)*2048 + v1.X - v2.X, 2)
-           + Math.Pow((v1.TileZ - v2.TileZ) * 2048 + v1.Z - v2.Z, 2);
-       }
-   }
+    public class dVector
+    {
+        public int TileX, TileZ;
+        public double X, Z;
+        public dVector(int tilex1, double x1, int tilez1, double z1) { TileX = tilex1; TileZ = tilez1; X = x1; Z = z1; }
+        static public double DistanceSqr(dVector v1, dVector v2)
+        {
+            return Math.Pow((v1.TileX - v2.TileX) * 2048 + v1.X - v2.X, 2)
++ Math.Pow((v1.TileZ - v2.TileZ) * 2048 + v1.Z - v2.Z, 2);
+        }
+    }
 }

--- a/Source/RunActivity/Viewer3D/Debugging/MessageViewer.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/MessageViewer.cs
@@ -21,82 +21,82 @@ using System.Windows.Forms;
 namespace Orts.Viewer3D.Debugging
 {
     public partial class MessageViewer : Form
-   {
-	   private void clearAllClick(object sender, EventArgs e)
-	   {
-		   messages.Items.Clear();
-	   }
+    {
+        private void clearAllClick(object sender, EventArgs e)
+        {
+            messages.Items.Clear();
+        }
 
-	   private void composeClick(object sender, EventArgs e)
-	   {
-		   MSG.Enabled = true;
-		   MultiPlayer.MPManager.Instance().ComposingText = true;
-	   }
-	   
-	   private void replySelectedClick(object sender, EventArgs e)
-	   {
-		   var count = 0;
-		   while (count < 3)
-		   {
-			   try
-			   {
-				   var chosen = messages.SelectedItems;
-				   var msg = MSG.Text;
-				   msg = msg.Replace("\r", "");
-				   msg = msg.Replace("\t", "");
-				   if (msg == "") return;
-				   if (chosen.Count > 0)
-				   {
-					   var user = "";
+        private void composeClick(object sender, EventArgs e)
+        {
+            MSG.Enabled = true;
+            MultiPlayer.MPManager.Instance().ComposingText = true;
+        }
 
-					   for (var i = 0; i < chosen.Count; i++)
-					   {
-						   var tmp = (string)chosen[i];
-						   var index = tmp.IndexOf(':');
-						   if (index < 0) continue;
-						   tmp = tmp.Substring(0, index)+"\r";
-						   if (user.Contains(tmp)) continue;
-						   user += tmp;
-					   }
-					   user += "0END";
+        private void replySelectedClick(object sender, EventArgs e)
+        {
+            var count = 0;
+            while (count < 3)
+            {
+                try
+                {
+                    var chosen = messages.SelectedItems;
+                    var msg = MSG.Text;
+                    msg = msg.Replace("\r", "");
+                    msg = msg.Replace("\t", "");
+                    if (msg == "") return;
+                    if (chosen.Count > 0)
+                    {
+                        var user = "";
 
-					   MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
-					   MSG.Text = "";
-					   //MSG.Enabled = false;
-					   MultiPlayer.MPManager.Instance().ComposingText = false;
+                        for (var i = 0; i < chosen.Count; i++)
+                        {
+                            var tmp = (string)chosen[i];
+                            var index = tmp.IndexOf(':');
+                            if (index < 0) continue;
+                            tmp = tmp.Substring(0, index) + "\r";
+                            if (user.Contains(tmp)) continue;
+                            user += tmp;
+                        }
+                        user += "0END";
 
-				   }
-				   return;
-			   }
-			   catch { count++; }
-		   }
-	   }
-	   public MessageViewer()
-	   {
-		   InitializeComponent();
-	   }
+                        MultiPlayer.MPManager.Notify((new MultiPlayer.MSGText(MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
+                        MSG.Text = "";
+                        //MSG.Enabled = false;
+                        MultiPlayer.MPManager.Instance().ComposingText = false;
 
-	   public bool addNewMessage(double time, string msg)
-	   {
-		   var count = 0;
-		   while (count < 3)
-		   {
-			   try
-			   {
-				   if (messages.Items.Count > 10)
-				   {
-					   messages.Items.RemoveAt(0);
-				   }
-				   messages.Items.Add(msg);
-				   Show();
-				   Visible = true;
-				   BringToFront();
-				   break;
-			   }
-			   catch { count++; }
-		   }
-		   return true;
-	   }
+                    }
+                    return;
+                }
+                catch { count++; }
+            }
+        }
+        public MessageViewer()
+        {
+            InitializeComponent();
+        }
 
-   }
+        public bool addNewMessage(double time, string msg)
+        {
+            var count = 0;
+            while (count < 3)
+            {
+                try
+                {
+                    if (messages.Items.Count > 10)
+                    {
+                        messages.Items.RemoveAt(0);
+                    }
+                    messages.Items.Add(msg);
+                    Show();
+                    Visible = true;
+                    BringToFront();
+                    break;
+                }
+                catch { count++; }
+            }
+            return true;
+        }
+
+    }
 }

--- a/Source/RunActivity/Viewer3D/DriverMachineInterface.cs
+++ b/Source/RunActivity/Viewer3D/DriverMachineInterface.cs
@@ -45,7 +45,7 @@ namespace Orts.Viewer3D
         const float FontHeightDial = 16;
         const float FontHeightReleaseSpeed = 17;
         const float FontHeightCurrentSpeed = 18;
-        
+
         const int LineQuarter = 11;
         const int RadiusText = 99;
         readonly int[] CurrentSpeedPosition = new int[] { 150, 135, 120, 137 }; // x 10^0, x 10^1, x 10^2, y
@@ -64,10 +64,10 @@ namespace Orts.Viewer3D
         readonly Color ColorRed = new Color(191, 0, 2);
         //readonly Color ColorDarkYellow = new Color(105, 105, 0);
         //readonly Color ColorBackground = new Color(3, 17, 34); // dark blue
-        
+
         const string UnitMetricString = "km/h";
         const string UnitImperialString = "mph";
-        
+
         // Some national railways specify the unit (km/h or mph) is to be shown on dial, in contrast to ETA.
         bool UnitVisible;
         bool UnitMetric;
@@ -76,7 +76,7 @@ namespace Orts.Viewer3D
         // Some national railways specify the scale lines and numbers above a certain limit not to be visible
         int MaxVisibleScale;
         int[] StandardScales;
-        
+
         float MidSpeed;
         string Unit;
 
@@ -109,18 +109,18 @@ namespace Orts.Viewer3D
 
         readonly Rectangle SourceRectangle = new Rectangle(0, 0, Width, Height);
         public float Scale { get; private set; }
-        
+
         public CircularSpeedGauge(int width, int height, int maxSpeed, bool unitMetric, bool unitVisible, bool dialQuarterLines, int maxVisibleScale, MSTSLocomotive locomotive, Viewer viewer)
         {
             UnitVisible = unitVisible;
             SetUnit(unitMetric);
-            
+
             DialQuarterLines = dialQuarterLines;
             MaxSpeed = maxSpeed;
             MaxVisibleScale = maxVisibleScale;
             Viewer = viewer;
             Locomotive = locomotive;
-            
+
             SizeTo(width, height);
             SetRange(MaxSpeed);
 
@@ -145,7 +145,7 @@ namespace Orts.Viewer3D
                         ) ? Color.White : Color.TransparentBlack;
             }
         }
-        
+
         /// <summary>
         /// Select the actual unit of measure for speed
         /// </summary>
@@ -168,7 +168,7 @@ namespace Orts.Viewer3D
                 StandardScales = StandardScalesMpH;
             }
         }
-        
+
         /// <summary>
         /// Set new font heights to match the actual scale.
         /// </summary>
@@ -243,7 +243,7 @@ namespace Orts.Viewer3D
                     {
                         DialLineCoords.Add(new Vector4(x, y, LineFull, angle + MathHelper.PiOver2));
 
-                        if (MaxSpeed != StandardScales[StandardScales.Length - 1] || speed < MidSpeed 
+                        if (MaxSpeed != StandardScales[StandardScales.Length - 1] || speed < MidSpeed
                             || UnitMetric && speed % 100 == 0
                             || !UnitMetric && speed % 40 == 0)
                         {
@@ -265,7 +265,7 @@ namespace Orts.Viewer3D
                     }
                     else
                         DialLineCoords.Add(new Vector4(x, y, LineHalf, angle + MathHelper.PiOver2));
-                    
+
                     longLine++;
                     longLine %= MaxSpeed != StandardScales[StandardScales.Length - 1] ? 2 : UnitMetric ? 5 : (speed + 5 > MidSpeed) ? 4 : 2;
                 }
@@ -274,13 +274,13 @@ namespace Orts.Viewer3D
                     DialLineCoords.Add(new Vector4(x, y, LineQuarter, angle + MathHelper.PiOver2));
                 }
             }
-            
+
             if (Unit != "")
             {
                 var unitPosition = new Point((int)(UnitCenterPosition[0] - FontDialSpeeds.MeasureString(Unit) / Scale / 2f), (int)(UnitCenterPosition[1] - textHeight / 2f));
                 DialSpeeds.Add(new TextPrimitive(unitPosition, Color.White, Unit, FontDialSpeeds));
             }
-            
+
             Active = true;
         }
 
@@ -363,7 +363,7 @@ namespace Orts.Viewer3D
             }
 
             if (!Active) return;
-            
+
             int x = 0, y = 0;
 
             foreach (var lines in DialLineCoords)
@@ -479,13 +479,13 @@ namespace Orts.Viewer3D
         {
             CircularSpeedGauge.PrepareFrame();
         }
-        
+
         internal override void Draw(SpriteBatch spriteBatch, Point position)
         {
             // Hack to adjust for track monitor
             position.X += 8;
             position.Y += 20;
-            
+
             CircularSpeedGauge.Draw(spriteBatch, position);
         }
     }
@@ -528,7 +528,7 @@ namespace Orts.Viewer3D
             }
         }
 
-		public override void Draw(GraphicsDevice graphicsDevice)
+        public override void Draw(GraphicsDevice graphicsDevice)
         {
             CircularSpeedGauge.Draw(ControlView.SpriteBatch, new Point(DrawPosition.X, DrawPosition.Y));
         }

--- a/Source/RunActivity/Viewer3D/DynamicTrack.cs
+++ b/Source/RunActivity/Viewer3D/DynamicTrack.cs
@@ -102,7 +102,7 @@ namespace Orts.Viewer3D
                 {   // Both heading and translation change 
                     // nextRoot is found by moving from Point-of-Curve (PC) to
                     // center (O)to Point-of-Tangent (PT).
-                    float radius = subsection.trackSections[0].param2*Math.Sign(-subsection.trackSections[0].param1); // meters
+                    float radius = subsection.trackSections[0].param2 * Math.Sign(-subsection.trackSections[0].param1); // meters
                     Vector3 left = radius * Vector3.Cross(Vector3.Up, heading); // Vector from PC to O
                     Matrix rot = Matrix.CreateRotationY(-length); // Heading change (rotation about O)
                     // Shared method returns displacement from present world position and, by reference,

--- a/Source/RunActivity/Viewer3D/Forest.cs
+++ b/Source/RunActivity/Viewer3D/Forest.cs
@@ -130,7 +130,7 @@ namespace Orts.Viewer3D
                 forestVertex = new Vector3(forest.forestArea.X / 2, 0, forest.forestArea.Z / 2);
                 Vector3.Transform(ref forestVertex, ref position.XNAMatrix, out forestVertex);
                 forestVertices.Add(forestVertex);
-                bool[] considerTile = new bool [4] {false, false, false, false};
+                bool[] considerTile = new bool[4] { false, false, false, false };
                 foreach (var fVertex in forestVertices)
                 {
                     if (fVertex.X > 1024) considerTile[0] = true;
@@ -162,22 +162,22 @@ namespace Orts.Viewer3D
                 }
                 if (considerTile[0] && considerTile[2])
                 {
-                    addList = FindTracksAndRoadsClose(position.TileX + 1, position.TileZ +1);
+                    addList = FindTracksAndRoadsClose(position.TileX + 1, position.TileZ + 1);
                     FindTracksAndRoadsMoreClose(ref sections, addList, forest, position, InvForestXNAMatrix);
                 }
                 if (considerTile[0] && considerTile[3])
                 {
-                    addList = FindTracksAndRoadsClose(position.TileX + 1, position.TileZ -1);
+                    addList = FindTracksAndRoadsClose(position.TileX + 1, position.TileZ - 1);
                     FindTracksAndRoadsMoreClose(ref sections, addList, forest, position, InvForestXNAMatrix);
                 }
                 if (considerTile[1] && considerTile[2])
                 {
-                    addList = FindTracksAndRoadsClose(position.TileX-1, position.TileZ + 1);
+                    addList = FindTracksAndRoadsClose(position.TileX - 1, position.TileZ + 1);
                     FindTracksAndRoadsMoreClose(ref sections, addList, forest, position, InvForestXNAMatrix);
                 }
                 if (considerTile[1] && considerTile[3])
                 {
-                    addList = FindTracksAndRoadsClose(position.TileX-1, position.TileZ - 1);
+                    addList = FindTracksAndRoadsClose(position.TileX - 1, position.TileZ - 1);
                     FindTracksAndRoadsMoreClose(ref sections, addList, forest, position, InvForestXNAMatrix);
                 }
             }
@@ -336,7 +336,7 @@ namespace Orts.Viewer3D
 
             // Do a preliminary cull based on a bounding square around the track section.
             // Bounding distance is (radius * angle + error) by (radius * angle + error) around starting coordinates but no more than 2 for angle.
-            var boundingDistance = trackSection.SectionCurve.Radius * Math.Min(Math.Abs(MathHelper.ToRadians(trackSection.SectionCurve.Angle)), 2) + MaximumCenterlineOffset+treeWidth;
+            var boundingDistance = trackSection.SectionCurve.Radius * Math.Min(Math.Abs(MathHelper.ToRadians(trackSection.SectionCurve.Angle)), 2) + MaximumCenterlineOffset + treeWidth;
             var dx = Math.Abs(x - sx);
             var dz = Math.Abs(z - sz);
             if (dx > boundingDistance || dz > boundingDistance)

--- a/Source/RunActivity/Viewer3D/InfoDisplay.cs
+++ b/Source/RunActivity/Viewer3D/InfoDisplay.cs
@@ -126,61 +126,63 @@ namespace Orts.Viewer3D
 
         void RecordSteamPerformance()
         {
-           MSTSSteamLocomotive steamloco = (MSTSSteamLocomotive)Viewer.PlayerLocomotive;
-                        float SteamspeedMpH = MpS.ToMpH(steamloco.SpeedMpS);
-                        if (SteamspeedMpH >= previousLoggedSteamSpeedMpH + 5) // Add a new record every time speed increases by 5 mph
-                        {
-                            previousLoggedSteamSpeedMpH = (float)(int)SteamspeedMpH; // Keep speed records close to whole numbers
+            MSTSSteamLocomotive steamloco = (MSTSSteamLocomotive)Viewer.PlayerLocomotive;
+            float SteamspeedMpH = MpS.ToMpH(steamloco.SpeedMpS);
+            if (SteamspeedMpH >= previousLoggedSteamSpeedMpH + 5) // Add a new record every time speed increases by 5 mph
+            {
+                previousLoggedSteamSpeedMpH = (float)(int)SteamspeedMpH; // Keep speed records close to whole numbers
 
-                            Logger.Data(MpS.FromMpS(Viewer.PlayerLocomotive.SpeedMpS, false).ToString("F0"));
-                            Logger.Data(S.ToM(steamloco.SteamPerformanceTimeS).ToString("F1"));
-                            Logger.Data(Viewer.PlayerLocomotive.ThrottlePercent.ToString("F0"));
-                            Logger.Data(Viewer.PlayerTrain.MUReverserPercent.ToString("F0"));
-                            Logger.Data(N.ToLbf(Viewer.PlayerLocomotive.MotiveForceN).ToString("F0"));
-                            Logger.Data(steamloco.IndicatedHorsePowerHP.ToString("F0"));
-                            Logger.Data(steamloco.DrawBarPullLbsF.ToString("F0"));
-                            Logger.Data(steamloco.DrawbarHorsePowerHP.ToString("F0"));
-                            Logger.Data(N.ToLbf(steamloco.LocomotiveCouplerForceN).ToString("F0"));
-                            Logger.Data(N.ToLbf(steamloco.LocoTenderFrictionForceN).ToString("F0"));
-                            Logger.Data(N.ToLbf(steamloco.TotalFrictionForceN).ToString("F0"));
-                            Logger.Data(Kg.ToTUK(steamloco.TrainLoadKg).ToString("F0"));
-                            Logger.Data(steamloco.BoilerPressurePSI.ToString("F0"));
-                            Logger.Data(steamloco.LogSteamChestPressurePSI.ToString("F0"));
-                            Logger.Data(steamloco.LogInitialPressurePSI.ToString("F0"));
-                            Logger.Data(steamloco.LogCutoffPressurePSI.ToString("F0"));
-                            Logger.Data(steamloco.LogReleasePressurePSI.ToString("F0"));
-                            Logger.Data(steamloco.LogBackPressurePSI.ToString("F0"));
-                            
-                            Logger.Data(steamloco.MeanEffectivePressurePSI.ToString("F0"));
+                Logger.Data(MpS.FromMpS(Viewer.PlayerLocomotive.SpeedMpS, false).ToString("F0"));
+                Logger.Data(S.ToM(steamloco.SteamPerformanceTimeS).ToString("F1"));
+                Logger.Data(Viewer.PlayerLocomotive.ThrottlePercent.ToString("F0"));
+                Logger.Data(Viewer.PlayerTrain.MUReverserPercent.ToString("F0"));
+                Logger.Data(N.ToLbf(Viewer.PlayerLocomotive.MotiveForceN).ToString("F0"));
+                Logger.Data(steamloco.IndicatedHorsePowerHP.ToString("F0"));
+                Logger.Data(steamloco.DrawBarPullLbsF.ToString("F0"));
+                Logger.Data(steamloco.DrawbarHorsePowerHP.ToString("F0"));
+                Logger.Data(N.ToLbf(steamloco.LocomotiveCouplerForceN).ToString("F0"));
+                Logger.Data(N.ToLbf(steamloco.LocoTenderFrictionForceN).ToString("F0"));
+                Logger.Data(N.ToLbf(steamloco.TotalFrictionForceN).ToString("F0"));
+                Logger.Data(Kg.ToTUK(steamloco.TrainLoadKg).ToString("F0"));
+                Logger.Data(steamloco.BoilerPressurePSI.ToString("F0"));
+                Logger.Data(steamloco.LogSteamChestPressurePSI.ToString("F0"));
+                Logger.Data(steamloco.LogInitialPressurePSI.ToString("F0"));
+                Logger.Data(steamloco.LogCutoffPressurePSI.ToString("F0"));
+                Logger.Data(steamloco.LogReleasePressurePSI.ToString("F0"));
+                Logger.Data(steamloco.LogBackPressurePSI.ToString("F0"));
 
-
-                            Logger.Data(steamloco.CurrentSuperheatTempF.ToString("F0"));
-
-                            Logger.Data(pS.TopH(steamloco.CylinderSteamUsageLBpS).ToString("F0"));
-                            Logger.Data(pS.TopH(steamloco.WaterConsumptionLbpS).ToString("F0"));
-                            Logger.Data(Kg.ToLb(pS.TopH(steamloco.FuelBurnRateSmoothedKGpS)).ToString("F0"));
+                Logger.Data(steamloco.MeanEffectivePressurePSI.ToString("F0"));
 
 
-                            Logger.Data(steamloco.SuperheaterSteamUsageFactor.ToString("F2"));
-                            Logger.Data(steamloco.CumulativeCylinderSteamConsumptionLbs.ToString("F0"));
-                            Logger.Data(steamloco.CumulativeWaterConsumptionLbs.ToString("F0"));
+                Logger.Data(steamloco.CurrentSuperheatTempF.ToString("F0"));
 
-                            Logger.Data(steamloco.CutoffPressureDropRatio.ToString("F2"));
+                Logger.Data(pS.TopH(steamloco.CylinderSteamUsageLBpS).ToString("F0"));
+                Logger.Data(pS.TopH(steamloco.WaterConsumptionLbpS).ToString("F0"));
+                Logger.Data(Kg.ToLb(pS.TopH(steamloco.FuelBurnRateSmoothedKGpS)).ToString("F0"));
 
-                            Logger.Data(steamloco.HPCylinderMEPPSI.ToString("F0"));
-                            Logger.Data(steamloco.LogLPInitialPressurePSI.ToString("F0"));
-                            Logger.Data(steamloco.LogLPCutoffPressurePSI.ToString("F0"));
-                            Logger.Data(steamloco.LogLPReleasePressurePSI.ToString("F0"));
-                            Logger.Data(steamloco.LogLPBackPressurePSI.ToString("F0"));
-                            Logger.Data(steamloco.CutoffPressureDropRatio.ToString("F2"));
-                            Logger.Data(steamloco.LPCylinderMEPPSI.ToString("F0"));
 
-                            Logger.End();
-                        }
+                Logger.Data(steamloco.SuperheaterSteamUsageFactor.ToString("F2"));
+                Logger.Data(steamloco.CumulativeCylinderSteamConsumptionLbs.ToString("F0"));
+                Logger.Data(steamloco.CumulativeWaterConsumptionLbs.ToString("F0"));
+
+                Logger.Data(steamloco.CutoffPressureDropRatio.ToString("F2"));
+
+                Logger.Data(steamloco.HPCylinderMEPPSI.ToString("F0"));
+                Logger.Data(steamloco.LogLPInitialPressurePSI.ToString("F0"));
+                Logger.Data(steamloco.LogLPCutoffPressurePSI.ToString("F0"));
+                Logger.Data(steamloco.LogLPReleasePressurePSI.ToString("F0"));
+                Logger.Data(steamloco.LogLPBackPressurePSI.ToString("F0"));
+                Logger.Data(steamloco.CutoffPressureDropRatio.ToString("F2"));
+                Logger.Data(steamloco.LPCylinderMEPPSI.ToString("F0"));
+
+                Logger.End();
+            }
         }
 
 #if DEBUG_DUMP_STEAM_POWER_CURVE
-        public bool IsRecordingSteamPowerCurve { get 
+        public bool IsRecordingSteamPowerCurve
+        {
+            get
             {
                 return Viewer.Settings.DataLogger
                 && !Viewer.Settings.DataLogPerformance
@@ -218,7 +220,7 @@ namespace Orts.Viewer3D
                 LastUpdateRealTime = Viewer.RealTime;
                 Profile(elapsedRealSeconds);
             }
-                        
+
 #if DEBUG_DUMP_STEAM_POWER_CURVE
             if (IsRecordingSteamPowerCurve)
             {
@@ -234,7 +236,7 @@ namespace Orts.Viewer3D
                 else
 
 
-            //Here's where the logger stores the data from each frame
+                //Here's where the logger stores the data from each frame
                 if (Viewer.Settings.DataLogger)
                 {
                     Logger.Separator = (DataLogger.Separators)Enum.Parse(typeof(DataLogger.Separators), Viewer.Settings.DataLoggerSeparator);
@@ -331,7 +333,7 @@ namespace Orts.Viewer3D
                         {
                             Logger.Data((Viewer.PlayerLocomotive as MSTSElectricLocomotive).Pantographs[1].CommandUp.ToString());
                             Logger.Data((Viewer.PlayerLocomotive as MSTSElectricLocomotive).Pantographs[2].CommandUp.ToString());
-                            Logger.Data((Viewer.PlayerLocomotive as MSTSElectricLocomotive).Pantographs.List.Count > 2 ? 
+                            Logger.Data((Viewer.PlayerLocomotive as MSTSElectricLocomotive).Pantographs.List.Count > 2 ?
                                 (Viewer.PlayerLocomotive as MSTSElectricLocomotive).Pantographs[3].CommandUp.ToString() : null);
                             Logger.Data((Viewer.PlayerLocomotive as MSTSElectricLocomotive).Pantographs.List.Count > 3 ?
                                 (Viewer.PlayerLocomotive as MSTSElectricLocomotive).Pantographs[4].CommandUp.ToString() : null);
@@ -376,7 +378,7 @@ namespace Orts.Viewer3D
                         }
 #endif
                     }
-                Logger.End();
+                    Logger.End();
 #if DEBUG_DUMP_STEAM_POWER_CURVE
                 }
 #endif
@@ -400,8 +402,8 @@ namespace Orts.Viewer3D
                 if (settings.DataLogPerformance)
                 {
                     headerLine = String.Join(Convert.ToString((char)separator),
-                        new string[] 
-                            {    
+                        new string[]
+                            {
                                 "SVN",
                                 "Frame",
                                 "Memory",
@@ -427,7 +429,7 @@ namespace Orts.Viewer3D
                         headerLine += Convert.ToString((char)separator);
 
                     headerLine += String.Join(Convert.ToString((char)separator),
-                            new string[] 
+                            new string[]
                             {
                                 "Time",
                                 "Player Direction",
@@ -472,8 +474,8 @@ namespace Orts.Viewer3D
                 if (settings.DataLogSteamPerformance)
                 {
                     headerLine = String.Join(Convert.ToString((char)separator),
-                        new string[] 
-                            {    
+                        new string[]
+                            {
                                 "Speed (mph)",
                                 "Time (M)",
                                 "Throttle (%)",
@@ -501,7 +503,7 @@ namespace Orts.Viewer3D
                                 "Cumulative Steam (lbs)",
                                 "Cumulative Water (lbs)",
                                 "Cutoff pressure Ratio",
-                                
+
                                 "HP MEP (psi)",
                                 "LPInitial Pressure (psi)",
                                 "LPCutoff Pressure (psi)",
@@ -520,10 +522,10 @@ namespace Orts.Viewer3D
                 && !settings.DataLogMisc
                 && !settings.DataLogSteamPerformance)
                 {
-                    
+
                     headerLine = String.Join(Convert.ToString((char)separator),
-                        new string[] 
-                            {    
+                        new string[]
+                            {
                                 "speed (mph)",
                                 "power (hp)",
                                 "throttle (%)",

--- a/Source/RunActivity/Viewer3D/Lights.cs
+++ b/Source/RunActivity/Viewer3D/Lights.cs
@@ -210,23 +210,23 @@ namespace Orts.Viewer3D
 
         bool UpdateState()
         {
-			Debug.Assert(Viewer.PlayerTrain.LeadLocomotive == Viewer.PlayerLocomotive ||Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING ||
+            Debug.Assert(Viewer.PlayerTrain.LeadLocomotive == Viewer.PlayerLocomotive || Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING ||
                 Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.REMOTE || Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.STATIC, "PlayerTrain.LeadLocomotive must be PlayerLocomotive.");
-			var locomotive = Car.Train != null && Car.Train.IsActualPlayerTrain ? Viewer.PlayerLocomotive : null;
+            var locomotive = Car.Train != null && Car.Train.IsActualPlayerTrain ? Viewer.PlayerLocomotive : null;
             if (locomotive == null && Car.Train != null && Car.Train.TrainType == Train.TRAINTYPE.REMOTE && Car is MSTSLocomotive && (Car as MSTSLocomotive) == Car.Train.LeadLocomotive)
                 locomotive = Car.Train.LeadLocomotive;
-			var mstsLocomotive = locomotive as MSTSLocomotive;
+            var mstsLocomotive = locomotive as MSTSLocomotive;
 
             // Headlight
-			var newTrainHeadlight = locomotive != null ? locomotive.Headlight : Car.Train != null && Car.Train.TrainType != Train.TRAINTYPE.STATIC ? 2 : 0;
+            var newTrainHeadlight = locomotive != null ? locomotive.Headlight : Car.Train != null && Car.Train.TrainType != Train.TRAINTYPE.STATIC ? 2 : 0;
             // Unit
-			var locomotiveFlipped = locomotive != null && locomotive.Flipped;
-			var locomotiveReverseCab = mstsLocomotive != null && mstsLocomotive.UsingRearCab;
+            var locomotiveFlipped = locomotive != null && locomotive.Flipped;
+            var locomotiveReverseCab = mstsLocomotive != null && mstsLocomotive.UsingRearCab;
             var newCarIsReversed = Car.Flipped ^ locomotiveFlipped ^ locomotiveReverseCab;
-			var newCarIsFirst = Car.Train == null || (locomotiveFlipped ^ locomotiveReverseCab ? Car.Train.LastCar : Car.Train.FirstCar) == Car;
-			var newCarIsLast = Car.Train == null || (locomotiveFlipped ^ locomotiveReverseCab ? Car.Train.FirstCar : Car.Train.LastCar) == Car;
+            var newCarIsFirst = Car.Train == null || (locomotiveFlipped ^ locomotiveReverseCab ? Car.Train.LastCar : Car.Train.FirstCar) == Car;
+            var newCarIsLast = Car.Train == null || (locomotiveFlipped ^ locomotiveReverseCab ? Car.Train.FirstCar : Car.Train.LastCar) == Car;
             // Penalty
-			var newPenalty = mstsLocomotive != null && mstsLocomotive.TrainBrakeController.EmergencyBraking;
+            var newPenalty = mstsLocomotive != null && mstsLocomotive.TrainBrakeController.EmergencyBraking;
             // Control
             var newCarIsPlayer = (Car.Train != null && Car.Train == Viewer.PlayerTrain) || (Car.Train != null && Car.Train.TrainType == Train.TRAINTYPE.REMOTE);
             // Service - if a player or AI train, then will considered to be in servie, loose consists will not be considered to be in service.

--- a/Source/RunActivity/Viewer3D/MSTSSky.cs
+++ b/Source/RunActivity/Viewer3D/MSTSSky.cs
@@ -42,7 +42,7 @@ namespace Orts.Viewer3D
         public static float mstsskyTilev;
         public static float mstscloudTileu;
         public static float mstscloudTilev;
-        
+
     }
     #endregion
 
@@ -119,7 +119,7 @@ namespace Orts.Viewer3D
         /// </summary>
         public void PrepareFrame(RenderFrame frame, ElapsedTime elapsedTime)
         {
-             // Adjust dome position so the bottom edge is not visible
+            // Adjust dome position so the bottom edge is not visible
             Vector3 ViewerXNAPosition = new Vector3(MSTSSkyViewer.Camera.Location.X, MSTSSkyViewer.Camera.Location.Y - 100, -MSTSSkyViewer.Camera.Location.Z);
             Matrix XNASkyWorldLocation = Matrix.CreateTranslation(ViewerXNAPosition);
 
@@ -306,7 +306,7 @@ namespace Orts.Viewer3D
         private static int mstsskySides = MSTSSkyConstants.skySides;
         public int mstscloudDomeRadiusDiff = 600;
         // skyLevels: Used for iterating vertically through the "levels" of the hemisphere polygon
-        private static int mstsskyLevels =  MSTSSkyConstants.skyLevels;
+        private static int mstsskyLevels = MSTSSkyConstants.skyLevels;
         private static float mstsskytextureu = MSTSSkyConstants.mstsskyTileu;
         private static float mstsskytexturev = MSTSSkyConstants.mstsskyTilev;
         private static float mstscloudtextureu = MSTSSkyConstants.mstscloudTileu;
@@ -404,9 +404,9 @@ namespace Orts.Viewer3D
 
                     // UV coordinates - top overlay
                     float uvRadius;
-                    uvRadius = (0.5f - (float)(0.5f * (i - 1)) / mstsskyLevels );
+                    uvRadius = (0.5f - (float)(0.5f * (i - 1)) / mstsskyLevels);
                     float uv_u = tile_u * (0.5f - ((float)Math.Cos(MathHelper.ToRadians((360 / mstsskySides) * (mstsskySides - j))) * uvRadius));
-                    float uv_v = tile_v * (0.5f - ((float)Math.Sin(MathHelper.ToRadians((360 / mstsskySides) * (mstsskySides - j))) * uvRadius ));
+                    float uv_v = tile_v * (0.5f - ((float)Math.Sin(MathHelper.ToRadians((360 / mstsskySides) * (mstsskySides - j))) * uvRadius));
 
                     // Store the position, texture coordinates and normal (normalized position vector) for the current vertex
                     vertexList[vertexIndex].Position = new Vector3(x, y, z);
@@ -418,7 +418,7 @@ namespace Orts.Viewer3D
             // Single vertex at zenith
             vertexList[vertexIndex].Position = new Vector3(0, radius, 0);
             vertexList[vertexIndex].Normal = new Vector3(0, 1, 0);
-            vertexList[vertexIndex].TextureCoordinate = new Vector2(0.5f * tile_u, 0.5f *tile_v); // (top overlay)
+            vertexList[vertexIndex].TextureCoordinate = new Vector2(0.5f * tile_u, 0.5f * tile_v); // (top overlay)
         }
 
         /// <summary>
@@ -550,7 +550,7 @@ namespace Orts.Viewer3D
         private Matrix XNAMoonMatrix;
         IEnumerator<EffectPass> ShaderPassesSky;
         IEnumerator<EffectPass> ShaderPassesMoon;
-        List<IEnumerator<EffectPass>>ShaderPassesClouds = new List<IEnumerator<EffectPass>>();
+        List<IEnumerator<EffectPass>> ShaderPassesClouds = new List<IEnumerator<EffectPass>>();
         private float mstsskytexturex;
         private float mstsskytexturey;
         private float mstscloudtexturex;
@@ -560,13 +560,13 @@ namespace Orts.Viewer3D
             : base(viewer, null)
         {
             MSTSSkyShader = Viewer.MaterialManager.SkyShader;
-            
+
             //// TODO: This should happen on the loader thread. 
             if (viewer.ENVFile.SkyLayers != null)
             {
                 var mstsskytexture = Viewer.ENVFile.SkyLayers.ToArray();
                 int count = Viewer.ENVFile.SkyLayers.Count;
-                
+
 
                 string[] mstsSkyTexture = new string[Viewer.ENVFile.SkyLayers.Count];
 
@@ -574,14 +574,14 @@ namespace Orts.Viewer3D
                 {
                     mstsSkyTexture[i] = Viewer.Simulator.RoutePath + @"\envfiles\textures\" + mstsskytexture[i].TextureName.ToString();
                     MSTSSkyTexture.Add(Orts.Formats.Msts.AceFile.Texture2DFromFile(Viewer.RenderProcess.GraphicsDevice, mstsSkyTexture[i]));
-                    if( i == 0 )
+                    if (i == 0)
                     {
                         MSTSDayTexture = MSTSSkyTexture[i];
                         mstsskytexturex = mstsskytexture[i].TileX;
                         mstsskytexturey = mstsskytexture[i].TileY;
 
                     }
-                    else if(mstsskytexture[i].Fadein_Begin_Time != null)
+                    else if (mstsskytexture[i].Fadein_Begin_Time != null)
                     {
                         MSTSSkyStarTexture = MSTSSkyTexture[i];
                         mstsskytexturex = mstsskytexture[i].TileX;

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -87,7 +87,7 @@ namespace Orts.Viewer3D
                     else if (Path.GetExtension(path) == ".ace")
                     {
                         var alternativeTexture = Path.ChangeExtension(path, ".dds");
-                        
+
                         if (Viewer.Settings.PreferDDSTexture && File.Exists(alternativeTexture))
                         {
                             DDSLib.DDSFromFile(alternativeTexture, GraphicsDevice, true, out texture);
@@ -104,11 +104,12 @@ namespace Orts.Viewer3D
 
                                 p = System.IO.Directory.GetParent(p.FullName);//go up one level
                                 var s = p.FullName + "\\" + Path.GetFileName(path);
-                                if (File.Exists(s) &&  s.ToLower().Contains("texture")) //in texure and exists
+                                if (File.Exists(s) && s.ToLower().Contains("texture")) //in texure and exists
                                 {
                                     texture = Orts.Formats.Msts.AceFile.Texture2DFromFile(GraphicsDevice, s);
                                 }
-                                else {
+                                else
+                                {
                                     if (required)
                                         Trace.TraceWarning("Missing texture {0} replaced with default texture", path);
                                     return defaultTexture;
@@ -173,7 +174,7 @@ namespace Orts.Viewer3D
                 return SharedMaterialManager.MissingTexture;
             }
         }
-        
+
         public void Mark()
         {
             TextureMarks = new Dictionary<string, bool>(Textures.Count);
@@ -361,53 +362,53 @@ namespace Orts.Viewer3D
             return Materials[materialKey];
         }
 
-       public bool LoadNightTextures()
+        public bool LoadNightTextures()
         {
             int count = 0;
             foreach (KeyValuePair<string, Material> materialPair in Materials)
             {
-                 if (materialPair.Value is SceneryMaterial)
+                if (materialPair.Value is SceneryMaterial)
                 {
                     var material = materialPair.Value as SceneryMaterial;
                     if (material.LoadNightTexture()) count++;
-                     if (count >= 20)
-                     {
-                         count = 0;
-                         // retest if there is enough free memory left;
-                         var remainingMemorySpace = Viewer.LoadMemoryThreshold - Viewer.HUDWindow.GetWorkingSetSize();
-                         if (remainingMemorySpace < 0)
-                         { 
-                             return false; // too bad, no more space, other night textures won't be loaded
-                         }
-                     }
+                    if (count >= 20)
+                    {
+                        count = 0;
+                        // retest if there is enough free memory left;
+                        var remainingMemorySpace = Viewer.LoadMemoryThreshold - Viewer.HUDWindow.GetWorkingSetSize();
+                        if (remainingMemorySpace < 0)
+                        {
+                            return false; // too bad, no more space, other night textures won't be loaded
+                        }
+                    }
                 }
             }
             return true;
-         }
+        }
 
-       public bool LoadDayTextures()
-       {
-           int count = 0;
-           foreach (KeyValuePair<string, Material> materialPair in Materials)
-           {
-               if (materialPair.Value is SceneryMaterial)
-               {
-                   var material = materialPair.Value as SceneryMaterial;
-                   if (material.LoadDayTexture()) count++;
-                   if (count >= 20)
-                   {
-                       count = 0;
-                       // retest if there is enough free memory left;
-                       var remainingMemorySpace = Viewer.LoadMemoryThreshold - Viewer.HUDWindow.GetWorkingSetSize();
-                       if (remainingMemorySpace < 0)
-                       {
-                           return false; // too bad, no more space, other night textures won't be loaded
-                       }
-                   }
-               }
-           }
-           return true;
-       }
+        public bool LoadDayTextures()
+        {
+            int count = 0;
+            foreach (KeyValuePair<string, Material> materialPair in Materials)
+            {
+                if (materialPair.Value is SceneryMaterial)
+                {
+                    var material = materialPair.Value as SceneryMaterial;
+                    if (material.LoadDayTexture()) count++;
+                    if (count >= 20)
+                    {
+                        count = 0;
+                        // retest if there is enough free memory left;
+                        var remainingMemorySpace = Viewer.LoadMemoryThreshold - Viewer.HUDWindow.GetWorkingSetSize();
+                        if (remainingMemorySpace < 0)
+                        {
+                            return false; // too bad, no more space, other night textures won't be loaded
+                        }
+                    }
+                }
+            }
+            return true;
+        }
 
         public void Mark()
         {
@@ -426,7 +427,7 @@ namespace Orts.Viewer3D
         {
             foreach (var path in MaterialMarks.Where(kvp => !kvp.Value).Select(kvp => kvp.Key))
                 Materials.Remove(path);
-		}
+        }
 
         public void LoadPrep()
         {
@@ -459,13 +460,13 @@ namespace Orts.Viewer3D
         float distance = 1000;
         internal void UpdateShaders()
         {
-            if(Viewer.Settings.UseMSTSEnv == false)
+            if (Viewer.Settings.UseMSTSEnv == false)
                 sunDirection = Viewer.World.Sky.solarDirection;
             else
                 sunDirection = Viewer.World.MSTSSky.mstsskysolarDirection;
 
             SceneryShader.SetLightVector_ZFar(sunDirection, Viewer.Settings.ViewingDistance);
-            
+
             // Headlight illumination
             if (Viewer.PlayerLocomotiveViewer != null
                 && Viewer.PlayerLocomotiveViewer.lightDrawer != null
@@ -504,13 +505,13 @@ namespace Orts.Viewer3D
                     else if (sunDirection.Y >= 0.15)
                     {
                         clampValue = 0.5f; // at daytime min headlight
-                        distance = lightDrawer.LightConeDistance*0.1f; // and min distance
+                        distance = lightDrawer.LightConeDistance * 0.1f; // and min distance
 
                     }
                     else
                     {
                         clampValue = 1 - 2.5f * (sunDirection.Y + 0.05f); // in the meantime interpolate
-                        distance = lightDrawer.LightConeDistance*(1-4.5f*(sunDirection.Y + 0.05f)); //ditto
+                        distance = lightDrawer.LightConeDistance * (1 - 4.5f * (sunDirection.Y + 0.05f)); //ditto
                     }
                     SceneryShader.SetHeadlight(ref lightDrawer.LightConePosition, ref lightDrawer.LightConeDirection, distance, lightDrawer.LightConeMinDotProduct, (float)(Viewer.Simulator.GameTime - fadeStartTimer), fadeDuration, clampValue, ref lightDrawer.LightConeColor);
                 }
@@ -566,7 +567,7 @@ namespace Orts.Viewer3D
         {
             if (String.IsNullOrEmpty(Key))
                 return 0;
-            return Key.Length%10;
+            return Key.Length % 10;
         }
 
         [CallOnThread("Loader")]
@@ -699,13 +700,13 @@ namespace Orts.Viewer3D
             Texture = SharedMaterialManager.MissingTexture;
             NightTexture = SharedMaterialManager.MissingTexture;
             // <CSComment> if "trainset" is in the path (true for night textures for 3DCabs) deferred load of night textures is disabled 
-            if (!String.IsNullOrEmpty(texturePath) && (Options & SceneryMaterialOptions.NightTexture) != 0 && ((!viewer.DontLoadNightTextures && !viewer.DontLoadDayTextures) 
+            if (!String.IsNullOrEmpty(texturePath) && (Options & SceneryMaterialOptions.NightTexture) != 0 && ((!viewer.DontLoadNightTextures && !viewer.DontLoadDayTextures)
                 || TexturePath.Contains(@"\trainset\")))
             {
                 var nightTexturePath = Helpers.GetNightTextureFile(Viewer.Simulator, texturePath);
                 if (!String.IsNullOrEmpty(nightTexturePath))
                     NightTexture = Viewer.TextureManager.Get(nightTexturePath.ToLower());
-               Texture = Viewer.TextureManager.Get(texturePath, true);
+                Texture = Viewer.TextureManager.Get(texturePath, true);
             }
             else if ((Options & SceneryMaterialOptions.NightTexture) != 0 && viewer.DontLoadNightTextures)
             {
@@ -736,14 +737,14 @@ namespace Orts.Viewer3D
 
         }
 
-       public bool LoadNightTexture ()
-         {
+        public bool LoadNightTexture()
+        {
             bool oneMore = false;
-            if (((Options & SceneryMaterialOptions.NightTexture) != 0) && (NightTexture == SharedMaterialManager.MissingTexture))               
+            if (((Options & SceneryMaterialOptions.NightTexture) != 0) && (NightTexture == SharedMaterialManager.MissingTexture))
             {
                 var nightTexturePath = Helpers.GetNightTextureFile(Viewer.Simulator, TexturePath);
                 if (!String.IsNullOrEmpty(nightTexturePath))
-                { 
+                {
                     NightTexture = Viewer.TextureManager.Get(nightTexturePath.ToLower());
                     oneMore = true;
                 }
@@ -751,16 +752,16 @@ namespace Orts.Viewer3D
             return oneMore;
         }
 
-       public bool LoadDayTexture ()
-       {
-           bool oneMore = false;
-           if (Texture == SharedMaterialManager.MissingTexture && !String.IsNullOrEmpty(TexturePath))
-           {
+        public bool LoadDayTexture()
+        {
+            bool oneMore = false;
+            if (Texture == SharedMaterialManager.MissingTexture && !String.IsNullOrEmpty(TexturePath))
+            {
                 Texture = Viewer.TextureManager.Get(TexturePath.ToLower());
                 oneMore = true;
-           }
-           return oneMore;
-       }
+            }
+            return oneMore;
+        }
 
         public override void SetState(GraphicsDevice graphicsDevice, Material previousMaterial)
         {
@@ -888,7 +889,7 @@ namespace Orts.Viewer3D
                 shader.ImageTexture = NightTexture;
                 shader.ImageTextureIsNight = true;
             }
-             else
+            else
             {
                 shader.ImageTexture = Texture;
                 shader.ImageTextureIsNight = false;
@@ -1019,11 +1020,11 @@ namespace Orts.Viewer3D
             BlurVertexDeclaration = new VertexDeclaration(Viewer.RenderProcess.GraphicsDevice, VertexPositionNormalTexture.VertexElements);
             BlurVertexBuffer = new VertexBuffer(Viewer.RenderProcess.GraphicsDevice, typeof(VertexPositionNormalTexture), 4, BufferUsage.WriteOnly);
             BlurVertexBuffer.SetData(new[] {
-				new VertexPositionNormalTexture(new Vector3(-1, +1, 0), Vector3.Zero, new Vector2(0, 0)),
-				new VertexPositionNormalTexture(new Vector3(-1, -1, 0), Vector3.Zero, new Vector2(0, shadowMapResolution)),
-				new VertexPositionNormalTexture(new Vector3(+1, +1, 0), Vector3.Zero, new Vector2(shadowMapResolution, 0)),
-				new VertexPositionNormalTexture(new Vector3(+1, -1, 0), Vector3.Zero, new Vector2(shadowMapResolution, shadowMapResolution)),
-			});
+                new VertexPositionNormalTexture(new Vector3(-1, +1, 0), Vector3.Zero, new Vector2(0, 0)),
+                new VertexPositionNormalTexture(new Vector3(-1, -1, 0), Vector3.Zero, new Vector2(0, shadowMapResolution)),
+                new VertexPositionNormalTexture(new Vector3(+1, +1, 0), Vector3.Zero, new Vector2(shadowMapResolution, 0)),
+                new VertexPositionNormalTexture(new Vector3(+1, -1, 0), Vector3.Zero, new Vector2(shadowMapResolution, shadowMapResolution)),
+            });
         }
 
         public void SetState(GraphicsDevice graphicsDevice, Mode mode)
@@ -1252,7 +1253,7 @@ namespace Orts.Viewer3D
             {
                 basicEffect = new BasicEffect(Viewer.RenderProcess.GraphicsDevice, null);
                 basicEffect.Alpha = a;
-                basicEffect.DiffuseColor = new Vector3(r , g , b );
+                basicEffect.DiffuseColor = new Vector3(r, g, b);
                 basicEffect.SpecularColor = new Vector3(0.25f, 0.25f, 0.25f);
                 basicEffect.SpecularPower = 5.0f;
                 basicEffect.AmbientLightColor = new Vector3(0.2f, 0.2f, 0.2f);

--- a/Source/RunActivity/Viewer3D/Noise.cs
+++ b/Source/RunActivity/Viewer3D/Noise.cs
@@ -43,11 +43,11 @@ namespace Orts.Viewer3D
 
             float n0, n1;
 
-            float t0 = 1.0f - x0*x0;
+            float t0 = 1.0f - x0 * x0;
             t0 *= t0;
             n0 = t0 * t0 * grad(perm[i0 & 0xff], x0);
 
-            float t1 = 1.0f - x1*x1;
+            float t1 = 1.0f - x1 * x1;
             t1 *= t1;
             n1 = t1 * t1 * grad(perm[i1 & 0xff], x1);
             // The maximum value of this noise is 8*(3/4)^4 = 2.53125
@@ -69,23 +69,23 @@ namespace Orts.Viewer3D
             float n0, n1, n2; // Noise contributions from the three corners
 
             // Skew the input space to determine which simplex cell we're in
-            float s = (x+y)*F2; // Hairy factor for 2D
+            float s = (x + y) * F2; // Hairy factor for 2D
             float xs = x + s;
             float ys = y + s;
             int i = FastFloor(xs);
             int j = FastFloor(ys);
 
-            float t = (float)(i+j)*G2;
-            float X0 = i-t; // Unskew the cell origin back to (x,y) space
-            float Y0 = j-t;
-            float x0 = x-X0; // The x,y distances from the cell origin
-            float y0 = y-Y0;
+            float t = (float)(i + j) * G2;
+            float X0 = i - t; // Unskew the cell origin back to (x,y) space
+            float Y0 = j - t;
+            float x0 = x - X0; // The x,y distances from the cell origin
+            float y0 = y - Y0;
 
             // For the 2D case, the simplex shape is an equilateral triangle.
             // Determine which simplex we are in.
             int i1, j1; // Offsets for second (middle) corner of simplex in (i,j) coords
-            if(x0>y0) {i1=1; j1=0;} // lower triangle, XY order: (0,0)->(1,0)->(1,1)
-            else {i1=0; j1=1;}      // upper triangle, YX order: (0,0)->(0,1)->(1,1)
+            if (x0 > y0) { i1 = 1; j1 = 0; } // lower triangle, XY order: (0,0)->(1,0)->(1,1)
+            else { i1 = 0; j1 = 1; }      // upper triangle, YX order: (0,0)->(0,1)->(1,1)
 
             // A step of (1,0) in (i,j) means a step of (1-c,-c) in (x,y), and
             // a step of (0,1) in (i,j) means a step of (-c,1-c) in (x,y), where
@@ -101,25 +101,28 @@ namespace Orts.Viewer3D
             int jj = j % 256;
 
             // Calculate the contribution from the three corners
-            float t0 = 0.5f - x0*x0-y0*y0;
-            if(t0 < 0.0f) n0 = 0.0f;
-            else {
+            float t0 = 0.5f - x0 * x0 - y0 * y0;
+            if (t0 < 0.0f) n0 = 0.0f;
+            else
+            {
                 t0 *= t0;
-                n0 = t0 * t0 * grad(perm[ii+perm[jj]], x0, y0); 
+                n0 = t0 * t0 * grad(perm[ii + perm[jj]], x0, y0);
             }
 
-            float t1 = 0.5f - x1*x1-y1*y1;
-            if(t1 < 0.0f) n1 = 0.0f;
-            else {
+            float t1 = 0.5f - x1 * x1 - y1 * y1;
+            if (t1 < 0.0f) n1 = 0.0f;
+            else
+            {
                 t1 *= t1;
-                n1 = t1 * t1 * grad(perm[ii+i1+perm[jj+j1]], x1, y1);
+                n1 = t1 * t1 * grad(perm[ii + i1 + perm[jj + j1]], x1, y1);
             }
 
-            float t2 = 0.5f - x2*x2-y2*y2;
-            if(t2 < 0.0f) n2 = 0.0f;
-            else {
+            float t2 = 0.5f - x2 * x2 - y2 * y2;
+            if (t2 < 0.0f) n2 = 0.0f;
+            else
+            {
                 t2 *= t2;
-                n2 = t2 * t2 * grad(perm[ii+1+perm[jj+1]], x2, y2);
+                n2 = t2 * t2 * grad(perm[ii + 1 + perm[jj + 1]], x2, y2);
             }
 
             // Add contributions from each corner to get the final noise value.
@@ -127,7 +130,7 @@ namespace Orts.Viewer3D
             return 40.0f * (n0 + n1 + n2); // TODO: The scale factor is preliminary!
         }
 
-       
+
         public static float Generate(float x, float y, float z)
         {
             // Simple skewing factors for the 3D case
@@ -137,21 +140,21 @@ namespace Orts.Viewer3D
             float n0, n1, n2, n3; // Noise contributions from the four corners
 
             // Skew the input space to determine which simplex cell we're in
-            float s = (x+y+z)*F3; // Very nice and simple skew factor for 3D
-            float xs = x+s;
-            float ys = y+s;
-            float zs = z+s;
+            float s = (x + y + z) * F3; // Very nice and simple skew factor for 3D
+            float xs = x + s;
+            float ys = y + s;
+            float zs = z + s;
             int i = FastFloor(xs);
             int j = FastFloor(ys);
             int k = FastFloor(zs);
 
-            float t = (float)(i+j+k)*G3; 
-            float X0 = i-t; // Unskew the cell origin back to (x,y,z) space
-            float Y0 = j-t;
-            float Z0 = k-t;
-            float x0 = x-X0; // The x,y,z distances from the cell origin
-            float y0 = y-Y0;
-            float z0 = z-Z0;
+            float t = (float)(i + j + k) * G3;
+            float X0 = i - t; // Unskew the cell origin back to (x,y,z) space
+            float Y0 = j - t;
+            float Z0 = k - t;
+            float x0 = x - X0; // The x,y,z distances from the cell origin
+            float y0 = y - Y0;
+            float z0 = z - Z0;
 
             // For the 3D case, the simplex shape is a slightly irregular tetrahedron.
             // Determine which simplex we are in.
@@ -159,16 +162,18 @@ namespace Orts.Viewer3D
             int i2, j2, k2; // Offsets for third corner of simplex in (i,j,k) coords
 
             /* This code would benefit from a backport from the GLSL version! */
-            if(x0>=y0) {
-                if(y0>=z0)
-                { i1=1; j1=0; k1=0; i2=1; j2=1; k2=0; } // X Y Z order
-                else if(x0>=z0) { i1=1; j1=0; k1=0; i2=1; j2=0; k2=1; } // X Z Y order
-                else { i1=0; j1=0; k1=1; i2=1; j2=0; k2=1; } // Z X Y order
-                }
-            else { // x0<y0
-                if(y0<z0) { i1=0; j1=0; k1=1; i2=0; j2=1; k2=1; } // Z Y X order
-                else if(x0<z0) { i1=0; j1=1; k1=0; i2=0; j2=1; k2=1; } // Y Z X order
-                else { i1=0; j1=1; k1=0; i2=1; j2=1; k2=0; } // Y X Z order
+            if (x0 >= y0)
+            {
+                if (y0 >= z0)
+                { i1 = 1; j1 = 0; k1 = 0; i2 = 1; j2 = 1; k2 = 0; } // X Y Z order
+                else if (x0 >= z0) { i1 = 1; j1 = 0; k1 = 0; i2 = 1; j2 = 0; k2 = 1; } // X Z Y order
+                else { i1 = 0; j1 = 0; k1 = 1; i2 = 1; j2 = 0; k2 = 1; } // Z X Y order
+            }
+            else
+            { // x0<y0
+                if (y0 < z0) { i1 = 0; j1 = 0; k1 = 1; i2 = 0; j2 = 1; k2 = 1; } // Z Y X order
+                else if (x0 < z0) { i1 = 0; j1 = 1; k1 = 0; i2 = 0; j2 = 1; k2 = 1; } // Y Z X order
+                else { i1 = 0; j1 = 1; k1 = 0; i2 = 1; j2 = 1; k2 = 0; } // Y X Z order
             }
 
             // A step of (1,0,0) in (i,j,k) means a step of (1-c,-c,-c) in (x,y,z),
@@ -179,12 +184,12 @@ namespace Orts.Viewer3D
             float x1 = x0 - i1 + G3; // Offsets for second corner in (x,y,z) coords
             float y1 = y0 - j1 + G3;
             float z1 = z0 - k1 + G3;
-            float x2 = x0 - i2 + 2.0f*G3; // Offsets for third corner in (x,y,z) coords
-            float y2 = y0 - j2 + 2.0f*G3;
-            float z2 = z0 - k2 + 2.0f*G3;
-            float x3 = x0 - 1.0f + 3.0f*G3; // Offsets for last corner in (x,y,z) coords
-            float y3 = y0 - 1.0f + 3.0f*G3;
-            float z3 = z0 - 1.0f + 3.0f*G3;
+            float x2 = x0 - i2 + 2.0f * G3; // Offsets for third corner in (x,y,z) coords
+            float y2 = y0 - j2 + 2.0f * G3;
+            float z2 = z0 - k2 + 2.0f * G3;
+            float x3 = x0 - 1.0f + 3.0f * G3; // Offsets for last corner in (x,y,z) coords
+            float y3 = y0 - 1.0f + 3.0f * G3;
+            float z3 = z0 - 1.0f + 3.0f * G3;
 
             // Wrap the integer indices at 256, to avoid indexing perm[] out of bounds
             int ii = Mod(i, 256);
@@ -192,32 +197,36 @@ namespace Orts.Viewer3D
             int kk = Mod(k, 256);
 
             // Calculate the contribution from the four corners
-            float t0 = 0.6f - x0*x0 - y0*y0 - z0*z0;
-            if(t0 < 0.0f) n0 = 0.0f;
-            else {
+            float t0 = 0.6f - x0 * x0 - y0 * y0 - z0 * z0;
+            if (t0 < 0.0f) n0 = 0.0f;
+            else
+            {
                 t0 *= t0;
-                n0 = t0 * t0 * grad(perm[ii+perm[jj+perm[kk]]], x0, y0, z0);
+                n0 = t0 * t0 * grad(perm[ii + perm[jj + perm[kk]]], x0, y0, z0);
             }
 
-            float t1 = 0.6f - x1*x1 - y1*y1 - z1*z1;
-            if(t1 < 0.0f) n1 = 0.0f;
-            else {
+            float t1 = 0.6f - x1 * x1 - y1 * y1 - z1 * z1;
+            if (t1 < 0.0f) n1 = 0.0f;
+            else
+            {
                 t1 *= t1;
-                n1 = t1 * t1 * grad(perm[ii+i1+perm[jj+j1+perm[kk+k1]]], x1, y1, z1);
+                n1 = t1 * t1 * grad(perm[ii + i1 + perm[jj + j1 + perm[kk + k1]]], x1, y1, z1);
             }
 
-            float t2 = 0.6f - x2*x2 - y2*y2 - z2*z2;
-            if(t2 < 0.0f) n2 = 0.0f;
-            else {
+            float t2 = 0.6f - x2 * x2 - y2 * y2 - z2 * z2;
+            if (t2 < 0.0f) n2 = 0.0f;
+            else
+            {
                 t2 *= t2;
-                n2 = t2 * t2 * grad(perm[ii+i2+perm[jj+j2+perm[kk+k2]]], x2, y2, z2);
+                n2 = t2 * t2 * grad(perm[ii + i2 + perm[jj + j2 + perm[kk + k2]]], x2, y2, z2);
             }
 
-            float t3 = 0.6f - x3*x3 - y3*y3 - z3*z3;
-            if(t3<0.0f) n3 = 0.0f;
-            else {
+            float t3 = 0.6f - x3 * x3 - y3 * y3 - z3 * z3;
+            if (t3 < 0.0f) n3 = 0.0f;
+            else
+            {
                 t3 *= t3;
-                n3 = t3 * t3 * grad(perm[ii+1+perm[jj+1+perm[kk+1]]], x3, y3, z3);
+                n3 = t3 * t3 * grad(perm[ii + 1 + perm[jj + 1 + perm[kk + 1]]], x3, y3, z3);
             }
 
             // Add contributions from each corner to get the final noise value.
@@ -250,7 +259,7 @@ namespace Orts.Viewer3D
               129,22,39,253, 19,98,108,110,79,113,224,232,178,185, 112,104,218,246,97,228,
               251,34,242,193,238,210,144,12,191,179,162,241, 81,51,145,235,249,14,239,107,
               49,192,214, 31,181,199,106,157,184, 84,204,176,115,121,50,45,127, 4,150,254,
-              138,236,205,93,222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180 
+              138,236,205,93,222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180
             };
 
         private static int FastFloor(float x)
@@ -264,35 +273,37 @@ namespace Orts.Viewer3D
             return a < 0 ? a + m : a;
         }
 
-        private static float grad( int hash, float x )
+        private static float grad(int hash, float x)
         {
             int h = hash & 15;
             float grad = 1.0f + (h & 7);   // Gradient value 1.0, 2.0, ..., 8.0
             if ((h & 8) != 0) grad = -grad;         // Set a random sign for the gradient
-            return ( grad * x );           // Multiply the gradient with the distance
+            return (grad * x);           // Multiply the gradient with the distance
         }
 
-        private static float grad( int hash, float x, float y )
+        private static float grad(int hash, float x, float y)
         {
             int h = hash & 7;      // Convert low 3 bits of hash code
-            float u = h<4 ? x : y;  // into 8 simple gradient directions,
-            float v = h<4 ? y : x;  // and compute the dot product with (x,y).
-            return ((h&1) != 0 ? -u : u) + ((h&2) != 0 ? -2.0f*v : 2.0f*v);
+            float u = h < 4 ? x : y;  // into 8 simple gradient directions,
+            float v = h < 4 ? y : x;  // and compute the dot product with (x,y).
+            return ((h & 1) != 0 ? -u : u) + ((h & 2) != 0 ? -2.0f * v : 2.0f * v);
         }
 
-        private static float grad( int hash, float x, float y , float z ) {
+        private static float grad(int hash, float x, float y, float z)
+        {
             int h = hash & 15;     // Convert low 4 bits of hash code into 12 simple
-            float u = h<8 ? x : y; // gradient directions, and compute dot product.
-            float v = h<4 ? y : h==12||h==14 ? x : z; // Fix repeats at h = 12 to 15
-            return ((h&1) != 0 ? -u : u) + ((h&2) != 0 ? -v : v);
+            float u = h < 8 ? x : y; // gradient directions, and compute dot product.
+            float v = h < 4 ? y : h == 12 || h == 14 ? x : z; // Fix repeats at h = 12 to 15
+            return ((h & 1) != 0 ? -u : u) + ((h & 2) != 0 ? -v : v);
         }
 
-        private static float grad( int hash, float x, float y, float z, float t ) {
+        private static float grad(int hash, float x, float y, float z, float t)
+        {
             int h = hash & 31;      // Convert low 5 bits of hash code into 32 simple
-            float u = h<24 ? x : y; // gradient directions, and compute dot product.
-            float v = h<16 ? y : z;
-            float w = h<8 ? z : t;
-            return ((h&1) != 0 ? -u : u) + ((h&2) != 0 ? -v : v) + ((h&4) != 0 ? -w : w);
+            float u = h < 24 ? x : y; // gradient directions, and compute dot product.
+            float v = h < 16 ? y : z;
+            float w = h < 8 ? z : t;
+            return ((h & 1) != 0 ? -u : u) + ((h & 2) != 0 ? -v : v) + ((h & 4) != 0 ? -w : w);
         }
     }
 }

--- a/Source/RunActivity/Viewer3D/OpenAL.cs
+++ b/Source/RunActivity/Viewer3D/OpenAL.cs
@@ -402,7 +402,7 @@ namespace Orts.Viewer3D
                 return "Out Of Memory";
             else if (error == AL_NO_ERROR)
                 return "No Error";
-            
+
             return "";
         }
 
@@ -455,7 +455,7 @@ namespace Orts.Viewer3D
                     ORTS.Common.NativeMethods.WritePrivateProfileString("General", "sources", "1024", configFile);
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Trace.TraceError("Couldn't check or set OpenAL max sound sources in %AppData%\\Roaming\\alsoft.ini: ", ex.Message);
             }
@@ -604,26 +604,26 @@ namespace Orts.Viewer3D
     public class WaveFileData
     {
         // Constants from C header files
-        private const ushort WAVE_FORMAT_PCM                = 1;
-        private const ushort WAVE_FORMAT_EXTENSIBLE         = 0xFFFE;
+        private const ushort WAVE_FORMAT_PCM = 1;
+        private const ushort WAVE_FORMAT_EXTENSIBLE = 0xFFFE;
 
-        private const ushort SPEAKER_FRONT_LEFT             = 0x1;
-        private const ushort SPEAKER_FRONT_RIGHT            = 0x2;
-        private const ushort SPEAKER_FRONT_CENTER           = 0x4;
-        private const ushort SPEAKER_LOW_FREQUENCY          = 0x8;
-        private const ushort SPEAKER_BACK_LEFT              = 0x10;
-        private const ushort SPEAKER_BACK_RIGHT             = 0x20;
-        private const ushort SPEAKER_FRONT_LEFT_OF_CENTER   = 0x40;
-        private const ushort SPEAKER_FRONT_RIGHT_OF_CENTER  = 0x80;
-        private const ushort SPEAKER_BACK_CENTER            = 0x100;
-        private const ushort SPEAKER_SIDE_LEFT              = 0x200;
-        private const ushort SPEAKER_SIDE_RIGHT             = 0x400;
-        private const ushort SPEAKER_TOP_CENTER             = 0x800;
-        private const ushort SPEAKER_TOP_FRONT_LEFT         = 0x1000;
-        private const ushort SPEAKER_TOP_FRONT_CENTER       = 0x2000;
-        private const ushort SPEAKER_TOP_FRONT_RIGHT        = 0x4000;
-        private const ushort SPEAKER_TOP_BACK_LEFT          = 0x8000;
-        
+        private const ushort SPEAKER_FRONT_LEFT = 0x1;
+        private const ushort SPEAKER_FRONT_RIGHT = 0x2;
+        private const ushort SPEAKER_FRONT_CENTER = 0x4;
+        private const ushort SPEAKER_LOW_FREQUENCY = 0x8;
+        private const ushort SPEAKER_BACK_LEFT = 0x10;
+        private const ushort SPEAKER_BACK_RIGHT = 0x20;
+        private const ushort SPEAKER_FRONT_LEFT_OF_CENTER = 0x40;
+        private const ushort SPEAKER_FRONT_RIGHT_OF_CENTER = 0x80;
+        private const ushort SPEAKER_BACK_CENTER = 0x100;
+        private const ushort SPEAKER_SIDE_LEFT = 0x200;
+        private const ushort SPEAKER_SIDE_RIGHT = 0x400;
+        private const ushort SPEAKER_TOP_CENTER = 0x800;
+        private const ushort SPEAKER_TOP_FRONT_LEFT = 0x1000;
+        private const ushort SPEAKER_TOP_FRONT_CENTER = 0x2000;
+        private const ushort SPEAKER_TOP_FRONT_RIGHT = 0x4000;
+        private const ushort SPEAKER_TOP_BACK_LEFT = 0x8000;
+
         // General info about current wave file
         public bool isKnownType;
         public WAVEFORMATEXTENSIBLE wfEXT;
@@ -677,7 +677,7 @@ namespace Orts.Viewer3D
             // Read Wave file header
             WAVEFILEHEADER waveFileHeader = new WAVEFILEHEADER();
             {
-                GetNextStructureValue<WAVEFILEHEADER>(pFile, out waveFileHeader, - 1);
+                GetNextStructureValue<WAVEFILEHEADER>(pFile, out waveFileHeader, -1);
                 // Check if wave file
                 string hdr = new string(waveFileHeader.szRIFF);
                 if (hdr != "RIFF" && hdr != "WAVE")
@@ -689,7 +689,7 @@ namespace Orts.Viewer3D
                     while (GetNextStructureValue<RIFFCHUNK>(pFile, out riffChunk, -1))
                     {
                         // Format chunk
-                        hdr = new string (riffChunk.szChunkName);
+                        hdr = new string(riffChunk.szChunkName);
                         if (hdr == "fmt ")
                         {
                             WAVEFORMATEXTENSIBLE waveFmt = new WAVEFORMATEXTENSIBLE();
@@ -701,7 +701,7 @@ namespace Orts.Viewer3D
                                 if (waveFmt.Format.wFormatTag == WAVE_FORMAT_PCM)
                                 {
                                     isKnownType = true;
-                                    wtType =  WAVEFORMATTYPE.WT_PCM;
+                                    wtType = WAVEFORMATTYPE.WT_PCM;
                                     waveFmt.wValidBitsPerSample = waveFmt.Format.wBitsPerSample;
                                 }
                                 else if (waveFmt.Format.wFormatTag == WAVE_FORMAT_EXTENSIBLE)
@@ -803,7 +803,7 @@ namespace Orts.Viewer3D
         /// </summary>
         /// <param name="pulFormat">Place to put the format number</param>
         /// <returns>True if success</returns>
-        private bool GetALFormat(ref int pulFormat, ref bool mstsMonoTreatment, ushort origNChannels )
+        private bool GetALFormat(ref int pulFormat, ref bool mstsMonoTreatment, ushort origNChannels)
         {
             pulFormat = 0;
 
@@ -1084,7 +1084,7 @@ namespace Orts.Viewer3D
                         wfi.CuePoints[i] = 0xFFFFFFFF;
                         adjPos = prevAdjPos;
                     }
-                    
+
                     BufferLens[i] = (int)adjPos - (int)prevAdjPos;
                     if (BufferLens[i] > 0)
                     {
@@ -1095,7 +1095,7 @@ namespace Orts.Viewer3D
                     {
                         BufferIDs[i] = 0;
                     }
-                    
+
                     if (i == wfi.CuePoints.Length - 1)
                     {
                         BufferLens[i + 1] = (int)wfi.ulDataSize - (int)adjPos;
@@ -1129,7 +1129,7 @@ namespace Orts.Viewer3D
             Buffer.BlockCopy(buffer, offset, retval, 0, len);
             return retval;
         }
-        
+
         /// <summary>
         /// Reads a given structure from a FileStream
         /// </summary>
@@ -1161,11 +1161,11 @@ namespace Orts.Viewer3D
                 handle.Free();
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
-        } 
+        }
     }
 }
 

--- a/Source/RunActivity/Viewer3D/ParticleEmitter.cs
+++ b/Source/RunActivity/Viewer3D/ParticleEmitter.cs
@@ -148,7 +148,7 @@ namespace Orts.Viewer3D
         internal void Mark()
         {
             if (Material != null) // stops error messages if a special effect entry is not a defined OR parameter
-            Material.Mark();
+                Material.Mark();
         }
     }
 
@@ -210,7 +210,7 @@ namespace Orts.Viewer3D
 
         Viewer viewer;
         GraphicsDevice graphicsDevice;
-        
+
         static float windDisplacementX;
         static float windDisplacementZ;
 
@@ -473,7 +473,7 @@ namespace Orts.Viewer3D
             if (Viewer.Settings.UseMSTSEnv == false)
                 shader.LightVector = Viewer.World.Sky.solarDirection;
             else
-                shader.LightVector = Viewer.World.MSTSSky.mstsskysolarDirection; 
+                shader.LightVector = Viewer.World.MSTSSky.mstsskysolarDirection;
 
             var rs = graphicsDevice.RenderState;
             rs.AlphaBlendEnable = true;

--- a/Source/RunActivity/Viewer3D/Popups/ActivityWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/ActivityWindow.cs
@@ -149,7 +149,7 @@ namespace Orts.Viewer3D.Popups
             if (Owner.Viewer.Simulator.IsReplaying) Owner.Viewer.Simulator.Confirmer.Confirm(CabControl.Activity, CabSetting.On);
             ResumeMenu();
         }
-        
+
         public override void PrepareFrame(ElapsedTime elapsedTime, bool updateFull)
         {
             base.PrepareFrame(elapsedTime, updateFull);
@@ -214,7 +214,7 @@ namespace Orts.Viewer3D.Popups
                                         PopupTime = DateTime.Now;
                                         Visible = Owner.Viewer.HelpWindow.ActivityUpdated = true;
                                     }
-                                }                              
+                                }
                             }
                             else
                             {

--- a/Source/RunActivity/Viewer3D/Popups/CarOperationsWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/CarOperationsWindow.cs
@@ -48,7 +48,7 @@ namespace Orts.Viewer3D.Popups
             Label ID, buttonHandbrake, buttonTogglePower, buttonToggleMU, buttonToggleBrakeHose, buttonToggleAngleCockA, buttonToggleAngleCockB, buttonToggleBleedOffValve, buttonClose;
 
             var vbox = base.Layout(layout).AddLayoutVertical();
-            vbox.Add(ID = new Label(vbox.RemainingWidth, Owner.TextFontDefault.Height, Viewer.Catalog.GetString("Car ID") + "  " + (CarPosition >= Viewer.PlayerTrain.Cars.Count? " " :Viewer.PlayerTrain.Cars[CarPosition].CarID), LabelAlignment.Center));
+            vbox.Add(ID = new Label(vbox.RemainingWidth, Owner.TextFontDefault.Height, Viewer.Catalog.GetString("Car ID") + "  " + (CarPosition >= Viewer.PlayerTrain.Cars.Count ? " " : Viewer.PlayerTrain.Cars[CarPosition].CarID), LabelAlignment.Center));
             ID.Color = Color.Red;
             vbox.AddHorizontalSeparator();
             vbox.Add(buttonHandbrake = new Label(vbox.RemainingWidth, Owner.TextFontDefault.Height, Viewer.Catalog.GetString("Toggle Handbrake"), LabelAlignment.Center));

--- a/Source/RunActivity/Viewer3D/Popups/CompassWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/CompassWindow.cs
@@ -26,31 +26,31 @@ using System;
 namespace Orts.Viewer3D.Popups
 {
     public class CompassWindow : Window
-	{
-		PopupCompass Compass;
-		Label Latitude;
-		Label Longitude;
+    {
+        PopupCompass Compass;
+        Label Latitude;
+        Label Longitude;
 
-		public CompassWindow(WindowManager owner)
-			: base(owner, Window.DecorationSize.X + owner.TextFontDefault.Height * 15, Window.DecorationSize.Y + owner.TextFontDefault.Height * 4, Viewer.Catalog.GetString("Compass"))
-		{
-		}
+        public CompassWindow(WindowManager owner)
+            : base(owner, Window.DecorationSize.X + owner.TextFontDefault.Height * 15, Window.DecorationSize.Y + owner.TextFontDefault.Height * 4, Viewer.Catalog.GetString("Compass"))
+        {
+        }
 
-		protected override ControlLayout Layout(ControlLayout layout)
-		{
-			var vbox = base.Layout(layout).AddLayoutVertical();
-			vbox.Add(Compass = new PopupCompass(vbox.RemainingWidth, vbox.RemainingHeight - vbox.TextHeight));
-			{
-				var hbox = vbox.AddLayoutHorizontalLineOfText();
-				var w = hbox.RemainingWidth / 9;
-				hbox.Add(new Label(1 * w, hbox.RemainingHeight, Viewer.Catalog.GetString("Lat:"), LabelAlignment.Right));
-				hbox.Add(Latitude = new Label(3 * w, hbox.RemainingHeight, "000.000000", LabelAlignment.Right));
-				hbox.AddSpace(w, hbox.RemainingHeight);
-				hbox.Add(new Label(1 * w, hbox.RemainingHeight, Viewer.Catalog.GetString("Lon:"), LabelAlignment.Right));
-				hbox.Add(Longitude = new Label(3 * w, hbox.RemainingHeight, "000.000000", LabelAlignment.Right));
-			}
-			return vbox;
-		}
+        protected override ControlLayout Layout(ControlLayout layout)
+        {
+            var vbox = base.Layout(layout).AddLayoutVertical();
+            vbox.Add(Compass = new PopupCompass(vbox.RemainingWidth, vbox.RemainingHeight - vbox.TextHeight));
+            {
+                var hbox = vbox.AddLayoutHorizontalLineOfText();
+                var w = hbox.RemainingWidth / 9;
+                hbox.Add(new Label(1 * w, hbox.RemainingHeight, Viewer.Catalog.GetString("Lat:"), LabelAlignment.Right));
+                hbox.Add(Latitude = new Label(3 * w, hbox.RemainingHeight, "000.000000", LabelAlignment.Right));
+                hbox.AddSpace(w, hbox.RemainingHeight);
+                hbox.Add(new Label(1 * w, hbox.RemainingHeight, Viewer.Catalog.GetString("Lon:"), LabelAlignment.Right));
+                hbox.Add(Longitude = new Label(3 * w, hbox.RemainingHeight, "000.000000", LabelAlignment.Right));
+            }
+            return vbox;
+        }
 
         public override void PrepareFrame(ElapsedTime elapsedTime, bool updateFull)
         {
@@ -70,20 +70,20 @@ namespace Orts.Viewer3D.Popups
                 Latitude.Text = MathHelper.ToDegrees((float)latitude).ToString("F6");
                 Longitude.Text = MathHelper.ToDegrees((float)longitude).ToString("F6");
             }
-		}
-	}
+        }
+    }
 
-	public class PopupCompass : Control
-	{
-		static Texture2D CompassTexture;
-		static int[] HeadingHalfWidths;
+    public class PopupCompass : Control
+    {
+        static Texture2D CompassTexture;
+        static int[] HeadingHalfWidths;
         WindowTextFont Font;
-		public float Heading;
+        public float Heading;
 
-		public PopupCompass(int width, int height)
-			: base(0, 0, width, height)
-		{
-		}
+        public PopupCompass(int width, int height)
+            : base(0, 0, width, height)
+        {
+        }
 
         public override void Initialize(WindowManager windowManager)
         {
@@ -126,5 +126,5 @@ namespace Orts.Viewer3D.Popups
             }
             spriteBatch.Draw(CompassTexture, new Rectangle(offset.X + Position.X + Position.Width / 2, offset.Y + Position.Bottom - height, 1, height), Color.White);
         }
-	}
+    }
 }

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -437,7 +437,7 @@ namespace Orts.Viewer3D.Popups
             else if (Viewer.PlayerTrain.IsWheelSlipWarninq)
                 TableAddLine(table, Viewer.Catalog.GetString("Wheel slip warning") + "???");
 
-            if (Viewer.PlayerTrain.IsBrakeSkid )
+            if (Viewer.PlayerTrain.IsBrakeSkid)
                 TableAddLine(table, Viewer.Catalog.GetString("Wheel skid") + "!!!");
 
             if (Viewer.PlayerLocomotive.GetSanderOn())
@@ -454,7 +454,7 @@ namespace Orts.Viewer3D.Popups
                 var color = Math.Abs(Viewer.PlayerLocomotive.SpeedMpS) > 0.1f ? "!!!" : "???";
                 var status = "";
                 if ((Viewer.PlayerLocomotive as MSTSWagon).DoorLeftOpen)
-                    status += Viewer.Catalog.GetString((Viewer.PlayerLocomotive as MSTSLocomotive).GetCabFlipped()? "Right" : "Left");
+                    status += Viewer.Catalog.GetString((Viewer.PlayerLocomotive as MSTSLocomotive).GetCabFlipped() ? "Right" : "Left");
                 if ((Viewer.PlayerLocomotive as MSTSWagon).DoorRightOpen)
                     status += string.Format(status == "" ? "{0}" : " {0}", Viewer.Catalog.GetString((Viewer.PlayerLocomotive as MSTSLocomotive).GetCabFlipped() ? "Left" : "Right"));
                 status += color;
@@ -485,7 +485,7 @@ namespace Orts.Viewer3D.Popups
             float tonnage = 0f;
             foreach (var car in train.Cars)
             {
-                if(car.WagonType == TrainCar.WagonTypes.Freight || car.WagonType == TrainCar.WagonTypes.Passenger)
+                if (car.WagonType == TrainCar.WagonTypes.Freight || car.WagonType == TrainCar.WagonTypes.Passenger)
                     tonnage += car.MassKG;
             }
             TableSetCells(table, 0,
@@ -598,79 +598,79 @@ namespace Orts.Viewer3D.Popups
             var HUDSteamEngineType = mstsLocomotive.SteamEngineType;
             var HUDEngineType = mstsLocomotive.EngineType;
 
-                // If vacuum brakes are used then use this display
-                if ((Viewer.PlayerLocomotive as MSTSLocomotive).BrakeSystem is VacuumSinglePipe)
-                {
+            // If vacuum brakes are used then use this display
+            if ((Viewer.PlayerLocomotive as MSTSLocomotive).BrakeSystem is VacuumSinglePipe)
+            {
 
-                        if ((Viewer.PlayerLocomotive as MSTSLocomotive).VacuumBrakeEQFitted)
-                            {
-                                TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}",
-                                Viewer.Catalog.GetString("PlayerLoco"),
-                                Viewer.Catalog.GetString("Main reservoir"),
-                                FormatStrings.FormatPressure(Vac.FromPress((Viewer.PlayerLocomotive as MSTSLocomotive).VacuumMainResVacuumPSIAorInHg), PressureUnit.InHg, PressureUnit.InHg, true),
-                                Viewer.Catalog.GetString("Exhauster"),
-                                (Viewer.PlayerLocomotive as MSTSLocomotive).VacuumExhausterIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off")));
-                            }
-
-                        else if ((Viewer.PlayerLocomotive as MSTSLocomotive).VacuumPumpFitted && (Viewer.PlayerLocomotive as MSTSLocomotive).SmallEjectorFitted)
-                            {
-                                // Display if vacuum pump, large ejector and small ejector fitted
-                                TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}\t{5}\t{6}\t\t{7}\t\t{8}",
-                                Viewer.Catalog.GetString("PlayerLoco"),
-                                Viewer.Catalog.GetString("Large Ejector"),
-                                (Viewer.PlayerLocomotive as MSTSLocomotive).LargeSteamEjectorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
-                                Viewer.Catalog.GetString("Small Ejector"),
-                                (Viewer.PlayerLocomotive as MSTSLocomotive).SmallSteamEjectorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
-                                Viewer.Catalog.GetString("Pressure"),
-                                FormatStrings.FormatPressure((Viewer.PlayerLocomotive as MSTSLocomotive).SteamEjectorSmallPressurePSI, PressureUnit.PSI, (Viewer.PlayerLocomotive as MSTSLocomotive).BrakeSystemPressureUnits[BrakeSystemComponent.MainReservoir], true),
-                                Viewer.Catalog.GetString("Vacuum Pump"),
-                                (Viewer.PlayerLocomotive as MSTSLocomotive).VacuumPumpOperating ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off")
-                                ));
-                            }
-                        else if ((Viewer.PlayerLocomotive as MSTSLocomotive).VacuumPumpFitted && !(Viewer.PlayerLocomotive as MSTSLocomotive).SmallEjectorFitted) // Change display so that small ejector is not displayed for vacuum pump operated locomotives
-                            {
-                                // Display if vacuum pump, and large ejector only fitted
-                                TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}",
-                                Viewer.Catalog.GetString("PlayerLoco"),
-                                Viewer.Catalog.GetString("Large Ejector"),
-                                (Viewer.PlayerLocomotive as MSTSLocomotive).LargeSteamEjectorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
-                                Viewer.Catalog.GetString("Vacuum Pump"),
-                                (Viewer.PlayerLocomotive as MSTSLocomotive).VacuumPumpOperating ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off")));
-                            }
-                        else
-                            {
-                                // Display if large ejector and small ejector only fitted
-                                TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}\t{5}\t{6}",
-                                Viewer.Catalog.GetString("PlayerLoco"),
-                                Viewer.Catalog.GetString("Large Ejector"),
-                                (Viewer.PlayerLocomotive as MSTSLocomotive).LargeSteamEjectorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
-                                Viewer.Catalog.GetString("Small Ejector"),
-                                (Viewer.PlayerLocomotive as MSTSLocomotive).SmallSteamEjectorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
-                                Viewer.Catalog.GetString("Pressure"),
-                                FormatStrings.FormatPressure((Viewer.PlayerLocomotive as MSTSLocomotive).SteamEjectorSmallPressurePSI, PressureUnit.PSI, (Viewer.PlayerLocomotive as MSTSLocomotive).BrakeSystemPressureUnits[BrakeSystemComponent.MainReservoir], true)));
-                            }
-
-                        // Lines to show brake system volumes
-                        TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}\t{5}\t{6}",
-                        Viewer.Catalog.GetString("Brake Sys Vol"),
-                        Viewer.Catalog.GetString("Train Pipe"),
-                        FormatStrings.FormatVolume(train.TotalTrainBrakePipeVolumeM3, mstsLocomotive.IsMetric),
-                        Viewer.Catalog.GetString("Brake Cyl"),
-                        FormatStrings.FormatVolume(train.TotalTrainBrakeCylinderVolumeM3, mstsLocomotive.IsMetric),
-                        Viewer.Catalog.GetString("Air Vol"),
-                        FormatStrings.FormatVolume(train.TotalCurrentTrainBrakeSystemVolumeM3, mstsLocomotive.IsMetric)
-                        ));
-
-                }
-                else  // Default to air or electronically braked, use this display
+                if ((Viewer.PlayerLocomotive as MSTSLocomotive).VacuumBrakeEQFitted)
                 {
                     TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}",
-                        Viewer.Catalog.GetString("PlayerLoco"),
-                        Viewer.Catalog.GetString("Main reservoir"),
-                        FormatStrings.FormatPressure((Viewer.PlayerLocomotive as MSTSLocomotive).MainResPressurePSI, PressureUnit.PSI, (Viewer.PlayerLocomotive as MSTSLocomotive).BrakeSystemPressureUnits[BrakeSystemComponent.MainReservoir], true),
-                        Viewer.Catalog.GetString("Compressor"),
-                        (Viewer.PlayerLocomotive as MSTSLocomotive).CompressorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off")));
+                    Viewer.Catalog.GetString("PlayerLoco"),
+                    Viewer.Catalog.GetString("Main reservoir"),
+                    FormatStrings.FormatPressure(Vac.FromPress((Viewer.PlayerLocomotive as MSTSLocomotive).VacuumMainResVacuumPSIAorInHg), PressureUnit.InHg, PressureUnit.InHg, true),
+                    Viewer.Catalog.GetString("Exhauster"),
+                    (Viewer.PlayerLocomotive as MSTSLocomotive).VacuumExhausterIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off")));
                 }
+
+                else if ((Viewer.PlayerLocomotive as MSTSLocomotive).VacuumPumpFitted && (Viewer.PlayerLocomotive as MSTSLocomotive).SmallEjectorFitted)
+                {
+                    // Display if vacuum pump, large ejector and small ejector fitted
+                    TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}\t{5}\t{6}\t\t{7}\t\t{8}",
+                    Viewer.Catalog.GetString("PlayerLoco"),
+                    Viewer.Catalog.GetString("Large Ejector"),
+                    (Viewer.PlayerLocomotive as MSTSLocomotive).LargeSteamEjectorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
+                    Viewer.Catalog.GetString("Small Ejector"),
+                    (Viewer.PlayerLocomotive as MSTSLocomotive).SmallSteamEjectorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
+                    Viewer.Catalog.GetString("Pressure"),
+                    FormatStrings.FormatPressure((Viewer.PlayerLocomotive as MSTSLocomotive).SteamEjectorSmallPressurePSI, PressureUnit.PSI, (Viewer.PlayerLocomotive as MSTSLocomotive).BrakeSystemPressureUnits[BrakeSystemComponent.MainReservoir], true),
+                    Viewer.Catalog.GetString("Vacuum Pump"),
+                    (Viewer.PlayerLocomotive as MSTSLocomotive).VacuumPumpOperating ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off")
+                    ));
+                }
+                else if ((Viewer.PlayerLocomotive as MSTSLocomotive).VacuumPumpFitted && !(Viewer.PlayerLocomotive as MSTSLocomotive).SmallEjectorFitted) // Change display so that small ejector is not displayed for vacuum pump operated locomotives
+                {
+                    // Display if vacuum pump, and large ejector only fitted
+                    TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}",
+                    Viewer.Catalog.GetString("PlayerLoco"),
+                    Viewer.Catalog.GetString("Large Ejector"),
+                    (Viewer.PlayerLocomotive as MSTSLocomotive).LargeSteamEjectorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
+                    Viewer.Catalog.GetString("Vacuum Pump"),
+                    (Viewer.PlayerLocomotive as MSTSLocomotive).VacuumPumpOperating ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off")));
+                }
+                else
+                {
+                    // Display if large ejector and small ejector only fitted
+                    TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}\t{5}\t{6}",
+                    Viewer.Catalog.GetString("PlayerLoco"),
+                    Viewer.Catalog.GetString("Large Ejector"),
+                    (Viewer.PlayerLocomotive as MSTSLocomotive).LargeSteamEjectorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
+                    Viewer.Catalog.GetString("Small Ejector"),
+                    (Viewer.PlayerLocomotive as MSTSLocomotive).SmallSteamEjectorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
+                    Viewer.Catalog.GetString("Pressure"),
+                    FormatStrings.FormatPressure((Viewer.PlayerLocomotive as MSTSLocomotive).SteamEjectorSmallPressurePSI, PressureUnit.PSI, (Viewer.PlayerLocomotive as MSTSLocomotive).BrakeSystemPressureUnits[BrakeSystemComponent.MainReservoir], true)));
+                }
+
+                // Lines to show brake system volumes
+                TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}\t{5}\t{6}",
+                Viewer.Catalog.GetString("Brake Sys Vol"),
+                Viewer.Catalog.GetString("Train Pipe"),
+                FormatStrings.FormatVolume(train.TotalTrainBrakePipeVolumeM3, mstsLocomotive.IsMetric),
+                Viewer.Catalog.GetString("Brake Cyl"),
+                FormatStrings.FormatVolume(train.TotalTrainBrakeCylinderVolumeM3, mstsLocomotive.IsMetric),
+                Viewer.Catalog.GetString("Air Vol"),
+                FormatStrings.FormatVolume(train.TotalCurrentTrainBrakeSystemVolumeM3, mstsLocomotive.IsMetric)
+                ));
+
+            }
+            else  // Default to air or electronically braked, use this display
+            {
+                TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}",
+                    Viewer.Catalog.GetString("PlayerLoco"),
+                    Viewer.Catalog.GetString("Main reservoir"),
+                    FormatStrings.FormatPressure((Viewer.PlayerLocomotive as MSTSLocomotive).MainResPressurePSI, PressureUnit.PSI, (Viewer.PlayerLocomotive as MSTSLocomotive).BrakeSystemPressureUnits[BrakeSystemComponent.MainReservoir], true),
+                    Viewer.Catalog.GetString("Compressor"),
+                    (Viewer.PlayerLocomotive as MSTSLocomotive).CompressorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off")));
+            }
 
             // Display data for other locomotives
             for (var i = 0; i < train.Cars.Count; i++)
@@ -754,7 +754,7 @@ namespace Orts.Viewer3D.Popups
 
             if (mstsLocomotive != null)
             {
-                if ( mstsLocomotive.AdvancedAdhesionModel)
+                if (mstsLocomotive.AdvancedAdhesionModel)
                 {
                     var HUDSteamEngineType = mstsLocomotive.SteamEngineType;
                     var HUDEngineType = mstsLocomotive.EngineType;
@@ -766,7 +766,7 @@ namespace Orts.Viewer3D.Popups
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Wag Adhesion"), "{0:F0}%", mstsLocomotive.WagonCoefficientFrictionHUD * 100.0f);
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Tang. Force"), "{0:F0}", FormatStrings.FormatForce(N.FromLbf(mstsLocomotive.SteamTangentialWheelForce), mstsLocomotive.IsMetric));
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Static Force"), "{0:F0}", FormatStrings.FormatForce(N.FromLbf(mstsLocomotive.SteamStaticWheelForce), mstsLocomotive.IsMetric));
-                      //  TableAddLabelValue(table, Viewer.Catalog.GetString("Axle brake force"), "{0}", FormatStrings.FormatForce(mstsLocomotive.LocomotiveAxle.BrakeForceN, mstsLocomotive.IsMetric));
+                        //  TableAddLabelValue(table, Viewer.Catalog.GetString("Axle brake force"), "{0}", FormatStrings.FormatForce(mstsLocomotive.LocomotiveAxle.BrakeForceN, mstsLocomotive.IsMetric));
                     }
                     else  // Advanced adhesion non steam locomotives HUD display
                     {
@@ -849,8 +849,8 @@ namespace Orts.Viewer3D.Popups
                 TableSetCell(table, 7, "{0}", FormatStrings.FormatForce(car.TunnelForceN, car.IsMetric));
                 TableSetCell(table, 8, "{0}", FormatStrings.FormatForce(car.WindForceN, car.IsMetric));
                 TableSetCell(table, 9, "{0}", FormatStrings.FormatForce(car.CouplerForceU, car.IsMetric));
-                TableSetCell(table, 10, "{0} : {1}", car.HUDCouplerRigidIndication == 2 ? "F" : car.HUDCouplerRigidIndication == 1 ? "R": "N", car.CouplerExceedBreakLimit ? "xxx" : car.CouplerOverloaded ? "O/L" : car.HUDCouplerForceIndication == 1 ? "Pull" : car.HUDCouplerForceIndication == 2 ? "Push" : "-");
-                TableSetCell(table, 11, "{0}", FormatStrings.FormatVeryShortDistanceDisplay( car.CouplerSlackM, car.IsMetric));
+                TableSetCell(table, 10, "{0} : {1}", car.HUDCouplerRigidIndication == 2 ? "F" : car.HUDCouplerRigidIndication == 1 ? "R" : "N", car.CouplerExceedBreakLimit ? "xxx" : car.CouplerOverloaded ? "O/L" : car.HUDCouplerForceIndication == 1 ? "Pull" : car.HUDCouplerForceIndication == 2 ? "Push" : "-");
+                TableSetCell(table, 11, "{0}", FormatStrings.FormatVeryShortDistanceDisplay(car.CouplerSlackM, car.IsMetric));
                 TableSetCell(table, 12, "{0}", FormatStrings.FormatLargeMass(car.MassKG, car.IsMetric, car.IsUK));
                 TableSetCell(table, 13, "{0:F2}%", -car.CurrentElevationPercent);
                 TableSetCell(table, 14, "{0}", FormatStrings.FormatDistance(car.CurrentCurveRadius, car.IsMetric));

--- a/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
@@ -48,7 +48,7 @@ namespace Orts.Viewer3D.Popups
         Dictionary<int, string> DbfEvalActDepart = new Dictionary<int, string>();//Debrief eval
 
         Dictionary<string, double> DbfEvalValues = new Dictionary<string, double>();//Debrief eval
-        
+
         public static string logFileName { get { return Program.logFileName; } set { Program.logFileName = value; } }
         ControlLayout scrollbox;
         ControlLayoutHorizontal line;
@@ -379,7 +379,7 @@ namespace Orts.Viewer3D.Popups
                             //Station stops remaining
                             foreach (var item in DbfEvalActArrive)
                             {
-                              if (item.Value == "")
+                                if (item.Value == "")
                                     dbfstationstopsremaining++;
                             }
                             if (!actualStatusVisible)
@@ -1076,11 +1076,11 @@ namespace Orts.Viewer3D.Popups
             string starBlack = " ★ ★ ★ ★ ★";
             string starWhite = " ☆ ☆ ☆ ☆ ☆";
 
-            star = (starBlack.Substring(0, value / 10).ToString() + starWhite.Substring(value / 10, 10 - (value/10)).ToString());
+            star = (starBlack.Substring(0, value / 10).ToString() + starWhite.Substring(value / 10, 10 - (value / 10)).ToString());
             return star;
         }
 
-        private void outmesssagecolorcenter( string text, int colW, Color color, bool lScroll)
+        private void outmesssagecolorcenter(string text, int colW, Color color, bool lScroll)
         {
             if (lScroll)
             {
@@ -1091,9 +1091,9 @@ namespace Orts.Viewer3D.Popups
                 if (!lDebriefEvalFile) wDbfEval.Write(text.PadLeft(40 + text.Length / 2));
 
             line.Add(indicator = new Label(colW, line.RemainingHeight, Viewer.Catalog.GetString(text), LabelAlignment.Center));
-            indicator.Color =color;
-        }    
-        
+            indicator.Color = color;
+        }
+
         private void outmesssagecolor(string text, int colW, Color color, bool bScroll, int nmargin, int nwriteline)
         {
             string[] atext = text.Split('=');
@@ -1102,11 +1102,11 @@ namespace Orts.Viewer3D.Popups
             if (bScroll)
             {
                 line = scrollbox.AddLayoutHorizontalLineOfText();
-                if (!lDebriefEvalFile) wDbfEval.WriteLine(atext.Length > 1 ? atext[0].PadRight(nvalmargin[nmargin]) + " = " + atext[1]: text);
+                if (!lDebriefEvalFile) wDbfEval.WriteLine(atext.Length > 1 ? atext[0].PadRight(nvalmargin[nmargin]) + " = " + atext[1] : text);
             }
             else
             {
-                if (!lDebriefEvalFile) wDbfEval.Write(atext.Length > 1 ? atext[0].PadRight(nvalmargin[nmargin]) + " = " + atext[1]: text.PadRight(nvalmargin[nmargin]));
+                if (!lDebriefEvalFile) wDbfEval.Write(atext.Length > 1 ? atext[0].PadRight(nvalmargin[nmargin]) + " = " + atext[1] : text.PadRight(nvalmargin[nmargin]));
             }
 
             if (!lDebriefEvalFile)
@@ -1153,7 +1153,7 @@ namespace Orts.Viewer3D.Popups
                 line.Add(new Label(colW, line.RemainingHeight, Viewer.Catalog.GetString(text)));
             }
         }
-        
+
         private void consolewltext(string text)
         {
             if (!lDebriefEvalFile) wDbfEval.WriteLine(text + ".");
@@ -1183,7 +1183,7 @@ namespace Orts.Viewer3D.Popups
                     var label = new Label(tabWidth, hbox.RemainingHeight, Tabs[i].TabLabel, LabelAlignment.Center) { Color = ActiveTab == i ? Color.White : Color.Gray, Tag = i };
                     label.Click += label_Click;
                     hbox.Add(label);
-                    
+
                 }
                 vbox.AddHorizontalSeparator();
                 Tabs[ActiveTab].Layout(vbox);
@@ -1222,10 +1222,10 @@ namespace Orts.Viewer3D.Popups
             }
         }
 
-        
+
         ActivityTask LastActivityTask;
         bool StoppedAt;
-        
+
         public override void PrepareFrame(ElapsedTime elapsedTime, bool updateFull)
         {
 

--- a/Source/RunActivity/Viewer3D/Popups/LayeredWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/LayeredWindow.cs
@@ -22,20 +22,20 @@ using Microsoft.Xna.Framework.Graphics;
 namespace Orts.Viewer3D.Popups
 {
     public abstract class LayeredWindow : Window
-	{
-		public LayeredWindow(WindowManager owner, int width, int height, string caption)
-			: base(owner, width, height, caption)
-		{
-		}
+    {
+        public LayeredWindow(WindowManager owner, int width, int height, string caption)
+            : base(owner, width, height, caption)
+        {
+        }
 
-		protected override ControlLayout Layout(ControlLayout layout)
-		{
-			return layout;
-		}
+        protected override ControlLayout Layout(ControlLayout layout)
+        {
+            return layout;
+        }
 
-		public override void Draw(GraphicsDevice graphicsDevice)
-		{
-			// Don't draw the normal window stuff here.
-		}
-	}
+        public override void Draw(GraphicsDevice graphicsDevice)
+        {
+            // Don't draw the normal window stuff here.
+        }
+    }
 }

--- a/Source/RunActivity/Viewer3D/Popups/MessagesWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/MessagesWindow.cs
@@ -40,19 +40,19 @@ namespace Orts.Viewer3D.Popups
         List<Message> Messages = new List<Message>();
         bool MessagesChanged;
 
-		public List<string> GetTextMessages()
-		{
-			List<string> text = null;
-			foreach (var m in Messages)
-			{
-				if (true/*m.Text.StartsWith("TEXT")*/)
-				{
-					if (text == null) text = new List<string>();
-					text.Add(m.Text);
-				}
-			}
-			return text;
-		}
+        public List<string> GetTextMessages()
+        {
+            List<string> text = null;
+            foreach (var m in Messages)
+            {
+                if (true/*m.Text.StartsWith("TEXT")*/)
+                {
+                    if (text == null) text = new List<string>();
+                    text.Add(m.Text);
+                }
+            }
+            return text;
+        }
         public MessagesWindow(WindowManager owner)
             : base(owner, HorizontalPadding, VerticalPadding, "Messages")
         {
@@ -72,14 +72,14 @@ namespace Orts.Viewer3D.Popups
         {
             base.Restore(inf);
             var messages = new List<Message>(inf.ReadInt32());
-            for( var i = 0; i < messages.Capacity; i++ )
+            for (var i = 0; i < messages.Capacity; i++)
             {
                 messages.Add(new Message(inf));
                 // Reset the EndTime so the message lasts as long on restore as it did orginally.
                 // Without this reset, the band may last a very long time.
                 var last = messages.Count - 1;
                 var message = messages[last];
-                message.EndTime = Owner.Viewer.Simulator.GameTime + (message.EndTime - message.StartTime); 
+                message.EndTime = Owner.Viewer.Simulator.GameTime + (message.EndTime - message.StartTime);
                 MessagesChanged = true;
             }
             Messages = messages;
@@ -118,7 +118,7 @@ namespace Orts.Viewer3D.Popups
             var maxLines = vbox.RemainingHeight / TextSize;
             var messages = Messages.Take(maxLines).Reverse().ToList();
             vbox.AddSpace(0, vbox.RemainingHeight - TextSize * messages.Count());
-            foreach( var message in messages )
+            foreach (var message in messages)
             {
                 var hbox = vbox.AddLayoutHorizontal(TextSize);
                 var width = hbox.RemainingWidth;

--- a/Source/RunActivity/Viewer3D/Popups/QuitWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/QuitWindow.cs
@@ -38,23 +38,23 @@ namespace Orts.Viewer3D.Popups
             Label buttonQuit, buttonSave, buttonContinue;
             var vbox = base.Layout(layout).AddLayoutVertical();
             var heightForLabels = 10;
-			if (!Orts.MultiPlayer.MPManager.IsMultiPlayer())
-				heightForLabels = (vbox.RemainingHeight - 2 * ControlLayout.SeparatorSize) / 3;
-			else heightForLabels = (vbox.RemainingHeight - 2 * ControlLayout.SeparatorSize) / 2;
+            if (!Orts.MultiPlayer.MPManager.IsMultiPlayer())
+                heightForLabels = (vbox.RemainingHeight - 2 * ControlLayout.SeparatorSize) / 3;
+            else heightForLabels = (vbox.RemainingHeight - 2 * ControlLayout.SeparatorSize) / 2;
             var spacing = (heightForLabels - Owner.TextFontDefault.Height) / 2;
             vbox.AddSpace(0, spacing);
             vbox.Add(buttonQuit = new Label(vbox.RemainingWidth, Owner.TextFontDefault.Height, Viewer.Catalog.GetStringFmt("Quit {1} ({0})", Owner.Viewer.Settings.Input.Commands[(int)UserCommand.GameQuit], Application.ProductName), LabelAlignment.Center));
             vbox.AddSpace(0, spacing);
             vbox.AddHorizontalSeparator();
-			if (!Orts.MultiPlayer.MPManager.IsMultiPlayer())
-			{
+            if (!Orts.MultiPlayer.MPManager.IsMultiPlayer())
+            {
                 buttonSave = new Label(vbox.RemainingWidth, Owner.TextFontDefault.Height, Viewer.Catalog.GetStringFmt("Save your game ({0})", Owner.Viewer.Settings.Input.Commands[(int)UserCommand.GameSave]), LabelAlignment.Center);
-				vbox.AddSpace(0, spacing);
-				vbox.Add(buttonSave);
-				vbox.AddSpace(0, spacing);
-				vbox.AddHorizontalSeparator();
-				buttonSave.Click += new Action<Control, Point>(buttonSave_Click);
-			}
+                vbox.AddSpace(0, spacing);
+                vbox.Add(buttonSave);
+                vbox.AddSpace(0, spacing);
+                vbox.AddHorizontalSeparator();
+                buttonSave.Click += new Action<Control, Point>(buttonSave_Click);
+            }
             vbox.AddSpace(0, spacing);
             vbox.Add(buttonContinue = new Label(vbox.RemainingWidth, Owner.TextFontDefault.Height, Viewer.Catalog.GetStringFmt("Continue playing ({0})", Owner.Viewer.Settings.Input.Commands[(int)UserCommand.GamePauseMenu]), LabelAlignment.Center));
             buttonQuit.Click += new Action<Control, Point>(buttonQuit_Click);
@@ -75,7 +75,8 @@ namespace Orts.Viewer3D.Popups
         void buttonContinue_Click(Control arg1, Point arg2)
         {
             Visible = Owner.Viewer.Simulator.Paused = false;
-            if( Owner.Viewer.Log.PauseState == ReplayPauseState.During ) {
+            if (Owner.Viewer.Log.PauseState == ReplayPauseState.During)
+            {
                 Owner.Viewer.Log.PauseState = ReplayPauseState.Done;
             }
             Owner.Viewer.ResumeReplaying();

--- a/Source/RunActivity/Viewer3D/Popups/SignallingDebugWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/SignallingDebugWindow.cs
@@ -114,7 +114,7 @@ namespace Orts.Viewer3D.Popups
                             totalDistance += cache.Length;
                         }
                         var nodeIndex = cacheNode.TrackNodeIndex;
-                        while (cacheNode.TrackNodeIndex == nodeIndex && cacheNode.NextSection());
+                        while (cacheNode.TrackNodeIndex == nodeIndex && cacheNode.NextSection()) ;
                     }
 
                     var switchErrorDistance = initialNodeOffset + DisplayDistance + SignalWarningDistance;
@@ -211,7 +211,7 @@ namespace Orts.Viewer3D.Popups
                             }
                             else if (switchObj != null)
                             {
-								primitives.Add(new DispatcherLabel(currentPosition.WorldLocation, objDistance >= switchErrorDistance ? Color.Red : Color.White, String.Format("Switch ({0}, {1}-way, {2} set)", switchObj.TrackNode.Index, switchObj.TrackNode.Outpins, switchObj.TrackNode.TrJunctionNode.SelectedRoute + 1), Owner.TextFontDefaultOutlined));
+                                primitives.Add(new DispatcherLabel(currentPosition.WorldLocation, objDistance >= switchErrorDistance ? Color.Red : Color.White, String.Format("Switch ({0}, {1}-way, {2} set)", switchObj.TrackNode.Index, switchObj.TrackNode.Outpins, switchObj.TrackNode.TrJunctionNode.SelectedRoute + 1), Owner.TextFontDefaultOutlined));
                             }
                             else if (signalObj != null)
                             {
@@ -343,7 +343,8 @@ namespace Orts.Viewer3D.Popups
             Signal,
         }
 
-        public class TrackSectionCacheEntry {
+        public class TrackSectionCacheEntry
+        {
             public int Age;
             public Traveller.TravellerDirection Direction;
             public float Length;

--- a/Source/RunActivity/Viewer3D/Popups/TTDetachWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TTDetachWindow.cs
@@ -39,7 +39,7 @@ namespace Orts.Viewer3D.Popups
 
         DetachInfo reqDetach = null;
         TTTrain reqTrain;
-        
+
         public TTDetachWindow(WindowManager owner)
             : base(owner, Window.DecorationSize.X + WindowImageSizeWidth, Window.DecorationSize.Y + owner.TextFontDefault.Height * WindowImageSizeHeightFactor + ControlLayout.SeparatorSize * 2, Viewer.Catalog.GetString("Timetable Detach Menu"))
         {
@@ -95,7 +95,7 @@ namespace Orts.Viewer3D.Popups
                         }
                         else
                         {
-                            formedTrain = String.Concat(Viewer.Catalog.GetString("static consist"), " : ",reqDetach.DetachFormedTrainName);
+                            formedTrain = String.Concat(Viewer.Catalog.GetString("static consist"), " : ", reqDetach.DetachFormedTrainName);
                         }
                     }
 

--- a/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
@@ -44,45 +44,45 @@ namespace Orts.Viewer3D.Popups
 
         static readonly Dictionary<Train.END_AUTHORITY, string> AuthorityLabels = new Dictionary<Train.END_AUTHORITY, string>
         {
-			{ Train.END_AUTHORITY.END_OF_TRACK, "End Trck" },
-			{ Train.END_AUTHORITY.END_OF_PATH, "End Path" },
-			{ Train.END_AUTHORITY.RESERVED_SWITCH, "Switch" },
+            { Train.END_AUTHORITY.END_OF_TRACK, "End Trck" },
+            { Train.END_AUTHORITY.END_OF_PATH, "End Path" },
+            { Train.END_AUTHORITY.RESERVED_SWITCH, "Switch" },
             { Train.END_AUTHORITY.LOOP, "Loop" },
-			{ Train.END_AUTHORITY.TRAIN_AHEAD, "TrainAhd" },
-			{ Train.END_AUTHORITY.MAX_DISTANCE, "Max Dist" },
-			{ Train.END_AUTHORITY.NO_PATH_RESERVED, "No Path" },
+            { Train.END_AUTHORITY.TRAIN_AHEAD, "TrainAhd" },
+            { Train.END_AUTHORITY.MAX_DISTANCE, "Max Dist" },
+            { Train.END_AUTHORITY.NO_PATH_RESERVED, "No Path" },
             { Train.END_AUTHORITY.SIGNAL, "Signal" },
             { Train.END_AUTHORITY.END_OF_AUTHORITY, "End Auth" },
-		};
+        };
 
         static readonly Dictionary<Train.OUTOFCONTROL, string> OutOfControlLabels = new Dictionary<Train.OUTOFCONTROL, string>
         {
-			{ Train.OUTOFCONTROL.SPAD, "SPAD" },
-			{ Train.OUTOFCONTROL.SPAD_REAR, "SPAD-Rear" },
+            { Train.OUTOFCONTROL.SPAD, "SPAD" },
+            { Train.OUTOFCONTROL.SPAD_REAR, "SPAD-Rear" },
             { Train.OUTOFCONTROL.MISALIGNED_SWITCH, "Misalg Sw" },
-			{ Train.OUTOFCONTROL.OUT_OF_AUTHORITY, "Off Auth" },
-			{ Train.OUTOFCONTROL.OUT_OF_PATH, "Off Path" },
-			{ Train.OUTOFCONTROL.SLIPPED_INTO_PATH, "Splipped" },
-			{ Train.OUTOFCONTROL.SLIPPED_TO_ENDOFTRACK, "Slipped" },
-			{ Train.OUTOFCONTROL.OUT_OF_TRACK, "Off Track" },
+            { Train.OUTOFCONTROL.OUT_OF_AUTHORITY, "Off Auth" },
+            { Train.OUTOFCONTROL.OUT_OF_PATH, "Off Path" },
+            { Train.OUTOFCONTROL.SLIPPED_INTO_PATH, "Splipped" },
+            { Train.OUTOFCONTROL.SLIPPED_TO_ENDOFTRACK, "Slipped" },
+            { Train.OUTOFCONTROL.OUT_OF_TRACK, "Off Track" },
             { Train.OUTOFCONTROL.SLIPPED_INTO_TURNTABLE, "Slip Turn" },
-			{ Train.OUTOFCONTROL.UNDEFINED, "Undefined" },
-		};
+            { Train.OUTOFCONTROL.UNDEFINED, "Undefined" },
+        };
 
         public TrackMonitorWindow(WindowManager owner)
             : base(owner, Window.DecorationSize.X + owner.TextFontDefault.Height * 10, Window.DecorationSize.Y + owner.TextFontDefault.Height * (5 + TrackMonitorHeightInLinesOfText) + ControlLayout.SeparatorSize * 3, Viewer.Catalog.GetString("Track Monitor"))
         {
-            ControlModeLabels = new Dictionary<Train.TRAIN_CONTROL, string> 
+            ControlModeLabels = new Dictionary<Train.TRAIN_CONTROL, string>
             {
-			    { Train.TRAIN_CONTROL.AUTO_SIGNAL , Viewer.Catalog.GetString("Auto Signal") },
-			    { Train.TRAIN_CONTROL.AUTO_NODE, Viewer.Catalog.GetString("Node") },
-			    { Train.TRAIN_CONTROL.MANUAL, Viewer.Catalog.GetString("Manual") },
+                { Train.TRAIN_CONTROL.AUTO_SIGNAL , Viewer.Catalog.GetString("Auto Signal") },
+                { Train.TRAIN_CONTROL.AUTO_NODE, Viewer.Catalog.GetString("Node") },
+                { Train.TRAIN_CONTROL.MANUAL, Viewer.Catalog.GetString("Manual") },
                 { Train.TRAIN_CONTROL.EXPLORER, Viewer.Catalog.GetString("Explorer") },
-			    { Train.TRAIN_CONTROL.OUT_OF_CONTROL, Viewer.Catalog.GetString("OutOfControl : ") },
+                { Train.TRAIN_CONTROL.OUT_OF_CONTROL, Viewer.Catalog.GetString("OutOfControl : ") },
                 { Train.TRAIN_CONTROL.INACTIVE, Viewer.Catalog.GetString("Inactive") },
                 { Train.TRAIN_CONTROL.TURNTABLE, Viewer.Catalog.GetString("Turntable") },
-			    { Train.TRAIN_CONTROL.UNDEFINED, Viewer.Catalog.GetString("Unknown") },
-		    };
+                { Train.TRAIN_CONTROL.UNDEFINED, Viewer.Catalog.GetString("Unknown") },
+            };
         }
 
         protected override ControlLayout Layout(ControlLayout layout)
@@ -186,7 +186,7 @@ namespace Orts.Viewer3D.Popups
         WindowTextFont Font;
 
         bool metric;
-     
+
         public static int DbfEvalOverSpeed;//Debrief eval
         bool istrackColorRed = false;//Debrief eval
         public static Double DbfEvalOverSpeedTimeS = 0;//Debrief eval
@@ -383,7 +383,7 @@ namespace Orts.Viewer3D.Popups
             {
                 istrackColorRed = true;
                 DbfEvalIniOverSpeedTimeS = Orts.MultiPlayer.MPManager.Simulator.ClockTime;
-            }            
+            }
 
             if (istrackColorRed && trackColor != Color.Red)//Debrief Eval
             {
@@ -684,7 +684,7 @@ namespace Orts.Viewer3D.Popups
                 }
             }
             // reverse display of signals to have correct superposition
-            for (int iItems = itemList.Count-1 ; iItems >=0; iItems--)
+            for (int iItems = itemList.Count - 1; iItems >= 0; iItems--)
             {
                 var thisItem = itemList[iItems];
                 switch (thisItem.ItemType)
@@ -790,7 +790,7 @@ namespace Orts.Viewer3D.Popups
         void drawSignalBackward(SpriteBatch spriteBatch, Point offset, int startObjectArea, int endObjectArea, int zeroPoint, float maxDistance, float distanceFactor, bool forward, Train.TrainObjectItem thisItem, bool signalShown)
         {
             var displayItem = SignalMarkers[thisItem.SignalState];
- 
+
             var displayRequired = false;
             var itemLocation = 0;
             var itemOffset = 0;

--- a/Source/RunActivity/Viewer3D/Popups/TracksDebugWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TracksDebugWindow.cs
@@ -75,7 +75,7 @@ namespace Orts.Viewer3D.Popups
                     {
                         var previousLocation = currentPosition.WorldLocation;
                         var remaining = currentPosition.MoveInSection(DisplaySegmentLength);
-                        if ((Math.Abs(remaining - DisplaySegmentLength ) < Tolerance) && !currentPosition.NextVectorSection())
+                        if ((Math.Abs(remaining - DisplaySegmentLength) < Tolerance) && !currentPosition.NextVectorSection())
                             break;
                         primitives.Add(new DispatcherLineSegment(previousLocation, currentPosition.WorldLocation, Color.LightBlue, 2));
                     }

--- a/Source/RunActivity/Viewer3D/Popups/TrainListWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainListWindow.cs
@@ -80,7 +80,7 @@ namespace Orts.Viewer3D.Popups
                 foreach (var thisTrain in Owner.Viewer.Simulator.AI.AITrains)
                 {
                     if (thisTrain.MovementState != AITrain.AI_MOVEMENT_STATE.AI_STATIC && thisTrain.TrainType != Train.TRAINTYPE.PLAYER
-                        && ! (thisTrain.TrainType == Train.TRAINTYPE.AI_INCORPORATED && !thisTrain.IncorporatingTrain.IsPathless))
+                        && !(thisTrain.TrainType == Train.TRAINTYPE.AI_INCORPORATED && !thisTrain.IncorporatingTrain.IsPathless))
                     {
                         var line = scrollbox.AddLayoutHorizontalLineOfText();
                         TrainLabel number, name, viewed;
@@ -127,7 +127,7 @@ namespace Orts.Viewer3D.Popups
                             }
                             number.Color = Color.Yellow;
                             name.Color = Color.Yellow;
-                         }
+                        }
                     }
                 }
             }
@@ -179,7 +179,7 @@ namespace Orts.Viewer3D.Popups
                 Viewer.Simulator.TrainSwitcher.ClickedTrainFromList = true;
 
             }
-            if (PickedTrainFromList != null && (PickedTrainFromList == Viewer.SelectedTrain || (PickedTrainFromList.TrainType == Train.TRAINTYPE.AI_INCORPORATED && 
+            if (PickedTrainFromList != null && (PickedTrainFromList == Viewer.SelectedTrain || (PickedTrainFromList.TrainType == Train.TRAINTYPE.AI_INCORPORATED &&
                 (PickedTrainFromList as AITrain).IncorporatingTrain.IsPathless && (PickedTrainFromList as AITrain).IncorporatingTrain == Viewer.SelectedTrain)) && !PickedTrainFromList.IsActualPlayerTrain &&
                 Viewer.Simulator.IsAutopilotMode && PickedTrainFromList.IsPlayable)
             {
@@ -198,4 +198,4 @@ namespace Orts.Viewer3D.Popups
             }
         }
     }
- }
+}

--- a/Source/RunActivity/Viewer3D/Popups/Window.cs
+++ b/Source/RunActivity/Viewer3D/Popups/Window.cs
@@ -238,35 +238,35 @@ namespace Orts.Viewer3D.Popups
                 var vertexData = new[] {
 					//  0  1  2  3
 					new VertexPositionTexture(new Vector3(0 * location.Width + 00, 0 * location.Height + 00, 0), new Vector2(0.00f / 2, 0.00f)),
-					new VertexPositionTexture(new Vector3(0 * location.Width + gp, 0 * location.Height + 00, 0), new Vector2(0.25f / 2, 0.00f)),
-					new VertexPositionTexture(new Vector3(1 * location.Width - gp, 0 * location.Height + 00, 0), new Vector2(0.75f / 2, 0.00f)),
-					new VertexPositionTexture(new Vector3(1 * location.Width - 00, 0 * location.Height + 00, 0), new Vector2(1.00f / 2, 0.00f)),
+                    new VertexPositionTexture(new Vector3(0 * location.Width + gp, 0 * location.Height + 00, 0), new Vector2(0.25f / 2, 0.00f)),
+                    new VertexPositionTexture(new Vector3(1 * location.Width - gp, 0 * location.Height + 00, 0), new Vector2(0.75f / 2, 0.00f)),
+                    new VertexPositionTexture(new Vector3(1 * location.Width - 00, 0 * location.Height + 00, 0), new Vector2(1.00f / 2, 0.00f)),
 					//  4  5  6  7
 					new VertexPositionTexture(new Vector3(0 * location.Width + 00, 0 * location.Height + gp, 0), new Vector2(0.00f / 2, 0.25f)),
-					new VertexPositionTexture(new Vector3(0 * location.Width + gp, 0 * location.Height + gp, 0), new Vector2(0.25f / 2, 0.25f)),
-					new VertexPositionTexture(new Vector3(1 * location.Width - gp, 0 * location.Height + gp, 0), new Vector2(0.75f / 2, 0.25f)),
-					new VertexPositionTexture(new Vector3(1 * location.Width - 00, 0 * location.Height + gp, 0), new Vector2(1.00f / 2, 0.25f)),
+                    new VertexPositionTexture(new Vector3(0 * location.Width + gp, 0 * location.Height + gp, 0), new Vector2(0.25f / 2, 0.25f)),
+                    new VertexPositionTexture(new Vector3(1 * location.Width - gp, 0 * location.Height + gp, 0), new Vector2(0.75f / 2, 0.25f)),
+                    new VertexPositionTexture(new Vector3(1 * location.Width - 00, 0 * location.Height + gp, 0), new Vector2(1.00f / 2, 0.25f)),
 					//  8  9 10 11
 					new VertexPositionTexture(new Vector3(0 * location.Width + 00, 1 * location.Height - gp, 0), new Vector2(0.00f / 2, 0.75f)),
-					new VertexPositionTexture(new Vector3(0 * location.Width + gp, 1 * location.Height - gp, 0), new Vector2(0.25f / 2, 0.75f)),
-					new VertexPositionTexture(new Vector3(1 * location.Width - gp, 1 * location.Height - gp, 0), new Vector2(0.75f / 2, 0.75f)),
-					new VertexPositionTexture(new Vector3(1 * location.Width - 00, 1 * location.Height - gp, 0), new Vector2(1.00f / 2, 0.75f)),
+                    new VertexPositionTexture(new Vector3(0 * location.Width + gp, 1 * location.Height - gp, 0), new Vector2(0.25f / 2, 0.75f)),
+                    new VertexPositionTexture(new Vector3(1 * location.Width - gp, 1 * location.Height - gp, 0), new Vector2(0.75f / 2, 0.75f)),
+                    new VertexPositionTexture(new Vector3(1 * location.Width - 00, 1 * location.Height - gp, 0), new Vector2(1.00f / 2, 0.75f)),
 					// 12 13 14 15
 					new VertexPositionTexture(new Vector3(0 * location.Width + 00, 1 * location.Height - 00, 0), new Vector2(0.00f / 2, 1.00f)),
-					new VertexPositionTexture(new Vector3(0 * location.Width + gp, 1 * location.Height - 00, 0), new Vector2(0.25f / 2, 1.00f)),
-					new VertexPositionTexture(new Vector3(1 * location.Width - gp, 1 * location.Height - 00, 0), new Vector2(0.75f / 2, 1.00f)),
-					new VertexPositionTexture(new Vector3(1 * location.Width - 00, 1 * location.Height - 00, 0), new Vector2(1.00f / 2, 1.00f)),
-				};
+                    new VertexPositionTexture(new Vector3(0 * location.Width + gp, 1 * location.Height - 00, 0), new Vector2(0.25f / 2, 1.00f)),
+                    new VertexPositionTexture(new Vector3(1 * location.Width - gp, 1 * location.Height - 00, 0), new Vector2(0.75f / 2, 1.00f)),
+                    new VertexPositionTexture(new Vector3(1 * location.Width - 00, 1 * location.Height - 00, 0), new Vector2(1.00f / 2, 1.00f)),
+                };
                 WindowVertexBuffer = new VertexBuffer(graphicsDevice, typeof(VertexPositionTexture), vertexData.Length, BufferUsage.WriteOnly);
                 WindowVertexBuffer.SetData(vertexData);
             }
             if (WindowIndexBuffer == null)
             {
                 var indexData = new short[] {
-					0, 4, 1, 5, 2, 6, 3, 7,
-					11, 6, 10, 5, 9, 4, 8,
-					12, 9, 13, 10, 14, 11, 15,
-				};
+                    0, 4, 1, 5, 2, 6, 3, 7,
+                    11, 6, 10, 5, 9, 4, 8,
+                    12, 9, 13, 10, 14, 11, 15,
+                };
                 WindowIndexBuffer = new IndexBuffer(graphicsDevice, typeof(short), indexData.Length, BufferUsage.WriteOnly);
                 WindowIndexBuffer.SetData(indexData);
             }

--- a/Source/RunActivity/Viewer3D/Popups/WindowManager.cs
+++ b/Source/RunActivity/Viewer3D/Popups/WindowManager.cs
@@ -31,10 +31,10 @@ using System.Linq;
 namespace Orts.Viewer3D.Popups
 {
     public class WindowManager : RenderPrimitive
-	{
-		public static Texture2D WhiteTexture;
-		public static Texture2D ScrollbarTexture;
-		public static Texture2D LabelShadowTexture;
+    {
+        public static Texture2D WhiteTexture;
+        public static Texture2D ScrollbarTexture;
+        public static Texture2D LabelShadowTexture;
         public static Texture2D NoticeTexture;
         public static Texture2D PauseTexture;
 
@@ -48,7 +48,7 @@ namespace Orts.Viewer3D.Popups
             spriteBatch.Draw(FlushTexture, Vector2.Zero, Color.Black);
         }
 
-		public readonly Viewer Viewer;
+        public readonly Viewer Viewer;
         public readonly WindowTextManager TextManager;
         public readonly WindowTextFont TextFontDefault;
         public readonly WindowTextFont TextFontDefaultOutlined;
@@ -65,9 +65,9 @@ namespace Orts.Viewer3D.Popups
         SpriteBatch SpriteBatch;
         Matrix Identity = Matrix.Identity;
         Matrix XNAView = Matrix.Identity;
-		Matrix XNAProjection = Matrix.Identity;
+        Matrix XNAProjection = Matrix.Identity;
         internal Point ScreenSize = new Point(10000, 10000); // Arbitrary but necessary.
-		ResolveTexture2D Screen;
+        ResolveTexture2D Screen;
 
         public WindowManager(Viewer viewer)
         {
@@ -172,28 +172,28 @@ namespace Orts.Viewer3D.Popups
                 window.Restore(inf);
         }
 
-		[CallOnThread("Updater")]
-		public void ScreenChanged()
-		{
-			var oldScreenSize = ScreenSize;
-			ScreenSize = Viewer.DisplaySize;
+        [CallOnThread("Updater")]
+        public void ScreenChanged()
+        {
+            var oldScreenSize = ScreenSize;
+            ScreenSize = Viewer.DisplaySize;
 
-			// Buffer for screen texture, also same size as viewport and using the backbuffer format.
-			if (Viewer.Settings.WindowGlass)
-			{
-				if (Screen != null)
-					Screen.Dispose();
-				Screen = new ResolveTexture2D(Viewer.GraphicsDevice, ScreenSize.X, ScreenSize.Y, 1, Viewer.GraphicsDevice.PresentationParameters.BackBufferFormat);
-			}
+            // Buffer for screen texture, also same size as viewport and using the backbuffer format.
+            if (Viewer.Settings.WindowGlass)
+            {
+                if (Screen != null)
+                    Screen.Dispose();
+                Screen = new ResolveTexture2D(Viewer.GraphicsDevice, ScreenSize.X, ScreenSize.Y, 1, Viewer.GraphicsDevice.PresentationParameters.BackBufferFormat);
+            }
 
-			// Reposition all the windows.
+            // Reposition all the windows.
             foreach (var window in Windows)
             {
                 if (oldScreenSize.X - window.Location.Width > 0 && oldScreenSize.Y - window.Location.Height > 0)
                     window.MoveTo((ScreenSize.X - window.Location.Width) * window.Location.X / (oldScreenSize.X - window.Location.Width), (ScreenSize.Y - window.Location.Height) * window.Location.Y / (oldScreenSize.Y - window.Location.Height));
                 window.ScreenChanged();
             }
-		}
+        }
 
         double LastPrepareRealTime;
         [CallOnThread("Updater")]
@@ -214,34 +214,34 @@ namespace Orts.Viewer3D.Popups
 
         [CallOnThread("Render")]
         public override void Draw(GraphicsDevice graphicsDevice)
-		{
-			// Nothing visible? Nothing more to do!
-			if (!VisibleWindows.Any())
-				return;
+        {
+            // Nothing visible? Nothing more to do!
+            if (!VisibleWindows.Any())
+                return;
 
-			// Construct a view where (0, 0) is the top-left and (width, height) is
-			// bottom-right, so that popups can act more like normal window things.
-			XNAView = Matrix.CreateTranslation(-ScreenSize.X / 2, -ScreenSize.Y / 2, 0) *
-				Matrix.CreateTranslation(-0.5f, -0.5f, 0) *
-				Matrix.CreateScale(1, -1, 1);
-			// Project into a flat view of the same size as the viewport.
-			XNAProjection = Matrix.CreateOrthographic(ScreenSize.X, ScreenSize.Y, 0, 100);
+            // Construct a view where (0, 0) is the top-left and (width, height) is
+            // bottom-right, so that popups can act more like normal window things.
+            XNAView = Matrix.CreateTranslation(-ScreenSize.X / 2, -ScreenSize.Y / 2, 0) *
+                Matrix.CreateTranslation(-0.5f, -0.5f, 0) *
+                Matrix.CreateScale(1, -1, 1);
+            // Project into a flat view of the same size as the viewport.
+            XNAProjection = Matrix.CreateOrthographic(ScreenSize.X, ScreenSize.Y, 0, 100);
 
             var rs = graphicsDevice.RenderState;
-			foreach (var window in VisibleWindows)
-			{
-				var xnaWorld = window.XNAWorld;
+            foreach (var window in VisibleWindows)
+            {
+                var xnaWorld = window.XNAWorld;
 
-				if (Screen != null)
-					graphicsDevice.ResolveBackBuffer(Screen);
+                if (Screen != null)
+                    graphicsDevice.ResolveBackBuffer(Screen);
                 PopupWindowMaterial.SetState(graphicsDevice, Screen);
                 PopupWindowMaterial.Render(graphicsDevice, window, ref xnaWorld, ref XNAView, ref XNAProjection);
                 PopupWindowMaterial.ResetState(graphicsDevice);
 
                 SpriteBatch.Begin(SpriteBlendMode.AlphaBlend, SpriteSortMode.Immediate, SaveStateMode.None);
-				window.Draw(SpriteBatch);
-				SpriteBatch.End();
-			}
+                window.Draw(SpriteBatch);
+                SpriteBatch.End();
+            }
             // For performance, we call SpriteBatch.Begin() with SaveStateMode.None above, but we now need to restore
             // the state ourselves.
             rs.AlphaBlendEnable = false;
@@ -250,67 +250,67 @@ namespace Orts.Viewer3D.Popups
             rs.DepthBufferEnable = true;
             rs.DestinationBlend = Blend.Zero;
             rs.SourceBlend = Blend.One;
-		}
+        }
 
-		internal void Add(Window window)
-		{
-			Windows.Add(window);
+        internal void Add(Window window)
+        {
+            Windows.Add(window);
             WindowsZOrder = Windows.Concat(new[] { window }).ToArray();
         }
 
-		public bool HasVisiblePopupWindows()
-		{
+        public bool HasVisiblePopupWindows()
+        {
             return WindowsZOrder.Any(w => w.Visible);
-		}
+        }
 
-		public IEnumerable<Window> VisibleWindows
-		{
-			get
-			{
+        public IEnumerable<Window> VisibleWindows
+        {
+            get
+            {
                 return WindowsZOrder.Where(w => w.Visible);
-			}
-		}
+            }
+        }
 
-		public const int DragMinimumDistance = 2;
+        public const int DragMinimumDistance = 2;
 
-		Point mouseDownPosition;
-		public Point MouseDownPosition { get { return mouseDownPosition; } }
+        Point mouseDownPosition;
+        public Point MouseDownPosition { get { return mouseDownPosition; } }
 
-		Window mouseActiveWindow;
-		public Window MouseActiveWindow { get { return mouseActiveWindow; } }
+        Window mouseActiveWindow;
+        public Window MouseActiveWindow { get { return mouseActiveWindow; } }
 
-		double LastUpdateRealTime;
-		[CallOnThread("Updater")]
+        double LastUpdateRealTime;
+        [CallOnThread("Updater")]
         public void HandleUserInput(ElapsedTime elapsedTime)
         {
-			if (UserInput.IsMouseLeftButtonPressed)
-			{
-				mouseDownPosition = new Point(UserInput.MouseX, UserInput.MouseY);
+            if (UserInput.IsMouseLeftButtonPressed)
+            {
+                mouseDownPosition = new Point(UserInput.MouseX, UserInput.MouseY);
                 mouseActiveWindow = VisibleWindows.LastOrDefault(w => w.Interactive && w.Location.Contains(mouseDownPosition));
                 if ((mouseActiveWindow != null) && (mouseActiveWindow != WindowsZOrder.Last()))
                     BringWindowToTop(mouseActiveWindow);
-			}
+            }
 
-			if (mouseActiveWindow != null)
-			{
-				if (UserInput.IsMouseLeftButtonPressed)
-					mouseActiveWindow.MouseDown();
-				else if (UserInput.IsMouseLeftButtonReleased)
-					mouseActiveWindow.MouseUp();
+            if (mouseActiveWindow != null)
+            {
+                if (UserInput.IsMouseLeftButtonPressed)
+                    mouseActiveWindow.MouseDown();
+                else if (UserInput.IsMouseLeftButtonReleased)
+                    mouseActiveWindow.MouseUp();
 
-				if (UserInput.IsMouseMoved)
-					mouseActiveWindow.MouseMove();
+                if (UserInput.IsMouseMoved)
+                    mouseActiveWindow.MouseMove();
 
-				if (Viewer.RealTime - LastUpdateRealTime >= 0.1)
-				{
-					LastUpdateRealTime = Viewer.RealTime;
-					mouseActiveWindow.HandleUserInput();
-				}
+                if (Viewer.RealTime - LastUpdateRealTime >= 0.1)
+                {
+                    LastUpdateRealTime = Viewer.RealTime;
+                    mouseActiveWindow.HandleUserInput();
+                }
 
-				if (UserInput.IsMouseLeftButtonReleased)
-					mouseActiveWindow = null;
-			}
-		}
+                if (UserInput.IsMouseLeftButtonReleased)
+                    mouseActiveWindow = null;
+            }
+        }
 
         public void BringWindowToTop(Window mouseActiveWindow)
         {
@@ -342,7 +342,7 @@ namespace Orts.Viewer3D.Popups
             WindowManagerMaterial.Mark();
             PopupWindowMaterial.Mark();
             Label3DMaterial.Mark();
-			foreach (var window in Windows)
+            foreach (var window in Windows)
                 window.Mark();
         }
 

--- a/Source/RunActivity/Viewer3D/Popups/WindowText.cs
+++ b/Source/RunActivity/Viewer3D/Popups/WindowText.cs
@@ -149,7 +149,7 @@ namespace Orts.Viewer3D.Popups
             OutlineSize = outlineSize;
             Characters = new CharacterGroup(Font, OutlineSize);
             if (Viewer3D.Viewer.Catalog != null)
-            EnsureCharacterData(Viewer3D.Viewer.Catalog.GetString("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890 \",.-+|!$%&/()=?;:'_[]"));
+                EnsureCharacterData(Viewer3D.Viewer.Catalog.GetString("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890 \",.-+|!$%&/()=?;:'_[]"));
         }
 
         /// <summary>

--- a/Source/RunActivity/Viewer3D/Precipitation.cs
+++ b/Source/RunActivity/Viewer3D/Precipitation.cs
@@ -37,7 +37,7 @@ namespace Orts.Viewer3D
         public const float MaxIntensityPPSPM2_16 = 0.010f;
         // Default 32 bit version.
         public const float MaxIntensityPPSPM2 = 0.035f;
-                
+
         readonly Viewer Viewer;
         readonly WeatherControl WeatherControl;
         readonly Weather Weather;
@@ -81,7 +81,7 @@ namespace Orts.Viewer3D
             // Added random Wind.X value for rain and snow.
             // Max value used by randWind.Next is max value - 1.
             Wind.X = Viewer.Simulator.WeatherType == Orts.Formats.Msts.WeatherType.Snow ? Viewer.Random.Next(2, 6) : Viewer.Random.Next(15, 21);
-                                    
+
             var gameTime = (float)Viewer.Simulator.GameTime;
             Pricipitation.Initialize(Viewer.Simulator.WeatherType, Wind);
             // Camera is null during first initialisation.
@@ -187,10 +187,10 @@ namespace Orts.Viewer3D
             VertexBuffer = new DynamicVertexBuffer(graphicsDevice, typeof(ParticleVertex), MaxParticles * VerticiesPerParticle, BufferUsage.WriteOnly);
             VertexBuffer.ContentLost += VertexBuffer_ContentLost;
             // Processing either 32bit or 16bit InitIndexBuffer depending on GraphicsDeviceCapabilities.
-           if (graphicsDevice.GraphicsDeviceCapabilities.MaxVertexIndex > 0xFFFF) // As an integer, 0xFFFF is 65535.
-               IndexBuffer = InitIndexBuffer(graphicsDevice, MaxParticles * IndiciesPerParticle);
-           else
-               IndexBuffer = InitIndexBuffer16(graphicsDevice, MaxParticles * IndiciesPerParticle);
+            if (graphicsDevice.GraphicsDeviceCapabilities.MaxVertexIndex > 0xFFFF) // As an integer, 0xFFFF is 65535.
+                IndexBuffer = InitIndexBuffer(graphicsDevice, MaxParticles * IndiciesPerParticle);
+            else
+                IndexBuffer = InitIndexBuffer16(graphicsDevice, MaxParticles * IndiciesPerParticle);
             Heights = new HeightCache(8);
             // This Trace command is used to show how much memory is used.
             Trace.TraceInformation(String.Format("Allocation for {0:N0} particles:\n\n  {1,13:N0} B RAM vertex data\n  {2,13:N0} B RAM index data (temporary)\n  {1,13:N0} B VRAM DynamicVertexBuffer\n  {2,13:N0} B VRAM IndexBuffer", MaxParticles, Marshal.SizeOf(typeof(ParticleVertex)) * MaxParticles * VerticiesPerParticle, (graphicsDevice.GraphicsDeviceCapabilities.MaxVertexIndex > 0xFFFF ? sizeof(uint) : sizeof(ushort)) * MaxParticles * IndiciesPerParticle));
@@ -297,7 +297,7 @@ namespace Orts.Viewer3D
         public void DynamicUpdate(WeatherControl weatherControl, Weather weather, Viewer viewer, ref Vector3 wind)
         {
             if (weather.PrecipitationLiquidity == 0 || weather.PrecipitationLiquidity == 1) return;
-            ParticleDuration = ParticleBoxHeightM / ((RainVelocityMpS-SnowVelocityMpS) *  weather.PrecipitationLiquidity + SnowVelocityMpS)/ ParticleVelocityFactor;
+            ParticleDuration = ParticleBoxHeightM / ((RainVelocityMpS - SnowVelocityMpS) * weather.PrecipitationLiquidity + SnowVelocityMpS) / ParticleVelocityFactor;
             wind.X = 18 * weather.PrecipitationLiquidity + 2;
             ParticleDirection = wind;
         }
@@ -486,7 +486,7 @@ namespace Orts.Viewer3D
             SnowTexture = SharedTextureManager.Get(Viewer.RenderProcess.GraphicsDevice, System.IO.Path.Combine(Viewer.ContentPath, "Snowflake.png"));
             DynamicPrecipitationTexture[0] = SnowTexture;
             DynamicPrecipitationTexture[11] = RainTexture;
-            for (int i = 1; i<=10; i++)
+            for (int i = 1; i <= 10; i++)
             {
                 var path = "Raindrop" + i.ToString() + ".png";
                 DynamicPrecipitationTexture[11 - i] = SharedTextureManager.Get(Viewer.RenderProcess.GraphicsDevice, System.IO.Path.Combine(Viewer.ContentPath, path));

--- a/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
+++ b/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
@@ -113,7 +113,7 @@ namespace Orts.Viewer3D.Processes
 
             // Look for an action to perform.
             var action = "";
-            var actions = new[] { "start", "resume", "replay", "replay_from_save", "test"};
+            var actions = new[] { "start", "resume", "replay", "replay_from_save", "test" };
             foreach (var possibleAction in actions)
                 if (args.Contains("-" + possibleAction) || args.Contains("/" + possibleAction, StringComparer.OrdinalIgnoreCase))
                 {
@@ -302,7 +302,7 @@ namespace Orts.Viewer3D.Processes
             {
                 Client.Send((new MSGPlayer(UserName, Code, Simulator.conFileName, Simulator.patFileName, Simulator.Trains[0], 0, Simulator.Settings.AvatarURL)).ToString());
                 // wait 5 seconds to see if you get a reply from server with updated position/consist data, else go on
-               
+
                 System.Threading.Thread.Sleep(5000);
                 if (Simulator.Trains[0].jumpRequested)
                 {
@@ -330,7 +330,7 @@ namespace Orts.Viewer3D.Processes
             // This is the "sortable" date format, ISO 8601, but with "." in place of the ":" which are not valid in filenames.
             var fileStem = String.Format("{0} {1} {2:yyyy'-'MM'-'dd HH'.'mm'.'ss}", Simulator.Activity != null ? Simulator.ActivityFileName :
                 (!String.IsNullOrEmpty(Simulator.TimetableFileName) ? Simulator.RoutePathName + " " + Simulator.TimetableFileName : Simulator.RoutePathName),
-                MPManager.IsMultiPlayer() && MPManager.IsServer() ? "$Multipl$ " : "" , DateTime.Now);
+                MPManager.IsMultiPlayer() && MPManager.IsServer() ? "$Multipl$ " : "", DateTime.Now);
 
             using (BinaryWriter outf = new BinaryWriter(new FileStream(UserSettings.UserDataFolder + "\\" + fileStem + ".save", FileMode.Create, FileAccess.Write)))
             {
@@ -368,7 +368,7 @@ namespace Orts.Viewer3D.Processes
                 Viewer.Save(outf, fileStem);
                 // Save multiplayer parameters
                 if (MPManager.IsMultiPlayer() && MPManager.IsServer())
-                    MPManager.OnlineTrains.Save (outf);
+                    MPManager.OnlineTrains.Save(outf);
 
                 // Write out position within file so we can check when restoring.
                 outf.Write(outf.BaseStream.Position);
@@ -379,7 +379,7 @@ namespace Orts.Viewer3D.Processes
             {
                 var dbfEvalFiles = Directory.GetFiles(UserSettings.UserDataFolder, Simulator.ActivityFileName + "*.dbfeval");
                 foreach (var files in dbfEvalFiles)
-                   File.Delete(files);//Delete all debrief eval files previously saved, for the same activity.//fileDbfEval
+                    File.Delete(files);//Delete all debrief eval files previously saved, for the same activity.//fileDbfEval
 
                 using (BinaryWriter outf = new BinaryWriter(new FileStream(UserSettings.UserDataFolder + "\\" + fileStem + ".dbfeval", FileMode.Create, FileAccess.Write)))
                 {
@@ -387,7 +387,7 @@ namespace Orts.Viewer3D.Processes
                     outf.Write(ActivityTaskPassengerStopAt.DbfEvalDepartBeforeBoarding.Count);
                     for (int i = 0; i < ActivityTaskPassengerStopAt.DbfEvalDepartBeforeBoarding.Count; i++)
                     {
-                        outf.Write((string) ActivityTaskPassengerStopAt.DbfEvalDepartBeforeBoarding[i]);
+                        outf.Write((string)ActivityTaskPassengerStopAt.DbfEvalDepartBeforeBoarding[i]);
                     }
                     outf.Write(Popups.TrackMonitor.DbfEvalOverSpeed);
                     outf.Write(Popups.TrackMonitor.DbfEvalOverSpeedTimeS);
@@ -1263,7 +1263,7 @@ namespace Orts.Viewer3D.Processes
                     new VertexPositionTexture(new Vector3(+dd - 0.5f, -dd + 0.5f, -3), new Vector2(1, 1)),
                 };
             }
-            
+
             public override void Draw(GraphicsDevice graphicsDevice)
             {
                 graphicsDevice.VertexDeclaration = VertexDeclaration;

--- a/Source/RunActivity/Viewer3D/Processes/SoundProcess.cs
+++ b/Source/RunActivity/Viewer3D/Processes/SoundProcess.cs
@@ -152,7 +152,7 @@ namespace Orts.Viewer3D.Processes
                 StartUpdateTime = viewer.RealTime;
                 int RetryUpdate = 0;
                 int restartIndex = -1;
-                
+
                 while (RetryUpdate >= 0)
                 {
                     bool updateInterrupted = false;
@@ -229,10 +229,10 @@ namespace Orts.Viewer3D.Processes
                 //    Trace.TraceInformation("Sound Source Update Interrupted more than once: {0}", UpdateInterrupts);
 
                 // <CSComment> the block below could provide better sound response but is more demanding in terms of CPU time, especially for slow CPUs
-/*              int resptime = (int)((viewer.RealTime - StartUpdateTime) * 1000);
-                SleepTime = 50 - resptime;
-                if (SleepTime < 5)
-                    SleepTime = 5;*/
+                /*              int resptime = (int)((viewer.RealTime - StartUpdateTime) * 1000);
+                                SleepTime = 50 - resptime;
+                                if (SleepTime < 5)
+                                    SleepTime = 5;*/
 #if DEBUG_SOURCE_SOURCES
                 SoundTime += (int)((viewer.RealTime - StartUpdateTime) * 1000);
                 if (viewer.RealTime - ConsoleWriteTime >= 15f)

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -77,16 +77,16 @@ namespace Orts.Viewer3D
         /// <see cref="RenderPrimitiveGroup"/>.
         /// </summary>
         public static readonly RenderPrimitiveSequence[] SequenceForBlended = new[] {
-			RenderPrimitiveSequence.CabBlended,
+            RenderPrimitiveSequence.CabBlended,
             RenderPrimitiveSequence.Sky,
-			RenderPrimitiveSequence.WorldBlended,
-			RenderPrimitiveSequence.Lights,
-			RenderPrimitiveSequence.Precipitation,
+            RenderPrimitiveSequence.WorldBlended,
+            RenderPrimitiveSequence.Lights,
+            RenderPrimitiveSequence.Precipitation,
             RenderPrimitiveSequence.Particles,
             RenderPrimitiveSequence.InteriorBlended,
             RenderPrimitiveSequence.Labels,
-			RenderPrimitiveSequence.OverlayBlended,
-		};
+            RenderPrimitiveSequence.OverlayBlended,
+        };
 
         /// <summary>
         /// Mapping from <see cref="RenderPrimitiveGroup"/> to <see cref="RenderPrimitiveSequence"/> for opaque
@@ -94,16 +94,16 @@ namespace Orts.Viewer3D
         /// <see cref="RenderPrimitiveGroup"/>.
         /// </summary>
         public static readonly RenderPrimitiveSequence[] SequenceForOpaque = new[] {
-			RenderPrimitiveSequence.CabOpaque,
+            RenderPrimitiveSequence.CabOpaque,
             RenderPrimitiveSequence.Sky,
-			RenderPrimitiveSequence.WorldOpaque,
-			RenderPrimitiveSequence.Lights,
-			RenderPrimitiveSequence.Precipitation,
+            RenderPrimitiveSequence.WorldOpaque,
+            RenderPrimitiveSequence.Lights,
+            RenderPrimitiveSequence.Precipitation,
             RenderPrimitiveSequence.Particles,
             RenderPrimitiveSequence.InteriorOpaque,
             RenderPrimitiveSequence.Labels,
-			RenderPrimitiveSequence.OverlayOpaque,
-		};
+            RenderPrimitiveSequence.OverlayOpaque,
+        };
 
         /// <summary>
         /// This is an adjustment for the depth buffer calculation which may be used to reduce the chance of co-planar primitives from fighting each other.
@@ -170,15 +170,15 @@ namespace Orts.Viewer3D
         }
     }
 
-	public class RenderItemCollection : IList<RenderItem>, IEnumerator<RenderItem>
-	{
-		RenderItem[] Items = new RenderItem[4];
-		int ItemCount;
-		int EnumeratorIndex;
+    public class RenderItemCollection : IList<RenderItem>, IEnumerator<RenderItem>
+    {
+        RenderItem[] Items = new RenderItem[4];
+        int ItemCount;
+        int EnumeratorIndex;
 
-		public RenderItemCollection()
-		{
-		}
+        public RenderItemCollection()
+        {
+        }
 
         public int Capacity
         {
@@ -188,165 +188,165 @@ namespace Orts.Viewer3D
             }
         }
 
-		public int Count
-		{
+        public int Count
+        {
             get
             {
                 return ItemCount;
             }
-		}
+        }
 
-		public void Sort(IComparer<RenderItem> comparer)
-		{
-			Array.Sort(Items, 0, ItemCount, comparer);
-		}
+        public void Sort(IComparer<RenderItem> comparer)
+        {
+            Array.Sort(Items, 0, ItemCount, comparer);
+        }
 
-		#region IList<RenderItem> Members
+        #region IList<RenderItem> Members
 
-		public int IndexOf(RenderItem item)
-		{
+        public int IndexOf(RenderItem item)
+        {
             throw new NotSupportedException();
-		}
+        }
 
-		public void Insert(int index, RenderItem item)
-		{
+        public void Insert(int index, RenderItem item)
+        {
             throw new NotSupportedException();
-		}
+        }
 
-		public void RemoveAt(int index)
-		{
+        public void RemoveAt(int index)
+        {
             throw new NotSupportedException();
-		}
+        }
 
-		public RenderItem this[int index]
-		{
-			get
-			{
-				throw new NotSupportedException();
-			}
-			set
-			{
+        public RenderItem this[int index]
+        {
+            get
+            {
                 throw new NotSupportedException();
-			}
-		}
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
 
-		#endregion
+        #endregion
 
-		#region ICollection<RenderItem> Members
+        #region ICollection<RenderItem> Members
 
-		public void Add(RenderItem item)
-		{
-			if (ItemCount == Items.Length)
-			{
-				var items = new RenderItem[Items.Length * 2];
-				Array.Copy(Items, 0, items, 0, Items.Length);
+        public void Add(RenderItem item)
+        {
+            if (ItemCount == Items.Length)
+            {
+                var items = new RenderItem[Items.Length * 2];
+                Array.Copy(Items, 0, items, 0, Items.Length);
                 Items = items;
-			}
-			Items[ItemCount] = item;
-			ItemCount++;
-		}
+            }
+            Items[ItemCount] = item;
+            ItemCount++;
+        }
 
-		public void Clear()
-		{
-			Array.Clear(Items, 0, ItemCount);
-			ItemCount = 0;
-		}
+        public void Clear()
+        {
+            Array.Clear(Items, 0, ItemCount);
+            ItemCount = 0;
+        }
 
-		public bool Contains(RenderItem item)
-		{
+        public bool Contains(RenderItem item)
+        {
             throw new NotSupportedException();
-		}
+        }
 
-		public void CopyTo(RenderItem[] array, int arrayIndex)
-		{
+        public void CopyTo(RenderItem[] array, int arrayIndex)
+        {
             throw new NotSupportedException();
-		}
+        }
 
-		int ICollection<RenderItem>.Count
-		{
+        int ICollection<RenderItem>.Count
+        {
             get
             {
                 throw new NotSupportedException();
             }
-		}
+        }
 
-		public bool IsReadOnly
-		{
+        public bool IsReadOnly
+        {
             get
             {
                 throw new NotSupportedException();
             }
-		}
+        }
 
-		public bool Remove(RenderItem item)
-		{
-			throw new NotSupportedException();
-		}
+        public bool Remove(RenderItem item)
+        {
+            throw new NotSupportedException();
+        }
 
-		#endregion
+        #endregion
 
-		#region IEnumerable<RenderItem> Members
+        #region IEnumerable<RenderItem> Members
 
-		public IEnumerator<RenderItem> GetEnumerator()
-		{
-			Reset();
-			return this;
-		}
+        public IEnumerator<RenderItem> GetEnumerator()
+        {
+            Reset();
+            return this;
+        }
 
-		#endregion
+        #endregion
 
-		#region IEnumerable Members
+        #region IEnumerable Members
 
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-		{
-			return GetEnumerator();
-		}
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
 
-		#endregion
+        #endregion
 
-		#region IEnumerator<RenderItem> Members
+        #region IEnumerator<RenderItem> Members
 
-		public RenderItem Current
-		{
+        public RenderItem Current
+        {
             get
             {
                 return Items[EnumeratorIndex];
             }
-		}
+        }
 
-		#endregion
+        #endregion
 
-		#region IEnumerator Members
+        #region IEnumerator Members
 
-		object System.Collections.IEnumerator.Current
-		{
+        object System.Collections.IEnumerator.Current
+        {
             get
             {
                 return Current;
             }
-		}
+        }
 
-		public bool MoveNext()
-		{
-			EnumeratorIndex++;
-			return EnumeratorIndex < ItemCount;
-		}
+        public bool MoveNext()
+        {
+            EnumeratorIndex++;
+            return EnumeratorIndex < ItemCount;
+        }
 
-		public void Reset()
-		{
-			EnumeratorIndex = -1;
-		}
+        public void Reset()
+        {
+            EnumeratorIndex = -1;
+        }
 
-		#endregion
+        #endregion
 
-		#region IDisposable Members
+        #region IDisposable Members
 
-		public void Dispose()
-		{
-			// No op.
-		}
+        public void Dispose()
+        {
+            // No op.
+        }
 
-		#endregion
+        #endregion
     }
 
     public class RenderFrame
@@ -369,7 +369,7 @@ namespace Orts.Viewer3D
         Vector3[] ShadowMapCenter;
 
         readonly Material DummyBlendedMaterial;
-		readonly Dictionary<Material, RenderItemCollection>[] RenderItems = new Dictionary<Material, RenderItemCollection>[(int)RenderPrimitiveSequence.Sentinel];
+        readonly Dictionary<Material, RenderItemCollection>[] RenderItems = new Dictionary<Material, RenderItemCollection>[(int)RenderPrimitiveSequence.Sentinel];
         readonly RenderItemCollection[] RenderShadowSceneryItems;
         readonly RenderItemCollection[] RenderShadowForestItems;
         readonly RenderItemCollection[] RenderShadowTerrainItems;
@@ -391,7 +391,7 @@ namespace Orts.Viewer3D
             DummyBlendedMaterial = new EmptyMaterial(null);
 
             for (int i = 0; i < RenderItems.Length; i++)
-				RenderItems[i] = new Dictionary<Material, RenderItemCollection>();
+                RenderItems[i] = new Dictionary<Material, RenderItemCollection>();
 
             if (Game.Settings.DynamicShadows)
             {
@@ -440,7 +440,7 @@ namespace Orts.Viewer3D
                     }
                 }
             }
-            
+
             // Clear out (reset) all of the RenderItem lists.
             for (var i = 0; i < RenderItems.Length; i++)
                 foreach (var mat in RenderItems[i].Keys)
@@ -687,7 +687,7 @@ namespace Orts.Viewer3D
             }
         }
 
-        void DrawShadows( GraphicsDevice graphicsDevice, bool logging )
+        void DrawShadows(GraphicsDevice graphicsDevice, bool logging)
         {
             if (logging) Console.WriteLine("  DrawShadows {");
             for (var shadowMapIndex = 0; shadowMapIndex < RenderProcess.ShadowMapCount; shadowMapIndex++)

--- a/Source/RunActivity/Viewer3D/RoadCars.cs
+++ b/Source/RunActivity/Viewer3D/RoadCars.cs
@@ -79,7 +79,7 @@ namespace Orts.Viewer3D
             }
 
             var sortedLevelCrossings = new SortedList<float, LevelCrossingItem>();
-            for (var crossingTraveller = new Traveller(Traveller); crossingTraveller.NextSection(); )
+            for (var crossingTraveller = new Traveller(Traveller); crossingTraveller.NextSection();)
                 if (crossingTraveller.IsTrack && crossingTraveller.TN.TrVectorNode.TrItemRefs != null)
                     foreach (var trItemRef in crossingTraveller.TN.TrVectorNode.TrItemRefs)
                         if (Viewer.Simulator.LevelCrossings.RoadCrossingItems.ContainsKey(trItemRef))
@@ -274,7 +274,7 @@ namespace Orts.Viewer3D
                     stopDistances.Add(cars[spawnerIndex - 1].Travelled - cars[spawnerIndex - 1].Length / 2);
                 else
                     stopDistances.Add(cars[spawnerIndex - 1].Travelled - cars[spawnerIndex - 1].Length * 0.65f - 4 - cars[spawnerIndex - 1].Speed * 0.5f);
-                }
+            }
 
             // Calculate whether we're too close to the minimum stopping distance (and need to slow down) or going too slowly (and need to speed up).
             var stopDistance = stopDistances.Count > 0 ? stopDistances.Min() - Travelled - Length / 2 : float.MaxValue;
@@ -292,7 +292,7 @@ namespace Orts.Viewer3D
             RearTraveller.Move(distance);
         }
 
-        public void ChangeSpeed (float speed)
+        public void ChangeSpeed(float speed)
         {
             if (speed > 0)
             {

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSDieselLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSDieselLocomotiveViewer.cs
@@ -79,7 +79,7 @@ namespace Orts.Viewer3D.RollingStock
         public override void PrepareFrame(RenderFrame frame, ElapsedTime elapsedTime)
         {
             var car = this.Car as MSTSDieselLocomotive;
-            
+
             // Diesel exhaust
             var exhaustParticles = car.Train != null && car.Train.TrainType == Train.TRAINTYPE.STATIC ? 0 : car.ExhaustParticles.SmoothedValue;
             foreach (var drawer in Exhaust)
@@ -89,7 +89,7 @@ namespace Orts.Viewer3D.RollingStock
                 var colorB = car.ExhaustColorB.SmoothedValue / 255f;
                 drawer.SetOutput(exhaustParticles, car.ExhaustMagnitude.SmoothedValue, new Color((byte)car.ExhaustColorR.SmoothedValue, (byte)car.ExhaustColorG.SmoothedValue, (byte)car.ExhaustColorB.SmoothedValue));
             }
-            
+
             base.PrepareFrame(frame, elapsedTime);
         }
     }

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSElectricLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSElectricLocomotiveViewer.cs
@@ -54,7 +54,7 @@ namespace Orts.Viewer3D.RollingStock
                     new CircuitBreakerClosingOrderButtonCommand(Viewer.Log, true);
                 }
             });
-            UserInputCommands.Add(UserCommand.ControlCircuitBreakerOpeningOrder, new Action[] { () => new CircuitBreakerOpeningOrderButtonCommand(Viewer.Log, false), () => new CircuitBreakerOpeningOrderButtonCommand(Viewer.Log, true)});
+            UserInputCommands.Add(UserCommand.ControlCircuitBreakerOpeningOrder, new Action[] { () => new CircuitBreakerOpeningOrderButtonCommand(Viewer.Log, false), () => new CircuitBreakerOpeningOrderButtonCommand(Viewer.Log, true) });
             UserInputCommands.Add(UserCommand.ControlCircuitBreakerClosingAuthorization, new Action[] { Noop, () => new CircuitBreakerClosingAuthorizationCommand(Viewer.Log, !ElectricLocomotive.PowerSupply.CircuitBreaker.DriverClosingAuthorization) });
             base.InitializeUserInputCommands();
         }

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -329,7 +329,7 @@ namespace Orts.Viewer3D.RollingStock
             if (Locomotive.TrainControlSystem != null && Locomotive.TrainControlSystem.Sounds.Count > 0)
                 foreach (var script in Locomotive.TrainControlSystem.Sounds.Keys)
                 {
-                         Viewer.SoundProcess.RemoveSoundSources(script);
+                    Viewer.SoundProcess.RemoveSoundSources(script);
                 }
             base.Unload();
         }
@@ -491,11 +491,11 @@ namespace Orts.Viewer3D.RollingStock
         public void ImmediateRefill()
         {
             var loco = this.Locomotive;
-            
+
             if (loco == null)
                 return;
-            
-            foreach(var car in loco.Train.Cars)
+
+            foreach (var car in loco.Train.Cars)
             {
                 // There is no need to check for the tender.  The MSTSSteamLocomotive is the primary key in the refueling process when using immediate refueling.
                 if (car is MSTSDieselLocomotive || car is MSTSSteamLocomotive)
@@ -529,7 +529,7 @@ namespace Orts.Viewer3D.RollingStock
             if (distanceToPickupM > match.IntakePoint.WidthM / 2)
             {
                 Viewer.Simulator.Confirmer.Message(ConfirmLevel.None, Viewer.Catalog.GetStringFmt("Refill: Distance to {0} supply is {1}.",
-                    PickupTypeDictionary[(uint)match.Pickup.PickupType], Viewer.Catalog.GetPluralStringFmt("{0} meter", "{0} meters", (long)(distanceToPickupM+1f))));
+                    PickupTypeDictionary[(uint)match.Pickup.PickupType], Viewer.Catalog.GetPluralStringFmt("{0} meter", "{0} meters", (long)(distanceToPickupM + 1f))));
                 return;
             }
             if (distanceToPickupM <= match.IntakePoint.WidthM / 2)
@@ -560,11 +560,11 @@ namespace Orts.Viewer3D.RollingStock
                 float fraction = 0;
 
                 // classical MSTS Freightanim, handled as usual
-                if(match.SteamLocomotiveWithTender != null)
+                if (match.SteamLocomotiveWithTender != null)
                     fraction = match.SteamLocomotiveWithTender.GetFilledFraction(match.Pickup.PickupType);
                 else
                     fraction = match.Wagon.GetFilledFraction(match.Pickup.PickupType);
-                                
+
                 if (fraction > 0.99)
                 {
                     Viewer.Simulator.Confirmer.Message(ConfirmLevel.None, Viewer.Catalog.GetStringFmt("Refill: {0} supply now replenished.",
@@ -1597,9 +1597,9 @@ namespace Orts.Viewer3D.RollingStock
                     {
                         DestinationRectangle.X = (int)(xratio * Control.PositionX) - Viewer.CabXOffsetPixels;
                         if (Gauge.Direction != 1 && !IsFire)
-                        DestinationRectangle.Y = (int)(yratio * (Control.PositionY + (zeropos > ypos ? zeropos : 2 * zeropos - ypos))) - Viewer.CabYOffsetPixels;
+                            DestinationRectangle.Y = (int)(yratio * (Control.PositionY + (zeropos > ypos ? zeropos : 2 * zeropos - ypos))) - Viewer.CabYOffsetPixels;
                         else
-                        DestinationRectangle.Y = (int)(yratio * (Control.PositionY + (zeropos < ypos ? zeropos : ypos))) + Viewer.CabYOffsetPixels;
+                            DestinationRectangle.Y = (int)(yratio * (Control.PositionY + (zeropos < ypos ? zeropos : ypos))) + Viewer.CabYOffsetPixels;
                         DestinationRectangle.Width = (int)(xratio * xpos);
                         DestinationRectangle.Height = (int)(yratio * (ypos > zeropos ? ypos - zeropos : zeropos - ypos));
                     }

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSSteamLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSSteamLocomotiveViewer.cs
@@ -62,7 +62,7 @@ namespace Orts.Viewer3D.RollingStock
                     Cylinders2.AddRange(emitter.Value);
                     car.Cylinder2SteamEffects = true;
                 }
-//          Not used in either MSTS or OR
+                //          Not used in either MSTS or OR
                 else if (emitter.Key.ToLowerInvariant() == "drainpipefx")        // Drainpipe was not used in MSTS, and has no control
                     Drainpipe.AddRange(emitter.Value);
                 else if (emitter.Key.ToLowerInvariant() == "injectors1fx")
@@ -104,18 +104,18 @@ namespace Orts.Viewer3D.RollingStock
         {
             SteamLocomotive.StartReverseDecrease(null);
         }
-        
+
         /// <summary>
         /// Overrides the base method as steam locomotives have only rudimentary gear boxes. 
         /// </summary>
         protected override void StartGearBoxIncrease()
         {
             SteamLocomotive.SteamStartGearBoxIncrease();
-        }        
-                
+        }
+
         protected override void StopGearBoxIncrease()
         {
-           SteamLocomotive.SteamStopGearBoxIncrease();
+            SteamLocomotive.SteamStopGearBoxIncrease();
         }
 
         protected override void StartGearBoxDecrease()
@@ -127,7 +127,7 @@ namespace Orts.Viewer3D.RollingStock
         {
             SteamLocomotive.SteamStopGearBoxDecrease();
         }
-                
+
 
         public override void InitializeUserInputCommands()
         {
@@ -152,7 +152,7 @@ namespace Orts.Viewer3D.RollingStock
             UserInputCommands.Add(UserCommand.ControlCylinderCompound, new Action[] { Noop, () => new ToggleCylinderCompoundCommand(Viewer.Log) });
             UserInputCommands.Add(UserCommand.ControlSmallEjectorIncrease, new Action[] { () => SteamLocomotive.StopSmallEjectorIncrease(), () => SteamLocomotive.StartSmallEjectorIncrease(null) });
             UserInputCommands.Add(UserCommand.ControlSmallEjectorDecrease, new Action[] { () => SteamLocomotive.StopSmallEjectorDecrease(), () => SteamLocomotive.StartSmallEjectorDecrease(null) });
-             base.InitializeUserInputCommands();
+            base.InitializeUserInputCommands();
         }
 
         /// <summary>
@@ -217,25 +217,25 @@ namespace Orts.Viewer3D.RollingStock
             foreach (var drawer in Cylinders)
                 drawer.SetOutput(car.Cylinders1SteamVelocityMpS, car.Cylinders1SteamVolumeM3pS, car.Cylinder1ParticleDurationS);
 
-             foreach (var drawer in Cylinders2)
+            foreach (var drawer in Cylinders2)
                 drawer.SetOutput(car.Cylinders2SteamVelocityMpS, car.Cylinders2SteamVolumeM3pS, car.Cylinder2ParticleDurationS);
 
             // TODO: Not used in either MSTS or OR - currently disabled by zero values set in SteamLocomotive file
-             foreach (var drawer in Drainpipe)
+            foreach (var drawer in Drainpipe)
                 drawer.SetOutput(car.DrainpipeSteamVelocityMpS, car.DrainpipeSteamVolumeM3pS, car.DrainpipeParticleDurationS);
 
-             foreach (var drawer in Injectors1)
+            foreach (var drawer in Injectors1)
                 drawer.SetOutput(car.Injector1SteamVelocityMpS, car.Injector1SteamVolumeM3pS, car.Injector1ParticleDurationS);
 
-             foreach (var drawer in Injectors2)
-                 drawer.SetOutput(car.Injector2SteamVelocityMpS, car.Injector2SteamVolumeM3pS, car.Injector2ParticleDurationS);
+            foreach (var drawer in Injectors2)
+                drawer.SetOutput(car.Injector2SteamVelocityMpS, car.Injector2SteamVolumeM3pS, car.Injector2ParticleDurationS);
 
-             foreach (var drawer in Compressor)
-                drawer.SetOutput(car.CompressorSteamVelocityMpS, car.CompressorSteamVolumeM3pS, car.CompressorParticleDurationS );
+            foreach (var drawer in Compressor)
+                drawer.SetOutput(car.CompressorSteamVelocityMpS, car.CompressorSteamVolumeM3pS, car.CompressorParticleDurationS);
 
             foreach (var drawer in Generator)
                 drawer.SetOutput(car.GeneratorSteamVelocityMpS, car.GeneratorSteamVolumeM3pS, car.GeneratorParticleDurationS);
-            
+
             foreach (var drawer in SafetyValves)
                 drawer.SetOutput(car.SafetyValvesSteamVelocityMpS, car.SafetyValvesSteamVolumeM3pS, car.SafetyValvesParticleDurationS);
 

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSWagonViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSWagonViewer.cs
@@ -89,7 +89,7 @@ namespace Orts.Viewer3D.RollingStock
         public MSTSWagonViewer(Viewer viewer, MSTSWagon car)
             : base(viewer, car)
         {
-            
+
             string steamTexture = viewer.Simulator.BasePath + @"\GLOBAL\TEXTURES\smokemain.ace";
             string dieselTexture = viewer.Simulator.BasePath + @"\GLOBAL\TEXTURES\dieselsmoke.ace";
 
@@ -116,7 +116,7 @@ namespace Orts.Viewer3D.RollingStock
                 // Exhaust for HEP/Power Generator
                 if (emitter.Key.ToLowerInvariant() == "wagongeneratorfx")
                     WagonGenerator.AddRange(emitter.Value);
-                
+
                 foreach (var drawer in WagonGenerator)
                 {
                     drawer.Initialize(dieselTexture);
@@ -191,7 +191,7 @@ namespace Orts.Viewer3D.RollingStock
             // This insection initialises the MSTS style freight animation - can either be for a coal load, which will adjust with usage, or a static animation, such as additional shape.
             if (car.FreightShapeFileName != null)
             {
-                
+
                 car.HasFreightAnim = true;
                 FreightShape = new AnimatedShape(viewer, wagonFolderSlash + car.FreightShapeFileName + '\0' + wagonFolderSlash, new WorldPosition(car.WorldPosition), ShapeFlags.ShadowCaster);
 
@@ -568,7 +568,7 @@ namespace Orts.Viewer3D.RollingStock
 
         private void UpdateAnimation(RenderFrame frame, ElapsedTime elapsedTime)
         {
-                        
+
             float distanceTravelledM = 0.0f; // Distance travelled by non-driven wheels
             float distanceTravelledDrivenM = 0.0f;  // Distance travelled by driven wheels
             float AnimationWheelRadiusM = 0.0f; // Radius of non driven wheels
@@ -629,16 +629,16 @@ namespace Orts.Viewer3D.RollingStock
 
             // Wheel rotation (animation) - for non-drive wheels in steam locomotives and all wheels in other stock
             if (WheelPartIndexes.Count > 0)
-             {
+            {
                 var wheelCircumferenceM = MathHelper.TwoPi * AnimationWheelRadiusM;
                 var rotationalDistanceR = MathHelper.TwoPi * distanceTravelledM / wheelCircumferenceM;  // in radians
                 WheelRotationR = MathHelper.WrapAngle(WheelRotationR - rotationalDistanceR);
                 var wheelRotationMatrix = Matrix.CreateRotationX(WheelRotationR);
                 foreach (var iMatrix in WheelPartIndexes)
-                 {
+                {
                     TrainCarShape.XNAMatrices[iMatrix] = wheelRotationMatrix * TrainCarShape.SharedShape.Matrices[iMatrix];
-                 }
-              }
+                }
+            }
 
 #if DEBUG_WHEEL_ANIMATION
 
@@ -679,8 +679,8 @@ namespace Orts.Viewer3D.RollingStock
                 FreightShape.Location.TileX = Car.WorldPosition.TileX;
                 FreightShape.Location.TileZ = Car.WorldPosition.TileZ;
 
-                    bool SteamAnimShape = false;
-                    float FuelControllerLevel = 0.0f;
+                bool SteamAnimShape = false;
+                float FuelControllerLevel = 0.0f;
 
                 // For coal load variation on locomotives determine the current fuel level - and whether locomotive is a tender or tank type locomotive.
                 if (MSTSWagon.WagonType == TrainCar.WagonTypes.Tender || MSTSWagon is MSTSSteamLocomotive)
@@ -703,24 +703,24 @@ namespace Orts.Viewer3D.RollingStock
                         {
                             FuelControllerLevel = NonTenderSteamLocomotive.FuelController.CurrentValue;
                             SteamAnimShape = true;
-                        } 
+                        }
                     }
                 }
 
-                    // Set height of FAs - if relevant conditions met, use default position co-ords defined above
-                    if (FreightShape.XNAMatrices.Length > 0)
+                // Set height of FAs - if relevant conditions met, use default position co-ords defined above
+                if (FreightShape.XNAMatrices.Length > 0)
+                {
+                    // For tender coal load animation 
+                    if (MSTSWagon.FreightAnimFlag > 0 && MSTSWagon.FreightAnimMaxLevelM > MSTSWagon.FreightAnimMinLevelM && SteamAnimShape)
                     {
-                        // For tender coal load animation 
-                        if (MSTSWagon.FreightAnimFlag > 0 && MSTSWagon.FreightAnimMaxLevelM > MSTSWagon.FreightAnimMinLevelM && SteamAnimShape)
-                        {
-                            FreightShape.XNAMatrices[0].M42 = MSTSWagon.FreightAnimMinLevelM + FuelControllerLevel * (MSTSWagon.FreightAnimMaxLevelM - MSTSWagon.FreightAnimMinLevelM);
-                        }
-                        // reproducing MSTS strange behavior; used to display loco crew when attached to tender
-                        else if (MSTSWagon.WagonType == TrainCar.WagonTypes.Tender) 
-                        {
-                            FreightShape.Location.XNAMatrix.M42 += MSTSWagon.FreightAnimMaxLevelM;
-                        }
+                        FreightShape.XNAMatrices[0].M42 = MSTSWagon.FreightAnimMinLevelM + FuelControllerLevel * (MSTSWagon.FreightAnimMaxLevelM - MSTSWagon.FreightAnimMinLevelM);
                     }
+                    // reproducing MSTS strange behavior; used to display loco crew when attached to tender
+                    else if (MSTSWagon.WagonType == TrainCar.WagonTypes.Tender)
+                    {
+                        FreightShape.Location.XNAMatrix.M42 += MSTSWagon.FreightAnimMaxLevelM;
+                    }
+                }
                 // Display Animation Shape                    
                 FreightShape.PrepareFrame(frame, elapsedTime);
             }

--- a/Source/RunActivity/Viewer3D/RollingStock/SubSystems/FreightAnimationsViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/SubSystems/FreightAnimationsViewer.cs
@@ -50,16 +50,16 @@ namespace Orts.Viewer3D.RollingStock.SubSystems
             {
                 foreach (var lodControl in FreightShape.SharedShape.LodControls)
                 {
-                    if ( lodControl.DistanceLevels.Length > 0)
+                    if (lodControl.DistanceLevels.Length > 0)
                     {
-                        foreach ( var distanceLevel in lodControl.DistanceLevels)
+                        foreach (var distanceLevel in lodControl.DistanceLevels)
                         {
                             if (distanceLevel.SubObjects.Length > 0
                                 && distanceLevel.SubObjects[0].ShapePrimitives.Length > 0
                                 && distanceLevel.SubObjects[0].ShapePrimitives[0].Hierarchy.Length > 0)
-                    {
-                        distanceLevel.SubObjects[0].ShapePrimitives[0].Hierarchy[0] = distanceLevel.SubObjects[0].ShapePrimitives[0].Hierarchy.Length;
-                    }
+                            {
+                                distanceLevel.SubObjects[0].ShapePrimitives[0].Hierarchy[0] = distanceLevel.SubObjects[0].ShapePrimitives[0].Hierarchy.Length;
+                            }
                         }
                     }
                 }

--- a/Source/RunActivity/Viewer3D/Scenery.cs
+++ b/Source/RunActivity/Viewer3D/Scenery.cs
@@ -462,7 +462,7 @@ namespace Orts.Viewer3D
                         if (Program.Simulator.CarSpawnerLists != null && ((CarSpawnerObj)worldObject).ListName != null)
                         {
                             ((CarSpawnerObj)worldObject).CarSpawnerListIdx = Program.Simulator.CarSpawnerLists.FindIndex(x => x.ListName == ((CarSpawnerObj)worldObject).ListName);
-                            if (((CarSpawnerObj)worldObject).CarSpawnerListIdx < 0 || ((CarSpawnerObj)worldObject).CarSpawnerListIdx > Program.Simulator.CarSpawnerLists.Count-1) ((CarSpawnerObj)worldObject).CarSpawnerListIdx = 0;
+                            if (((CarSpawnerObj)worldObject).CarSpawnerListIdx < 0 || ((CarSpawnerObj)worldObject).CarSpawnerListIdx > Program.Simulator.CarSpawnerLists.Count - 1) ((CarSpawnerObj)worldObject).CarSpawnerListIdx = 0;
                         }
                         else ((CarSpawnerObj)worldObject).CarSpawnerListIdx = 0;
                         carSpawners.Add(new RoadCarSpawner(viewer, worldMatrix, (CarSpawnerObj)worldObject));
@@ -480,7 +480,7 @@ namespace Orts.Viewer3D
                         if (animated)
                             sceneryObjects.Add(new AnimatedShape(viewer, shapeFilePath, worldMatrix, shadowCaster ? ShapeFlags.ShadowCaster : ShapeFlags.None));
                         else
-                            sceneryObjects.Add(new StaticShape(viewer, shapeFilePath, worldMatrix, shadowCaster ? ShapeFlags.ShadowCaster : ShapeFlags.None));                     
+                            sceneryObjects.Add(new StaticShape(viewer, shapeFilePath, worldMatrix, shadowCaster ? ShapeFlags.ShadowCaster : ShapeFlags.None));
                     }
                     else if (worldObject.GetType() == typeof(PickupObj))
                     {

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -107,8 +107,8 @@ namespace Orts.Viewer3D
             worldViewProjection.SetValue(w * vp);
 
             int vIn = Program.Simulator.Settings.DayAmbientLight;
-            
-            float FullBrightness = (float)vIn / 20.0f ;
+
+            float FullBrightness = (float)vIn / 20.0f;
             //const float HalfShadowBrightness = 0.75;
             const float HalfNightBrightness = 0.6f;
             const float ShadowBrightness = 0.5f;
@@ -302,7 +302,7 @@ namespace Orts.Viewer3D
                 var skyColor1 = Day2Night(0.25f, -0.25f, -0.5f, value.Y);
                 var skyColor2 = MathHelper.Clamp(skyColor1 + 0.55f, 0, 1);
                 var skyColor3 = 0.001f / (0.8f * Math.Abs(value.Y - 0.1f));
-                skyColor.SetValue(new Vector3(skyColor1, skyColor2, skyColor3)); 
+                skyColor.SetValue(new Vector3(skyColor1, skyColor2, skyColor3));
 
                 // Fade moon during daylight
                 var moonColor1 = value.Y > 0.1f ? (1 - value.Y) / 1.5f : 1;
@@ -331,9 +331,9 @@ namespace Orts.Viewer3D
         int _moonPhase;
         public float Random
         {
-            set 
-            { 
-                _moonPhase = (int)value; 
+            set
+            {
+                _moonPhase = (int)value;
                 moonTexCoord.SetValue(new Vector2((value % 2) / 2, (int)(value / 2) / 4));
             }
         }
@@ -354,7 +354,7 @@ namespace Orts.Viewer3D
 
         public float WindDirection
         {
-            set 
+            set
             {
                 var totalWindDisplacement = 50 * WindSpeed * _time; // This exaggerates the wind speed, but it is necessary to get a visible effect
                 windDisplacement.SetValue(new Vector2(-(float)Math.Sin(value) * totalWindDisplacement, (float)Math.Cos(value) * totalWindDisplacement));
@@ -410,14 +410,14 @@ namespace Orts.Viewer3D
             moonMaskTexture = Parameters["MoonMaskTexture"];
             cloudMapTexture = Parameters["CloudMapTexture"];
         }
-        
+
 
         // This function dims the lighting at night, with a transition period as the sun rises or sets
         static float Day2Night(float startNightTrans, float finishNightTrans, float minDarknessCoeff, float sunDirectionY)
         {
             int vIn = Program.Simulator.Settings.DayAmbientLight;
-            float dayAmbientLight = (float)vIn / 20.0f ;
-              
+            float dayAmbientLight = (float)vIn / 20.0f;
+
             // The following two are used to interpoate between day and night lighting (y = mx + b)
             var slope = (dayAmbientLight - minDarknessCoeff) / (startNightTrans - finishNightTrans); // "m"
             var incpt = dayAmbientLight - slope * startNightTrans; // "b"

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -1120,7 +1120,7 @@ namespace Orts.Viewer3D
             : base(viewer, path, initialPosition, flags)
         {
             Transfertable = transfertable;
-            AnimationKey = (Transfertable.XPos - Transfertable.CenterOffset.X)/ Transfertable.Width * SharedShape.Animations[0].FrameCount;
+            AnimationKey = (Transfertable.XPos - Transfertable.CenterOffset.X) / Transfertable.Width * SharedShape.Animations[0].FrameCount;
             for (var imatrix = 0; imatrix < SharedShape.Matrices.Length; ++imatrix)
             {
                 if (SharedShape.MatrixNames[imatrix].ToLower() == transfertable.Animations[0].ToLower())
@@ -1430,14 +1430,14 @@ namespace Orts.Viewer3D
             Trace.Write("S");
             var filePath = FilePath;
             // commented lines allow reading the animation block from an additional file in an Openrails subfolder
-//           string dir = Path.GetDirectoryName(filePath);
-//            string file = Path.GetFileName(filePath);
-//            string orFilePath = dir + @"\openrails\" + file;
+            //           string dir = Path.GetDirectoryName(filePath);
+            //            string file = Path.GetFileName(filePath);
+            //            string orFilePath = dir + @"\openrails\" + file;
             var sFile = new ShapeFile(filePath, Viewer.Settings.SuppressShapeWarnings);
-//            if (file.ToLower().Contains("turntable") && File.Exists(orFilePath))
-//            {
-//                sFile.ReadAnimationBlock(orFilePath);
-//            }
+            //            if (file.ToLower().Contains("turntable") && File.Exists(orFilePath))
+            //            {
+            //                sFile.ReadAnimationBlock(orFilePath);
+            //            }
 
 
             var textureFlags = Helpers.TextureFlags.None;

--- a/Source/RunActivity/Viewer3D/Signals.cs
+++ b/Source/RunActivity/Viewer3D/Signals.cs
@@ -551,11 +551,11 @@ namespace Orts.Viewer3D
             GlowIntensityNight = glowNight;
 
             var verticies = new[] {
-				new VertexPositionColorTexture(new Vector3(-radius, +radius, 0), color, new Vector2(u1, v0)),
-				new VertexPositionColorTexture(new Vector3(+radius, +radius, 0), color, new Vector2(u0, v0)),
-				new VertexPositionColorTexture(new Vector3(-radius, -radius, 0), color, new Vector2(u1, v1)),
-				new VertexPositionColorTexture(new Vector3(+radius, -radius, 0), color, new Vector2(u0, v1)),
-			};
+                new VertexPositionColorTexture(new Vector3(-radius, +radius, 0), color, new Vector2(u1, v0)),
+                new VertexPositionColorTexture(new Vector3(+radius, +radius, 0), color, new Vector2(u0, v0)),
+                new VertexPositionColorTexture(new Vector3(-radius, -radius, 0), color, new Vector2(u1, v1)),
+                new VertexPositionColorTexture(new Vector3(+radius, -radius, 0), color, new Vector2(u0, v1)),
+            };
 
             VertexDeclaration = new VertexDeclaration(viewer.GraphicsDevice, VertexPositionColorTexture.VertexElements);
             VertexBuffer = new VertexBuffer(viewer.GraphicsDevice, VertexPositionColorTexture.SizeInBytes * verticies.Length, BufferUsage.WriteOnly);

--- a/Source/RunActivity/Viewer3D/Sky.cs
+++ b/Source/RunActivity/Viewer3D/Sky.cs
@@ -225,7 +225,7 @@ namespace Orts.Viewer3D
         // Number of point indices (each dome = 912 for 24 sides: 7 levels of 24 triangle pairs each
         // plus 24 triangles at the zenith)
         // plus six more for the moon quad
-        private static short indexCount = 6 + 2 * (SkyConstants.skySides * 6 *SkyConstants.skyLevels + 3 * SkyConstants.skySides);
+        private static short indexCount = 6 + 2 * (SkyConstants.skySides * 6 * SkyConstants.skyLevels + 3 * SkyConstants.skySides);
 
         /// <summary>
         /// Constructor.
@@ -304,8 +304,8 @@ namespace Orts.Viewer3D
             {
                 // The "oblate" factor is used to flatten the dome to an ellipsoid. Used for the inner (cloud)
                 // dome only. Gives the clouds a flatter appearance.
-                float y = (float)Math.Sin(MathHelper.ToRadians((360 / skySides) * (i-1))) * radius * oblate;
-                float yRadius = radius * (float)Math.Cos(MathHelper.ToRadians((360 / skySides) * (i-1)));
+                float y = (float)Math.Sin(MathHelper.ToRadians((360 / skySides) * (i - 1))) * radius * oblate;
+                float yRadius = radius * (float)Math.Cos(MathHelper.ToRadians((360 / skySides) * (i - 1)));
                 for (int j = 0; j < skySides; j++) // (=24 for top overlay)
                 {
 

--- a/Source/RunActivity/Viewer3D/Sound.cs
+++ b/Source/RunActivity/Viewer3D/Sound.cs
@@ -141,7 +141,7 @@ namespace Orts.Viewer3D
             if (filename == null)
                 return;
 
-            string[] pathArray = {Viewer.Simulator.RoutePath, Viewer.Simulator.BasePath};            
+            string[] pathArray = { Viewer.Simulator.RoutePath, Viewer.Simulator.BasePath };
             var fullPath = ORTSPaths.GetFileFromFolders(pathArray, @"SOUND\" + filename);
             if (fullPath == null)
             {
@@ -159,7 +159,7 @@ namespace Orts.Viewer3D
             //Trace.TraceInformation("TrackSoundSource Uninitialize");
             if (_activeInSource != null)
                 _activeInSource.Uninitialize();
-            if (_activeOutSource !=null)
+            if (_activeOutSource != null)
                 _activeOutSource.Uninitialize();
         }
 
@@ -193,12 +193,12 @@ namespace Orts.Viewer3D
                 }
                 else
                     if (Car.Train.SpeedMpS < -0.1f)
-                    {
-                        CarIncr = -1;
-                        CarLeading = Car.Train.Cars.Count - 1;
-                    }
-                    else
-                        return;
+                {
+                    CarIncr = -1;
+                    CarLeading = Car.Train.Cars.Count - 1;
+                }
+                else
+                    return;
 
                 var CarNo = Car.Train.Cars.IndexOf(Car);
                 float trackSoundDistSquared = 0;
@@ -248,13 +248,13 @@ namespace Orts.Viewer3D
                                 _curTType != SharedSMSFileManager.SwitchSMSNumber &&
                                 _curTType != SharedSMSFileManager.CurveSMSNumber &&
                                 _curTType != SharedSMSFileManager.CurveSwitchSMSNumber))
-                                Car.TrackSoundType = _curTType;
-                            else
-                            {
-                                Car.TrackSoundType = 0;
-                                _curTType = 0;
-                            }
-                     }
+                            Car.TrackSoundType = _curTType;
+                        else
+                        {
+                            Car.TrackSoundType = 0;
+                            _curTType = 0;
+                        }
+                    }
                     else Car.TrackSoundType = _curTType;
                 }
                 else
@@ -262,16 +262,16 @@ namespace Orts.Viewer3D
                     var CarAhead = Car.Train.Cars[CarNo - CarIncr];
                     if (CarAhead.TrackSoundLocation != WorldLocation.None)
                     {
-//                        if (stateChange)
-//                            Trace.TraceInformation("Time {4} TrainName {6} carNo {0} IsOnSwitch {1} IsOnCurve {7} TracksoundType {2} _CurTType {3} AheadTrackSoundType {5}",
-//                                Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, CarAhead.TrackSoundType, Car.Train.Name, CarOnCurve);
-                        if ((_curTType == Car.TrackSoundType || stateChange ) && Car.TrackSoundType != CarAhead.TrackSoundType)
+                        //                        if (stateChange)
+                        //                            Trace.TraceInformation("Time {4} TrainName {6} carNo {0} IsOnSwitch {1} IsOnCurve {7} TracksoundType {2} _CurTType {3} AheadTrackSoundType {5}",
+                        //                                Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, CarAhead.TrackSoundType, Car.Train.Name, CarOnCurve);
+                        if ((_curTType == Car.TrackSoundType || stateChange) && Car.TrackSoundType != CarAhead.TrackSoundType)
                         {
                             Car.TrackSoundType = CarAhead.TrackSoundType;
                             Car.TrackSoundLocation = new WorldLocation(CarAhead.TrackSoundLocation);
                             Car.TrackSoundDistSquared = WorldLocation.GetDistanceSquared(Car.WorldPosition.WorldLocation, Car.TrackSoundLocation);
-//                            Trace.TraceInformation("Time {4} TrainName {5} carNo {0} IsOnSwitch {1} IsOnCurve {6} TracksoundType {2} _CurTType {3} to standard",
-//                              Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, Car.Train.Name, CarOnCurve);
+                            //                            Trace.TraceInformation("Time {4} TrainName {5} carNo {0} IsOnSwitch {1} IsOnCurve {6} TracksoundType {2} _CurTType {3} to standard",
+                            //                              Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, Car.Train.Name, CarOnCurve);
                             if (stateChange)
                             {
                                 _curTType = Car.TrackSoundType;
@@ -285,8 +285,8 @@ namespace Orts.Viewer3D
                                 Car.TrackSoundDistSquared = trackSoundDistSquared;
                             else
                             {
-//                                if (_curTType != Car.TrackSoundType) Trace.TraceInformation("Time {4} TrainName {5} carNo {0} IsOnSwitch {1} IsOnCurve {6} TracksoundType {2} _CurTType {3} standard",
-//                                  Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, Car.Train.Name, CarOnCurve);
+                                //                                if (_curTType != Car.TrackSoundType) Trace.TraceInformation("Time {4} TrainName {5} carNo {0} IsOnSwitch {1} IsOnCurve {6} TracksoundType {2} _CurTType {3} standard",
+                                //                                  Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, Car.Train.Name, CarOnCurve);
                                 _curTType = Car.TrackSoundType;
                             }
                         }
@@ -314,9 +314,9 @@ namespace Orts.Viewer3D
 #if DEBUGSCR
                     Trace.TraceInformation("Sound region changed from {0} to {1}.", _prevTType, _curTType);
 #endif
-//                    if (!stateChange) Trace.TraceInformation("StandardChange Time {4} TrainName {5} carNo {0} IsOnSwitch {1} TracksoundType {2} _CurTType {3} _PrevTType {6}",
-//                        Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, Car.Train.Name, _prevTType);
-//                           Trace.TraceInformation("Train {0} Speed {1}, Car {2}: Sound Region {3} changed to {4} at distance {5}", Car.Train.Number, Car.Train.SpeedMpS, CarNo, _prevTType, _curTType, Math.Sqrt(trackSoundDistSquared));
+                    //                    if (!stateChange) Trace.TraceInformation("StandardChange Time {4} TrainName {5} carNo {0} IsOnSwitch {1} TracksoundType {2} _CurTType {3} _PrevTType {6}",
+                    //                        Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, Car.Train.Name, _prevTType);
+                    //                           Trace.TraceInformation("Train {0} Speed {1}, Car {2}: Sound Region {3} changed to {4} at distance {5}", Car.Train.Number, Car.Train.SpeedMpS, CarNo, _prevTType, _curTType, Math.Sqrt(trackSoundDistSquared));
                     if (CarNo == CarLeading)
                         Car.TrackSoundLocation = new WorldLocation(Car.WorldPosition.WorldLocation);
                     _prevTType = _curTType;
@@ -328,12 +328,12 @@ namespace Orts.Viewer3D
         {
             bool stateChange = false;
             if (SharedSMSFileManager.AutoTrackSound) stateChange = UpdateCarOnSwitchAndCurve();
-//            if (stateChange) Trace.TraceInformation("Time {4} TrainName {5} carNo {0} IsOnSwitch {1} IsOnCurve {6} TracksoundType {2} _CurTType {3} Radius {7} Before",
-//                Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, Car.Train.Name, CarOnCurve, Car.CurrentCurveRadius);
+            //            if (stateChange) Trace.TraceInformation("Time {4} TrainName {5} carNo {0} IsOnSwitch {1} IsOnCurve {6} TracksoundType {2} _CurTType {3} Radius {7} Before",
+            //                Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, Car.Train.Name, CarOnCurve, Car.CurrentCurveRadius);
             if ((!CarOnSwitch && !CarOnCurve) || !SharedSMSFileManager.AutoTrackSound)
                 UpdateTType(stateChange);
-//            if (stateChange) Trace.TraceInformation("Time {4} TrainName {5} carNo {0} IsOnSwitch {1} IsOnCurve {6} TracksoundType {2} _CurTType {3} Radius {7} After",
-//                Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, Car.Train.Name, CarOnCurve, Car.CurrentCurveRadius);
+            //            if (stateChange) Trace.TraceInformation("Time {4} TrainName {5} carNo {0} IsOnSwitch {1} IsOnCurve {6} TracksoundType {2} _CurTType {3} Radius {7} After",
+            //                Car.Train.Cars.IndexOf(Car), CarOnSwitch, Car.TrackSoundType, _curTType, Viewer.Simulator.GameTime, Car.Train.Name, CarOnCurve, Car.CurrentCurveRadius);
             bool retval = true;
             NeedsFrequentUpdate = false;
 
@@ -425,7 +425,7 @@ namespace Orts.Viewer3D
 
                     // resume results and select sound if change
                     if (carPreviouslyOnSwitch ^ CarOnSwitch || carPreviouslyOnCurve ^ CarOnCurve)
-                    { 
+                    {
                         stateChange = true;
                     }
                     if (stateChange && (CarOnSwitch || CarOnCurve))
@@ -486,7 +486,7 @@ namespace Orts.Viewer3D
     }
 
 
-    
+
     /// <summary>
     /// Represents an sms file
     /// </summary>
@@ -575,7 +575,7 @@ namespace Orts.Viewer3D
         /// <param name="viewer"></param>
         /// <param name="car"></param>
         /// <param name="smsFilePath"></param>
-        public SoundSource(Viewer viewer, MSTSWagon car, string wavFilePath, ORTSActSoundFileTypes ORTSActSoundFileType,  bool preCompiled)
+        public SoundSource(Viewer viewer, MSTSWagon car, string wavFilePath, ORTSActSoundFileTypes ORTSActSoundFileType, bool preCompiled)
         {
             Car = car;
             Initialize(viewer, car.WorldPosition.WorldLocation, Events.Source.MSTSCar, wavFilePath, ORTSActSoundFileType, preCompiled);
@@ -621,7 +621,7 @@ namespace Orts.Viewer3D
                 NeedsFrequentUpdate = false;
             }
         }
-        
+
         /// <summary>
         /// Current location of the sound source
         /// </summary>
@@ -686,7 +686,7 @@ namespace Orts.Viewer3D
 
             // find correct ScalabiltyGroup
             int iSG = 0;
-            while ( iSG < smsFile.Tr_SMS.ScalabiltyGroups.Count)
+            while (iSG < smsFile.Tr_SMS.ScalabiltyGroups.Count)
             {
                 if (smsFile.Tr_SMS.ScalabiltyGroups[iSG].DetailLevel <= Viewer.Settings.SoundDetailLevel)
                     break;
@@ -712,7 +712,7 @@ namespace Orts.Viewer3D
             }
         }
 
-                /// <summary>
+        /// <summary>
         /// Set properties of this SoundSource with default precompiled parameters, and generate SoundStreams
         /// </summary>
         /// <param name="viewer">Current <see cref="Viewer3D"/></param>
@@ -799,7 +799,7 @@ namespace Orts.Viewer3D
                 SetRolloffFactor();
 
                 // initialization of the only one sound stream
-                SoundStreams.Add(new SoundStream(WavFileName, eventSource, this)); 
+                SoundStreams.Add(new SoundStream(WavFileName, eventSource, this));
             }
         }
 
@@ -883,7 +883,7 @@ namespace Orts.Viewer3D
                 WasOutOfDistance = false;
             }
         }
-        
+
         public override bool Update()
         {
             if (Car != null && !Car.IsPartOfActiveTrain)
@@ -910,7 +910,7 @@ namespace Orts.Viewer3D
                     Active = true;
 
                     // restore any looping sounds
-                    foreach(SoundStream stream in SoundStreams)
+                    foreach (SoundStream stream in SoundStreams)
                         stream.Activate();
                 }
             }
@@ -1013,7 +1013,7 @@ namespace Orts.Viewer3D
         {
             if (DeactivationConditions == null)
                 return false;
-         
+
             if (ConditionsMet(DeactivationConditions))
                 return true;
 
@@ -1097,10 +1097,10 @@ namespace Orts.Viewer3D
         }
     }
 
-/////////////////////////////////////////////////////////
-// SOUND STREAM
-/////////////////////////////////////////////////////////
-        
+    /////////////////////////////////////////////////////////
+    // SOUND STREAM
+    /////////////////////////////////////////////////////////
+
     /// <summary>
     /// Owned by a <see cref="SoundSource"/>,
     /// can play only one sound at a time,
@@ -1205,17 +1205,17 @@ namespace Orts.Viewer3D
                         ORTSDiscreteTrigger ortsTrigger = new ORTSDiscreteTrigger(this, eventSource, (Orts.Formats.Msts.Discrete_Trigger)trigger, settings);
                         Triggers.Add(ortsTrigger);  // list them here so we can enable and disable 
                     }
-                        // unapplicable trigger type
+                    // unapplicable trigger type
                     else
                     {
                         Triggers.Add(new ORTSTrigger()); // null trigger
                         if (SoundSource.SMSFileName != "ingame.sms") Trace.TraceWarning("Trigger type of trigger number {2} in stream number {1} in file {0} is not existent or not applicable",
-                            SoundSource.SMSFileName, SoundSource.SoundStreams.Count, Triggers.Count-1);
+                            SoundSource.SMSFileName, SoundSource.SoundStreams.Count, Triggers.Count - 1);
                     }
                     IsReleasedWithJump |= (Triggers.Last().SoundCommand is ORTSReleaseLoopReleaseWithJump);
                 }  // for each mstsStream.Trigger
 
-            VariableTriggers = (from t in Triggers 
+            VariableTriggers = (from t in Triggers
                                 where t is ORTSVariableTrigger
                                 select t).ToList();
         }
@@ -1255,7 +1255,7 @@ namespace Orts.Viewer3D
 
             foreach (ORTSTrigger trigger in Triggers)
                 trigger.TryTrigger();
-            
+
             if (_InitialTrigger != null)
             {
                 // If no triggers active, Initialize the Initial
@@ -1264,8 +1264,8 @@ namespace Orts.Viewer3D
                     if (VariableTriggers.Count > 0 || Triggers.Count == 1)
                     {
                         TriggersList = from ORTSVariableTrigger t in VariableTriggers
-                                                where t.IsBellow
-                                                select t as ORTSTrigger;
+                                       where t.IsBellow
+                                       select t as ORTSTrigger;
                         if (TriggersList.Count() == VariableTriggers.Count && _InitialTrigger.SoundCommand is ORTSSoundPlayCommand
                             && !(_InitialTrigger.SoundCommand is ORTSPlayOneShot && _InitialTrigger.Signaled))
                         {
@@ -1277,9 +1277,9 @@ namespace Orts.Viewer3D
                 else
                 {
                     TriggersList = from t in Triggers
-                             where t.Signaled &&
-                             (t.SoundCommand is ORTSStartLoop || t.SoundCommand is ORTSStartLoopRelease)
-                             select t;
+                                   where t.Signaled &&
+                                   (t.SoundCommand is ORTSStartLoop || t.SoundCommand is ORTSStartLoopRelease)
+                                   select t;
                     if (TriggersList.Count() > 1 && _InitialTrigger.Signaled)
                         _InitialTrigger.Signaled = false;
                 }
@@ -1299,7 +1299,7 @@ namespace Orts.Viewer3D
             if (ALSoundSource == null)
                 return;
 
-            if (MSTSStream != null && MSTSStream.FrequencyCurve != null) 
+            if (MSTSStream != null && MSTSStream.FrequencyCurve != null)
             {
                 if (SoundSource.Car != null || SoundSource.Viewer.Camera.AttachedCar != null)
                 {
@@ -1482,9 +1482,9 @@ namespace Orts.Viewer3D
 
     } // class ORTSStream
 
-/////////////////////////////////////////////////////////
-// SOUND TRIGGERS
-/////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////
+    // SOUND TRIGGERS
+    /////////////////////////////////////////////////////////
 
     /// <summary>
     /// Trigger is defined in the SMS file as members of a SoundStream.
@@ -1520,7 +1520,7 @@ namespace Orts.Viewer3D
     /// <summary>
     /// Play this sound when a discrete TrainCar event occurs in the simulator
     /// </summary>
-    public class ORTSDiscreteTrigger: ORTSTrigger, Orts.Common.EventHandler
+    public class ORTSDiscreteTrigger : ORTSTrigger, Orts.Common.EventHandler
     {
         /// <summary>
         /// Event this trigger listens to
@@ -1616,7 +1616,7 @@ namespace Orts.Viewer3D
             SoundStream = soundStream;
             car = soundStream.SoundSource.Car;
             SMS = smsData;
-            SoundCommand = ORTSSoundCommand.FromMSTS(SMS.SoundCommand, soundStream );
+            SoundCommand = ORTSSoundCommand.FromMSTS(SMS.SoundCommand, soundStream);
             Initialize();
         }
 
@@ -1670,7 +1670,7 @@ namespace Orts.Viewer3D
     /// <summary>
     /// Play this sound immediately when this SoundSource becomes active, or in case no other VariableTriggers are active
     /// </summary>
-    public class ORTSInitialTrigger: ORTSTrigger
+    public class ORTSInitialTrigger : ORTSTrigger
     {
         private SoundStream SoundStream;
 
@@ -1724,7 +1724,7 @@ namespace Orts.Viewer3D
             Initialize();
         }
 
-        public override void  Initialize()
+        public override void Initialize()
         {
             UpdateTriggerAtSeconds();
         }
@@ -1782,7 +1782,7 @@ namespace Orts.Viewer3D
             Initialize();
         }
 
-        public override void  Initialize()
+        public override void Initialize()
         {
             StartValue = SMS.Event == Orts.Formats.Msts.Variable_Trigger.Events.Distance_Dec_Past ? float.MaxValue : 0;
 
@@ -1796,7 +1796,7 @@ namespace Orts.Viewer3D
             IsBellow = StartValue < SMS.Threshold;
         }
 
-        public override void TryTrigger( )
+        public override void TryTrigger()
         {
             float newValue = ReadValue();
             bool triggered = false;
@@ -1907,10 +1907,10 @@ namespace Orts.Viewer3D
     }  // class VariableTrigger
 
 
-/////////////////////////////////////////////////////////
-// SOUND COMMANDS
-/////////////////////////////////////////////////////////
-    
+    /////////////////////////////////////////////////////////
+    // SOUND COMMANDS
+    /////////////////////////////////////////////////////////
+
 
     /// <summary>
     /// Start playing the whole sound stream once, then stop
@@ -1936,18 +1936,18 @@ namespace Orts.Viewer3D
                     ORTSStream.ALSoundSource.Queue(p, PlayMode.OneShot, ORTSStream.SoundSource.IsExternal, ORTSStream.RepeatedTrigger);
             }
         }
-    } 
+    }
 
     /// <summary>
     /// Start looping the whole stream, release it only at the end
     /// </summary>
     public class ORTSStartLoop : ORTSSoundPlayCommand
     {
-        public ORTSStartLoop( SoundStream ortsStream, Orts.Formats.Msts.SoundPlayCommand mstsSoundPlayCommand )
-            : base( ortsStream, mstsSoundPlayCommand )
+        public ORTSStartLoop(SoundStream ortsStream, Orts.Formats.Msts.SoundPlayCommand mstsSoundPlayCommand)
+            : base(ortsStream, mstsSoundPlayCommand)
         {
         }
-        public override void  Run( )
+        public override void Run()
         {
             // Support for Loop functions - by GeorgeS
             string p = GetNextFile();
@@ -1957,7 +1957,7 @@ namespace Orts.Viewer3D
                     ORTSStream.ALSoundSource.Queue(p, PlayMode.Loop, ORTSStream.SoundSource.IsExternal, false);
             }
         }
-    } 
+    }
 
     /// <summary>
     /// Release the sound by playing the looped sustain part till its end, then play the last part
@@ -1968,7 +1968,7 @@ namespace Orts.Viewer3D
             : base(ortsStream)
         {
         }
-        
+
         public override void Run()
         {
             if (ORTSStream != null && ORTSStream.ALSoundSource != null)
@@ -2022,7 +2022,7 @@ namespace Orts.Viewer3D
     {
         int TriggerIndex;  // index into the stream's trigger list 
 
-        public ORTSDisableTrigger(SoundStream ortsStream, Orts.Formats.Msts.DisableTrigger smsData )
+        public ORTSDisableTrigger(SoundStream ortsStream, Orts.Formats.Msts.DisableTrigger smsData)
             : base(ortsStream)
         {
             TriggerIndex = smsData.TriggerID - 1;
@@ -2050,7 +2050,7 @@ namespace Orts.Viewer3D
 
         public override void Run()
         {
-            if ( TriggerIndex >= 0 && TriggerIndex < ORTSStream.Triggers.Count)
+            if (TriggerIndex >= 0 && TriggerIndex < ORTSStream.Triggers.Count)
                 ORTSStream.Triggers[TriggerIndex].Enabled = true;
         }
     }
@@ -2166,7 +2166,7 @@ namespace Orts.Viewer3D
         /// <returns></returns>
         public static ORTSSoundCommand Precompiled(string wavFileName, SoundStream soundStream)
         {
-            return new ORTSPlayOneShot(soundStream, wavFileName);        
+            return new ORTSPlayOneShot(soundStream, wavFileName);
         }
 
     }// ORTSSoundCommand
@@ -2227,8 +2227,8 @@ namespace Orts.Viewer3D
 
             //<CJComment>SMSFolder is often same as BasePath, which means this searches the more general folder 
             // before the more specific folder. This is surely not intended.</CJComment>
-            string[] pathArray = {ORTSStream.SoundSource.SMSFolder, 
-                                     Program.Simulator.RoutePath + @"\SOUND", 
+            string[] pathArray = {ORTSStream.SoundSource.SMSFolder,
+                                     Program.Simulator.RoutePath + @"\SOUND",
                                      Program.Simulator.BasePath + @"\SOUND"};
             var fullPath = ORTSPaths.GetFileFromFolders(pathArray, Files[iFile]);
             return (fullPath != null) ? fullPath : "";
@@ -2335,7 +2335,7 @@ namespace Orts.Viewer3D
 
                                 // Try to find forward
                                 d = tmp.DistanceTo(trItems[trNode].TileX, trItems[trNode].TileZ, trItems[trNode].X, trItems[trNode].Y, trItems[trNode].Z, 8192);
-                                
+
                                 if (d != -1)
                                 {
                                     // This is nearer than previous one
@@ -2439,8 +2439,8 @@ namespace Orts.Viewer3D
             WorldSoundFile wf = new WorldSoundFile(name, Viewer.Simulator.TDB.TrackDB.TrItemTable);
             if (wf.TR_WorldSoundFile != null)
             {
-                string[] pathArray = {Viewer.Simulator.RoutePath, Viewer.Simulator.BasePath};
-                
+                string[] pathArray = { Viewer.Simulator.RoutePath, Viewer.Simulator.BasePath };
+
                 var ls = new List<SoundSourceBase>();
                 foreach (var fss in wf.TR_WorldSoundFile.SoundSources)
                 {
@@ -2606,15 +2606,15 @@ namespace Orts.Viewer3D
     }
     public class ORTSActSoundSources
     {
-        public ORTSActSoundSources( )
+        public ORTSActSoundSources()
         {
         }
 
         public void Update()
         {
-            if (Program.Simulator.ActivityRun == null || Program.Simulator.ActivityRun.triggeredEventWrapper == null || 
+            if (Program.Simulator.ActivityRun == null || Program.Simulator.ActivityRun.triggeredEventWrapper == null ||
                 (Program.Simulator.ActivityRun.triggeredEventWrapper.ParsedObject.ORTSActSoundFile == null && (Program.Simulator.ActivityRun.triggeredEventWrapper.ParsedObject.Outcomes == null
-                || Program.Simulator.ActivityRun.triggeredEventWrapper.ParsedObject.Outcomes.ActivitySound == null))) 
+                || Program.Simulator.ActivityRun.triggeredEventWrapper.ParsedObject.Outcomes.ActivitySound == null)))
                 return;
             var localEventID = Program.Simulator.ActivityRun.triggeredEventWrapper.ParsedObject.ID;
             string ORTSActSoundFile;
@@ -2727,6 +2727,6 @@ namespace Orts.Viewer3D
             }
             return;
         }
-     }
+    }
 }
 

--- a/Source/RunActivity/Viewer3D/Terrain.cs
+++ b/Source/RunActivity/Viewer3D/Terrain.cs
@@ -235,7 +235,7 @@ namespace Orts.Viewer3D
             var uv = Tile.Shaders[Patch.ShaderIndex].terrain_uvcalcs;
             if (ts.Length > 1)
                 PatchMaterial = viewer.MaterialManager.Load(terrainMaterial, Helpers.GetTerrainTextureFile(viewer.Simulator, ts[0].Filename) + "\0" + Helpers.GetTerrainTextureFile(viewer.Simulator, ts[1].Filename) +
-                    (uv[1].D != 0 && uv[1].D != 32 ? "\0" + uv[1].D.ToString(): ""));
+                    (uv[1].D != 0 && uv[1].D != 32 ? "\0" + uv[1].D.ToString() : ""));
             else
                 PatchMaterial = viewer.MaterialManager.Load(terrainMaterial, Helpers.GetTerrainTextureFile(viewer.Simulator, ts[0].Filename) + "\0" + Helpers.GetTerrainTextureFile(viewer.Simulator, "microtex.ace"));
 
@@ -511,7 +511,7 @@ namespace Orts.Viewer3D
             PatchTexture = Viewer.TextureManager.Get(textures[0], defaultTexture);
             PatchTextureOverlay = textures.Length > 1 ? Viewer.TextureManager.Get(textures[1]) : null;
             var converted = textures.Length > 2 && Int32.TryParse(textures[2], out OverlayScale);
-            OverlayScale = OverlayScale != 0 && converted ?  OverlayScale : 32; 
+            OverlayScale = OverlayScale != 0 && converted ? OverlayScale : 32;
 
         }
 

--- a/Source/RunActivity/Viewer3D/Trains.cs
+++ b/Source/RunActivity/Viewer3D/Trains.cs
@@ -67,27 +67,27 @@ namespace Orts.Viewer3D
                     if (cancellation.IsCancellationRequested)
                         break;
                     try
-					{
-						if (cars.ContainsKey(car))
-							newCars.Add(car, cars[car]);
-						else
-							newCars.Add(car, LoadCar(car));
-					}
-					catch (Exception error) 
+                    {
+                        if (cars.ContainsKey(car))
+                            newCars.Add(car, cars[car]);
+                        else
+                            newCars.Add(car, LoadCar(car));
+                    }
+                    catch (Exception error)
                     {
                         Trace.WriteLine(new FileLoadException(car.WagFilePath, error));
                     }
                 }
                 Cars = newCars;
-				//for those cars not visible now, will unload them (to remove attached sound)
-				foreach (var car in cars)
-				{
-					if (!visibleCars.Contains(car.Key))
-					{
-						car.Value.Unload();
-					}
-				}
-			}
+                //for those cars not visible now, will unload them (to remove attached sound)
+                foreach (var car in cars)
+                {
+                    if (!visibleCars.Contains(car.Key))
+                    {
+                        car.Value.Unload();
+                    }
+                }
+            }
 
             // Ensure the player locomotive has a cab view loaded and anything else they need.
             cars = Cars;

--- a/Source/RunActivity/Viewer3D/UserInputRailDriver.cs
+++ b/Source/RunActivity/Viewer3D/UserInputRailDriver.cs
@@ -151,7 +151,7 @@ namespace Orts.Viewer3D
             }
             State.Changed = true;
         }
-        
+
         /// <summary>
         /// Error callback
         /// </summary>
@@ -164,14 +164,14 @@ namespace Orts.Viewer3D
 
         static float Percentage(float x, float x0, float x100)
         {
-            float p= 100 * (x - x0) / (x100 - x0);
+            float p = 100 * (x - x0) / (x100 - x0);
             if (p < 5)
                 return 0;
             if (p > 95)
                 return 100;
             return p;
         }
-        
+
         static float Percentage(float x, float xminus100, float x0, float xplus100)
         {
             float p = 100 * (x - x0) / (xplus100 - x0);
@@ -215,7 +215,7 @@ namespace Orts.Viewer3D
             for (int i = 0; i < WriteBuffer.Length; i++)
                 WriteBuffer[i] = 0;
             WriteBuffer[1] = 133;
-            WriteBuffer[7] = (byte) (on ? 1 : 0);
+            WriteBuffer[7] = (byte)(on ? 1 : 0);
             Device.WriteData(WriteBuffer);
         }
 
@@ -234,7 +234,7 @@ namespace Orts.Viewer3D
             if (!Active || playerLoco == null || Device == null)
                 return;
             float speed = 10 * MpS.FromMpS(playerLoco.SpeedMpS, playerLoco.IsMetric);
-            int s = (int) (speed >= 0 ? speed + .5 : -speed + .5);
+            int s = (int)(speed >= 0 ? speed + .5 : -speed + .5);
             if (s != LEDSpeed)
             {
                 if (s < 100)
@@ -272,7 +272,7 @@ namespace Orts.Viewer3D
                     return;
                 }
             }
-			// TODO: This is... kinda weird and cool at the same time. STF parsing being used on RailDriver's calebration file. Probably should be a dedicated parser, though.
+            // TODO: This is... kinda weird and cool at the same time. STF parsing being used on RailDriver's calebration file. Probably should be a dedicated parser, though.
             STFReader reader = new STFReader(file, false);
             while (!reader.Eof)
             {
@@ -280,8 +280,8 @@ namespace Orts.Viewer3D
                 if (token == "Position")
                 {
                     string name = reader.ReadItem();
-                    int min= -1;
-                    int max= -1;
+                    int min = -1;
+                    int max = -1;
                     while (token != "}")
                     {
                         token = reader.ReadItem();
@@ -408,7 +408,7 @@ namespace Orts.Viewer3D
             //Commands[(int)UserCommand. gear shift] = new RailDriverUserCommand(4, 0x08);
             Commands[(int)UserCommand.ControlGearDown] = new RailDriverUserCommand(4, 0x08);
             //Commands[(int)UserCommand.ControlEmergency] = new RailDriverUserCommand(4, 0x30); handled elsewhere
-            Commands[(int)UserCommand. ControlAlerter] = new RailDriverUserCommand(4, 0x40);
+            Commands[(int)UserCommand.ControlAlerter] = new RailDriverUserCommand(4, 0x40);
             Commands[(int)UserCommand.ControlSander] = new RailDriverUserCommand(4, 0x80);
             Commands[(int)UserCommand.ControlPantograph1] = new RailDriverUserCommand(5, 0x01);
             Commands[(int)UserCommand.ControlBellToggle] = new RailDriverUserCommand(5, 0x02);
@@ -439,7 +439,7 @@ namespace Orts.Viewer3D
 
         public override string ToString()
         {
-            string s= String.Format("{0} {1} {2} {3} {4} {5} {6}", DirectionPercent, ThrottlePercent, DynamicBrakePercent, TrainBrakePercent, EngineBrakePercent, BailOff, Emergency);
+            string s = String.Format("{0} {1} {2} {3} {4} {5} {6}", DirectionPercent, ThrottlePercent, DynamicBrakePercent, TrainBrakePercent, EngineBrakePercent, BailOff, Emergency);
             for (int i = 0; i < 6; i++)
                 s += " " + ButtonData[i];
             return s;
@@ -455,29 +455,29 @@ namespace Orts.Viewer3D
             return (ButtonData[index] & mask) != 0 && (PreviousButtonData[index] & mask) == 0;
         }
 
-		public bool IsPressed(UserCommand command)
-		{
-			RailDriverUserCommand c = Commands[(int)command];
+        public bool IsPressed(UserCommand command)
+        {
+            RailDriverUserCommand c = Commands[(int)command];
             if (c == null || Changed == false)
                 return false;
-			return c.IsButtonDown(ButtonData) && !c.IsButtonDown(PreviousButtonData);
-		}
+            return c.IsButtonDown(ButtonData) && !c.IsButtonDown(PreviousButtonData);
+        }
 
-		public bool IsReleased(UserCommand command)
-		{
+        public bool IsReleased(UserCommand command)
+        {
             RailDriverUserCommand c = Commands[(int)command];
             if (c == null || Changed == false)
                 return false;
             return !c.IsButtonDown(ButtonData) && c.IsButtonDown(PreviousButtonData);
-		}
+        }
 
-		public bool IsDown(UserCommand command)
-		{
+        public bool IsDown(UserCommand command)
+        {
             RailDriverUserCommand c = Commands[(int)command];
             if (c == null)
                 return false;
             return c.IsButtonDown(ButtonData);
-		}
+        }
     }
 
     public class RailDriverUserCommand

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -445,8 +445,8 @@ namespace Orts.Viewer3D
             World.LoadPrep();
             if (Simulator.Settings.ConditionalLoadOfDayOrNightTextures) // We need to compute sun height only in this case
             {
-            MaterialManager.LoadPrep();
-            LoadMemoryThreshold = (long)HUDWindow.GetVirtualAddressLimit() - 512 * 1024 * 1024;
+                MaterialManager.LoadPrep();
+                LoadMemoryThreshold = (long)HUDWindow.GetVirtualAddressLimit() - 512 * 1024 * 1024;
             }
             Load();
 
@@ -1156,7 +1156,7 @@ namespace Orts.Viewer3D
                 {
                     var success = ((AITrain)PlayerLocomotive.Train).SwitchToPlayerControl();
                     if (success)
-                    {   
+                    {
                         Simulator.Confirmer.Message(ConfirmLevel.Information, Viewer.Catalog.GetString("Switched to player control"));
                         DbfEvalAutoPilot = false;//Debrief eval
                     }
@@ -1178,8 +1178,8 @@ namespace Orts.Viewer3D
                 }
             }
 
-            if (DbfEvalAutoPilot && (Simulator.ClockTime - DbfEvalIniAutoPilotTimeS) > 1.0000 )
-            {              
+            if (DbfEvalAutoPilot && (Simulator.ClockTime - DbfEvalIniAutoPilotTimeS) > 1.0000)
+            {
                 DbfEvalAutoPilotTimeS = DbfEvalAutoPilotTimeS + (Simulator.ClockTime - DbfEvalIniAutoPilotTimeS);//Debrief eval
                 train.DbfEvalValueChanged = true;
                 DbfEvalIniAutoPilotTimeS = Simulator.ClockTime;//Debrief eval
@@ -1308,7 +1308,7 @@ namespace Orts.Viewer3D
 
             // explore 2D cabview controls
 
-            if (Camera is CabCamera && (PlayerLocomotiveViewer as MSTSLocomotiveViewer)._hasCabRenderer && MouseChangingControl == null && 
+            if (Camera is CabCamera && (PlayerLocomotiveViewer as MSTSLocomotiveViewer)._hasCabRenderer && MouseChangingControl == null &&
                 RenderProcess.IsMouseVisible)
             {
                 if (!UserInput.IsMouseLeftButtonPressed)
@@ -1359,7 +1359,7 @@ namespace Orts.Viewer3D
                         if (cabRenderer is CabViewDiscreteRenderer)
                         {
                             foreach (var iMatrix in animatedPart.Value.MatrixIndexes)
-                            { 
+                            {
                                 var matrix = Matrix.Identity;
                                 var hi = iMatrix;
                                 while (hi >= 0 && hi < trainCarShape.Hierarchy.Length && trainCarShape.Hierarchy[hi] != -1)
@@ -1482,7 +1482,7 @@ namespace Orts.Viewer3D
             // Diesel and electric locos have a Reverser lever and,
             // in the neutral position, direction == N
             return car.Direction == Direction.N
-                // Steam locos never have direction == N, so check for setting close to zero.
+            // Steam locos never have direction == N, so check for setting close to zero.
             || Math.Abs(car.Train.MUReverserPercent) <= 1;
         }
         /// <summary>

--- a/Source/RunActivity/Viewer3D/Water.cs
+++ b/Source/RunActivity/Viewer3D/Water.cs
@@ -60,11 +60,11 @@ namespace Orts.Viewer3D
         void LoadStaticData()
         {
             if (Viewer.ENVFile.WaterLayers != null)
-            WaterLayers = Viewer.ENVFile.WaterLayers.Select(layer => new KeyValuePair<float, Material>(layer.Height, Viewer.MaterialManager.Load("Water", Viewer.Simulator.RoutePath + @"\envfiles\textures\" + layer.TextureName))).ToArray();
-  
+                WaterLayers = Viewer.ENVFile.WaterLayers.Select(layer => new KeyValuePair<float, Material>(layer.Height, Viewer.MaterialManager.Load("Water", Viewer.Simulator.RoutePath + @"\envfiles\textures\" + layer.TextureName))).ToArray();
+
             PatchVertexDeclaration = new VertexDeclaration(Viewer.GraphicsDevice, VertexPositionNormalTexture.VertexElements);
             PatchVertexStride = VertexPositionNormalTexture.SizeInBytes;
-            
+
         }
 
         [CallOnThread("Updater")]
@@ -103,7 +103,7 @@ namespace Orts.Viewer3D
             {
                 for (var x = 0; x < tile.PatchCount; ++x)
                 {
-                    
+
                     var patch = tile.GetPatch(x, z);
 
                     if (!patch.WaterEnabled)

--- a/Source/RunActivity/Viewer3D/Weather.cs
+++ b/Source/RunActivity/Viewer3D/Weather.cs
@@ -106,7 +106,7 @@ namespace Orts.Viewer3D
                     UpdateSoundSources();
                     UpdateVolume();
                     // We have a pause in weather change, depending from randomization level
-                    dynamicWeather.stableWeatherTimer = ( 4.0f - Viewer.Settings.ActWeatherRandomizationLevel) * 600 + Simulator.Random.Next(300) - 150;
+                    dynamicWeather.stableWeatherTimer = (4.0f - Viewer.Settings.ActWeatherRandomizationLevel) * 600 + Simulator.Random.Next(300) - 150;
                     weatherChangeOn = true;
                 }
 
@@ -154,7 +154,7 @@ namespace Orts.Viewer3D
             {
                 dynamicWeather = new DynamicWeather();
                 dynamicWeather.Restore(inf);
-              }
+            }
             UpdateVolume();
         }
 
@@ -263,7 +263,7 @@ namespace Orts.Viewer3D
             // First define overcast
             var randValue = Simulator.Random.Next(170);
             var intermValue = randValue >= 50 ? (float)(randValue - 50f) : (float)randValue;
-            Weather.OvercastFactor = intermValue >= 20 ? (float)(intermValue - 20f)/100f: (float)intermValue/100f; // give more probability to less overcast
+            Weather.OvercastFactor = intermValue >= 20 ? (float)(intermValue - 20f) / 100f : (float)intermValue / 100f; // give more probability to less overcast
             Viewer.Simulator.WeatherType = Orts.Formats.Msts.WeatherType.Clear;
             // Then check if we are in precipitation zone
             if (Weather.OvercastFactor > 0.5)
@@ -290,9 +290,9 @@ namespace Orts.Viewer3D
             else Weather.PricipitationIntensityPPSPM2 = 0;
             // and now define visibility
             randValue = Simulator.Random.Next(2000);
-            if (Weather.PricipitationIntensityPPSPM2 > 0 || Weather.OvercastFactor > 0.7f )
-            // use first digit to define power of ten and the other three to define the multiplying number
-                Weather.FogDistance =  Math.Max ( 100, (float)Math.Pow(10 , ((int)(randValue / 1000) + 2)) * (float)((randValue % 1000 + 1) / 100f));
+            if (Weather.PricipitationIntensityPPSPM2 > 0 || Weather.OvercastFactor > 0.7f)
+                // use first digit to define power of ten and the other three to define the multiplying number
+                Weather.FogDistance = Math.Max(100, (float)Math.Pow(10, ((int)(randValue / 1000) + 2)) * (float)((randValue % 1000 + 1) / 100f));
             else
                 Weather.FogDistance = Math.Max(500, (float)Math.Pow(10, (int)((randValue / 1000) + 3)) * (float)((randValue % 1000 + 1) / 100f));
             return true;
@@ -317,14 +317,14 @@ namespace Orts.Viewer3D
             // Compare player train lat/lon with array of desert zones
             for (int i = 0; i < DesertZones.Length / 4; i++)
             {
-                if (LatitudeDeg > DesertZones[i,0] && LatitudeDeg < DesertZones[i,1] && LongitudeDeg > DesertZones[i,2] && LongitudeDeg < DesertZones[i,3]
+                if (LatitudeDeg > DesertZones[i, 0] && LatitudeDeg < DesertZones[i, 1] && LongitudeDeg > DesertZones[i, 2] && LongitudeDeg < DesertZones[i, 3]
                      && Viewer.PlayerLocomotive.Train.FrontTDBTraveller.Location.Y < 1000 ||
-                     LatitudeDeg > DesertZones[i, 0] + 1 && LatitudeDeg < DesertZones[i, 1] -1 && LongitudeDeg > DesertZones[i, 2] + 1 && LongitudeDeg < DesertZones[i, 3] -1)
+                     LatitudeDeg > DesertZones[i, 0] + 1 && LatitudeDeg < DesertZones[i, 1] - 1 && LongitudeDeg > DesertZones[i, 2] + 1 && LongitudeDeg < DesertZones[i, 3] - 1)
                 {
                     DesertZone = true;
                     return;
                 }
-            } 
+            }
         }
 
         [CallOnThread("Updater")]
@@ -438,7 +438,7 @@ namespace Orts.Viewer3D
                     if (dynamicWeather != null) dynamicWeather.ORTSPrecipitationIntensity = -1;
                 }
                 if (UserInput.IsDown(UserCommand.DebugPrecipitationIncrease) || UserInput.IsDown(UserCommand.DebugPrecipitationDecrease)) UpdateVolume();
- 
+
                 // Change in precipitation liquidity, passing from rain to snow and vice-versa
                 if (UserInput.IsDown(UserCommand.DebugPrecipitationLiquidityIncrease))
                 {
@@ -506,7 +506,7 @@ namespace Orts.Viewer3D
             }
             if (Program.Simulator != null && Program.Simulator.ActivityRun != null && Program.Simulator.ActivityRun.triggeredEventWrapper != null &&
                (Program.Simulator.ActivityRun.triggeredEventWrapper.ParsedObject.ORTSWeatherChange != null || Program.Simulator.ActivityRun.triggeredEventWrapper.ParsedObject.Outcomes.ORTSWeatherChange != null))
-                // Start a weather change sequence in activity mode
+            // Start a weather change sequence in activity mode
             {
                 // if not yet weather changes, create the instance
                 if (dynamicWeather == null)
@@ -516,10 +516,10 @@ namespace Orts.Viewer3D
                 var weatherChange = Program.Simulator.ActivityRun.triggeredEventWrapper.ParsedObject.Outcomes.ORTSWeatherChange != null ?
                     Program.Simulator.ActivityRun.triggeredEventWrapper.ParsedObject.Outcomes.ORTSWeatherChange : Program.Simulator.ActivityRun.triggeredEventWrapper.ParsedObject.ORTSWeatherChange;
                 dynamicWeather.WeatherChange_Init(weatherChange, this);
-                Program.Simulator.ActivityRun.triggeredEventWrapper = null;               
+                Program.Simulator.ActivityRun.triggeredEventWrapper = null;
             }
             if (weatherChangeOn)
-                // manage the weather change sequence
+            // manage the weather change sequence
             {
                 dynamicWeather.WeatherChange_Update(elapsedTime, this);
             }
@@ -696,7 +696,7 @@ namespace Orts.Viewer3D
                 {
                     precipitationIntensityTimer -= elapsedTime.ClockSeconds;
                     if (precipitationIntensityTimer <= 0) precipitationIntensityTimer = 0;
-                    else if (weatherControl.RandomizedWeather == false ) wChangeOn = true;
+                    else if (weatherControl.RandomizedWeather == false) wChangeOn = true;
                     var oldPricipitationIntensityPPSPM2 = weatherControl.Weather.PricipitationIntensityPPSPM2;
                     weatherControl.Weather.PricipitationIntensityPPSPM2 = ORTSPrecipitationIntensity - precipitationIntensityTimer * precipitationIntensityChangeRate;
                     if (weatherControl.Weather.PricipitationIntensityPPSPM2 > 0)
@@ -813,7 +813,7 @@ namespace Orts.Viewer3D
                     ORTSPrecipitationIntensityTransitionTimeS = weatherChangeTimer;
                 }
                 if (ORTSPrecipitationIntensity >= 0)
-                { 
+                {
                     precipitationIntensityTimer = (float)ORTSPrecipitationIntensityTransitionTimeS;
                     // Pricipitation ranges from 0 to max PrecipitationViewer.MaxIntensityPPSPM2 if 32bit.
                     // 16bit uses PrecipitationViewer.MaxIntensityPPSPM2_16
@@ -996,7 +996,7 @@ namespace Orts.Viewer3D
             // overcast
             if (setValue < 0 && randomize)
             {
-                setValue = (float)(Viewer.Random.Next((int)maxValue*100)/100);  // ensure there is a value if range is 0 - 1
+                setValue = (float)(Viewer.Random.Next((int)maxValue * 100) / 100);  // ensure there is a value if range is 0 - 1
             }
             else
             {
@@ -1072,7 +1072,7 @@ namespace Orts.Viewer3D
             else if (lastWeather is WeatherSettingOvercast)
             {
                 WeatherSettingOvercast lastWeatherOvercast = lastWeather as WeatherSettingOvercast;
-                AWOvercastCloudcover = Math.Max(0, Math.Min(1, (lastWeatherOvercast.Overcast/100) +
+                AWOvercastCloudcover = Math.Max(0, Math.Min(1, (lastWeatherOvercast.Overcast / 100) +
                     ((float)Viewer.Random.Next((int)(-0.5f * lastWeatherOvercast.OvercastVariation), (int)(0.5f * lastWeatherOvercast.OvercastVariation)) / 100)));
                 AWActualVisibility = Weather.FogDistance = lastWeatherOvercast.OvercastVisibilityM;
 
@@ -1263,7 +1263,7 @@ namespace Orts.Viewer3D
 
             // check for change in required weather
             // time to change but no change after midnight and further weather available
-            if (Time < 24*3600 && Time > AWNextChangeTime && AWActiveIndex < (weatherDetails.Count - 1))
+            if (Time < 24 * 3600 && Time > AWNextChangeTime && AWActiveIndex < (weatherDetails.Count - 1))
             {
                 // if precipitation still active or fog not lifted, postpone change by one minute
                 if (AWPrecipitationActiveType != WeatherType.Clear || fogActive)
@@ -1355,7 +1355,7 @@ namespace Orts.Viewer3D
 
             // determine actual duration of precipitation
             float maxDuration = AWNextChangeTime - weatherDetails[AWActiveIndex].Time;
-            AWPrecipitationTotalDuration = (float)maxDuration * (lastWeatherPrecipitation.PrecipitationProbability/100f);  // nominal value
+            AWPrecipitationTotalDuration = (float)maxDuration * (lastWeatherPrecipitation.PrecipitationProbability / 100f);  // nominal value
             AWPrecipitationTotalDuration = (0.9f + ((float)Viewer.Random.Next(20) / 20)) * AWPrecipitationTotalDuration; // randomized value, +- 10% 
             AWPrecipitationTotalDuration = Math.Min(AWPrecipitationTotalDuration, maxDuration); // but never exceeding maximum duration
             AWPrecipitationNextSpell = lastWeatherPrecipitation.Time; // set start of spell to start of weather change
@@ -1399,7 +1399,7 @@ namespace Orts.Viewer3D
                 float baseDensitiy = PrecipitationViewer.MaxIntensityPPSPM2 * lastWeatherPrecipitation.PrecipitationDensity;
                 AWPrecipitationActualPPSPM2 = MathHelper.Clamp(((1.0f + ((float)Viewer.Random.Next(-precvariation, precvariation) / 100)) * baseDensitiy),
                                                PrecipitationViewer.MinIntensityPPSPM2, PrecipitationViewer.MaxIntensityPPSPM2);
-                AWPrecipitationRequiredPPSPM2 = MathHelper.Clamp(((1.0f + ((float)Viewer.Random.Next(-precvariation, precvariation) / 100)) * baseDensitiy), 
+                AWPrecipitationRequiredPPSPM2 = MathHelper.Clamp(((1.0f + ((float)Viewer.Random.Next(-precvariation, precvariation) / 100)) * baseDensitiy),
                                                PrecipitationViewer.MinIntensityPPSPM2, PrecipitationViewer.MaxIntensityPPSPM2);
 
                 // rate of change is max. difference over random timespan between 1 and 10 mins.
@@ -1413,7 +1413,7 @@ namespace Orts.Viewer3D
                 float endrate = 1.75f * lastWeatherPrecipitation.PrecipitationRateOfChange +
                                (0.5F * (float)(Viewer.Random.Next((int)(lastWeatherPrecipitation.PrecipitationRateOfChange * 100))) / 100f);
                 float spellEndPhase = Math.Min(60f + (300f * endrate), 600);
-             
+
                 float avduration = AWPrecipitationTotalDuration / AWPrecipitationTotalSpread;
                 float actduration = (0.5f + ((float)Viewer.Random.Next(100) / 100)) * avduration;
                 float spellEndTime = Math.Min(startTime + actduration, AWNextChangeTime);
@@ -1590,7 +1590,7 @@ namespace Orts.Viewer3D
             outf.Write(1);
 
             // save input details
-            foreach(WeatherSetting autoweather in weatherDetails)
+            foreach (WeatherSetting autoweather in weatherDetails)
             {
                 if (autoweather is WeatherSettingFog)
                 {

--- a/Source/RunActivity/Viewer3D/Wire.cs
+++ b/Source/RunActivity/Viewer3D/Wire.cs
@@ -351,7 +351,7 @@ namespace Orts.Viewer3D
             VerticalNumSegments += (uint)count - 1;
         }
     }
-    
+
     // Dynamic Wire profile class
     public class WireProfile : TrProfile
     {
@@ -570,7 +570,7 @@ namespace Orts.Viewer3D
             if (DTrackData.IsCurved == 0) ObjectRadius = 0.5f * DTrackData.param1; // half-length
             else ObjectRadius = DTrackData.param2 * (float)Math.Sin(0.5 * Math.Abs(DTrackData.param1)); // half chord length
         }
-        
+
         /// <summary>
         /// Builds a Wire LOD to WireProfile specifications as one vertex buffer and one index buffer.
         /// The order in which the buffers are built reflects the nesting in the TrProfile.  The nesting order is:

--- a/Source/Tests/Orts.Parsers.Msts/StfReader.cs
+++ b/Source/Tests/Orts.Parsers.Msts/StfReader.cs
@@ -753,7 +753,7 @@ namespace Tests.Orts.Parsers.Msts.StfException
 
 }
 namespace Tests.Orts.Parsers.Msts.StfReader
-{   
+{
     // NEW_READER compilation flag is set for those tests that can be performed (compiled) only for the new STFReader, 
     // but not on the old reader. The new reader should also pass all tests that compile on the old reader.
     // This means in this file NEW_READER flag adds a number of tests, but it should also work if the flag is not set.
@@ -1453,14 +1453,14 @@ namespace Tests.Orts.Parsers.Msts.StfReader
             var reader = Create.Reader("Comment(a)" + someFollowingToken);
             Assert.Equal(someFollowingToken, reader.ReadItem());
         }
-        
+
         [Fact]
         public static void WarnOnMissingBlockAfterComment()
         {
             // todo: old stf reader would simply return 'b'. Throwing an exception is perhaps harsh
             AssertWarnings.NotExpected();
             string someFollowingToken = "b";
-            AssertStfException.Throws(() => 
+            AssertStfException.Throws(() =>
             {
                 var reader = Create.Reader("comment a " + someFollowingToken);
                 Assert.Equal(someFollowingToken, reader.ReadItem());
@@ -2243,8 +2243,8 @@ namespace Tests.Orts.Parsers.Msts.StfReader
     public class OnReadingBoolBlockShould
     {
         static readonly bool SOMEDEFAULT = false;
-        static readonly bool[] SOMEDEFAULTS1 = new bool[] { false, true, false, true, true, true, true  };
-        static readonly string[] STRINGDEFAULTS1 = new string[] { "false", "true", "0", "1", "1.1", "-2.9e3", "non"  };
+        static readonly bool[] SOMEDEFAULTS1 = new bool[] { false, true, false, true, true, true, true };
+        static readonly string[] STRINGDEFAULTS1 = new string[] { "false", "true", "0", "1", "1.1", "-2.9e3", "non" };
 
         [Fact]
         public static void OnEofWarnAndReturnDefault()
@@ -2270,16 +2270,16 @@ namespace Tests.Orts.Parsers.Msts.StfReader
         [Fact]
         public static void ReturnStringValueInBlock()
         {
-            string[] inputValues = {"true", "false"};
-            bool[] expectedValues = {true, false};
+            string[] inputValues = { "true", "false" };
+            bool[] expectedValues = { true, false };
             StfTokenReaderCommon.ReturnValueInBlock<bool>(expectedValues, inputValues, reader => reader.ReadBoolBlock(false));
         }
 
         [Fact]
         public static void ReturnIntValueInBlock()
         {
-            string[] inputValues = {"0", "1", "-2"};
-            bool[] expectedValues = {false, true, true};
+            string[] inputValues = { "0", "1", "-2" };
+            bool[] expectedValues = { false, true, true };
             StfTokenReaderCommon.ReturnValueInBlock<bool>(expectedValues, inputValues, reader => reader.ReadBoolBlock(false));
         }
 
@@ -2289,9 +2289,9 @@ namespace Tests.Orts.Parsers.Msts.StfReader
             bool[] expectedValues;
             string[] inputValues = { "0.1", "1.1", "something", "()" };
             bool expectedValue = false;
-            expectedValues = new bool[]{ expectedValue, expectedValue, expectedValue, expectedValue};
+            expectedValues = new bool[] { expectedValue, expectedValue, expectedValue, expectedValue };
             StfTokenReaderCommon.ReturnValueInBlock<bool>(expectedValues, inputValues, reader => reader.ReadBoolBlock(expectedValue));
-            
+
             expectedValue = true;
             expectedValues = new bool[] { expectedValue, expectedValue, expectedValue, expectedValue };
             StfTokenReaderCommon.ReturnValueInBlock<bool>(expectedValues, inputValues, reader => reader.ReadBoolBlock(expectedValue));
@@ -2338,7 +2338,7 @@ namespace Tests.Orts.Parsers.Msts.StfReader
             var reader = Create.Reader(inputString);
             foreach (string testValue in testValues)
             {
-                bool result = ! expectedResult;
+                bool result = !expectedResult;
                 result = reader.ReadBoolBlock(expectedResult);
                 Assert.Equal(expectedResult, result);
             }

--- a/Source/Tests/Orts.Parsers.OR/TimetableReaderTests.cs
+++ b/Source/Tests/Orts.Parsers.OR/TimetableReaderTests.cs
@@ -44,7 +44,8 @@ namespace Tests.Orts.Parsers.OR
             }
             using (var file = new TestFile("\t"))
             {
-                Assert.Throws(typeof(InvalidDataException), () => {
+                Assert.Throws(typeof(InvalidDataException), () =>
+                {
                     var tr = new TimetableReader(file.FileName);
                 });
             }


### PR DESCRIPTION
This is the result of running `dotnet format` (with version 3.1.37601+256f37159dc60b29f76999749f57f4338324f102) on the entire `Source` directory.

The [supported formatting options](https://github.com/dotnet/format/wiki/Supported-.editorconfig-options) are all about whitespace, for now, so this diff is entirely adding and removing spaces.