### PR TITLE
Fading signal lamps

### DIFF
--- a/Source/Documentation/Manual/features-route.rst
+++ b/Source/Documentation/Manual/features-route.rst
@@ -725,13 +725,13 @@ Fading signal lamps
 
 In Open Rails, signal lamps fade on and off for a visually pleasing transition 
 effect. The fade time defaults to one-fifth of a second. It can be customized in 
-the ``SignalType`` block of the ``sigcfg.dat`` file using the ``ORTSOnOffTime`` 
+the ``SignalType`` block of the ``sigcfg.dat`` file using the ``ORTSOnOffTimeS`` 
 property::
 
    SignalTypes( ...
        SignalType ( "AM14Light"
            ...
-           ORTSOnOffTime ( 0.2 )
+           ORTSOnOffTimeS ( 0.2 )
        )
    )
 

--- a/Source/Documentation/Manual/features-route.rst
+++ b/Source/Documentation/Manual/features-route.rst
@@ -720,8 +720,20 @@ there either, Open Rails selects texture ``GLOBAL\TEXTURES\diselsmoke.ace``. It 
 strongly suggested to use a specific texture to display the overhead wire. A possible 
 texture to be used can be downloaded here ``Documentation\SampleFiles\Manual\overheadwire.zip``.
 
+Fading signal lamps
+===================
 
+In Open Rails, signal lamps fade on and off for a visually pleasing transition 
+effect. The fade time defaults to one-fifth of a second. It can be customized in 
+the ``SignalType`` block of the ``sigcfg.dat`` file using the ``ORTSOnOffTime`` 
+property::
 
+   SignalTypes( ...
+       SignalType ( "AM14Light"
+           ...
+           ORTSOnOffTime ( 0.2 )
+       )
+   )
 
-
-
+The value is the fade time in seconds. Use ``0`` to disable the effect 
+completely.

--- a/Source/Orts.Formats.Msts/SignalConfigurationFile.cs
+++ b/Source/Orts.Formats.Msts/SignalConfigurationFile.cs
@@ -475,7 +475,7 @@ namespace Orts.Formats.Msts
             LightTextureName = String.Empty;
             FlashTimeOn = 1.0f;
             FlashTimeOff = 1.0f;
-            OnOffTime = 0.5f;
+            OnOffTime = 0.2f;
         }
 
         /// <summary>

--- a/Source/Orts.Formats.Msts/SignalConfigurationFile.cs
+++ b/Source/Orts.Formats.Msts/SignalConfigurationFile.cs
@@ -439,6 +439,8 @@ namespace Orts.Formats.Msts
         public float FlashTimeOn { get; private set; }
         /// <summary>Off duration for flashing light. (In seconds.)</summary>
         public float FlashTimeOff { get; private set; }
+        /// <summary>Transition time between lit and unlit states. (In seconds.)</summary>
+        public float OnOffTime { get; private set; }
         /// <summary>The name of the texture to use for the lights</summary>
         public string LightTextureName { get; private set; }
         /// <summary></summary>
@@ -473,6 +475,7 @@ namespace Orts.Formats.Msts
             LightTextureName = String.Empty;
             FlashTimeOn = 1.0f;
             FlashTimeOff = 1.0f;
+            OnOffTime = 0.5f;
         }
 
         /// <summary>
@@ -519,6 +522,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsnightglow", ()=>{ NightGlow = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),                
                 new STFReader.TokenProcessor("ortsdaylight", ()=>{ DayLight = stf.ReadBoolBlock(true); }),
                 new STFReader.TokenProcessor("ortsnormalsubtype", ()=>{ ORTSNormalSubtype = ReadORTSNormalSubtype(stf, ORTSNormalSubtypes); }),
+                new STFReader.TokenProcessor("ortsonofftime", ()=>{ OnOffTime = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("sigflashduration", ()=>{
                     stf.MustMatch("(");
                     FlashTimeOn = stf.ReadFloat(STFReader.UNITS.None, null);

--- a/Source/Orts.Formats.Msts/SignalConfigurationFile.cs
+++ b/Source/Orts.Formats.Msts/SignalConfigurationFile.cs
@@ -440,7 +440,7 @@ namespace Orts.Formats.Msts
         /// <summary>Off duration for flashing light. (In seconds.)</summary>
         public float FlashTimeOff { get; private set; }
         /// <summary>Transition time between lit and unlit states. (In seconds.)</summary>
-        public float OnOffTime { get; private set; }
+        public float OnOffTimeS { get; private set; }
         /// <summary>The name of the texture to use for the lights</summary>
         public string LightTextureName { get; private set; }
         /// <summary></summary>
@@ -475,7 +475,7 @@ namespace Orts.Formats.Msts
             LightTextureName = String.Empty;
             FlashTimeOn = 1.0f;
             FlashTimeOff = 1.0f;
-            OnOffTime = 0.2f;
+            OnOffTimeS = 0.2f;
         }
 
         /// <summary>
@@ -522,7 +522,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsnightglow", ()=>{ NightGlow = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),                
                 new STFReader.TokenProcessor("ortsdaylight", ()=>{ DayLight = stf.ReadBoolBlock(true); }),
                 new STFReader.TokenProcessor("ortsnormalsubtype", ()=>{ ORTSNormalSubtype = ReadORTSNormalSubtype(stf, ORTSNormalSubtypes); }),
-                new STFReader.TokenProcessor("ortsonofftime", ()=>{ OnOffTime = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
+                new STFReader.TokenProcessor("ortsonofftimes", ()=>{ OnOffTimeS = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("sigflashduration", ()=>{
                     stf.MustMatch("(");
                     FlashTimeOn = stf.ReadFloat(STFReader.UNITS.None, null);

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -548,9 +548,9 @@ float4 PSSignalLight(in VERTEX_OUTPUT In) : COLOR0
     clip(Color.a - ReferenceAlpha);
 	// No ambient and shadow effects for signal lights.
 	// Apply signal coloring effect.
-	float3 litColor = lerp(Color.rgb, In.Color.rgb, Color.r) * SignalLightIntensity;
+	float3 litColor = lerp(Color.rgb, In.Color.rgb, Color.r);
 	// No specular effect, overcast effect, night-time darkening, headlights or fogging effect for signal lights.
-	return float4(litColor, Color.a);
+	return float4(litColor, Color.a * SignalLightIntensity);
 }
 
 ////////////////////    T E C H N I Q U E S    /////////////////////////////////

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -48,6 +48,7 @@ float    ImageTextureIsNight;
 float    NightColorModifier;
 float    HalfNightColorModifier;
 float    VegetationAmbientModifier;
+float    SignalLightIntensity;
 float4   EyeVector;
 float3   SideVector;
 float    ReferenceAlpha;
@@ -547,7 +548,7 @@ float4 PSSignalLight(in VERTEX_OUTPUT In) : COLOR0
     clip(Color.a - ReferenceAlpha);
 	// No ambient and shadow effects for signal lights.
 	// Apply signal coloring effect.
-	float3 litColor = lerp(Color.rgb, In.Color.rgb, Color.r);
+	float3 litColor = lerp(Color.rgb, In.Color.rgb, Color.r) * SignalLightIntensity;
 	// No specular effect, overcast effect, night-time darkening, headlights or fogging effect for signal lights.
 	return float4(litColor, Color.a);
 }

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -132,13 +132,15 @@ namespace Orts.Viewer3D
         public RenderPrimitive RenderPrimitive;
         public Matrix XNAMatrix;
         public ShapeFlags Flags;
+        public object ItemData;
 
-        public RenderItem(Material material, RenderPrimitive renderPrimitive, ref Matrix xnaMatrix, ShapeFlags flags)
+        public RenderItem(Material material, RenderPrimitive renderPrimitive, ref Matrix xnaMatrix, ShapeFlags flags, object itemData = null)
         {
             Material = material;
             RenderPrimitive = renderPrimitive;
             XNAMatrix = xnaMatrix;
             Flags = flags;
+            ItemData = itemData;
         }
 
         public class Comparer : IComparer<RenderItem>
@@ -566,7 +568,7 @@ namespace Orts.Viewer3D
         [CallOnThread("Updater")]
         public void AddPrimitive(Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix)
         {
-            AddPrimitive(material, primitive, group, ref xnaMatrix, ShapeFlags.None);
+            AddPrimitive(material, primitive, group, ref xnaMatrix, ShapeFlags.None, null);
         }
 
         static readonly bool[] PrimitiveBlendedScenery = new bool[] { true, false }; // Search for opaque pixels in alpha blended primitives, thus maintaining correct DepthBuffer
@@ -575,6 +577,12 @@ namespace Orts.Viewer3D
 
         [CallOnThread("Updater")]
         public void AddPrimitive(Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ShapeFlags flags)
+        {
+            AddPrimitive(material, primitive, group, ref xnaMatrix, flags, null);
+        }
+
+        [CallOnThread("Updater")]
+        public void AddPrimitive(Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ShapeFlags flags, object itemData)
         {
             var getBlending = material.GetBlending();
             var blending = getBlending && material is SceneryMaterial ? PrimitiveBlendedScenery : getBlending ? PrimitiveBlended : PrimitiveNotBlended;
@@ -590,7 +598,7 @@ namespace Orts.Viewer3D
                     items = new RenderItemCollection();
                     sequence.Add(sortingMaterial, items);
                 }
-                items.Add(new RenderItem(material, primitive, ref xnaMatrix, flags));
+                items.Add(new RenderItem(material, primitive, ref xnaMatrix, flags, itemData));
             }
             if (((flags & ShapeFlags.AutoZBias) != 0) && (primitive.ZBias == 0))
                 primitive.ZBias = 1;

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -81,6 +81,7 @@ namespace Orts.Viewer3D
         readonly EffectParameter nightColorModifier;
         readonly EffectParameter halfNightColorModifier;
         readonly EffectParameter vegetationAmbientModifier;
+        readonly EffectParameter signalLightIntensity;
         readonly EffectParameter eyeVector;
         readonly EffectParameter sideVector;
         readonly EffectParameter imageTexture;
@@ -180,6 +181,8 @@ namespace Orts.Viewer3D
             headlightPosition.SetValue(Vector4.Zero);
         }
 
+        public float SignalLightIntensity { set { signalLightIntensity.SetValue(value); } }
+
         public float Overcast { set { overcast.SetValue(new Vector2(value, value / 2)); } }
 
         public Vector3 ViewerPos { set { viewerPos.SetValue(value); } }
@@ -220,6 +223,7 @@ namespace Orts.Viewer3D
             nightColorModifier = Parameters["NightColorModifier"];
             halfNightColorModifier = Parameters["HalfNightColorModifier"];
             vegetationAmbientModifier = Parameters["VegetationAmbientModifier"];
+            signalLightIntensity = Parameters["SignalLightIntensity"];
             eyeVector = Parameters["EyeVector"];
             sideVector = Parameters["SideVector"];
             imageTexture = Parameters["ImageTexture"];

--- a/Source/RunActivity/Viewer3D/Signals.cs
+++ b/Source/RunActivity/Viewer3D/Signals.cs
@@ -352,7 +352,7 @@ namespace Orts.Viewer3D
                     bool semaphoreDark = SemaphorePos != SemaphoreTarget && SignalTypeData.LightsSemaphoreChange[i];
                     bool constantDark = !SignalTypeData.DrawAspects[DisplayState].DrawLights[i];
                     bool flashingDark = SignalTypeData.DrawAspects[DisplayState].FlashLights[i] && (CumulativeTime > SignalTypeData.FlashTimeOn);
-                    state.SetIntensity(semaphoreDark || constantDark || flashingDark ? 0 : 1, elapsedTime);
+                    state.UpdateIntensity(semaphoreDark || constantDark || flashingDark ? 0 : 1, elapsedTime);
                     if (!state.IsIlluminated())
                         continue;
 
@@ -557,6 +557,7 @@ namespace Orts.Viewer3D
     {
         private readonly float onOffTime;
         private float intensity = 0;
+        private bool firstUpdate = true;
 
         public SignalLightState(float onOffTime)
         {
@@ -568,14 +569,15 @@ namespace Orts.Viewer3D
             return intensity;
         }
 
-        public void SetIntensity(float target, ElapsedTime et)
+        public void UpdateIntensity(float target, ElapsedTime et)
         {
-            if (onOffTime == 0)
+            if (firstUpdate || onOffTime == 0)
                 intensity = target;
             else if (target > intensity)
                 intensity = Math.Min(intensity + et.ClockSeconds / onOffTime, target);
             else if (target < intensity)
                 intensity = Math.Max(intensity - et.ClockSeconds / onOffTime, target);
+            firstUpdate = false;
         }
 
         public bool IsIlluminated()

--- a/Source/RunActivity/Viewer3D/Signals.cs
+++ b/Source/RunActivity/Viewer3D/Signals.cs
@@ -294,7 +294,7 @@ namespace Orts.Viewer3D
 
                 lightStates = new SignalLightState[SignalTypeData.Lights.Count];
                 for (var i = 0; i < SignalTypeData.Lights.Count; i++)
-                    lightStates[i] = new SignalLightState(SignalTypeData.OnOffTime);
+                    lightStates[i] = new SignalLightState(SignalTypeData.OnOffTimeS);
 
 #if DEBUG_SIGNAL_SHAPES
                 Console.Write("  HEAD type={0,-8} lights={1,-2} sem={2}", SignalTypeData.Type, SignalTypeData.Lights.Count, SignalTypeData.Semaphore);
@@ -428,7 +428,7 @@ namespace Orts.Viewer3D
             public readonly Dictionary<int, SignalAspectData> DrawAspects = new Dictionary<int, SignalAspectData>();
             public readonly float FlashTimeOn;
             public readonly float FlashTimeTotal;
-            public readonly float OnOffTime;
+            public readonly float OnOffTimeS;
             public readonly bool Semaphore;
             public readonly bool DayLight = true;
             public readonly float SemaphoreAnimationTime;
@@ -500,7 +500,7 @@ namespace Orts.Viewer3D
                     DayLight = mstsSignalType.DayLight;
                 }
 
-                OnOffTime = mstsSignalType.OnOffTime;
+                OnOffTimeS = mstsSignalType.OnOffTimeS;
             }
         }
 

--- a/Source/RunActivity/Viewer3D/Signals.cs
+++ b/Source/RunActivity/Viewer3D/Signals.cs
@@ -294,7 +294,7 @@ namespace Orts.Viewer3D
 
                 lightStates = new SignalLightState[SignalTypeData.Lights.Count];
                 for (var i = 0; i < SignalTypeData.Lights.Count; i++)
-                    lightStates[i] = new SignalLightState();
+                    lightStates[i] = new SignalLightState(SignalTypeData.OnOffTime);
 
 #if DEBUG_SIGNAL_SHAPES
                 Console.Write("  HEAD type={0,-8} lights={1,-2} sem={2}", SignalTypeData.Type, SignalTypeData.Lights.Count, SignalTypeData.Semaphore);
@@ -428,6 +428,7 @@ namespace Orts.Viewer3D
             public readonly Dictionary<int, SignalAspectData> DrawAspects = new Dictionary<int, SignalAspectData>();
             public readonly float FlashTimeOn;
             public readonly float FlashTimeTotal;
+            public readonly float OnOffTime;
             public readonly bool Semaphore;
             public readonly bool DayLight = true;
             public readonly float SemaphoreAnimationTime;
@@ -498,6 +499,8 @@ namespace Orts.Viewer3D
                     SemaphoreAnimationTime = mstsSignalType.SemaphoreInfo;
                     DayLight = mstsSignalType.DayLight;
                 }
+
+                OnOffTime = mstsSignalType.OnOffTime;
             }
         }
 
@@ -552,8 +555,13 @@ namespace Orts.Viewer3D
     /// </summary>
     internal class SignalLightState
     {
-        static readonly float LightOnOffTime = 0.5f; // Transition time in seconds.
+        private readonly float onOffTime;
         private float intensity = 0;
+
+        public SignalLightState(float onOffTime)
+        {
+            this.onOffTime = onOffTime;
+        }
 
         public float GetIntensity()
         {
@@ -562,10 +570,12 @@ namespace Orts.Viewer3D
 
         public void SetIntensity(float target, ElapsedTime et)
         {
-            if (target > intensity)
-                intensity = Math.Min(intensity + et.ClockSeconds / LightOnOffTime, target);
+            if (onOffTime == 0)
+                intensity = target;
+            else if (target > intensity)
+                intensity = Math.Min(intensity + et.ClockSeconds / onOffTime, target);
             else if (target < intensity)
-                intensity = Math.Max(intensity - et.ClockSeconds / LightOnOffTime, target);
+                intensity = Math.Max(intensity - et.ClockSeconds / onOffTime, target);
         }
 
         public bool IsIlluminated()


### PR DESCRIPTION
Change signal lamps to fade on and off. Effect is customizable by route builders.

[(Elvas Tower)](http://www.elvastower.com/forums/index.php?/topic/33951-smooth-signal-lamp-transitions/) [(Trello)](https://trello.com/c/P9rYgv8V/461-fading-signal-lamps)