### PR TITLE
added more checks to GetValidWindowSize()

### DIFF
--- a/Source/Menu/Options.cs
+++ b/Source/Menu/Options.cs
@@ -461,7 +461,7 @@ namespace ORTS
             Settings.DistantMountainsViewingDistance = (int)numericDistantMountainsViewingDistance.Value * 1000;
             Settings.ViewingFOV = (int)numericViewingFOV.Value;
             Settings.WorldObjectDensity = (int)numericWorldObjectDensity.Value;
-            Settings.WindowSize = GetValidWindowSize();
+            Settings.WindowSize = GetValidWindowSize(comboWindowSize);
 
             Settings.DayAmbientLight = (int)trackDayAmbientLight.Value;
             Settings.DoubleWire = checkDoubleWire.Checked;
@@ -539,13 +539,18 @@ namespace ORTS
             Settings.Save();
         }
 
-        private string GetValidWindowSize()
+        /// <summary>
+        /// Returns user's [width]x[height] if expression is valid and values are sane, else returns previous value of setting.
+        /// </summary>
+        private string GetValidWindowSize(ComboBox comboWindowSize)
         {
             // "1024X780" instead of "1024x780" then "Start" resulted in an immediate return to the Menu with no OpenRailsLog.txt and a baffled user.
-            var windowSizeArray = comboWindowSize.Text.ToLower().Replace(" ", "").Split('x');
-            return (int.TryParse(windowSizeArray[0], out int width) && int.TryParse(windowSizeArray[1], out int height))
-                ? $"{width}x{height}"
-                : Settings.WindowSize; // i.e. no change or message. Just ignore non-numeric entries
+            var sizeArray = comboWindowSize.Text.ToLower().Replace(" ", "").Split('x');
+            if (sizeArray.Count() == 2)
+                if (int.TryParse(sizeArray[0], out int width) && int.TryParse(sizeArray[1], out int height))
+                    if ((100 < width && width < 10000) && (100 < height && height < 100000)) // sanity check
+                        return $"{width}x{height}";
+            return Settings.WindowSize; // i.e. no change or message. Just ignore non-numeric entries
         }
 
         void buttonDefaultKeys_Click(object sender, EventArgs e)


### PR DESCRIPTION
Thanks for your catch, PerpetualKid,

_this will crash if the string.Split does not return an array of expect length, and should be checked also!_

THis new version avoids that fatal error and also does some sanity checking.

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)