### PR TITLE
Allowing manual CallOn from dispatcher window

### DIFF
--- a/Source/Orts.Simulation/MultiPlayer/Message.cs
+++ b/Source/Orts.Simulation/MultiPlayer/Message.cs
@@ -3535,10 +3535,7 @@ namespace Orts.MultiPlayer
                     }
                     break;
                 case 4:
-                    if (signal.enabledTrain != null)
-                    {
-                        signal.enabledTrain.Train.AllowedCallOnSignal = signal;
-                    }
+                    signal.SetManualCallOn(true);
                     break;
             }
         }

--- a/Source/Orts.Simulation/MultiPlayer/Message.cs
+++ b/Source/Orts.Simulation/MultiPlayer/Message.cs
@@ -3534,6 +3534,12 @@ namespace Orts.MultiPlayer
                         sigHead.draw_state = sigHead.def_draw_state(sigHead.state);
                     }
                     break;
+                case 4:
+                    if (signal.enabledTrain != null)
+                    {
+                        signal.enabledTrain.Train.AllowedCallOnSignal = signal;
+                    }
+                    break;
             }
         }
 

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -236,6 +236,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
         public int IndexNextSignal = -1;                 // Index in SignalObjectItems for next signal
         public int IndexNextSpeedlimit = -1;             // Index in SignalObjectItems for next speedpost
         public SignalObject[] NextSignalObject = new SignalObject[2];  // direct reference to next signal
+        public SignalObject AllowedCallOnSignal;         // Signal for which train has call on allowed by dispatcher
 
         public float TrainMaxSpeedMpS;                   // Max speed as set by route (default value)
         public float AllowedMaxSpeedMpS;                 // Max speed as allowed
@@ -2483,6 +2484,9 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 // system will take back control of the signal
                 if (signalObject.holdState == SignalObject.HoldState.ManualPass ||
                     signalObject.holdState == SignalObject.HoldState.ManualApproach) signalObject.holdState = SignalObject.HoldState.None;
+
+                if (AllowedCallOnSignal == signalObject)
+                    AllowedCallOnSignal = null;
             }
             UpdateSectionStateManual();                                                           // update track occupation          //
             UpdateManualMode(SignalObjIndex);                                                     // update route clearance           //
@@ -2510,6 +2514,9 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 // system will take back control of the signal
                 if (signalObject.holdState == SignalObject.HoldState.ManualPass ||
                     signalObject.holdState == SignalObject.HoldState.ManualApproach) signalObject.holdState = SignalObject.HoldState.None;
+
+                if (AllowedCallOnSignal == signalObject)
+                    AllowedCallOnSignal = null;
             }
             UpdateSectionStateExplorer();                                                         // update track occupation          //
             UpdateExplorerMode(SignalObjIndex);                                                   // update route clearance           //
@@ -7064,6 +7071,9 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     signalObject.holdState = SignalObject.HoldState.None;
                 }
 
+                if (AllowedCallOnSignal == signalObject)
+                    AllowedCallOnSignal = null;
+
                 signalObject.resetSignalEnabled();
             }
         }
@@ -7215,6 +7225,9 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
 
         public virtual bool TestCallOn(SignalObject thisSignal, bool allowOnNonePlatform, TCSubpathRoute thisRoute, string dumpfile)
         {
+            if (AllowedCallOnSignal == thisSignal)
+                return true;
+
             bool intoPlatform = false;
 
             foreach (Train.TCRouteElement routeElement in thisSignal.signalRoute)
@@ -7558,6 +7571,9 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 //the following is added by JTang, passing a hold signal, will take back control by the system
                 if (thisSignal.holdState == SignalObject.HoldState.ManualPass ||
                     thisSignal.holdState == SignalObject.HoldState.ManualApproach) thisSignal.holdState = SignalObject.HoldState.None;
+
+                if (AllowedCallOnSignal == thisSignal)
+                    AllowedCallOnSignal = null;
 
                 thisSignal.resetSignalEnabled();
             }

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -2485,8 +2485,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 if (signalObject.holdState == SignalObject.HoldState.ManualPass ||
                     signalObject.holdState == SignalObject.HoldState.ManualApproach) signalObject.holdState = SignalObject.HoldState.None;
 
-                if (AllowedCallOnSignal != NextSignalObject[0] && AllowedCallOnSignal != NextSignalObject[1])
-                    AllowedCallOnSignal = null;
+                AllowedCallOnSignal = null;
             }
             UpdateSectionStateManual();                                                           // update track occupation          //
             UpdateManualMode(SignalObjIndex);                                                     // update route clearance           //
@@ -2515,8 +2514,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 if (signalObject.holdState == SignalObject.HoldState.ManualPass ||
                     signalObject.holdState == SignalObject.HoldState.ManualApproach) signalObject.holdState = SignalObject.HoldState.None;
 
-                if (AllowedCallOnSignal != NextSignalObject[0] && AllowedCallOnSignal != NextSignalObject[1])
-                    AllowedCallOnSignal = null;
+                AllowedCallOnSignal = null;
             }
             UpdateSectionStateExplorer();                                                         // update track occupation          //
             UpdateExplorerMode(SignalObjIndex);                                                   // update route clearance           //
@@ -7071,8 +7069,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     signalObject.holdState = SignalObject.HoldState.None;
                 }
 
-                if (AllowedCallOnSignal != NextSignalObject[0] && AllowedCallOnSignal != NextSignalObject[1])
-                    AllowedCallOnSignal = null;
+                AllowedCallOnSignal = null;
 
                 signalObject.resetSignalEnabled();
             }
@@ -7572,8 +7569,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 if (thisSignal.holdState == SignalObject.HoldState.ManualPass ||
                     thisSignal.holdState == SignalObject.HoldState.ManualApproach) thisSignal.holdState = SignalObject.HoldState.None;
 
-                if (AllowedCallOnSignal != NextSignalObject[0] && AllowedCallOnSignal != NextSignalObject[1])
-                    AllowedCallOnSignal = null;
+                AllowedCallOnSignal = null;
 
                 thisSignal.resetSignalEnabled();
             }

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -2485,7 +2485,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 if (signalObject.holdState == SignalObject.HoldState.ManualPass ||
                     signalObject.holdState == SignalObject.HoldState.ManualApproach) signalObject.holdState = SignalObject.HoldState.None;
 
-                if (AllowedCallOnSignal == signalObject)
+                if (AllowedCallOnSignal != NextSignalObject[0] && AllowedCallOnSignal != NextSignalObject[1])
                     AllowedCallOnSignal = null;
             }
             UpdateSectionStateManual();                                                           // update track occupation          //
@@ -2515,7 +2515,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 if (signalObject.holdState == SignalObject.HoldState.ManualPass ||
                     signalObject.holdState == SignalObject.HoldState.ManualApproach) signalObject.holdState = SignalObject.HoldState.None;
 
-                if (AllowedCallOnSignal == signalObject)
+                if (AllowedCallOnSignal != NextSignalObject[0] && AllowedCallOnSignal != NextSignalObject[1])
                     AllowedCallOnSignal = null;
             }
             UpdateSectionStateExplorer();                                                         // update track occupation          //
@@ -7071,7 +7071,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                     signalObject.holdState = SignalObject.HoldState.None;
                 }
 
-                if (AllowedCallOnSignal == signalObject)
+                if (AllowedCallOnSignal != NextSignalObject[0] && AllowedCallOnSignal != NextSignalObject[1])
                     AllowedCallOnSignal = null;
 
                 signalObject.resetSignalEnabled();
@@ -7572,7 +7572,7 @@ public float TrainCurrentCarriageHeatTempC;     // Current train carriage heat
                 if (thisSignal.holdState == SignalObject.HoldState.ManualPass ||
                     thisSignal.holdState == SignalObject.HoldState.ManualApproach) thisSignal.holdState = SignalObject.HoldState.None;
 
-                if (AllowedCallOnSignal == thisSignal)
+                if (AllowedCallOnSignal != NextSignalObject[0] && AllowedCallOnSignal != NextSignalObject[1])
                     AllowedCallOnSignal = null;
 
                 thisSignal.resetSignalEnabled();

--- a/Source/Orts.Simulation/Simulation/Signalling/SIGSCRfile.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/SIGSCRfile.cs
@@ -1026,6 +1026,7 @@ namespace Orts.Simulation.Signalling
                         dumpfile = String.Concat(dpr_fileLoc, "printproc.txt");
                     }
 #endif
+                    thisHead.mainSignal.CallOnEnabled = true;
                     temp_value = thisHead.mainSignal.TrainHasCallOn(true, dumpfile);
                     return_value = Convert.ToInt32(temp_value);
                     break;
@@ -1048,6 +1049,7 @@ namespace Orts.Simulation.Signalling
                         dumpfile = String.Concat(dpr_fileLoc, "printproc.txt");
                     }
 #endif
+                    thisHead.mainSignal.CallOnEnabled = true;
                     temp_value = thisHead.mainSignal.TrainHasCallOn(false, dumpfile);
                     return_value = Convert.ToInt32(temp_value);
                     break;

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -8358,7 +8358,7 @@ namespace Orts.Simulation.Signalling
         public bool StationHold = false;        // Set if signal must be held at station - processed by signal script
         protected List<KeyValuePair<int, int>> LockedTrains;
 
-        public bool CallOnEnabled = false;
+        public bool CallOnEnabled = false;      // set if signal script file uses CallOn functionality
 
         public bool enabled
         {
@@ -12514,6 +12514,8 @@ namespace Orts.Simulation.Signalling
             bool[] returnValue = new bool[2] { false, false };
             MstsSignalAspect thisAspect = this_sig_lr(MstsSignalFunction.NORMAL);
 
+            SetManualCallOn(false);
+
             // signal not enabled - set lock, reset if cleared (auto signal can clear without enabling)
 
             if (enabledTrain == null || enabledTrain.Train == null)
@@ -12579,6 +12581,20 @@ namespace Orts.Simulation.Signalling
             holdState = HoldState.None;
         }
 
+        //================================================================================================//
+        /// <summary>
+        /// Set call on manually from dispatcher
+        /// </summary>
+        public void SetManualCallOn(bool state)
+        {
+            if (enabledTrain != null)
+            {
+                if (state && CallOnEnabled)
+                    enabledTrain.Train.AllowedCallOnSignal = this;
+                else if (enabledTrain.Train.AllowedCallOnSignal == this)
+                    enabledTrain.Train.AllowedCallOnSignal = null;
+            }
+        }
     }  // SignalObject
 
 

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -8358,6 +8358,8 @@ namespace Orts.Simulation.Signalling
         public bool StationHold = false;        // Set if signal must be held at station - processed by signal script
         protected List<KeyValuePair<int, int>> LockedTrains;
 
+        public bool CallOnEnabled = false;
+
         public bool enabled
         {
             get

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -12590,9 +12590,14 @@ namespace Orts.Simulation.Signalling
             if (enabledTrain != null)
             {
                 if (state && CallOnEnabled)
+                {
                     enabledTrain.Train.AllowedCallOnSignal = this;
+                    clearHoldSignalDispatcher();
+                }
                 else if (enabledTrain.Train.AllowedCallOnSignal == this)
+                {
                     enabledTrain.Train.AllowedCallOnSignal = null;
+                }
             }
         }
     }  // SignalObject

--- a/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
@@ -1530,7 +1530,18 @@ namespace Orts.Viewer3D.Debugging
 		  var y = LastCursorPosition.Y;
 		  if (LastCursorPosition.Y < 100) y = 100;
 		  if (LastCursorPosition.Y > pictureBox1.Size.Height - 100) y = pictureBox1.Size.Height - 100;
-		  boxSetSignal.Location = new System.Drawing.Point(LastCursorPosition.X + 2, y);
+
+          if (boxSetSignal.Items.Count == 5)
+              boxSetSignal.Items.RemoveAt(4);
+
+          if (signalPickedItem.Signal.enabledTrain != null && signalPickedItem.Signal.CallOnEnabled)
+          {
+              /*if (signalPickedItem.Signal.enabledTrain.Train.AllowedCallOnSignal == signalPickedItem.Signal)
+                  boxSetSignal.Items.Add("Disable call on");*/
+              boxSetSignal.Items.Add("Enable call on");
+          }
+           
+          boxSetSignal.Location = new System.Drawing.Point(LastCursorPosition.X + 2, y);
 		  boxSetSignal.Enabled = true;
 		  boxSetSignal.Focus();
 		  boxSetSignal.SelectedIndex = -1;
@@ -1965,6 +1976,12 @@ namespace Orts.Viewer3D.Debugging
                       sigHead.draw_state = sigHead.def_draw_state(sigHead.state);
                   }
 				  break;
+              case 4: 
+                  if (signal.enabledTrain != null)
+                  {
+                      signal.enabledTrain.Train.AllowedCallOnSignal = signal;
+                  }
+                  break;
 		  }
 		  UnHandleItemPick();
 	  }

--- a/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
@@ -1531,17 +1531,20 @@ namespace Orts.Viewer3D.Debugging
 		  if (LastCursorPosition.Y < 100) y = 100;
 		  if (LastCursorPosition.Y > pictureBox1.Size.Height - 100) y = pictureBox1.Size.Height - 100;
 
-          if (boxSetSignal.Items.Count == 5)
-              boxSetSignal.Items.RemoveAt(4);
+		  if (boxSetSignal.Items.Count == 5)
+			  boxSetSignal.Items.RemoveAt(4);
 
-          if (signalPickedItem.Signal.enabledTrain != null && signalPickedItem.Signal.CallOnEnabled)
-          {
-              /*if (signalPickedItem.Signal.enabledTrain.Train.AllowedCallOnSignal == signalPickedItem.Signal)
-                  boxSetSignal.Items.Add("Disable call on");*/
-              boxSetSignal.Items.Add("Enable call on");
-          }
-           
-          boxSetSignal.Location = new System.Drawing.Point(LastCursorPosition.X + 2, y);
+		  if (signalPickedItem.Signal.enabledTrain != null && signalPickedItem.Signal.CallOnEnabled)
+		  {
+			  if (signalPickedItem.Signal.enabledTrain.Train.AllowedCallOnSignal != signalPickedItem.Signal)
+			  boxSetSignal.Items.Add("Enable call on");
+			  /*else
+				  boxSetSignal.Items.Add("Disable call on");*/
+			  // To disable Call On signal must be manually set to stop, to avoid signal state change
+			  // in the interval between this list is shown and the option is selected by dispatcher
+		  }
+
+		  boxSetSignal.Location = new System.Drawing.Point(LastCursorPosition.X + 2, y);
 		  boxSetSignal.Enabled = true;
 		  boxSetSignal.Focus();
 		  boxSetSignal.SelectedIndex = -1;
@@ -1976,11 +1979,8 @@ namespace Orts.Viewer3D.Debugging
                       sigHead.draw_state = sigHead.def_draw_state(sigHead.state);
                   }
 				  break;
-              case 4: 
-                  if (signal.enabledTrain != null)
-                  {
-                      signal.enabledTrain.Train.AllowedCallOnSignal = signal;
-                  }
+              case 4:
+                  signal.SetManualCallOn(true);
                   break;
 		  }
 		  UnHandleItemPick();


### PR DESCRIPTION
In activity mode, TrainHasCallOn() and TrainHasCallOn_Restricted() sigscr functions will always return the same value for the same signal. I add the possibility of manually allowing a train to call on, selecting an option in signal's menu of dispatcher window. This option is only available in signals whose scripts make use of call on functions.
Discussion: http://www.elvastower.com/forums/index.php?/topic/33899-manual-shunting-using-dispatcher-window/
Roadmap: https://trello.com/c/I19VVKlz