### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1868278 AI train authorization to pass red signal not saved

### DIFF
--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -8513,6 +8513,7 @@ namespace Orts.Simulation.Signalling
             ApproachControlSet = inf.ReadBoolean();
             ClaimLocked = inf.ReadBoolean();
             ForcePropOnApproachControl = inf.ReadBoolean();
+            hasPermission = (Permission)inf.ReadInt32();
 
             // set dummy train, route direction index will be set later on restore of train
 
@@ -8659,6 +8660,7 @@ namespace Orts.Simulation.Signalling
             outf.Write(ApproachControlSet);
             outf.Write(ClaimLocked);
             outf.Write(ForcePropOnApproachControl);
+            outf.Write((int)hasPermission);
             outf.Write(LockedTrains.Count);
             for (int cnt = 0; cnt < LockedTrains.Count; cnt++)
             {


### PR DESCRIPTION
See here http://www.elvastower.com/forums/index.php?/topic/33818-ai-behavior-state-is-not-saved/ .