### PR TITLE
Extended starting friction parameters

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -61,10 +61,11 @@ number should be used instead of zero.
 
 When a car is pulled from steady state, an additional force is needed due
 to higher bearing forces. The situation is simplified by using a different
-calculation at low speed (5 mph and lower). Empirical static friction
-forces are used for different classes of mass (under 10 tons, 10 to 100
+calculation at low speed (``ORTSMergeSpeed`` and lower). Empirical static
+friction forces are used for different classes of mass (under 10 tons, 10 to 100
 tons and above 100 tons). In addition, if weather conditions are poor
-(snowing is set), the static friction is increased.
+(snowing is set), the static friction is increased. This low-speed friction
+force can be manually specified with ``ORTSStandstillFriction``.
 
 When running on a curve and if the
 :ref:`Curve dependent resistance <options-curve-resistance>` option is

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1358,6 +1358,7 @@ namespace Orts.Simulation.RollingStocks
             StandstillFrictionN = inf.ReadSingle();
             MergeSpeedFrictionN = inf.ReadSingle();
             IsBelowMergeSpeed = inf.ReadBoolean();
+            MergeSpeedMpS = inf.ReadSingle();
             MassKG = inf.ReadSingle();
             MaxBrakeForceN = inf.ReadSingle();
             MaxHandbrakeForceN = inf.ReadSingle();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -110,7 +110,7 @@ namespace Orts.Simulation.RollingStocks
         protected float Friction5N;               // Friction at 5mph
         public float StandstillFrictionN;
         public float MergeSpeedFrictionN;
-        public float MergeSpeedMpS;
+        public float MergeSpeedMpS = MpS.FromMpH(5f);
         public float DavisAN;           // davis equation constant
         public float DavisBNSpM;        // davis equation constant for speed
         public float DavisCNSSpMM;      // davis equation constant for speed squared
@@ -956,7 +956,7 @@ namespace Orts.Simulation.RollingStocks
                 case "wagon(ortswagonfrontalarea": WagonFrontalAreaM2 = stf.ReadFloatBlock(STFReader.UNITS.AreaDefaultFT2, null); break;
                 case "wagon(ortstraillocomotiveresistancefactor": TrailLocoResistanceFactor = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;
                 case "wagon(ortsstandstillfriction": StandstillFrictionN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
-                case "wagon(ortsmergespeed": MergeSpeedMpS = stf.ReadFloatBlock(STFReader.UNITS.Speed, null); break;
+                case "wagon(ortsmergespeed": MergeSpeedMpS = stf.ReadFloatBlock(STFReader.UNITS.Speed, MergeSpeedMpS); break;
                 case "wagon(effects(specialeffects": ParseEffects(lowercasetoken, stf); break;
                 case "wagon(ortsbearingtype":
                     stf.MustMatch("(");

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -79,6 +79,8 @@ namespace Orts.Simulation.RollingStocks
         public bool IsStandStill = true;  // Used for MSTS type friction
         public bool IsDavisFriction = true; // Default to new Davis type friction
         public bool IsLowSpeed = true; // set indicator for low speed operation  0 - 5mph
+        public bool IsORTSFriction = true; // Default to new Davis type friction
+        public bool IsBelowMergeSpeed = true; // set indicator for low speed operation as per given speed
 
         Interpolator BrakeShoeFrictionFactor;  // Factor of friction for wagon brake shoes
         const float WaterLBpUKG = 10.0f;    // lbs of water in 1 gal (uk)
@@ -103,9 +105,13 @@ namespace Orts.Simulation.RollingStocks
         public float ExternalSoundPassThruPercent = -1;
         public float WheelRadiusM = 1;          // provide some defaults in case it's missing from the wag
         protected float StaticFrictionFactorN;    // factor to multiply friction by to determine static or starting friction - will vary depending upon whether roller or friction bearing
-        float FrictionLowSpeedN;
+        float FrictionLowSpeedN; // Davis low speed value 0 - 5 mph
+        float FrictionBelowMergeSpeedN; // Davis low speed value for defined speed
         public float Friction0N;        // static friction
         protected float Friction5N;               // Friction at 5mph
+        public float StandstillFrictionN;
+        public float MergeSpeedFrictionN;
+        public float MergeSpeedMpS;
         public float DavisAN;           // davis equation constant
         public float DavisBNSpM;        // davis equation constant for speed
         public float DavisCNSSpMM;      // davis equation constant for speed squared
@@ -950,6 +956,8 @@ namespace Orts.Simulation.RollingStocks
                 case "wagon(ortsdavisdragconstant": DavisDragConstant = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;
                 case "wagon(ortswagonfrontalarea": WagonFrontalAreaM2 = stf.ReadFloatBlock(STFReader.UNITS.AreaDefaultFT2, null); break;
                 case "wagon(ortstraillocomotiveresistancefactor": TrailLocoResistanceFactor = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;
+                case "wagon(ortsstandstillfriction": StandstillFrictionN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
+                case "wagon(ortsmergespeed": MergeSpeedMpS = stf.ReadFloatBlock(STFReader.UNITS.Speed, null); break;
                 case "wagon(effects(specialeffects": ParseEffects(lowercasetoken, stf); break;
                 case "wagon(ortsbearingtype":
                     stf.MustMatch("(");
@@ -1142,6 +1150,11 @@ namespace Orts.Simulation.RollingStocks
             FrictionC2 = copy.FrictionC2;
             FrictionE2 = copy.FrictionE2;
             EffectData = copy.EffectData;
+            IsORTSFriction = copy.IsORTSFriction;
+            IsBelowMergeSpeed = copy.IsBelowMergeSpeed;
+            StandstillFrictionN = copy.StandstillFrictionN;
+            MergeSpeedFrictionN = copy.MergeSpeedFrictionN;
+            MergeSpeedMpS = copy.MergeSpeedMpS;
             IsDavisFriction = copy.IsDavisFriction;
             IsRollerBearing = copy.IsRollerBearing;
             IsLowTorqueRollerBearing = copy.IsLowTorqueRollerBearing;
@@ -1299,6 +1312,11 @@ namespace Orts.Simulation.RollingStocks
             outf.Write(DavisAN);
             outf.Write(DavisBNSpM);
             outf.Write(DavisCNSSpMM);
+            outf.Write(StandstillFrictionN);
+            outf.Write(MergeSpeedFrictionN);
+            outf.Write(IsORTSFriction);
+            outf.Write(IsBelowMergeSpeed);
+            outf.Write(MergeSpeedMpS);
             outf.Write(MassKG);
             outf.Write(MaxBrakeForceN);
             outf.Write(MaxHandbrakeForceN);
@@ -1340,6 +1358,10 @@ namespace Orts.Simulation.RollingStocks
             DavisAN = inf.ReadSingle();
             DavisBNSpM = inf.ReadSingle();
             DavisCNSSpMM = inf.ReadSingle();
+            IsORTSFriction = inf.ReadBoolean();
+            StandstillFrictionN = inf.ReadSingle();
+            MergeSpeedFrictionN = inf.ReadSingle();
+            IsBelowMergeSpeed = inf.ReadBoolean();
             MassKG = inf.ReadSingle();
             MaxBrakeForceN = inf.ReadSingle();
             MaxHandbrakeForceN = inf.ReadSingle();
@@ -1622,13 +1644,170 @@ namespace Orts.Simulation.RollingStocks
 
         private void UpdateTrainBaseResistance()
         {
-
             if (IsDavisFriction == true) // test to see if OR thinks that Davis Values have been entered in WG file.
             {
                 if (DavisAN == 0 || DavisBNSpM == 0 || DavisCNSSpMM == 0) // If Davis parameters are not defined in WAG file, then set falg to use default friction values
                     IsDavisFriction = false; // set to false - indicating that Davis friction is not used
             }
+            if (IsORTSFriction == true && IsDavisFriction == true) // test to see if OR thinks that Davis Values have been entered in WG file.
+            {
+                if (StandstillFrictionN == 0 || MergeSpeedMpS == 0) // If Davis parameters are not defined in WAG file, then set falg to use default friction values
+                    IsORTSFriction = false; // set to false - indicating that Davis friction is not used
+            }
+            if (IsORTSFriction) // test to see if OR thinks that Davis Values have been entered in WAG file.
+            {
+                    // Davis formulas only apply above merge speed, so different treatment required for low speed
+                    if (AbsSpeedMpS > MpS.FromMpH(MergeSpeedMpS / 1.609344f * 3.6f))     // if speed above merge speed then turn off low speed calculations
+                        IsBelowMergeSpeed = false;
+                    else if (AbsSpeedMpS < MpS.FromMpH(MergeSpeedMpS / 1.60934f * 3.6f))
+                        IsBelowMergeSpeed = true;
+                    if (AbsSpeedMpS <= 0.0)
+                        IsBelowMergeSpeed = true;
 
+                    if (IsBelowMergeSpeed)
+                    {
+
+                        // Dtermine the starting friction factor based upon the type of bearing
+
+                        float StartFrictionLoadN = StandstillFrictionN;  // Starting friction
+
+                        // Determine the starting resistance due to wheel bearing temperature
+                        // Note reference values in lbf and US tons - converted to metric values as appropriate
+                        // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+                        // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+                        const float RunGrad = -0.0085714285714286f;
+                        const float RunIntersect = 1.2142857142857f;
+                        if (WheelBearingTemperatureDegC < -10)
+                        {
+                        // Set to snowing (frozen value)
+                        StartFrictionLoadN = 1.2f;  // Starting friction, snowing
+                        }
+                        else if (WheelBearingTemperatureDegC > 25)
+                        {
+                        // Set to normal temperature value
+                        StartFrictionLoadN = 1.0f;  // Starting friction, not snowing
+                        }
+                        else
+                        {
+                        // Set to variable value as bearing heats and cools
+                        StartFrictionLoadN = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
+                        }
+                        StaticFrictionFactorN = StartFrictionLoadN;
+
+                        // Determine the running resistance due to wheel bearing temperature
+                        float WheelBearingTemperatureResistanceFactor = 0;
+
+                        // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
+                        // bearing. Assume that resistance will increase by 30% as temperature drops below 0 DegC.
+                        // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+                        // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+
+                        if (WheelBearingTemperatureDegC < -10)
+                        {
+                            // Set to snowing (frozen value)
+                            WheelBearingTemperatureResistanceFactor = 1.3f;
+                        }
+                        else if (WheelBearingTemperatureDegC > 25)
+                        {
+                            // Set to normal temperature value
+                            WheelBearingTemperatureResistanceFactor = 1.0f;
+                        }
+                        else
+                        {
+                            // Set to variable value as bearing heats and cools
+                            WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
+                        }
+                        // If hot box has been initiated, then increase friction on the wagon significantly
+                        if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
+                        {
+                            WheelBearingTemperatureResistanceFactor = 2.0f;
+                            StaticFrictionFactorN *= 2.0f;
+                        }
+                        // Calculation of resistance @ low speeds
+                        // Wind resistance is not included at low speeds, as it does not have a significant enough impact
+                        MergeSpeedFrictionN = DavisAN * WheelBearingTemperatureResistanceFactor + (MergeSpeedMpS) * (DavisBNSpM + (MergeSpeedMpS) * DavisCNSSpMM); // Calculate friction @ merge speed
+                        Friction0N = StandstillFrictionN * StaticFrictionFactorN; // Static friction x external resistance as this matches reference value
+                        FrictionBelowMergeSpeedN = ((1.0f - (AbsSpeedMpS / (MergeSpeedMpS))) * (Friction0N - MergeSpeedFrictionN)) + MergeSpeedFrictionN; // Calculate friction below merge speed - decreases linearly with speed
+                        FrictionForceN = FrictionBelowMergeSpeedN; // At low speed use this value
+                    }
+                    else
+                    {
+                        // Determine the running resistance due to wheel bearing temperature
+                        float WheelBearingTemperatureResistanceFactor = 0;
+
+                        // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
+                        // bearing. Assume that resisnce will increase by 30% as temperature drops below 0 DegC.
+                        // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+                        // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+                        const float RunGrad = -0.0085714285714286f;
+                        const float RunIntersect = 1.2142857142857f;
+
+                        if (WheelBearingTemperatureDegC < -10)
+                        {
+                            // Set to snowing (frozen value)
+                            WheelBearingTemperatureResistanceFactor = 1.3f;
+                        }
+                        else if (WheelBearingTemperatureDegC > 25)
+                        {
+                            // Set to normal temperature value
+                            WheelBearingTemperatureResistanceFactor = 1.0f;
+                        }
+                        else
+                        {
+                            // Set to variable value as bearing heats and cools
+                            WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
+
+                        }
+
+                        // If hot box has been initiated, then increase friction on the wagon significantly
+                        if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
+                        {
+                            WheelBearingTemperatureResistanceFactor = 2.0f;
+                        }
+
+                        FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * DavisCNSSpMM); // for normal speed operation
+
+                        // if this car is a locomotive, but not the lead one then recalculate the resistance with lower value as drag will not be as high on trailing locomotives
+                        // Only the drag (C) factor changes if a trailing locomotive, so only running resistance, and not starting resistance needs to be corrected
+                        if (WagonType == WagonTypes.Engine && Train.LeadLocomotive != this)
+                        {
+                            FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
+                        }
+
+                        // Test to identify whether a tender is attached to the leading engine, if not then the resistance should also be derated as for the locomotive
+                        bool IsLeadTender = false;
+                        if (WagonType == WagonTypes.Tender)
+                        {
+                            bool PrevCarLead = false;
+                            foreach (var car in Train.Cars)
+                            {
+                                // If this car is a tender and the previous car is the lead locomotive then set the flag so that resistance will be reduced
+                                if (car == this && PrevCarLead)
+                                {
+                                    IsLeadTender = true;
+                                    break;  // If the tender has been identified then break out of the loop, otherwise keep going until whole train is done.
+                                }
+                                // Identify whether car is a lead locomotive or not. This is kept for when the next iteration (next car) is checked.
+                                if (Train.LeadLocomotive == car)
+                                {
+                                    PrevCarLead = true;
+                                }
+                                else
+                                {
+                                    PrevCarLead = false;
+                                }
+
+                            }
+
+                            // If tender is coupled to a trailing locomotive then reduce resistance
+                            if (!IsLeadTender)
+                            {
+                                FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
+                            }
+
+                        }
+                    }
+            }
             if (IsDavisFriction == false)    // If Davis parameters are not defined in WAG file, then use default methods
             {
 
@@ -1743,7 +1922,7 @@ namespace Orts.Simulation.RollingStocks
 
             }
 
-            if (IsDavisFriction)  // If set to use next Davis friction then do so
+            if (IsDavisFriction && !IsORTSFriction)  // If set to use next Davis friction then do so
             {
                 // Davis formulas only apply above about 5mph, so different treatment required for low speed < 5mph.
                 if (AbsSpeedMpS > MpS.FromMpH(5.05f))     // if speed above 5 mph then turn off low speed calculations

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1656,157 +1656,112 @@ namespace Orts.Simulation.RollingStocks
             }
             if (IsORTSFriction) // test to see if OR thinks that Davis Values have been entered in WAG file.
             {
-                    // Davis formulas only apply above merge speed, so different treatment required for low speed
-                    if (AbsSpeedMpS > MpS.FromMpH(MergeSpeedMpS / 1.609344f * 3.6f))     // if speed above merge speed then turn off low speed calculations
-                        IsBelowMergeSpeed = false;
-                    else if (AbsSpeedMpS < MpS.FromMpH(MergeSpeedMpS / 1.60934f * 3.6f))
-                        IsBelowMergeSpeed = true;
-                    if (AbsSpeedMpS <= 0.0)
-                        IsBelowMergeSpeed = true;
+                // Davis formulas only apply above merge speed, so different treatment required for low speed
+                if (AbsSpeedMpS > MpS.FromMpH(MergeSpeedMpS / 1.609344f * 3.6f))     // if speed above merge speed then turn off low speed calculations
+                    IsBelowMergeSpeed = false;
+                else if (AbsSpeedMpS < MpS.FromMpH(MergeSpeedMpS / 1.60934f * 3.6f))
+                    IsBelowMergeSpeed = true;
+                if (AbsSpeedMpS <= 0.0)
+                    IsBelowMergeSpeed = true;
 
-                    if (IsBelowMergeSpeed)
-                    {
+                if (IsBelowMergeSpeed)
+                {
+                    // Dtermine the starting friction factor based upon the type of bearing
+                    float StartFrictionLoadN = StandstillFrictionN;  // Starting friction
 
-                        // Dtermine the starting friction factor based upon the type of bearing
-
-                        float StartFrictionLoadN = StandstillFrictionN;  // Starting friction
-
-                        // Determine the starting resistance due to wheel bearing temperature
-                        // Note reference values in lbf and US tons - converted to metric values as appropriate
-                        // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                        // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
-                        const float RunGrad = -0.0085714285714286f;
-                        const float RunIntersect = 1.2142857142857f;
-                        if (WheelBearingTemperatureDegC < -10)
-                        {
-                        // Set to snowing (frozen value)
+                    // Determine the starting resistance due to wheel bearing temperature
+                    // Note reference values in lbf and US tons - converted to metric values as appropriate
+                    // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+                    // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+                    const float RunGrad = -0.0085714285714286f;
+                    const float RunIntersect = 1.2142857142857f;
+                    if (WheelBearingTemperatureDegC < -10) // Set to snowing (frozen value)
                         StartFrictionLoadN = 1.2f;  // Starting friction, snowing
-                        }
-                        else if (WheelBearingTemperatureDegC > 25)
-                        {
-                        // Set to normal temperature value
+                    else if (WheelBearingTemperatureDegC > 25) // Set to normal temperature value
                         StartFrictionLoadN = 1.0f;  // Starting friction, not snowing
-                        }
-                        else
-                        {
-                        // Set to variable value as bearing heats and cools
+                    else // Set to variable value as bearing heats and cools
                         StartFrictionLoadN = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
-                        }
-                        StaticFrictionFactorN = StartFrictionLoadN;
+                    StaticFrictionFactorN = StartFrictionLoadN;
 
-                        // Determine the running resistance due to wheel bearing temperature
-                        float WheelBearingTemperatureResistanceFactor = 0;
+                    // Determine the running resistance due to wheel bearing temperature
+                    float WheelBearingTemperatureResistanceFactor = 0;
 
-                        // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
-                        // bearing. Assume that resistance will increase by 30% as temperature drops below 0 DegC.
-                        // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                        // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+                    // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
+                    // bearing. Assume that resistance will increase by 30% as temperature drops below 0 DegC.
+                    // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+                    // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
 
-                        if (WheelBearingTemperatureDegC < -10)
-                        {
-                            // Set to snowing (frozen value)
-                            WheelBearingTemperatureResistanceFactor = 1.3f;
-                        }
-                        else if (WheelBearingTemperatureDegC > 25)
-                        {
-                            // Set to normal temperature value
-                            WheelBearingTemperatureResistanceFactor = 1.0f;
-                        }
-                        else
-                        {
-                            // Set to variable value as bearing heats and cools
-                            WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
-                        }
-                        // If hot box has been initiated, then increase friction on the wagon significantly
-                        if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
-                        {
-                            WheelBearingTemperatureResistanceFactor = 2.0f;
-                            StaticFrictionFactorN *= 2.0f;
-                        }
-                        // Calculation of resistance @ low speeds
-                        // Wind resistance is not included at low speeds, as it does not have a significant enough impact
-                        MergeSpeedFrictionN = DavisAN * WheelBearingTemperatureResistanceFactor + (MergeSpeedMpS) * (DavisBNSpM + (MergeSpeedMpS) * DavisCNSSpMM); // Calculate friction @ merge speed
-                        Friction0N = StandstillFrictionN * StaticFrictionFactorN; // Static friction x external resistance as this matches reference value
-                        FrictionBelowMergeSpeedN = ((1.0f - (AbsSpeedMpS / (MergeSpeedMpS))) * (Friction0N - MergeSpeedFrictionN)) + MergeSpeedFrictionN; // Calculate friction below merge speed - decreases linearly with speed
-                        FrictionForceN = FrictionBelowMergeSpeedN; // At low speed use this value
-                    }
-                    else
+                    if (WheelBearingTemperatureDegC < -10) // Set to snowing (frozen value)
+                        WheelBearingTemperatureResistanceFactor = 1.3f;
+                    else if (WheelBearingTemperatureDegC > 25) // Set to normal temperature value
+                        WheelBearingTemperatureResistanceFactor = 1.0f;
+                    else // Set to variable value as bearing heats and cools
+                        WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
+                    // If hot box has been initiated, then increase friction on the wagon significantly
+                    if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
                     {
-                        // Determine the running resistance due to wheel bearing temperature
-                        float WheelBearingTemperatureResistanceFactor = 0;
-
-                        // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
-                        // bearing. Assume that resisnce will increase by 30% as temperature drops below 0 DegC.
-                        // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                        // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
-                        const float RunGrad = -0.0085714285714286f;
-                        const float RunIntersect = 1.2142857142857f;
-
-                        if (WheelBearingTemperatureDegC < -10)
-                        {
-                            // Set to snowing (frozen value)
-                            WheelBearingTemperatureResistanceFactor = 1.3f;
-                        }
-                        else if (WheelBearingTemperatureDegC > 25)
-                        {
-                            // Set to normal temperature value
-                            WheelBearingTemperatureResistanceFactor = 1.0f;
-                        }
-                        else
-                        {
-                            // Set to variable value as bearing heats and cools
-                            WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
-
-                        }
-
-                        // If hot box has been initiated, then increase friction on the wagon significantly
-                        if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
-                        {
-                            WheelBearingTemperatureResistanceFactor = 2.0f;
-                        }
-
-                        FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * DavisCNSSpMM); // for normal speed operation
-
-                        // if this car is a locomotive, but not the lead one then recalculate the resistance with lower value as drag will not be as high on trailing locomotives
-                        // Only the drag (C) factor changes if a trailing locomotive, so only running resistance, and not starting resistance needs to be corrected
-                        if (WagonType == WagonTypes.Engine && Train.LeadLocomotive != this)
-                        {
-                            FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
-                        }
-
-                        // Test to identify whether a tender is attached to the leading engine, if not then the resistance should also be derated as for the locomotive
-                        bool IsLeadTender = false;
-                        if (WagonType == WagonTypes.Tender)
-                        {
-                            bool PrevCarLead = false;
-                            foreach (var car in Train.Cars)
-                            {
-                                // If this car is a tender and the previous car is the lead locomotive then set the flag so that resistance will be reduced
-                                if (car == this && PrevCarLead)
-                                {
-                                    IsLeadTender = true;
-                                    break;  // If the tender has been identified then break out of the loop, otherwise keep going until whole train is done.
-                                }
-                                // Identify whether car is a lead locomotive or not. This is kept for when the next iteration (next car) is checked.
-                                if (Train.LeadLocomotive == car)
-                                {
-                                    PrevCarLead = true;
-                                }
-                                else
-                                {
-                                    PrevCarLead = false;
-                                }
-
-                            }
-
-                            // If tender is coupled to a trailing locomotive then reduce resistance
-                            if (!IsLeadTender)
-                            {
-                                FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
-                            }
-
-                        }
+                        WheelBearingTemperatureResistanceFactor = 2.0f;
+                        StaticFrictionFactorN *= 2.0f;
                     }
+                    // Calculation of resistance @ low speeds
+                    // Wind resistance is not included at low speeds, as it does not have a significant enough impact
+                    MergeSpeedFrictionN = DavisAN * WheelBearingTemperatureResistanceFactor + (MergeSpeedMpS) * (DavisBNSpM + (MergeSpeedMpS) * DavisCNSSpMM); // Calculate friction @ merge speed
+                    Friction0N = StandstillFrictionN * StaticFrictionFactorN; // Static friction x external resistance as this matches reference value
+                    FrictionBelowMergeSpeedN = ((1.0f - (AbsSpeedMpS / (MergeSpeedMpS))) * (Friction0N - MergeSpeedFrictionN)) + MergeSpeedFrictionN; // Calculate friction below merge speed - decreases linearly with speed
+                    FrictionForceN = FrictionBelowMergeSpeedN; // At low speed use this value
+                }
+                else
+                {
+                    // Determine the running resistance due to wheel bearing temperature
+                    float WheelBearingTemperatureResistanceFactor = 0;
+
+                    // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
+                    // bearing. Assume that resisnce will increase by 30% as temperature drops below 0 DegC.
+                    // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+                    // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+                    const float RunGrad = -0.0085714285714286f;
+                    const float RunIntersect = 1.2142857142857f;
+
+                    if (WheelBearingTemperatureDegC < -10) // Set to snowing (frozen value)
+                        WheelBearingTemperatureResistanceFactor = 1.3f;
+                    else if (WheelBearingTemperatureDegC > 25) // Set to normal temperature value
+                        WheelBearingTemperatureResistanceFactor = 1.0f;
+                    else // Set to variable value as bearing heats and cools
+                        WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
+
+                    // If hot box has been initiated, then increase friction on the wagon significantly
+                    if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
+                        WheelBearingTemperatureResistanceFactor = 2.0f;
+
+                    FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * DavisCNSSpMM); // for normal speed operation
+
+                    // if this car is a locomotive, but not the lead one then recalculate the resistance with lower value as drag will not be as high on trailing locomotives
+                    // Only the drag (C) factor changes if a trailing locomotive, so only running resistance, and not starting resistance needs to be corrected
+                    if (WagonType == WagonTypes.Engine && Train.LeadLocomotive != this)
+                        FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
+
+                    // Test to identify whether a tender is attached to the leading engine, if not then the resistance should also be derated as for the locomotive
+                    bool IsLeadTender = false;
+                    if (WagonType == WagonTypes.Tender)
+                    {
+                        bool PrevCarLead = false;
+                        foreach (var car in Train.Cars)
+                        {
+                            // If this car is a tender and the previous car is the lead locomotive then set the flag so that resistance will be reduced
+                            if (car == this && PrevCarLead)
+                            {
+                                IsLeadTender = true;
+                                break;  // If the tender has been identified then break out of the loop, otherwise keep going until whole train is done.
+                            }
+                            // Identify whether car is a lead locomotive or not. This is kept for when the next iteration (next car) is checked.
+                            PrevCarLead = Train.LeadLocomotive == car;
+                        }
+
+                        // If tender is coupled to a trailing locomotive then reduce resistance
+                        if (!IsLeadTender)
+                            FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
+                    }
+                }
             }
             if (IsDavisFriction == false)    // If Davis parameters are not defined in WAG file, then use default methods
             {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -79,7 +79,6 @@ namespace Orts.Simulation.RollingStocks
         public bool IsStandStill = true;  // Used for MSTS type friction
         public bool IsDavisFriction = true; // Default to new Davis type friction
         public bool IsLowSpeed = true; // set indicator for low speed operation  0 - 5mph
-        public bool IsORTSFriction = true; // Default to new Davis type friction
         public bool IsBelowMergeSpeed = true; // set indicator for low speed operation as per given speed
 
         Interpolator BrakeShoeFrictionFactor;  // Factor of friction for wagon brake shoes
@@ -1150,7 +1149,6 @@ namespace Orts.Simulation.RollingStocks
             FrictionC2 = copy.FrictionC2;
             FrictionE2 = copy.FrictionE2;
             EffectData = copy.EffectData;
-            IsORTSFriction = copy.IsORTSFriction;
             IsBelowMergeSpeed = copy.IsBelowMergeSpeed;
             StandstillFrictionN = copy.StandstillFrictionN;
             MergeSpeedFrictionN = copy.MergeSpeedFrictionN;
@@ -1314,7 +1312,6 @@ namespace Orts.Simulation.RollingStocks
             outf.Write(DavisCNSSpMM);
             outf.Write(StandstillFrictionN);
             outf.Write(MergeSpeedFrictionN);
-            outf.Write(IsORTSFriction);
             outf.Write(IsBelowMergeSpeed);
             outf.Write(MergeSpeedMpS);
             outf.Write(MassKG);
@@ -1358,7 +1355,6 @@ namespace Orts.Simulation.RollingStocks
             DavisAN = inf.ReadSingle();
             DavisBNSpM = inf.ReadSingle();
             DavisCNSSpMM = inf.ReadSingle();
-            IsORTSFriction = inf.ReadBoolean();
             StandstillFrictionN = inf.ReadSingle();
             MergeSpeedFrictionN = inf.ReadSingle();
             IsBelowMergeSpeed = inf.ReadBoolean();
@@ -1641,441 +1637,379 @@ namespace Orts.Simulation.RollingStocks
             }
         }
 
-
         private void UpdateTrainBaseResistance()
         {
-            if (IsDavisFriction == true) // test to see if OR thinks that Davis Values have been entered in WG file.
+            IsDavisFriction = DavisAN != 0 && DavisBNSpM != 0 && DavisCNSSpMM != 0; // test to see if OR thinks that Davis Values have been entered in WG file.
+            IsLowSpeed = AbsSpeedMpS < MpS.FromMpH(5f);
+            IsBelowMergeSpeed = AbsSpeedMpS < MergeSpeedMpS;
+            IsStandStill = AbsSpeedMpS < 0.1f;
+            bool isStartingFriction = StandstillFrictionN != 0 && MergeSpeedMpS != 0;
+
+            if (IsDavisFriction) // If set to use next Davis friction then do so
             {
-                if (DavisAN == 0 || DavisBNSpM == 0 || DavisCNSSpMM == 0) // If Davis parameters are not defined in WAG file, then set falg to use default friction values
-                    IsDavisFriction = false; // set to false - indicating that Davis friction is not used
-            }
-            if (IsORTSFriction == true && IsDavisFriction == true) // test to see if OR thinks that Davis Values have been entered in WG file.
-            {
-                if (StandstillFrictionN == 0 || MergeSpeedMpS == 0) // If Davis parameters are not defined in WAG file, then set falg to use default friction values
-                    IsORTSFriction = false; // set to false - indicating that Davis friction is not used
-            }
-            if (IsORTSFriction) // test to see if OR thinks that Davis Values have been entered in WAG file.
-            {
-                // Davis formulas only apply above merge speed, so different treatment required for low speed
-                if (AbsSpeedMpS > MpS.FromMpH(MergeSpeedMpS / 1.609344f * 3.6f))     // if speed above merge speed then turn off low speed calculations
-                    IsBelowMergeSpeed = false;
-                else if (AbsSpeedMpS < MpS.FromMpH(MergeSpeedMpS / 1.60934f * 3.6f))
-                    IsBelowMergeSpeed = true;
-                if (AbsSpeedMpS <= 0.0)
-                    IsBelowMergeSpeed = true;
-
-                if (IsBelowMergeSpeed)
-                {
-                    // Dtermine the starting friction factor based upon the type of bearing
-                    float StartFrictionLoadN = StandstillFrictionN;  // Starting friction
-
-                    // Determine the starting resistance due to wheel bearing temperature
-                    // Note reference values in lbf and US tons - converted to metric values as appropriate
-                    // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                    // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
-                    const float RunGrad = -0.0085714285714286f;
-                    const float RunIntersect = 1.2142857142857f;
-                    if (WheelBearingTemperatureDegC < -10) // Set to snowing (frozen value)
-                        StartFrictionLoadN = 1.2f;  // Starting friction, snowing
-                    else if (WheelBearingTemperatureDegC > 25) // Set to normal temperature value
-                        StartFrictionLoadN = 1.0f;  // Starting friction, not snowing
-                    else // Set to variable value as bearing heats and cools
-                        StartFrictionLoadN = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
-                    StaticFrictionFactorN = StartFrictionLoadN;
-
-                    // Determine the running resistance due to wheel bearing temperature
-                    float WheelBearingTemperatureResistanceFactor = 0;
-
-                    // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
-                    // bearing. Assume that resistance will increase by 30% as temperature drops below 0 DegC.
-                    // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                    // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
-
-                    if (WheelBearingTemperatureDegC < -10) // Set to snowing (frozen value)
-                        WheelBearingTemperatureResistanceFactor = 1.3f;
-                    else if (WheelBearingTemperatureDegC > 25) // Set to normal temperature value
-                        WheelBearingTemperatureResistanceFactor = 1.0f;
-                    else // Set to variable value as bearing heats and cools
-                        WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
-                    // If hot box has been initiated, then increase friction on the wagon significantly
-                    if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
-                    {
-                        WheelBearingTemperatureResistanceFactor = 2.0f;
-                        StaticFrictionFactorN *= 2.0f;
-                    }
-                    // Calculation of resistance @ low speeds
-                    // Wind resistance is not included at low speeds, as it does not have a significant enough impact
-                    MergeSpeedFrictionN = DavisAN * WheelBearingTemperatureResistanceFactor + (MergeSpeedMpS) * (DavisBNSpM + (MergeSpeedMpS) * DavisCNSSpMM); // Calculate friction @ merge speed
-                    Friction0N = StandstillFrictionN * StaticFrictionFactorN; // Static friction x external resistance as this matches reference value
-                    FrictionBelowMergeSpeedN = ((1.0f - (AbsSpeedMpS / (MergeSpeedMpS))) * (Friction0N - MergeSpeedFrictionN)) + MergeSpeedFrictionN; // Calculate friction below merge speed - decreases linearly with speed
-                    FrictionForceN = FrictionBelowMergeSpeedN; // At low speed use this value
-                }
+                if (isStartingFriction && IsBelowMergeSpeed) // Davis formulas only apply above merge speed, so different treatment required for low speed
+                    UpdateTrainBaseResistance_StartingFriction();
+                else if (IsLowSpeed) // Davis formulas only apply above about 5mph, so different treatment required for low speed < 5mph.
+                    UpdateTrainBaseResistance_DavisLowSpeed();
                 else
+                    UpdateTrainBaseResistance_DavisHighSpeed();
+            }
+            else if (isStartingFriction && IsBelowMergeSpeed)
+            {
+                UpdateTrainBaseResistance_StartingFriction();
+            }
+            else
+            {
+                UpdateTrainBaseResistance_ORTS();
+            }
+        }
+
+        /// <summary>
+        /// Update train base resistance with the conventional Open Rails algorithm.
+        /// </summary>
+        /// <remarks>
+        /// For all speeds.
+        /// </remarks>
+        private void UpdateTrainBaseResistance_ORTS()
+        {
+            if (FrictionV2 < 0 || FrictionV2 > 4.4407f) // > 10 mph
+            {   // not fcalc ignore friction and use default davis equation
+                // Starting Friction 
+                //
+                //                      Above Freezing   Below Freezing
+                //    Journal Bearing      25 lb/ton        35 lb/ton   (short ton)
+                //     Roller Bearing       5 lb/ton        15 lb/ton
+                //
+                // [2009-10-25 from http://www.arema.org/publications/pgre/ ]
+                //Friction0N = MassKG * 30f /* lb/ton */ * 4.84e-3f;  // convert lbs/short-ton to N/kg 
+                DavisAN = 6.3743f * MassKG / 1000 + 128.998f * 4;
+                DavisBNSpM = .49358f * MassKG / 1000;
+                DavisCNSSpMM = .11979f * 100 / 10.76f;
+                Friction0N = DavisAN * 2.0f;            //More firendly to high load trains and the new physics
+            }
+            else
+            {   // probably fcalc, recover approximate davis equation
+                float mps1 = FrictionV2;
+                float mps2 = 80 * .44704f;
+                float s = mps2 - mps1;
+                float x1 = mps1 * mps1;
+                float x2 = mps2 * mps2;
+                float sx = (x2 - x1) / 2;
+                float y0 = FrictionC1 * (float)Math.Pow(mps1, FrictionE1) + FrictionC2 * mps1;
+                float y1 = FrictionC2 * (float)Math.Pow(mps1, FrictionE2) * mps1;
+                float y2 = FrictionC2 * (float)Math.Pow(mps2, FrictionE2) * mps2;
+                float sy = y0 * (mps2 - mps1) + (y2 - y1) / (1 + FrictionE2);
+                y1 *= mps1;
+                y2 *= mps2;
+                float syx = y0 * (x2 - x1) / 2 + (y2 - y1) / (2 + FrictionE2);
+                x1 *= mps1;
+                x2 *= mps2;
+                float sx2 = (x2 - x1) / 3;
+                y1 *= mps1;
+                y2 *= mps2;
+                float syx2 = y0 * (x2 - x1) / 3 + (y2 - y1) / (3 + FrictionE2);
+                x1 *= mps1;
+                x2 *= mps2;
+                float sx3 = (x2 - x1) / 4;
+                x1 *= mps1;
+                x2 *= mps2;
+                float sx4 = (x2 - x1) / 5;
+                float s1 = syx - sy * sx / s;
+                float s2 = sx * sx2 / s - sx3;
+                float s3 = sx2 - sx * sx / s;
+                float s4 = syx2 - sy * sx2 / s;
+                float s5 = sx2 * sx2 / s - sx4;
+                float s6 = sx3 - sx * sx2 / s;
+                DavisCNSSpMM = (s1 * s6 - s3 * s4) / (s3 * s5 - s2 * s6);
+                DavisBNSpM = (s1 + DavisCNSSpMM * s2) / s3;
+                DavisAN = (sy - DavisBNSpM * sx - DavisCNSSpMM * sx2) / s;
+                Friction0N = FrictionC1;
+                if (FrictionE1 < 0)
+                    Friction0N *= (float)Math.Pow(.0025 * .44704, FrictionE1);
+            }
+
+            if (IsStandStill)
+            {
+                FrictionForceN = Friction0N;
+            }
+            else
+            {
+                FrictionForceN = DavisAN + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * DavisCNSSpMM);
+
+                // if this car is a locomotive, but not the lead one then recalculate the resistance with lower value as drag will not be as high on trailing locomotives
+                // Only the drag (C) factor changes if a trailing locomotive, so only running resistance, and not starting resistance needs to be corrected
+                if (WagonType == WagonTypes.Engine && Train.LeadLocomotive != this)
+                    FrictionForceN = DavisAN + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
+
+                // Test to identify whether a tender is attached to the leading engine, if not then the resistance should also be derated as for the locomotive
+                bool IsLeadTender = false;
+                if (WagonType == WagonTypes.Tender)
                 {
-                    // Determine the running resistance due to wheel bearing temperature
-                    float WheelBearingTemperatureResistanceFactor = 0;
-
-                    // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
-                    // bearing. Assume that resisnce will increase by 30% as temperature drops below 0 DegC.
-                    // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                    // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
-                    const float RunGrad = -0.0085714285714286f;
-                    const float RunIntersect = 1.2142857142857f;
-
-                    if (WheelBearingTemperatureDegC < -10) // Set to snowing (frozen value)
-                        WheelBearingTemperatureResistanceFactor = 1.3f;
-                    else if (WheelBearingTemperatureDegC > 25) // Set to normal temperature value
-                        WheelBearingTemperatureResistanceFactor = 1.0f;
-                    else // Set to variable value as bearing heats and cools
-                        WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
-
-                    // If hot box has been initiated, then increase friction on the wagon significantly
-                    if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
-                        WheelBearingTemperatureResistanceFactor = 2.0f;
-
-                    FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * DavisCNSSpMM); // for normal speed operation
-
-                    // if this car is a locomotive, but not the lead one then recalculate the resistance with lower value as drag will not be as high on trailing locomotives
-                    // Only the drag (C) factor changes if a trailing locomotive, so only running resistance, and not starting resistance needs to be corrected
-                    if (WagonType == WagonTypes.Engine && Train.LeadLocomotive != this)
-                        FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
-
-                    // Test to identify whether a tender is attached to the leading engine, if not then the resistance should also be derated as for the locomotive
-                    bool IsLeadTender = false;
-                    if (WagonType == WagonTypes.Tender)
+                    bool PrevCarLead = false;
+                    foreach (var car in Train.Cars)
                     {
-                        bool PrevCarLead = false;
-                        foreach (var car in Train.Cars)
+                        // If this car is a tender and the previous car is the lead locomotive then set the flag so that resistance will be reduced
+                        if (car == this && PrevCarLead)
                         {
-                            // If this car is a tender and the previous car is the lead locomotive then set the flag so that resistance will be reduced
-                            if (car == this && PrevCarLead)
-                            {
-                                IsLeadTender = true;
-                                break;  // If the tender has been identified then break out of the loop, otherwise keep going until whole train is done.
-                            }
-                            // Identify whether car is a lead locomotive or not. This is kept for when the next iteration (next car) is checked.
-                            PrevCarLead = Train.LeadLocomotive == car;
+                            IsLeadTender = true;
+                            break;  // If the tender has been identified then break out of the loop, otherwise keep going until whole train is done.
                         }
-
-                        // If tender is coupled to a trailing locomotive then reduce resistance
-                        if (!IsLeadTender)
-                            FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
+                        // Identify whether car is a lead locomotive or not. This is kept for when the next iteration (next car) is checked.
+                        PrevCarLead = Train.LeadLocomotive == car;
                     }
-                }
-            }
-            if (IsDavisFriction == false)    // If Davis parameters are not defined in WAG file, then use default methods
-            {
 
-                if (FrictionV2 < 0 || FrictionV2 > 4.4407f) // > 10 mph
-                {   // not fcalc ignore friction and use default davis equation
-                    // Starting Friction 
-                    //
-                    //                      Above Freezing   Below Freezing
-                    //    Journal Bearing      25 lb/ton        35 lb/ton   (short ton)
-                    //     Roller Bearing       5 lb/ton        15 lb/ton
-                    //
-                    // [2009-10-25 from http://www.arema.org/publications/pgre/ ]
-                    //Friction0N = MassKG * 30f /* lb/ton */ * 4.84e-3f;  // convert lbs/short-ton to N/kg 
-                    DavisAN = 6.3743f * MassKG / 1000 + 128.998f * 4;
-                    DavisBNSpM = .49358f * MassKG / 1000;
-                    DavisCNSSpMM = .11979f * 100 / 10.76f;
-                    Friction0N = DavisAN * 2.0f;            //More firendly to high load trains and the new physics
-                }
-                else
-                {   // probably fcalc, recover approximate davis equation
-                    float mps1 = FrictionV2;
-                    float mps2 = 80 * .44704f;
-                    float s = mps2 - mps1;
-                    float x1 = mps1 * mps1;
-                    float x2 = mps2 * mps2;
-                    float sx = (x2 - x1) / 2;
-                    float y0 = FrictionC1 * (float)Math.Pow(mps1, FrictionE1) + FrictionC2 * mps1;
-                    float y1 = FrictionC2 * (float)Math.Pow(mps1, FrictionE2) * mps1;
-                    float y2 = FrictionC2 * (float)Math.Pow(mps2, FrictionE2) * mps2;
-                    float sy = y0 * (mps2 - mps1) + (y2 - y1) / (1 + FrictionE2);
-                    y1 *= mps1;
-                    y2 *= mps2;
-                    float syx = y0 * (x2 - x1) / 2 + (y2 - y1) / (2 + FrictionE2);
-                    x1 *= mps1;
-                    x2 *= mps2;
-                    float sx2 = (x2 - x1) / 3;
-                    y1 *= mps1;
-                    y2 *= mps2;
-                    float syx2 = y0 * (x2 - x1) / 3 + (y2 - y1) / (3 + FrictionE2);
-                    x1 *= mps1;
-                    x2 *= mps2;
-                    float sx3 = (x2 - x1) / 4;
-                    x1 *= mps1;
-                    x2 *= mps2;
-                    float sx4 = (x2 - x1) / 5;
-                    float s1 = syx - sy * sx / s;
-                    float s2 = sx * sx2 / s - sx3;
-                    float s3 = sx2 - sx * sx / s;
-                    float s4 = syx2 - sy * sx2 / s;
-                    float s5 = sx2 * sx2 / s - sx4;
-                    float s6 = sx3 - sx * sx2 / s;
-                    DavisCNSSpMM = (s1 * s6 - s3 * s4) / (s3 * s5 - s2 * s6);
-                    DavisBNSpM = (s1 + DavisCNSSpMM * s2) / s3;
-                    DavisAN = (sy - DavisBNSpM * sx - DavisCNSSpMM * sx2) / s;
-                    Friction0N = FrictionC1;
-                    if (FrictionE1 < 0)
-                        Friction0N *= (float)Math.Pow(.0025 * .44704, FrictionE1);
-                }
-
-                if (AbsSpeedMpS > 0.1)
-                    IsStandStill = false;
-                if (AbsSpeedMpS == 0.0)
-                    IsStandStill = true;
-
-                if (IsStandStill)
-                    FrictionForceN = Friction0N;
-                else
-                {
-                    FrictionForceN = DavisAN + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * DavisCNSSpMM);
-
-                    // if this car is a locomotive, but not the lead one then recalculate the resistance with lower value as drag will not be as high on trailing locomotives
-                    // Only the drag (C) factor changes if a trailing locomotive, so only running resistance, and not starting resistance needs to be corrected
-                    if (WagonType == WagonTypes.Engine && Train.LeadLocomotive != this)
-                    {
+                    // If tender is coupled to a trailing locomotive then reduce resistance
+                    if (!IsLeadTender)
                         FrictionForceN = DavisAN + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
-                    }
+                }
+            }
+        }
 
-                    // Test to identify whether a tender is attached to the leading engine, if not then the resistance should also be derated as for the locomotive
-                    bool IsLeadTender = false;
-                    if (WagonType == WagonTypes.Tender)
-                    {
-                        bool PrevCarLead = false;
-                        foreach (var car in Train.Cars)
-                        {
-                            // If this car is a tender and the previous car is the lead locomotive then set the flag so that resistance will be reduced
-                            if (car == this && PrevCarLead)
-                            {
-                                IsLeadTender = true;
-                                break;  // If the tender has been identified then break out of the loop, otherwise keep going until whole train is done.
-                            }
-                            // Identify whether car is a lead locomotive or not. This is kept for when the next iteration (next car) is checked.
-                            if (Train.LeadLocomotive == car)
-                            {
-                                PrevCarLead = true;
-                            }
-                            else
-                            {
-                                PrevCarLead = false;
-                            }
+        /// <summary>
+        /// Update train base resistance with a manually specified starting friction.
+        /// </summary>
+        /// <remarks>
+        /// For speeds slower than the merge speed.
+        /// </remarks>
+        private void UpdateTrainBaseResistance_StartingFriction()
+        {
+            // Dtermine the starting friction factor based upon the type of bearing
+            float StartFrictionLoadN = StandstillFrictionN;  // Starting friction
 
-                        }
+            // Determine the starting resistance due to wheel bearing temperature
+            // Note reference values in lbf and US tons - converted to metric values as appropriate
+            // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+            // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+            const float RunGrad = -0.0085714285714286f;
+            const float RunIntersect = 1.2142857142857f;
+            if (WheelBearingTemperatureDegC < -10) // Set to snowing (frozen value)
+                StartFrictionLoadN = 1.2f;  // Starting friction, snowing
+            else if (WheelBearingTemperatureDegC > 25) // Set to normal temperature value
+                StartFrictionLoadN = 1.0f;  // Starting friction, not snowing
+            else // Set to variable value as bearing heats and cools
+                StartFrictionLoadN = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
+            StaticFrictionFactorN = StartFrictionLoadN;
 
-                        // If tender is coupled to a trailing locomotive then reduce resistance
-                        if (!IsLeadTender)
-                        {
-                            FrictionForceN = DavisAN + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
-                        }
+            // Determine the running resistance due to wheel bearing temperature
+            float WheelBearingTemperatureResistanceFactor = 0;
 
-                    }
+            // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
+            // bearing. Assume that resistance will increase by 30% as temperature drops below 0 DegC.
+            // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+            // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
 
+            if (WheelBearingTemperatureDegC < -10) // Set to snowing (frozen value)
+                WheelBearingTemperatureResistanceFactor = 1.3f;
+            else if (WheelBearingTemperatureDegC > 25) // Set to normal temperature value
+                WheelBearingTemperatureResistanceFactor = 1.0f;
+            else // Set to variable value as bearing heats and cools
+                WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
+            // If hot box has been initiated, then increase friction on the wagon significantly
+            if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
+            {
+                WheelBearingTemperatureResistanceFactor = 2.0f;
+                StaticFrictionFactorN *= 2.0f;
+            }
+            // Calculation of resistance @ low speeds
+            // Wind resistance is not included at low speeds, as it does not have a significant enough impact
+            MergeSpeedFrictionN = DavisAN * WheelBearingTemperatureResistanceFactor + (MergeSpeedMpS) * (DavisBNSpM + (MergeSpeedMpS) * DavisCNSSpMM); // Calculate friction @ merge speed
+            Friction0N = StandstillFrictionN * StaticFrictionFactorN; // Static friction x external resistance as this matches reference value
+            FrictionBelowMergeSpeedN = ((1.0f - (AbsSpeedMpS / (MergeSpeedMpS))) * (Friction0N - MergeSpeedFrictionN)) + MergeSpeedFrictionN; // Calculate friction below merge speed - decreases linearly with speed
+            FrictionForceN = FrictionBelowMergeSpeedN; // At low speed use this value
+        }
+
+        /// <summary>
+        /// Update train base resistance with the Davis function.
+        /// </summary>
+        /// <remarks>
+        /// For speeds slower than the "slow" speed.
+        /// </remarks>
+        private void UpdateTrainBaseResistance_DavisLowSpeed()
+        {
+            // Dtermine the starting friction factor based upon the type of bearing
+
+            float StartFrictionLowLoadN = 0.0f;  // Starting friction for a lightly loaded wagon
+            float StartFrictionHighLoadN = 0.0f; // Starting friction for a heavily loaded wagon
+
+            if (IsRollerBearing)
+            {
+                // Determine the starting resistance due to wheel bearing temperature
+                // Note reference values in lbf and US tons - converted to metric values as appropriate
+                // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+                // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+                const float LowGrad = -0.24342857142857f;
+                const float LowIntersect = 10.335714285714f;
+                const float HighGrad = -0.402f;
+                const float HighIntersect = 25.98f;
+
+                if (WheelBearingTemperatureDegC < -10)
+                {
+                    // Set to snowing (frozen value)
+                    StartFrictionLowLoadN = N.FromLbf(12.771f);  // Starting friction for a 10 ton(US) car with standard roller bearings, snowing
+                    StartFrictionHighLoadN = N.FromLbf(30.0f);  // Starting friction for a 100 ton(US) car with standard roller bearings, snowing
+                }
+                else if (WheelBearingTemperatureDegC > 25)
+                {
+                    // Set to normal temperature value
+                    StartFrictionLowLoadN = N.FromLbf(4.257f);  // Starting friction for a 10 ton(US) car with standard roller bearings, not snowing
+                    StartFrictionHighLoadN = N.FromLbf(15.93f);  // Starting friction for a 100 ton(US) car with standard roller bearings, not snowing
+                }
+                else
+                {
+                    // Set to variable value as bearing heats and cools
+                    StartFrictionLowLoadN = N.FromLbf(LowGrad * WheelBearingTemperatureDegC + LowIntersect);
+                    StartFrictionHighLoadN = N.FromLbf(HighGrad * WheelBearingTemperatureDegC + HighIntersect);
+                }
+
+                if (Kg.ToTUS(MassKG) < 10.0)
+                {
+                    StaticFrictionFactorN = StartFrictionLowLoadN;  // Starting friction for a < 10 ton(US) car with standard roller bearings
+                }
+                else if (Kg.ToTUS(MassKG) > 100.0)
+                {
+                    StaticFrictionFactorN = StartFrictionHighLoadN;  // Starting friction for a > 100 ton(US) car with standard roller bearings
+                }
+                else
+                {
+                    StaticFrictionFactorN = (((Kg.ToTUS(MassKG) - 10.0f) / 90.0f) * (StartFrictionHighLoadN - StartFrictionLowLoadN)) + StartFrictionLowLoadN;
+                }
+            }
+
+
+            else if (IsLowTorqueRollerBearing)
+            {
+                // Determine the starting resistance due to wheel bearing temperature
+                // Note reference values in lbf and US tons - converted to metric values as appropriate
+                // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+                // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+                const float LowGrad = -0.152f;
+                const float LowIntersect = 6.46f;
+                const float HighGrad = -0.4408f;
+                const float HighIntersect = 18.734f;
+
+                if (WheelBearingTemperatureDegC < -10)
+                {
+                    // Set to snowing (frozen value)
+                    StartFrictionLowLoadN = N.FromLbf(7.98f);  // Starting friction for a 10 ton(US) car with Low torque bearings, snowing
+                    StartFrictionHighLoadN = N.FromLbf(23.142f);  // Starting friction for a 100 ton(US) car with low torque bearings, snowing
+                }
+                else if (WheelBearingTemperatureDegC > 25)
+                {
+                    // Set to normal temperature value
+                    StartFrictionLowLoadN = N.FromLbf(2.66f);  // Starting friction for a 10 ton(US) car with Low troque bearings, not snowing
+                    StartFrictionHighLoadN = N.FromLbf(7.714f);  // Starting friction for a 100 ton(US) car with low torque bearings, not snowing
+                }
+                else
+                {
+                    // Set to variable value as bearing heats and cools
+                    StartFrictionLowLoadN = N.FromLbf(LowGrad * WheelBearingTemperatureDegC + LowIntersect);
+                    StartFrictionHighLoadN = N.FromLbf(HighGrad * WheelBearingTemperatureDegC + HighIntersect);
+                }
+
+                if (Kg.ToTUS(MassKG) < 10.0)
+                {
+                    StaticFrictionFactorN = StartFrictionLowLoadN;  // Starting friction for a < 10 ton(US) car with Low troque bearings
+                }
+                else if (Kg.ToTUS(MassKG) > 100.0)
+                {
+                    StaticFrictionFactorN = StartFrictionHighLoadN;  // Starting friction for a > 100 ton(US) car with low torque bearings
+                }
+                else
+                {
+                    StaticFrictionFactorN = (((Kg.ToTUS(MassKG) - 10.0f) / 90.0f) * (StartFrictionHighLoadN - StartFrictionLowLoadN)) + StartFrictionLowLoadN;
+                }
+
+            }
+            else  // default to friction (solid - journal) bearing
+            {
+
+                // Determine the starting resistance due to wheel bearing temperature
+                // Note reference values in lbf and US tons - converted to metric values as appropriate
+                // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+                // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+                const float LowGrad = -0.14285714285714f;
+                const float LowIntersect = 13.571428571429f;
+                const float HighGrad = -0.42857142857143f;
+                const float HighIntersect = 30.714285714286f;
+
+                if (WheelBearingTemperatureDegC < -10)
+                {
+                    // Set to snowing (frozen value)
+                    StartFrictionLowLoadN = N.FromLbf(15.0f); // Starting friction for a < 10 ton(US) car with friction (journal) bearings - ton (US), snowing
+                    StartFrictionHighLoadN = N.FromLbf(35.0f); // Starting friction for a > 100 ton(US) car with friction (journal) bearings - ton (US), snowing
+                }
+                else if (WheelBearingTemperatureDegC > 25)
+                {
+                    // Set to normal temperature value
+                    StartFrictionLowLoadN = N.FromLbf(10.0f); // Starting friction for a < 10 ton(US) car with friction (journal) bearings - ton (US), not snowing
+                    StartFrictionHighLoadN = N.FromLbf(20.0f); // Starting friction for a > 100 ton(US) car with friction (journal) bearings - ton (US), not snowing
+                }
+                else
+                {
+                    // Set to variable value as bearing heats and cools
+                    StartFrictionLowLoadN = N.FromLbf(LowGrad * WheelBearingTemperatureDegC + LowIntersect);
+                    StartFrictionHighLoadN = N.FromLbf(HighGrad * WheelBearingTemperatureDegC + HighIntersect);
+                }
+
+                if (Kg.ToTUS(MassKG) < 10.0)
+                {
+                    StaticFrictionFactorN = StartFrictionLowLoadN;  // Starting friction for a < 10 ton(US) car with friction (journal) bearings
+                }
+                else if (Kg.ToTUS(MassKG) > 100.0)
+                {
+                    StaticFrictionFactorN = StartFrictionHighLoadN;  // Starting friction for a > 100 ton(US) car with friction (journal) bearings
+                }
+                else
+                {
+                    StaticFrictionFactorN = (((Kg.ToTUS(MassKG) - 10.0f) / 90.0f) * (StartFrictionHighLoadN - StartFrictionLowLoadN)) + StartFrictionLowLoadN;
                 }
 
             }
 
-            if (IsDavisFriction && !IsORTSFriction)  // If set to use next Davis friction then do so
+            // Determine the running resistance due to wheel bearing temperature
+            float WheelBearingTemperatureResistanceFactor = 0;
+
+            // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
+            // bearing. Assume that resisnce will increase by 30% as temperature drops below 0 DegC.
+            // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+            // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+            const float RunGrad = -0.0085714285714286f;
+            const float RunIntersect = 1.2142857142857f;
+
+            if (WheelBearingTemperatureDegC < -10)
             {
-                // Davis formulas only apply above about 5mph, so different treatment required for low speed < 5mph.
-                if (AbsSpeedMpS > MpS.FromMpH(5.05f))     // if speed above 5 mph then turn off low speed calculations
-                    IsLowSpeed = false;
-                else if (AbsSpeedMpS < MpS.FromMpH(4.95f)) // if speed below 5 mph then turn on low speed calculations
-                    IsLowSpeed = true;
+                // Set to snowing (frozen value)
+                WheelBearingTemperatureResistanceFactor = 1.3f;
+            }
+            else if (WheelBearingTemperatureDegC > 25)
+            {
+                // Set to normal temperature value
+                WheelBearingTemperatureResistanceFactor = 1.0f;
+            }
+            else
+            {
+                // Set to variable value as bearing heats and cools
+                WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
 
-                // Ensure that flag is turned off at low speed
-                    if (AbsSpeedMpS <= 0.0)
-                    IsLowSpeed = true;
+            }
 
-                if (IsLowSpeed)
-                {
-
-                    // Dtermine the starting friction factor based upon the type of bearing
-
-                    float StartFrictionLowLoadN = 0.0f;  // Starting friction for a lightly loaded wagon
-                    float StartFrictionHighLoadN = 0.0f; // Starting friction for a heavily loaded wagon
-
-                    if (IsRollerBearing)
-                    {
-                        // Determine the starting resistance due to wheel bearing temperature
-                        // Note reference values in lbf and US tons - converted to metric values as appropriate
-                        // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                        // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
-                        const float LowGrad = -0.24342857142857f;
-                        const float LowIntersect = 10.335714285714f;
-                        const float HighGrad = -0.402f;
-                        const float HighIntersect = 25.98f;
-
-                        if (WheelBearingTemperatureDegC < -10)
-                        {
-                            // Set to snowing (frozen value)
-                            StartFrictionLowLoadN = N.FromLbf(12.771f);  // Starting friction for a 10 ton(US) car with standard roller bearings, snowing
-                            StartFrictionHighLoadN = N.FromLbf(30.0f);  // Starting friction for a 100 ton(US) car with standard roller bearings, snowing
-                        }
-                        else if (WheelBearingTemperatureDegC > 25)
-                        {
-                            // Set to normal temperature value
-                            StartFrictionLowLoadN = N.FromLbf(4.257f);  // Starting friction for a 10 ton(US) car with standard roller bearings, not snowing
-                            StartFrictionHighLoadN = N.FromLbf(15.93f);  // Starting friction for a 100 ton(US) car with standard roller bearings, not snowing
-                        }
-                        else
-                        {
-                            // Set to variable value as bearing heats and cools
-                            StartFrictionLowLoadN = N.FromLbf(LowGrad * WheelBearingTemperatureDegC + LowIntersect);
-                            StartFrictionHighLoadN = N.FromLbf(HighGrad * WheelBearingTemperatureDegC + HighIntersect);
-                        }
-
-                        if (Kg.ToTUS(MassKG) < 10.0)
-                        {
-                            StaticFrictionFactorN = StartFrictionLowLoadN;  // Starting friction for a < 10 ton(US) car with standard roller bearings
-                        }
-                        else if (Kg.ToTUS(MassKG) > 100.0)
-                        {
-                            StaticFrictionFactorN = StartFrictionHighLoadN;  // Starting friction for a > 100 ton(US) car with standard roller bearings
-                        }
-                        else
-                        {
-                            StaticFrictionFactorN = (((Kg.ToTUS(MassKG) - 10.0f) / 90.0f) * (StartFrictionHighLoadN - StartFrictionLowLoadN)) + StartFrictionLowLoadN;
-                        }
-                    }
-
-
-                    else if (IsLowTorqueRollerBearing)
-                    {
-                        // Determine the starting resistance due to wheel bearing temperature
-                        // Note reference values in lbf and US tons - converted to metric values as appropriate
-                        // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                        // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
-                        const float LowGrad = -0.152f;
-                        const float LowIntersect = 6.46f;
-                        const float HighGrad = -0.4408f;
-                        const float HighIntersect = 18.734f;
-
-                        if (WheelBearingTemperatureDegC < -10)
-                        {
-                            // Set to snowing (frozen value)
-                            StartFrictionLowLoadN = N.FromLbf(7.98f);  // Starting friction for a 10 ton(US) car with Low torque bearings, snowing
-                            StartFrictionHighLoadN = N.FromLbf(23.142f);  // Starting friction for a 100 ton(US) car with low torque bearings, snowing
-                        }
-                        else if (WheelBearingTemperatureDegC > 25)
-                        {
-                            // Set to normal temperature value
-                            StartFrictionLowLoadN = N.FromLbf(2.66f);  // Starting friction for a 10 ton(US) car with Low troque bearings, not snowing
-                            StartFrictionHighLoadN = N.FromLbf(7.714f);  // Starting friction for a 100 ton(US) car with low torque bearings, not snowing
-                        }
-                        else
-                        {
-                            // Set to variable value as bearing heats and cools
-                            StartFrictionLowLoadN = N.FromLbf(LowGrad * WheelBearingTemperatureDegC + LowIntersect);
-                            StartFrictionHighLoadN = N.FromLbf(HighGrad * WheelBearingTemperatureDegC + HighIntersect);
-                        }
-
-                        if (Kg.ToTUS(MassKG) < 10.0)
-                        {
-                            StaticFrictionFactorN = StartFrictionLowLoadN;  // Starting friction for a < 10 ton(US) car with Low troque bearings
-                        }
-                        else if (Kg.ToTUS(MassKG) > 100.0)
-                        {
-                            StaticFrictionFactorN = StartFrictionHighLoadN;  // Starting friction for a > 100 ton(US) car with low torque bearings
-                        }
-                        else
-                        {
-                            StaticFrictionFactorN = (((Kg.ToTUS(MassKG) - 10.0f) / 90.0f) * (StartFrictionHighLoadN - StartFrictionLowLoadN)) + StartFrictionLowLoadN;
-                        }
-
-                    }
-                    else  // default to friction (solid - journal) bearing
-                    {
-
-                        // Determine the starting resistance due to wheel bearing temperature
-                        // Note reference values in lbf and US tons - converted to metric values as appropriate
-                        // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                        // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
-                        const float LowGrad = -0.14285714285714f;
-                        const float LowIntersect = 13.571428571429f;
-                        const float HighGrad = -0.42857142857143f;
-                        const float HighIntersect = 30.714285714286f;
-
-                        if (WheelBearingTemperatureDegC < -10)
-                        {
-                            // Set to snowing (frozen value)
-                            StartFrictionLowLoadN = N.FromLbf(15.0f); // Starting friction for a < 10 ton(US) car with friction (journal) bearings - ton (US), snowing
-                            StartFrictionHighLoadN = N.FromLbf(35.0f); // Starting friction for a > 100 ton(US) car with friction (journal) bearings - ton (US), snowing
-                        }
-                        else if (WheelBearingTemperatureDegC > 25)
-                        {
-                            // Set to normal temperature value
-                            StartFrictionLowLoadN = N.FromLbf(10.0f); // Starting friction for a < 10 ton(US) car with friction (journal) bearings - ton (US), not snowing
-                            StartFrictionHighLoadN = N.FromLbf(20.0f); // Starting friction for a > 100 ton(US) car with friction (journal) bearings - ton (US), not snowing
-                        }
-                        else
-                        {
-                            // Set to variable value as bearing heats and cools
-                            StartFrictionLowLoadN = N.FromLbf(LowGrad * WheelBearingTemperatureDegC + LowIntersect);
-                            StartFrictionHighLoadN = N.FromLbf(HighGrad * WheelBearingTemperatureDegC + HighIntersect);
-                        }
-
-                        if (Kg.ToTUS(MassKG) < 10.0)
-                        {
-                            StaticFrictionFactorN = StartFrictionLowLoadN;  // Starting friction for a < 10 ton(US) car with friction (journal) bearings
-                        }
-                        else if (Kg.ToTUS(MassKG) > 100.0)
-                        {
-                            StaticFrictionFactorN = StartFrictionHighLoadN;  // Starting friction for a > 100 ton(US) car with friction (journal) bearings
-                        }
-                        else
-                        {
-                            StaticFrictionFactorN = (((Kg.ToTUS(MassKG) - 10.0f) / 90.0f) * (StartFrictionHighLoadN - StartFrictionLowLoadN)) + StartFrictionLowLoadN;
-                        }
-
-                    }
-
-                    // Determine the running resistance due to wheel bearing temperature
-                    float WheelBearingTemperatureResistanceFactor = 0;
-
-                    // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
-                    // bearing. Assume that resisnce will increase by 30% as temperature drops below 0 DegC.
-                    // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                    // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
-                    const float RunGrad = -0.0085714285714286f;
-                    const float RunIntersect = 1.2142857142857f;
-
-                    if (WheelBearingTemperatureDegC < -10)
-                    {
-                        // Set to snowing (frozen value)
-                        WheelBearingTemperatureResistanceFactor = 1.3f;
-                    }
-                    else if (WheelBearingTemperatureDegC > 25)
-                    {
-                        // Set to normal temperature value
-                        WheelBearingTemperatureResistanceFactor = 1.0f;
-                    }
-                    else
-                    {
-                        // Set to variable value as bearing heats and cools
-                        WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
-
-                    }
-
-                    // If hot box has been initiated, then increase friction on the wagon significantly
-                    if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
-                    {
-                        WheelBearingTemperatureResistanceFactor = 2.0f;
-                        StaticFrictionFactorN *= 2.0f;
-                    }
+            // If hot box has been initiated, then increase friction on the wagon significantly
+            if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
+            {
+                WheelBearingTemperatureResistanceFactor = 2.0f;
+                StaticFrictionFactorN *= 2.0f;
+            }
 
 
 
 
-                    // Calculation of resistance @ low speeds
-                    // Wind resistance is not included at low speeds, as it does not have a significant enough impact
-                    const float speed5 = 2.2352f; // 5 mph
-                    Friction5N = DavisAN * WheelBearingTemperatureResistanceFactor + speed5 * (DavisBNSpM + speed5 * DavisCNSSpMM); // Calculate friction @ 5 mph
-                    Friction0N = Kg.ToTUS(MassKG) * StaticFrictionFactorN; // Static friction is journal or roller bearing friction x weight factor based upon US tons as this matches reference value
-                    FrictionLowSpeedN = ((1.0f - (AbsSpeedMpS / speed5)) * (Friction0N - Friction5N)) + Friction5N; // Calculate friction below 5mph - decreases linearly with speed
-                    FrictionForceN = FrictionLowSpeedN; // At low speed use this value
+            // Calculation of resistance @ low speeds
+            // Wind resistance is not included at low speeds, as it does not have a significant enough impact
+            const float speed5 = 2.2352f; // 5 mph
+            Friction5N = DavisAN * WheelBearingTemperatureResistanceFactor + speed5 * (DavisBNSpM + speed5 * DavisCNSSpMM); // Calculate friction @ 5 mph
+            Friction0N = Kg.ToTUS(MassKG) * StaticFrictionFactorN; // Static friction is journal or roller bearing friction x weight factor based upon US tons as this matches reference value
+            FrictionLowSpeedN = ((1.0f - (AbsSpeedMpS / speed5)) * (Friction0N - Friction5N)) + Friction5N; // Calculate friction below 5mph - decreases linearly with speed
+            FrictionForceN = FrictionLowSpeedN; // At low speed use this value
 
 #if DEBUG_FRICTION
 
@@ -2088,90 +2022,89 @@ namespace Orts.Simulation.RollingStocks
                     Trace.TraceInformation("Stationary - Force0 lbf {0} Force5 lbf {1}", N.ToLbf(Friction0N), N.ToLbf(Friction5N));
 
 #endif
+        }
 
-                }
-                else
-                {
+        /// <summary>
+        /// Update train base resistance with the Davis function.
+        /// </summary>
+        /// <remarks>
+        /// For speeds faster than the "slow" speed.
+        /// </remarks>
+        private void UpdateTrainBaseResistance_DavisHighSpeed()
+        {
+            // Determine the running resistance due to wheel bearing temperature
+            float WheelBearingTemperatureResistanceFactor = 0;
 
-                    // Determine the running resistance due to wheel bearing temperature
-                    float WheelBearingTemperatureResistanceFactor = 0;
-                    
-                    // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
-                    // bearing. Assume that resisnce will increase by 30% as temperature drops below 0 DegC.
-                    // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
-                    // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
-                    const float RunGrad = -0.0085714285714286f;
-                    const float RunIntersect = 1.2142857142857f;
+            // Assume the running resistance is impacted by wheel bearing temperature, ie gets higher as tmperature decreasses. This will only impact the A parameter as it is related to
+            // bearing. Assume that resisnce will increase by 30% as temperature drops below 0 DegC.
+            // At -10 DegC it will be equal to the snowing value, as the temperature increases to 25 DegC, it will move towards the summer value
+            // Assume a linear relationship between the two sets of points above and plot a straight line relationship.
+            const float RunGrad = -0.0085714285714286f;
+            const float RunIntersect = 1.2142857142857f;
 
-                    if (WheelBearingTemperatureDegC < -10)
-                    {
-                        // Set to snowing (frozen value)
-                        WheelBearingTemperatureResistanceFactor = 1.3f;
-                    }
-                    else if (WheelBearingTemperatureDegC > 25)
-                    {
-                        // Set to normal temperature value
-                        WheelBearingTemperatureResistanceFactor = 1.0f;
-                    }
-                    else
-                    {
-                        // Set to variable value as bearing heats and cools
-                        WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
-
-                    }
-
-                    // If hot box has been initiated, then increase friction on the wagon significantly
-                    if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
-                    {
-                        WheelBearingTemperatureResistanceFactor = 2.0f;
-                    }
-                    
-                    FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * DavisCNSSpMM); // for normal speed operation
-
-                    // if this car is a locomotive, but not the lead one then recalculate the resistance with lower value as drag will not be as high on trailing locomotives
-                    // Only the drag (C) factor changes if a trailing locomotive, so only running resistance, and not starting resistance needs to be corrected
-                    if (WagonType == WagonTypes.Engine && Train.LeadLocomotive != this)
-                    {
-                        FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
-                    }
-
-                    // Test to identify whether a tender is attached to the leading engine, if not then the resistance should also be derated as for the locomotive
-                    bool IsLeadTender = false;
-                    if (WagonType == WagonTypes.Tender)
-                    {
-                        bool PrevCarLead = false;
-                        foreach (var car in Train.Cars)
-                        {
-                            // If this car is a tender and the previous car is the lead locomotive then set the flag so that resistance will be reduced
-                            if (car == this && PrevCarLead)
-                            {
-                                IsLeadTender = true;
-                                break;  // If the tender has been identified then break out of the loop, otherwise keep going until whole train is done.
-                            }
-                            // Identify whether car is a lead locomotive or not. This is kept for when the next iteration (next car) is checked.
-                            if (Train.LeadLocomotive == car)
-                            {
-                                PrevCarLead = true;
-                            }
-                            else
-                            {
-                                PrevCarLead = false;
-                            }
-
-                        }
-
-                        // If tender is coupled to a trailing locomotive then reduce resistance
-                        if (!IsLeadTender)
-                        {
-                            FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
-                        }
-
-                    }
-
-                }
+            if (WheelBearingTemperatureDegC < -10)
+            {
+                // Set to snowing (frozen value)
+                WheelBearingTemperatureResistanceFactor = 1.3f;
+            }
+            else if (WheelBearingTemperatureDegC > 25)
+            {
+                // Set to normal temperature value
+                WheelBearingTemperatureResistanceFactor = 1.0f;
+            }
+            else
+            {
+                // Set to variable value as bearing heats and cools
+                WheelBearingTemperatureResistanceFactor = RunGrad * WheelBearingTemperatureDegC + RunIntersect;
 
             }
 
+            // If hot box has been initiated, then increase friction on the wagon significantly
+            if (HotBoxActivated && ActivityElapsedDurationS > HotBoxStartTimeS)
+            {
+                WheelBearingTemperatureResistanceFactor = 2.0f;
+            }
+
+            FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * DavisCNSSpMM); // for normal speed operation
+
+            // if this car is a locomotive, but not the lead one then recalculate the resistance with lower value as drag will not be as high on trailing locomotives
+            // Only the drag (C) factor changes if a trailing locomotive, so only running resistance, and not starting resistance needs to be corrected
+            if (WagonType == WagonTypes.Engine && Train.LeadLocomotive != this)
+            {
+                FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
+            }
+
+            // Test to identify whether a tender is attached to the leading engine, if not then the resistance should also be derated as for the locomotive
+            bool IsLeadTender = false;
+            if (WagonType == WagonTypes.Tender)
+            {
+                bool PrevCarLead = false;
+                foreach (var car in Train.Cars)
+                {
+                    // If this car is a tender and the previous car is the lead locomotive then set the flag so that resistance will be reduced
+                    if (car == this && PrevCarLead)
+                    {
+                        IsLeadTender = true;
+                        break;  // If the tender has been identified then break out of the loop, otherwise keep going until whole train is done.
+                    }
+                    // Identify whether car is a lead locomotive or not. This is kept for when the next iteration (next car) is checked.
+                    if (Train.LeadLocomotive == car)
+                    {
+                        PrevCarLead = true;
+                    }
+                    else
+                    {
+                        PrevCarLead = false;
+                    }
+
+                }
+
+                // If tender is coupled to a trailing locomotive then reduce resistance
+                if (!IsLeadTender)
+                {
+                    FrictionForceN = DavisAN * WheelBearingTemperatureResistanceFactor + AbsSpeedMpS * (DavisBNSpM + AbsSpeedMpS * (TrailLocoResistanceFactor * DavisCNSSpMM));
+                }
+            }
         }
 
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -78,7 +78,6 @@ namespace Orts.Simulation.RollingStocks
         public bool IsFrictionBearing; //Has friction (or solid bearings)
         public bool IsStandStill = true;  // Used for MSTS type friction
         public bool IsDavisFriction = true; // Default to new Davis type friction
-        public bool IsLowSpeed = true; // set indicator for low speed operation  0 - 5mph
         public bool IsBelowMergeSpeed = true; // set indicator for low speed operation as per given speed
 
         Interpolator BrakeShoeFrictionFactor;  // Factor of friction for wagon brake shoes
@@ -1641,16 +1640,15 @@ namespace Orts.Simulation.RollingStocks
         private void UpdateTrainBaseResistance()
         {
             IsDavisFriction = DavisAN != 0 && DavisBNSpM != 0 && DavisCNSSpMM != 0; // test to see if OR thinks that Davis Values have been entered in WG file.
-            IsLowSpeed = AbsSpeedMpS < MpS.FromMpH(5f);
             IsBelowMergeSpeed = AbsSpeedMpS < MergeSpeedMpS;
             IsStandStill = AbsSpeedMpS < 0.1f;
-            bool isStartingFriction = StandstillFrictionN != 0 && MergeSpeedMpS != 0;
+            bool isStartingFriction = StandstillFrictionN != 0;
 
             if (IsDavisFriction) // If set to use next Davis friction then do so
             {
                 if (isStartingFriction && IsBelowMergeSpeed) // Davis formulas only apply above merge speed, so different treatment required for low speed
                     UpdateTrainBaseResistance_StartingFriction();
-                else if (IsLowSpeed) // Davis formulas only apply above about 5mph, so different treatment required for low speed < 5mph.
+                else if (IsBelowMergeSpeed)
                     UpdateTrainBaseResistance_DavisLowSpeed();
                 else
                     UpdateTrainBaseResistance_DavisHighSpeed();


### PR DESCRIPTION
Blueprint [Parameters to adjust friction at low or no speed](https://blueprints.launchpad.net/or/+spec/stationary-friction)

Additional .wag parameters for starting friction. Based off of code [shared](http://www.elvastower.com/forums/index.php?/topic/33919-orts-extended-friction-test/) by NickOnWheels of Elvas Tower.

I also refactored the super-sized `UpdateTrainBaseResistance` method. This results in a rather large diff, but my hope is that it's now much clearer which physics model applies during which states.

> README for new starting friction equation - by NickonWheels
> 
> First and foremost, the three Davis lines
> 
> ORTSDavis_A
> ORTSDavis_B
> ORTSDavis_C
> 
> work as before. However now it is POSSIBLE to replace ORTSBearingType with
> 
> ORTSStandstillFriction - the amount of static friction / defaults to newton but can use pounds, just like ORTSDavis_A
> ORTSMergeSpeed - the speed at which low speed calculations and Davis equations meet (while accelerating and decelerating) / uses meters per second, other units are untested
> 
> The older code section uses 5mph as merge speed throughout.
> 
> If you don´t want to bother with this new section ORTSBearingType (or lack thereof in regards to plain bearings) still works as before.
> Of course it´s hard to know what values seem to fit as FCalc won´t tell that.