### PR TITLE
Web server documentation and bug fixes

### DIFF
--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -210,6 +210,9 @@ When activated, the server can be accessed (on the local machine only) at
            | data types.
          - Orts.Viewer3D.WebServices.WebServer.ApiSampleData
 
+    There is no rate-limiting or caching, so mind your API calls' effects on the
+    simulator's performance.
+
 Audio Options
 =============
 

--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -168,6 +168,48 @@ Disable TCS scripts
 This option disables the train control system scripts for locomotives where
 these have been implemented.
 
+Enable web server
+-----------------
+
+This option enables an internal web server that can be used to display game and
+train status information in a browser, intended for use on secondary screens.
+When activated, the server can be accessed (on the local machine only) at
+``http://localhost:<port>``, where ``<port>`` is the specified port number.
+
+.. admonition:: For core developers
+
+    The web server serves content out of the ``Content\Web`` subfolder of the OR
+    program folder; it features a simple API to obtain data from the simulator.
+    Responses are OR data structures
+    `serialized <https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_JsonConvert.htm>`_
+    in JSON format. API call paths are case-sensitive.
+
+    .. list-table::
+       :widths: 15 15 35 35
+       :header-rows: 1
+
+       * - Method
+         - API call
+         - Description
+         - Response type
+       * - POST
+         - ``/API/HUD``
+         - | Retrieves the information rendered on the ``<F5>`` HUD, row by row,
+           | page by page. POST data should be ``=<n>`` where ``<n>`` is the
+           | desired HUD page number.
+         - Orts.Viewer3D.WebServices.WebServer.HudApiArray
+       * - GET
+         - | ``/API/TRAINMONITOR``
+           | or ``/API/TRAININFO``
+         - | Retrieves information rendered on the Track Monitor, such as speed,
+           | acceleration, grade, and upcoming hazards.
+         - Orts.Simulation.Physics.Train.TrainInfo
+       * - GET
+         - ``/API/APISAMPLE``
+         - | A test object that demonstrates the JSON serialization of various
+           | data types.
+         - Orts.Viewer3D.WebServices.WebServer.ApiSampleData
+
 Audio Options
 =============
 

--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -182,7 +182,7 @@ When activated, the server can be accessed (on the local machine only) at
     program folder; it features a simple API to obtain data from the simulator.
     Responses are OR data structures
     `serialized <https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_JsonConvert.htm>`_
-    in JSON format. API call paths are case-sensitive.
+    in JSON format.
 
     .. list-table::
        :widths: 15 15 35 35

--- a/Source/RunActivity/RunActivity.csproj
+++ b/Source/RunActivity/RunActivity.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/Source/RunActivity/RunActivity.csproj
+++ b/Source/RunActivity/RunActivity.csproj
@@ -396,9 +396,25 @@
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
   -->
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <WebContent Include="Viewer3D\WebServices\Web\*.*" />
+    </ItemGroup>
+    <ItemGroup>
+      <WebContentCss Include="Viewer3D\WebServices\Web\css\*.*" />
+    </ItemGroup>
+    <ItemGroup>
+      <WebContentImages Include="Viewer3D\WebServices\Web\images\*.*" />
+    </ItemGroup>
+    <ItemGroup>
+      <WebContentJs Include="Viewer3D\WebServices\Web\js\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(WebContent)" DestinationFolder="$(OutputPath)\Content\Web" ContinueOnError="true" />
+    <Copy SourceFiles="@(WebContentCss)" DestinationFolder="$(OutputPath)\Content\Web\css" ContinueOnError="true" />
+    <Copy SourceFiles="@(WebContentImages)" DestinationFolder="$(OutputPath)\Content\Web\images" ContinueOnError="true" />
+    <Copy SourceFiles="@(WebContentJs)" DestinationFolder="$(OutputPath)\Content\Web\js" ContinueOnError="true" />
+  </Target>
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/RunActivity/Viewer3D/WebServices/Web/js/ApiTrainInfo.js
+++ b/Source/RunActivity/Viewer3D/WebServices/Web/js/ApiTrainInfo.js
@@ -8,7 +8,7 @@ function ApiTrainInfo() {
         if (this.readyState == 4 && this.status == 200) {
             var obj = JSON.parse(hr.responseText);
 
-            strTrainInfoData.innerHTML = obj.allowedSpeedMps;
+            strTrainInfoData.innerHTML = obj.allowedSpeedMpS;
 
         }
     }

--- a/Source/RunActivity/Viewer3D/WebServices/WebServer.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/WebServer.cs
@@ -97,7 +97,7 @@ namespace Orts.Viewer3D.WebServices
         // ===========================================================================================
         // File exstensions this server will handle - any other extensions are returns as not found
         // ===========================================================================================
-        private static Dictionary<string, string> extensions = new Dictionary<string, string>()
+        private static Dictionary<string, string> extensions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             { "htm",  "text/html" },
             { "html", "text/html" },
@@ -488,7 +488,7 @@ namespace Orts.Viewer3D.WebServices
         // ===========================================================================================
         // 		API routing classes & functions
         // ===========================================================================================
-        public static Dictionary<string, Func<string, object>> ApiDict = new Dictionary<string, Func<string, object>>();
+        public static Dictionary<string, Func<string, object>> ApiDict = new Dictionary<string, Func<string, object>>(StringComparer.OrdinalIgnoreCase);
 
         public static string ExecuteApi(string apiName, string Parameters)
         {

--- a/Source/RunActivity/Viewer3D/WebServices/WebServer.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/WebServer.cs
@@ -34,6 +34,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Web;
 using Newtonsoft.Json;
 using Orts.Simulation;
 using Orts.Simulation.Physics;
@@ -258,7 +259,7 @@ namespace Orts.Viewer3D.WebServices
                         request.Method.Trim();
                         int start = lineRead.IndexOf('/');
                         int length = lineRead.LastIndexOf(" ") - start;
-                        request.URI = lineRead.Substring(start, length);
+                        request.URI = HttpUtility.UrlDecode(lineRead.Substring(start, length));
                     }
                     catch (Exception e)
                     {

--- a/Source/RunActivity/Viewer3D/WebServices/WebServer.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/WebServer.cs
@@ -60,7 +60,7 @@ namespace Orts.Viewer3D.WebServices
         public string Method = "";
         public string URI = "";
         public string Parameters;
-        public Dictionary<string, string> headers = new Dictionary<string, string>();
+        public Dictionary<string, string> headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, string> Headers { get => headers; set => headers = value; }
     }
 

--- a/Source/RunActivity/Viewer3D/WebServices/WebServer.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/WebServer.cs
@@ -459,10 +459,14 @@ namespace Orts.Viewer3D.WebServices
                             + System.Text.Encoding.UTF8.GetString(response.byteContent));
 
             // Begin sending the data to the remote device.
-            response.ClientSocket.BeginSend(byteData, 0,
-                                             byteData.Length, 0,
-                                             new AsyncCallback(SendHttpCallback),
-                                             response.ClientSocket);
+            try
+            {
+                response.ClientSocket.BeginSend(byteData, 0,
+                                                byteData.Length, 0,
+                                                new AsyncCallback(SendHttpCallback),
+                                                response.ClientSocket);
+            }
+            catch (SocketException) { }
         }
 
         // ===========================================================================================


### PR DESCRIPTION
- Add a description of the web server to the manual.
- Fix web content not getting copied to the Program folder.
- Fix other small bugs.
- Use case-insensitivity where appropriate for more intuitive behavior.
- Decode URI strings ("index%20-%20ApiSample.html" -> "index - ApiSample.html").