### PR TITLE
Add 2D cab letterboxing feature

### DIFF
--- a/Source/ORTS.Common/Input/UserCommand.cs
+++ b/Source/ORTS.Common/Input/UserCommand.cs
@@ -75,6 +75,7 @@
         [GetString("Camera Change Passenger Viewpoint")] CameraChangePassengerViewPoint,
         [GetString("Camera 3D Cab")] CameraThreeDimensionalCab,
         [GetString("Camera Toggle Show Cab")] CameraToggleShowCab,
+        [GetString("Camera Toggle Letterbox Cab")] CameraToggleLetterboxCab,
         [GetString("Camera Head Out Forward")] CameraHeadOutForward,
         [GetString("Camera Head Out Backward")] CameraHeadOutBackward,
         [GetString("Camera Outside Front")] CameraOutsideFront,

--- a/Source/ORTS.Settings/InputSettings.cs
+++ b/Source/ORTS.Settings/InputSettings.cs
@@ -331,6 +331,7 @@ namespace ORTS.Settings
             Commands[(int)UserCommand.CameraScrollLeft] = new UserCommandModifiableKeyInput(0x4B, KeyModifiers.Alt);
             Commands[(int)UserCommand.CameraScrollRight] = new UserCommandModifiableKeyInput(0x4D, KeyModifiers.Alt);
             Commands[(int)UserCommand.CameraChangePassengerViewPoint] = new UserCommandKeyInput(0x06, KeyModifiers.Shift);
+            Commands[(int)UserCommand.CameraToggleLetterboxCab] = new UserCommandKeyInput(0x02, KeyModifiers.Control);
             Commands[(int)UserCommand.CameraToggleShowCab] = new UserCommandKeyInput(0x02, KeyModifiers.Shift);
             Commands[(int)UserCommand.CameraTrackside] = new UserCommandKeyInput(0x05);
             Commands[(int)UserCommand.CameraSpecialTracksidePoint] = new UserCommandKeyInput(0x05, KeyModifiers.Shift);

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -339,6 +339,8 @@ namespace ORTS.Settings
         [Default(false)]
         public bool DataLogger { get; set; }
         [Default(false)]
+        public bool Letterbox2DCab { get; set; }
+        [Default(false)]
         public bool Profiling { get; set; }
         [Default(0)]
         public int ProfilingFrameCount { get; set; }

--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -2198,6 +2198,11 @@ namespace Orts.Viewer3D
                 ScrollRight(true, speed);
             if (UserInput.IsDown(UserCommand.CameraScrollLeft))
                 ScrollRight(false, speed);
+            if (UserInput.IsPressed(UserCommand.CameraToggleLetterboxCab))
+            {
+                Viewer.Settings.Letterbox2DCab = !Viewer.Settings.Letterbox2DCab;
+                Viewer.AdjustCabHeight(Viewer.DisplaySize.X, Viewer.DisplaySize.Y);
+            }
         }
     }
 

--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -2025,7 +2025,12 @@ namespace Orts.Viewer3D
 
         public void Initialize()
         {
-            if (Viewer.Settings.Cab2DStretch == 0 && Viewer.CabExceedsDisplayHorizontally <= 0)
+            if (Viewer.Settings.Letterbox2DCab)
+            {
+                float fovFactor = 1f - Math.Max((float)Viewer.CabXLetterboxPixels / Viewer.DisplaySize.X, (float)Viewer.CabYLetterboxPixels / Viewer.DisplaySize.Y);
+                FieldOfView = MathHelper.ToDegrees((float)(2 * Math.Atan(fovFactor * Math.Tan(MathHelper.ToRadians(Viewer.Settings.ViewingFOV / 2)))));
+            }
+            else if (Viewer.Settings.Cab2DStretch == 0 && Viewer.CabExceedsDisplayHorizontally <= 0)
             {
                 // We must modify FOV to get correct lookout
                     FieldOfView = MathHelper.ToDegrees((float)(2 * Math.Atan((float)Viewer.DisplaySize.Y / Viewer.DisplaySize.X / Viewer.CabTextureInverseRatio * Math.Tan(MathHelper.ToRadians(Viewer.Settings.ViewingFOV / 2)))));
@@ -2202,6 +2207,8 @@ namespace Orts.Viewer3D
             {
                 Viewer.Settings.Letterbox2DCab = !Viewer.Settings.Letterbox2DCab;
                 Viewer.AdjustCabHeight(Viewer.DisplaySize.X, Viewer.DisplaySize.Y);
+                if (attachedCar != null)
+                    Initialize();
             }
         }
     }

--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -2109,7 +2109,7 @@ namespace Orts.Viewer3D
         void PanUp(bool up, float speed)
         {
             int max = 0;
-            int min = Viewer.DisplaySize.Y - Viewer.CabHeightPixels; // -ve value
+            int min = Viewer.DisplaySize.Y - Viewer.CabHeightPixels - 2 * Viewer.CabYLetterboxPixels; // -ve value
             int cushionPixels = 40;
             int slowFactor = 4;
 
@@ -2143,7 +2143,7 @@ namespace Orts.Viewer3D
         void ScrollRight (bool right, float speed)
         {
             int min = 0;
-            int max = Viewer.CabWidthPixels - Viewer.DisplaySize.X; // -ve value
+            int max = Viewer.CabWidthPixels - Viewer.DisplaySize.X - 2 * Viewer.CabXLetterboxPixels; // -ve value
             int cushionPixels = 40;
             int slowFactor = 4;
 

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -1282,6 +1282,10 @@ namespace Orts.Viewer3D.RollingStock
             _CabRect.Width = _Viewer.CabWidthPixels;
             _CabRect.Height = _Viewer.CabHeightPixels;
 
+            // Cab view position adjusted to allow for letterboxing
+            _CabRect.X = _Viewer.CabXLetterboxPixels;
+            _CabRect.Y = _Viewer.CabYLetterboxPixels;
+
             if (_PrevScreenSize != _Viewer.DisplaySize && _Shader != null)
             {
                 _PrevScreenSize = _Viewer.DisplaySize;
@@ -1334,6 +1338,24 @@ namespace Orts.Viewer3D.RollingStock
                 else
                 {
                     _SpriteShader2DCabView.SpriteBatch.Draw(_CabTexture, stretchedCab, Color.White);
+                }
+
+                // Draw letterboxing.
+                Texture2D letterboxTexture = new Texture2D(graphicsDevice, 1, 1);
+                letterboxTexture.SetData<Color>(new Color[] { Color.Black });
+                Action<int, int, int, int> drawLetterbox = (x, y, w, h) =>
+                {
+                    _SpriteShader2DCabView.SpriteBatch.Draw(letterboxTexture, new Rectangle(x, y, w, h), Color.White);
+                };
+                if (_Viewer.CabXLetterboxPixels > 0)
+                {
+                    drawLetterbox(0, 0, _Viewer.CabXLetterboxPixels, _Viewer.DisplaySize.Y);
+                    drawLetterbox(_Viewer.CabXLetterboxPixels + _Viewer.CabWidthPixels, 0, _Viewer.DisplaySize.X - _Viewer.CabWidthPixels - _Viewer.CabXLetterboxPixels, _Viewer.DisplaySize.Y);
+                }
+                if (_Viewer.CabYLetterboxPixels > 0)
+                {
+                    drawLetterbox(0, 0, _Viewer.DisplaySize.X, _Viewer.CabYLetterboxPixels);
+                    drawLetterbox(0, _Viewer.CabYLetterboxPixels + _Viewer.CabHeightPixels, _Viewer.DisplaySize.X, _Viewer.DisplaySize.Y - _Viewer.CabHeightPixels - _Viewer.CabYLetterboxPixels);
                 }
             }
         }
@@ -1463,7 +1485,11 @@ namespace Orts.Viewer3D.RollingStock
             // Cab view height and vertical position adjusted to allow for clip or stretch.
             Position.X = (float)Viewer.CabWidthPixels / 640 * ((float)Control.PositionX + Origin.X * Scale) - Viewer.CabXOffsetPixels;
             Position.Y = (float)Viewer.CabHeightPixels / 480 * ((float)Control.PositionY + Origin.Y * Scale) + Viewer.CabYOffsetPixels;
-            ScaleToScreen = (float)Viewer.DisplaySize.X / 640 * Scale;
+            ScaleToScreen = (float)Viewer.CabWidthPixels / 640 * Scale;
+
+            // Cab view position adjusted to allow for letterboxing.
+            Position.X += Viewer.CabXLetterboxPixels;
+            Position.Y += Viewer.CabYLetterboxPixels;
 
             var rangeFraction = GetRangeFraction();
             var direction = ControlDial.Direction == 0 ? 1 : -1;
@@ -1650,6 +1676,10 @@ namespace Orts.Viewer3D.RollingStock
                     else DrawColor = new Color(Gauge.PositiveColor.R, Gauge.PositiveColor.G, Gauge.PositiveColor.B, Gauge.PositiveColor.A);
                 }
             }
+
+            // Cab view position adjusted to allow for letterboxing.
+            DestinationRectangle.X += Viewer.CabXLetterboxPixels;
+            DestinationRectangle.Y += Viewer.CabYLetterboxPixels;
         }
 
         public override void Draw(GraphicsDevice graphicsDevice)
@@ -1739,6 +1769,10 @@ namespace Orts.Viewer3D.RollingStock
             DestinationRectangle.Y = (int)(yratio * Control.PositionY * 1.0001) + Viewer.CabYOffsetPixels;
             DestinationRectangle.Width = (int)(xratio * Math.Min(Control.Width, Texture.Width));  // Allow only downscaling of the texture, and not upscaling
             DestinationRectangle.Height = (int)(yratio * Math.Min(Control.Height, Texture.Height));  // Allow only downscaling of the texture, and not upscaling
+
+            // Cab view position adjusted to allow for letterboxing.
+            DestinationRectangle.X += Viewer.CabXLetterboxPixels;
+            DestinationRectangle.Y += Viewer.CabYLetterboxPixels;
         }
 
         public override void Draw(GraphicsDevice graphicsDevice)
@@ -2116,6 +2150,10 @@ namespace Orts.Viewer3D.RollingStock
             DrawPosition.Y = (int)((Position.Y + Control.Height / 2) * Viewer.CabHeightPixels / 480) - DrawFont.Height / 2 + Viewer.CabYOffsetPixels;
             DrawPosition.Width = (int)(Control.Width * Viewer.DisplaySize.X / 640);
             DrawPosition.Height = (int)(Control.Height * Viewer.DisplaySize.Y / 480);
+
+            // Cab view position adjusted to allow for letterboxing.
+            DrawPosition.X += Viewer.CabXLetterboxPixels;
+            DrawPosition.Y += Viewer.CabYLetterboxPixels;
 
             if (Control.ControlType == CABViewControlTypes.CLOCK)
             {

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -1015,7 +1015,6 @@ namespace Orts.Viewer3D.RollingStock
     public class CabRenderer : RenderPrimitive
     {
         private CabSpriteBatchMaterial _SpriteShader2DCabView;
-        private Rectangle _CabRect = new Rectangle();
         private Matrix _Scale = Matrix.Identity;
         private Texture2D _CabTexture;
         private CabShader _Shader;  // Shaders must have unique Keys - below
@@ -1278,14 +1277,6 @@ namespace Orts.Viewer3D.RollingStock
             if (_CabTexture == SharedMaterialManager.MissingTexture)
                 return;
 
-            // Cab view height adjusted to allow for clip or stretch
-            _CabRect.Width = _Viewer.CabWidthPixels;
-            _CabRect.Height = _Viewer.CabHeightPixels;
-
-            // Cab view position adjusted to allow for letterboxing
-            _CabRect.X = _Viewer.CabXLetterboxPixels;
-            _CabRect.Y = _Viewer.CabYLetterboxPixels;
-
             if (_PrevScreenSize != _Viewer.DisplaySize && _Shader != null)
             {
                 _PrevScreenSize = _Viewer.DisplaySize;
@@ -1304,59 +1295,51 @@ namespace Orts.Viewer3D.RollingStock
 
         public override void Draw(GraphicsDevice graphicsDevice)
         {
+            var cabScale = new Vector2((float)_Viewer.CabWidthPixels / _CabTexture.Width, (float)_Viewer.CabHeightPixels / _CabTexture.Height);
             // Cab view vertical position adjusted to allow for clip or stretch.
-            Rectangle stretchedCab;
-            if (_Viewer.Simulator.CarVibrating > 0 || _Viewer.Simulator.UseSuperElevation > 0 || _Locomotive.Train.IsTilting)
+            var cabPos = new Vector2(_Viewer.CabXOffsetPixels / cabScale.X, -_Viewer.CabYOffsetPixels / cabScale.Y);
+            var cabSize = new Vector2((_Viewer.CabWidthPixels - _Viewer.CabExceedsDisplayHorizontally) / cabScale.X, (_Viewer.CabHeightPixels - _Viewer.CabExceedsDisplay) / cabScale.Y);
+            int round(float x)
             {
-                if (_CabTexture != null)
-                    stretchedCab = new Rectangle(-50, -40, _CabTexture.Width + 100, _CabTexture.Height + 80);
-                else stretchedCab = new Rectangle(_CabRect.Left - _Viewer.CabXOffsetPixels, _CabRect.Top + _Viewer.CabYOffsetPixels, _CabRect.Width, _CabRect.Height);
+                return (int)Math.Round(x);
             }
-            else
-                stretchedCab = new Rectangle(_CabRect.Left - _Viewer.CabXOffsetPixels, _CabRect.Top + _Viewer.CabYOffsetPixels, _CabRect.Width, _CabRect.Height);
+            var cabRect = new Rectangle(round(cabPos.X), round(cabPos.Y), round(cabSize.X), round(cabSize.Y));
 
             if (_Shader != null)
             {
                 // TODO: Readd ability to control night time lighting.
-                if (_Viewer.Settings.UseMSTSEnv == false)
-                    _Shader.SetData(_Viewer.MaterialManager.sunDirection, _isNightTexture, false, _Viewer.Simulator.Weather.OvercastFactor);
-                else
-                    _Shader.SetData(_Viewer.MaterialManager.sunDirection, _isNightTexture, false, _Viewer.World.MSTSSky.mstsskyovercastFactor);
-
-                _Shader.SetTextureData(stretchedCab.Left, stretchedCab.Top, stretchedCab.Width, stretchedCab.Height);
+                float overcast = _Viewer.Settings.UseMSTSEnv ? _Viewer.World.MSTSSky.mstsskyovercastFactor : _Viewer.Simulator.Weather.OvercastFactor;
+                _Shader.SetData(_Viewer.MaterialManager.sunDirection, _isNightTexture, false, overcast);
+                _Shader.SetTextureData(cabRect.Left, cabRect.Top, cabRect.Width, cabRect.Height);
             }
 
-            if (_CabTexture != null)
-            {
-                if (this._Viewer.Simulator.UseSuperElevation > 0 || _Viewer.Simulator.CarVibrating > 0 || _Locomotive.Train.IsTilting)
-                {
-                    var scale = new Vector2((float)_CabRect.Width / _CabTexture.Width, (float)_CabRect.Height / _CabTexture.Height);
-                    var place = new Vector2(_CabRect.Width / 2 - _Viewer.CabXOffsetPixels - 50 * scale.X, _CabRect.Height / 2 + _Viewer.CabYOffsetPixels - 40 * scale.Y);
-                    var place2 = new Vector2(_CabTexture.Width / 2, _CabTexture.Height / 2);
-                    _SpriteShader2DCabView.SpriteBatch.Draw(_CabTexture, place, stretchedCab, Color.White, 0, place2, scale, SpriteEffects.None, 0f);
-                }
-                else
-                {
-                    _SpriteShader2DCabView.SpriteBatch.Draw(_CabTexture, stretchedCab, Color.White);
-                }
+            if (_CabTexture == null)
+                return;
 
-                // Draw letterboxing.
-                Texture2D letterboxTexture = new Texture2D(graphicsDevice, 1, 1);
-                letterboxTexture.SetData<Color>(new Color[] { Color.Black });
-                Action<int, int, int, int> drawLetterbox = (x, y, w, h) =>
-                {
-                    _SpriteShader2DCabView.SpriteBatch.Draw(letterboxTexture, new Rectangle(x, y, w, h), Color.White);
-                };
-                if (_Viewer.CabXLetterboxPixels > 0)
-                {
-                    drawLetterbox(0, 0, _Viewer.CabXLetterboxPixels, _Viewer.DisplaySize.Y);
-                    drawLetterbox(_Viewer.CabXLetterboxPixels + _Viewer.CabWidthPixels, 0, _Viewer.DisplaySize.X - _Viewer.CabWidthPixels - _Viewer.CabXLetterboxPixels, _Viewer.DisplaySize.Y);
-                }
-                if (_Viewer.CabYLetterboxPixels > 0)
-                {
-                    drawLetterbox(0, 0, _Viewer.DisplaySize.X, _Viewer.CabYLetterboxPixels);
-                    drawLetterbox(0, _Viewer.CabYLetterboxPixels + _Viewer.CabHeightPixels, _Viewer.DisplaySize.X, _Viewer.DisplaySize.Y - _Viewer.CabHeightPixels - _Viewer.CabYLetterboxPixels);
-                }
+            var drawOrigin = new Vector2(_CabTexture.Width / 2, _CabTexture.Height / 2);
+            var drawPos = new Vector2(_Viewer.CabWidthPixels / 2, _Viewer.CabHeightPixels / 2);
+            // Cab view position adjusted to allow for letterboxing.
+            drawPos.X += _Viewer.CabXLetterboxPixels;
+            drawPos.Y += _Viewer.CabYLetterboxPixels;
+
+            _SpriteShader2DCabView.SpriteBatch.Draw(_CabTexture, drawPos, cabRect, Color.White, 0f, drawOrigin, cabScale, SpriteEffects.None, 0f);
+
+            // Draw letterboxing.
+            Texture2D letterboxTexture = new Texture2D(graphicsDevice, 1, 1);
+            letterboxTexture.SetData<Color>(new Color[] { Color.Black });
+            void drawLetterbox(int x, int y, int w, int h)
+            {
+                _SpriteShader2DCabView.SpriteBatch.Draw(letterboxTexture, new Rectangle(x, y, w, h), Color.White);
+            }
+            if (_Viewer.CabXLetterboxPixels > 0)
+            {
+                drawLetterbox(0, 0, _Viewer.CabXLetterboxPixels, _Viewer.DisplaySize.Y);
+                drawLetterbox(_Viewer.CabXLetterboxPixels + _Viewer.CabWidthPixels, 0, _Viewer.DisplaySize.X - _Viewer.CabWidthPixels - _Viewer.CabXLetterboxPixels, _Viewer.DisplaySize.Y);
+            }
+            if (_Viewer.CabYLetterboxPixels > 0)
+            {
+                drawLetterbox(0, 0, _Viewer.DisplaySize.X, _Viewer.CabYLetterboxPixels);
+                drawLetterbox(0, _Viewer.CabYLetterboxPixels + _Viewer.CabHeightPixels, _Viewer.DisplaySize.X, _Viewer.DisplaySize.Y - _Viewer.CabHeightPixels - _Viewer.CabYLetterboxPixels);
             }
         }
 

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -169,9 +169,10 @@ namespace Orts.Viewer3D
 
         // MSTS cab views are images with aspect ratio 4:3.
         // OR can use cab views with other aspect ratios where these are available.
-        // On screen with other aspect ratios (e.g. 16:9), two approaches are possible:
+        // On screen with other aspect ratios (e.g. 16:9), three approaches are possible:
         //   1) stretch the width to fit the screen. This gives flattened controls, most noticeable with round dials.
         //   2) clip the image losing a slice off top and bottom.
+        //   3) letterbox the image by drawing black bars in the unfilled spaces.
         // Setting.Cab2DStretch controls the amount of stretch and clip. 0 is entirely clipped and 100 is entirely stretched.
         // No difference is seen on screens with 4:3 aspect ratio.
         // This adjustment assumes that the cab view is 4:3. Where the cab view matches the aspect ratio of the screen, use an adjustment of 100.
@@ -181,6 +182,8 @@ namespace Orts.Viewer3D
         public int CabXOffsetPixels { get; set; }
         public int CabExceedsDisplay; // difference between cabview texture vertical resolution and display vertical resolution
         public int CabExceedsDisplayHorizontally; // difference between cabview texture horizontal resolution and display vertical resolution
+        public int CabYLetterboxPixels { get; set; } // offset the cab when drawing it if it is smaller than the display; both coordinates should always be >= 0
+        public int CabXLetterboxPixels { get; set; }
         public float CabTextureInverseRatio = 0.75f; // default of inverse of cab texture ratio 
 
         public CommandLog Log { get { return Simulator.Log; } }
@@ -618,28 +621,41 @@ namespace Orts.Viewer3D
             }
             int unstretchedCabHeightPixels = (int)(CabTextureInverseRatio * windowWidth);
             int unstretchedCabWidthPixels = (int)(windowHeight / CabTextureInverseRatio);
-            if (((float)windowHeight / windowWidth) < CabTextureInverseRatio)
+            float windowInverseRatio = (float)windowHeight / windowWidth;
+            if (Settings.Letterbox2DCab)
             {
-                // screen is wide-screen, so can choose between vertical scroll or horizontal stretch
-                CabExceedsDisplay = (int)((unstretchedCabHeightPixels - windowHeight) * ((100 - Settings.Cab2DStretch) / 100f));
-                CabExceedsDisplayHorizontally = 0;
-            }
-            else if (((float)windowHeight / windowWidth) > CabTextureInverseRatio)
-            {
-                // must scroll horizontally
-                CabExceedsDisplay = 0;
-                CabExceedsDisplayHorizontally = unstretchedCabWidthPixels - windowWidth;
+                CabWidthPixels = Math.Min((int)Math.Round(windowHeight / CabTextureInverseRatio), windowWidth);
+                CabHeightPixels = Math.Min((int)Math.Round(windowWidth * CabTextureInverseRatio), windowHeight);
+                CabXLetterboxPixels = (windowWidth - CabWidthPixels) / 2;
+                CabYLetterboxPixels = (windowHeight - CabHeightPixels) / 2;
+                CabExceedsDisplay = CabExceedsDisplayHorizontally = CabXOffsetPixels = CabYOffsetPixels = 0;
             }
             else
             {
-                // nice, window aspect ratio and cabview aspect ratio are identical
-                CabExceedsDisplay = 0;
-                CabExceedsDisplayHorizontally = 0;
+                if (windowInverseRatio == CabTextureInverseRatio)
+                {
+                    // nice, window aspect ratio and cabview aspect ratio are identical
+                    CabExceedsDisplay = 0;
+                    CabExceedsDisplayHorizontally = 0;
+                }
+                else if (windowInverseRatio < CabTextureInverseRatio)
+                {
+                    // screen is wide-screen, so can choose between vertical scroll or horizontal stretch
+                    CabExceedsDisplay = (int)((unstretchedCabHeightPixels - windowHeight) * ((100 - Settings.Cab2DStretch) / 100f));
+                    CabExceedsDisplayHorizontally = 0;
+                }
+                else
+                {
+                    // must scroll horizontally
+                    CabExceedsDisplay = 0;
+                    CabExceedsDisplayHorizontally = unstretchedCabWidthPixels - windowWidth;
+                }
+                CabHeightPixels = windowHeight + CabExceedsDisplay;
+                CabYOffsetPixels = -CabExceedsDisplay / 2; // Initial value is halfway. User can adjust with arrow keys.
+                CabWidthPixels = windowWidth + CabExceedsDisplayHorizontally;
+                CabXOffsetPixels = CabExceedsDisplayHorizontally / 2;
+                CabXLetterboxPixels = CabYLetterboxPixels = 0;
             }
-            CabHeightPixels = windowHeight + CabExceedsDisplay;
-            CabYOffsetPixels = -CabExceedsDisplay / 2; // Initial value is halfway. User can adjust with arrow keys.
-            CabWidthPixels = windowWidth + CabExceedsDisplayHorizontally;
-            CabXOffsetPixels = CabExceedsDisplayHorizontally / 2;
             if (CabCamera.IsAvailable) CabCamera.Initialize();
         }
 


### PR DESCRIPTION
Add a letterboxing feature for 2D cabs with non-matching aspect ratios. Turns on/off with Ctrl+1.

[Trello card.](http://www.elvastower.com/forums/index.php/topic/33908-letterboxing-for-2d-cabs/) [Elvas Tower discussion.](http://www.elvastower.com/forums/index.php/topic/33908-letterboxing-for-2d-cabs/)