### PR TITLE
Harmonize initialization of autopilotable player train with that of standard player trains

### DIFF
--- a/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
@@ -403,9 +403,10 @@ namespace Orts.Simulation.AIs
                 }
             }
 #endif
-            // check deadlocks
+            // check deadlocks; do it after placing for player train, like done for it when autopilot option unchecked
 
-            CheckDeadlock(ValidRoute[0], Number);
+            if (!IsActualPlayerTrain)
+                CheckDeadlock(ValidRoute[0], Number);
 
             // set initial position and state
 
@@ -465,6 +466,8 @@ namespace Orts.Simulation.AIs
                 }
 
                 InitializeSignals(false);           // Get signal information
+                if (IsActualPlayerTrain)
+                    CheckDeadlock(ValidRoute[0], Number);
                 TCRoute.SetReversalOffset(Length, false);  // set reversal information for first subpath
                 SetEndOfRouteAction();              // set action to ensure train stops at end of route
 
@@ -488,6 +491,9 @@ namespace Orts.Simulation.AIs
                     }
                 }
             }
+
+            if (IsActualPlayerTrain)
+                SetTrainSpeedLoggingFlag();
 
             if (CheckTrain)
             {

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -2400,7 +2400,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
                 if (DatalogTSContents[4] == 1)
                 {
-                    stringBuild.Append((0 - Cars[LeadLocomotiveIndex].CurrentElevationPercent).ToString("00.0"));
+                    stringBuild.Append((0 - Simulator.PlayerLocomotive.CurrentElevationPercent).ToString("00.0"));
                     stringBuild.Append(Separator);
                 }
 
@@ -2438,7 +2438,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 if (DatalogTSContents[9] == 1)
                 {
                     //                    stringBuild.Append(BrakeLine1PressurePSIorInHg.ToString("000"));
-                    stringBuild.Append(Cars[LeadLocomotiveIndex].BrakeSystem.GetCylPressurePSI().ToString("000"));
+                    stringBuild.Append(Simulator.PlayerLocomotive.BrakeSystem.GetCylPressurePSI().ToString("000"));
                     stringBuild.Append(Separator);
                 }
 
@@ -2556,25 +2556,8 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
             if (IsActualPlayerTrain)
             {
-                DatalogTrainSpeed = Simulator.Settings.DataLogTrainSpeed;
-                DatalogTSInterval = Simulator.Settings.DataLogTSInterval;
+                SetTrainSpeedLoggingFlag();
 
-                DatalogTSContents = new int[Simulator.Settings.DataLogTSContents.Length];
-                Simulator.Settings.DataLogTSContents.CopyTo(DatalogTSContents, 0);
-
-                // if logging required, derive filename and open file
-                if (DatalogTrainSpeed)
-                {
-                    DataLogFile = Simulator.DeriveLogFile("Speed");
-                    if (String.IsNullOrEmpty(DataLogFile))
-                    {
-                        DatalogTrainSpeed = false;
-                    }
-                    else
-                    {
-                        CreateLogFile();
-                    }
-                }
 
                 // if debug, print out all passing paths
 
@@ -2584,6 +2567,34 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
             }
 
             return (validPosition);
+        }
+
+        //================================================================================================//
+        /// <summary>
+        /// set train speed logging flag (valid per activity, so will be restored after save)
+        /// </summary>
+        
+        protected void SetTrainSpeedLoggingFlag()
+        {
+            DatalogTrainSpeed = Simulator.Settings.DataLogTrainSpeed;
+            DatalogTSInterval = Simulator.Settings.DataLogTSInterval;
+
+            DatalogTSContents = new int[Simulator.Settings.DataLogTSContents.Length];
+            Simulator.Settings.DataLogTSContents.CopyTo(DatalogTSContents, 0);
+
+            // if logging required, derive filename and open file
+            if (DatalogTrainSpeed)
+            {
+                DataLogFile = Simulator.DeriveLogFile("Speed");
+                if (String.IsNullOrEmpty(DataLogFile))
+                {
+                    DatalogTrainSpeed = false;
+                }
+                else
+                {
+                    CreateLogFile();
+                }
+            }
         }
 
         //================================================================================================//


### PR DESCRIPTION
See bug https://bugs.launchpad.net/or/+bug/1858323 Unjustified player train initialization differences.
As of now autopilotable player trains have an initialization procedure that differs from that of standard player trains. Some differences are justified, and some not. This patch modifies the initialization procedure of autopilotable player trains to in the points where differences with standard player trains is not justified.