### PR TITLE
Fix cab letterboxing memory leak

### DIFF
--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -1019,6 +1019,7 @@ namespace Orts.Viewer3D.RollingStock
         private SpriteBatchMaterial _Sprite2DCabView;
         private Matrix _Scale = Matrix.Identity;
         private Texture2D _CabTexture;
+        private readonly Texture2D _LetterboxTexture;
         private CabShader _Shader;
 
         private Point _PrevScreenSize;
@@ -1162,6 +1163,8 @@ namespace Orts.Viewer3D.RollingStock
 
             _PrevScreenSize = DisplaySize;
 
+            _LetterboxTexture = new Texture2D(viewer.GraphicsDevice, 1, 1);
+            _LetterboxTexture.SetData(new Color[] { Color.Black });
         }
 
         public CabRenderer(Viewer viewer, MSTSLocomotive car, CabViewFile CVFFile) //used by 3D cab as a refrence, thus many can be eliminated
@@ -1330,11 +1333,9 @@ namespace Orts.Viewer3D.RollingStock
             _Sprite2DCabView.SpriteBatch.Draw(_CabTexture, drawPos, cabRect, Color.White, 0f, drawOrigin, cabScale, SpriteEffects.None, 0f);
 
             // Draw letterboxing.
-            Texture2D letterboxTexture = new Texture2D(graphicsDevice, 1, 1);
-            letterboxTexture.SetData<Color>(new Color[] { Color.Black });
             void drawLetterbox(int x, int y, int w, int h)
             {
-                _Sprite2DCabView.SpriteBatch.Draw(letterboxTexture, new Rectangle(x, y, w, h), Color.White);
+                _Sprite2DCabView.SpriteBatch.Draw(_LetterboxTexture, new Rectangle(x, y, w, h), Color.White);
             }
             if (_Viewer.CabXLetterboxPixels > 0)
             {


### PR DESCRIPTION
There is a small memory leak in the cab letterboxing code that was reported [at Elvas Tower](http://www.elvastower.com/forums/index.php?/topic/34069-potential-memory-leak/). This is a fix. Beware: It won't auto-merge cleanly into the unstable branch.