### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1878687 Maximum gauge allowed smaller than Iberian gauge

### DIFF
--- a/Source/Menu/Options.Designer.cs
+++ b/Source/Menu/Options.Designer.cs
@@ -2157,7 +2157,7 @@
             this.numericSuperElevationGauge.Location = new System.Drawing.Point(26, 94);
             this.numericSuperElevationGauge.Margin = new System.Windows.Forms.Padding(23, 3, 3, 3);
             this.numericSuperElevationGauge.Maximum = new decimal(new int[] {
-            1600,
+            1800,
             0,
             0,
             0});


### PR DESCRIPTION
Maximum gauge allowed for superelevation is 1600mm, which is smaller than the Iberian and Indian gauge.