### PR TITLE
Show both DynamicBrakeForce and MotiveForce values in Locomotive HUD

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -3797,6 +3797,11 @@ namespace Orts.Simulation.RollingStocks
                         else
                             data = this.LocomotiveAxle.AxleForceN;
                         data = Math.Abs(data);
+                        if (DynamicBrakePercent > 0)
+                        {
+                            data = (DynamicBrakeForceN / MaxDynamicBrakeForceN) * DynamicBrakeMaxCurrentA;
+                            data = -Math.Abs(data); // Ensure that dynamic force is seen as a "-ve force" on the traction braking indicator
+                        }
                         switch (cvc.Units)
                         {
                             case CABViewControlUnits.AMPS:

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -3796,12 +3796,11 @@ namespace Orts.Simulation.RollingStocks
                             data = this.FilteredMotiveForceN;
                         else
                             data = this.LocomotiveAxle.AxleForceN;
-                        data = Math.Abs(data);
                         if (DynamicBrakePercent > 0)
                         {
                             data = (DynamicBrakeForceN / MaxDynamicBrakeForceN) * DynamicBrakeMaxCurrentA;
-                            data = -Math.Abs(data); // Ensure that dynamic force is seen as a "-ve force" on the traction braking indicator
                         }
+                        data = Math.Abs(data);
                         switch (cvc.Units)
                         {
                             case CABViewControlUnits.AMPS:

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -3798,7 +3798,7 @@ namespace Orts.Simulation.RollingStocks
                             data = this.LocomotiveAxle.AxleForceN;
                         if (DynamicBrakePercent > 0)
                         {
-                            data = (DynamicBrakeForceN / MaxDynamicBrakeForceN) * DynamicBrakeMaxCurrentA;
+                            data = DynamicBrakeForceN;
                         }
                         data = Math.Abs(data);
                         switch (cvc.Units)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -1511,8 +1511,9 @@ namespace Orts.Simulation.RollingStocks
                 AcceptMUSignals ? Simulator.Catalog.GetString("Yes") : Simulator.Catalog.GetString("No"),
                 ThrottlePercent,
                 String.Format("{0}{1}", FormatStrings.FormatSpeedDisplay(SpeedMpS, IsMetric), WheelSlip ? "!!!" : ""),
-                FormatStrings.FormatPower(MotiveForceN * SpeedMpS, IsMetric, false, false),
-                String.Format("{0}{1}", FormatStrings.FormatForce(MotiveForceN, IsMetric), CouplerExceedBreakLimit ? "???" : ""));
+                // For Locomotive HUD display shows "forward" motive power (& force) as a positive value, braking power (& force) will be shown as negative values.
+                FormatStrings.FormatPower((MotiveForceN - DynamicBrakeForceN) * SpeedMpS, IsMetric, false, false),   
+                String.Format("{0}{1}", FormatStrings.FormatForce((MotiveForceN - DynamicBrakeForceN), IsMetric), CouplerExceedBreakLimit ? "???" : ""));
         }
         public virtual string GetTrainBrakeStatus() { return null; }
         public virtual string GetEngineBrakeStatus() { return null; }


### PR DESCRIPTION
https://blueprints.launchpad.net/or/+spec/refactor-dynamic-brakeforce - allow display of both DynamicBrakeForce and MotiveForce values in Locomotive HUD as requested in this thread - http://www.elvastower.com/forums/index.php?/topic/33406-starting-with-u20190924-no-force-in-dynamics/