### PR TITLE
docs: Add build statuses and download links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Open Rails
 
+## Builds and downloads
+
+Type | Version  | Status | Downloads
+-- | -- | -- | --
+Official website and in-app updates | Stable   | - | [Downloads](http://www.openrails.org/download/program/?utm_campaign=documentation&utm_source=readme&utm_medium=referral)
+Official website and in-app updates | Testing  | ![Build status](https://james-ross.co.uk/projects/or/testing/ci_status.svg) | [Downloads](http://www.openrails.org/download/program/?utm_campaign=documentation&utm_source=readme&utm_medium=referral)
+Official website and in-app updates | Unstable | ![Build status](https://james-ross.co.uk/projects/or/ci_status.svg) | [Downloads](https://james-ross.co.uk/projects/or/builds?utm_campaign=documentation&utm_source=readme&utm_medium=referral)
+Code verification | Stable   | - | -
+Code verification | Testing  | [![Build status](https://ci.appveyor.com/api/projects/status/37hhwwna5809xyhl/branch/master?svg=true)](https://ci.appveyor.com/project/openrails/openrails/branch/master) | [Downloads](https://ci.appveyor.com/project/openrails/openrails/branch/master/artifacts)
+Code verification | Unstable | [![Build status](https://ci.appveyor.com/api/projects/status/37hhwwna5809xyhl/branch/unstable?svg=true)](https://ci.appveyor.com/project/openrails/openrails/branch/unstable) | [Downloads](https://ci.appveyor.com/project/openrails/openrails/branch/unstable/artifacts)
+
 ## Open Rails and Microsoft Train Simulator
 
 Our project provides a train simulator for the largest collection of digital content in the world - routes, rolling stock and activities - initially developed for Microsoft's Train Simulator product.


### PR DESCRIPTION
I thought it about time we listed and linked to all the builds and downloads. The build statuses are badges that update automatically.

![image](https://user-images.githubusercontent.com/1017843/83956258-ea9b0000-a853-11ea-9a63-35dd42ab97e8.png)
