### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1874383 Remote player trains at standstill not updated in MP

### DIFF
--- a/Source/Orts.Simulation/Simulation/Simulator.cs
+++ b/Source/Orts.Simulation/Simulation/Simulator.cs
@@ -674,7 +674,7 @@ namespace Orts.Simulation
 
             foreach (Train train in Trains)
             {
-                if (train.SpeedMpS != 0 &&
+                if ((train.SpeedMpS != 0 || (train.ControlMode == Train.TRAIN_CONTROL.EXPLORER && train.TrainType == Train.TRAINTYPE.REMOTE && MPManager.IsServer())) &&
                     train.GetType() != typeof(AITrain) && train.GetType() != typeof(TTTrain) &&
                     (PlayerLocomotive == null || train != PlayerLocomotive.Train))
                 {


### PR DESCRIPTION
When a remote train is at standstill, the server won't update its route, so signals aren't properly cleared. If a signal is at danger, the train has to move a bit to clear it. With this fix player trains controlled remotely are updated if stopped (only in server), as is done with local player train.