### PR TITLE
Add additional sound triggers for steam locomotives

### DIFF
--- a/Source/Documentation/Manual/sound.rst
+++ b/Source/Documentation/Manual/sound.rst
@@ -196,6 +196,15 @@ Trigger       Function
 143           BrakePipePressureStoppedChanging : for rolling stock equipped with train brakes, triggered when brake pipe/brakeline pressure stops changing
 =========     ============================================================================================================================================================================
 
+
+=========     ======================================================================
+Trigger       Function
+=========     ======================================================================
+147           SteamGearLeverToggle : Toggles when steam gear lever is moved.
+148           AIFiremanSoundOn : AI fireman mode is on.
+149           AIFiremanSoundOff : AI fireman mode is off, ie in Manual Firing mode.
+=========     ======================================================================
+
 Triggers from 150 to 158 are used for the circuit breaker sounds.
 
 The following triggers are activated when the state of the circuit breaker changes:

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -173,7 +173,7 @@ namespace Orts.Common
 
         BoilerBlowdownOn,
         BoilerBlowdownOff,
-        SteamGearLeverToggle,
+
         AIFiremanSoundOn,
         AIFiremanSoundOff
     }
@@ -328,7 +328,6 @@ namespace Orts.Common
                         case 142: return Event.BrakePipePressureDecrease;
                         case 143: return Event.BrakePipePressureStoppedChanging;
 
-                        case 147: return Event.SteamGearLeverToggle;
                         case 148: return Event.AIFiremanSoundOn;
                         case 149: return Event.AIFiremanSoundOff;
 

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -172,7 +172,10 @@ namespace Orts.Common
         HotBoxBearingOff,
 
         BoilerBlowdownOn,
-        BoilerBlowdownOff
+        BoilerBlowdownOff,
+
+        AIFiremanSoundOn,
+        AIFiremanSoundOff
     }
 
     public static class Events
@@ -358,6 +361,10 @@ namespace Orts.Common
 
                         case 175: return Event.BoilerBlowdownOn;
                         case 176: return Event.BoilerBlowdownOff;
+
+                        case 200: return Event.AIFiremanSoundOn;
+                        case 201: return Event.AIFiremanSoundOff;
+
                         //
 
                         default: return 0;

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -173,7 +173,7 @@ namespace Orts.Common
 
         BoilerBlowdownOn,
         BoilerBlowdownOff,
-
+        SteamGearLeverToggle,
         AIFiremanSoundOn,
         AIFiremanSoundOff
     }
@@ -328,6 +328,7 @@ namespace Orts.Common
                         case 142: return Event.BrakePipePressureDecrease;
                         case 143: return Event.BrakePipePressureStoppedChanging;
 
+                        case 147: return Event.SteamGearLeverToggle;
                         case 148: return Event.AIFiremanSoundOn;
                         case 149: return Event.AIFiremanSoundOff;
 

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -99,6 +99,7 @@ namespace Orts.Common
         SanderOff,
         SanderOn,
         SemaphoreArm,
+        SteamGearLeverChange,
         SmallEjectorChange,
         WaterInjector1Off,
         WaterInjector1On,
@@ -341,6 +342,7 @@ namespace Orts.Common
                         case 157: return Event.CircuitBreakerClosingAuthorizationOn;
                         case 158: return Event.CircuitBreakerClosingAuthorizationOff;
 
+                        case 159: return Event.SteamGearLeverChange;
                         case 160: return Event.SmallEjectorChange;
 
                         case 161: return Event.CabLightSwitchToggle;

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -172,10 +172,7 @@ namespace Orts.Common
         HotBoxBearingOff,
 
         BoilerBlowdownOn,
-        BoilerBlowdownOff,
-
-        AIFiremanSoundOn,
-        AIFiremanSoundOff
+        BoilerBlowdownOff
     }
 
     public static class Events
@@ -361,10 +358,6 @@ namespace Orts.Common
 
                         case 175: return Event.BoilerBlowdownOn;
                         case 176: return Event.BoilerBlowdownOff;
-
-                        case 200: return Event.AIFiremanSoundOn;
-                        case 201: return Event.AIFiremanSoundOff;
-
                         //
 
                         default: return 0;

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -173,6 +173,7 @@ namespace Orts.Common
 
         BoilerBlowdownOn,
         BoilerBlowdownOff,
+        SteamGearLeverToggle,
 
         AIFiremanSoundOn,
         AIFiremanSoundOff
@@ -328,6 +329,7 @@ namespace Orts.Common
                         case 142: return Event.BrakePipePressureDecrease;
                         case 143: return Event.BrakePipePressureStoppedChanging;
 
+                        case 147: return Event.SteamGearLeverToggle;
                         case 148: return Event.AIFiremanSoundOn;
                         case 149: return Event.AIFiremanSoundOff;
 

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -172,7 +172,10 @@ namespace Orts.Common
         HotBoxBearingOff,
 
         BoilerBlowdownOn,
-        BoilerBlowdownOff
+        BoilerBlowdownOff,
+
+        AIFiremanSoundOn,
+        AIFiremanSoundOff
     }
 
     public static class Events
@@ -324,6 +327,9 @@ namespace Orts.Common
                         case 141: return Event.BrakePipePressureIncrease;
                         case 142: return Event.BrakePipePressureDecrease;
                         case 143: return Event.BrakePipePressureStoppedChanging;
+
+                        case 148: return Event.AIFiremanSoundOn;
+                        case 149: return Event.AIFiremanSoundOff;
 
                         case 150: return Event.CircuitBreakerOpen;
                         case 151: return Event.CircuitBreakerClosing;

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -173,7 +173,6 @@ namespace Orts.Common
 
         BoilerBlowdownOn,
         BoilerBlowdownOff,
-        SteamGearLeverToggle,
 
         AIFiremanSoundOn,
         AIFiremanSoundOff
@@ -329,7 +328,6 @@ namespace Orts.Common
                         case 142: return Event.BrakePipePressureDecrease;
                         case 143: return Event.BrakePipePressureStoppedChanging;
 
-                        case 147: return Event.SteamGearLeverToggle;
                         case 148: return Event.AIFiremanSoundOn;
                         case 149: return Event.AIFiremanSoundOff;
 

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -99,7 +99,6 @@ namespace Orts.Common
         SanderOff,
         SanderOn,
         SemaphoreArm,
-        SteamGearLeverChange,
         SmallEjectorChange,
         WaterInjector1Off,
         WaterInjector1On,
@@ -342,7 +341,6 @@ namespace Orts.Common
                         case 157: return Event.CircuitBreakerClosingAuthorizationOn;
                         case 158: return Event.CircuitBreakerClosingAuthorizationOff;
 
-                        case 159: return Event.SteamGearLeverChange;
                         case 160: return Event.SmallEjectorChange;
 
                         case 161: return Event.CabLightSwitchToggle;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -6439,6 +6439,7 @@ public void SteamStartGearBoxIncrease()
                             SteamGearRatio = 0.0f;
                             MaxTractiveEffortLbf = 0.0f;
                             MaxIndicatedHorsePowerHP = 0.0f;
+                            SignalEvent(Event.SteamGearLeverChange);
 
                         }
                         else if (SteamGearPosition == 1.0)
@@ -6447,6 +6448,7 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioLow;
                             MaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioLow;
+                            SignalEvent(Event.SteamGearLeverChange);
 
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
@@ -6470,6 +6472,7 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioHigh;
                             MaxLocoSpeedMpH = MpS.ToMpH(HighMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioHigh;
+                            SignalEvent(Event.SteamGearLeverChange);
 
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
@@ -6518,6 +6521,8 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioLow;
                             MaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioLow;
+                            SignalEvent(Event.SteamGearLeverChange);
+
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
                             // Max IHP = (Max TE x Speed) / 375.0, use a factor of 0.85 to calculate max TE
@@ -6542,6 +6547,7 @@ public void SteamStartGearBoxIncrease()
                             SteamGearRatio = 0.0f;
                             MaxTractiveEffortLbf = 0.0f;
                             MaxIndicatedHorsePowerHP = 0.0f;
+                            SignalEvent(Event.SteamGearLeverChange);
                         }
                     }
                 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -7129,6 +7129,10 @@ public void SteamStartGearBoxIncrease()
     public void ToggleManualFiring()
         {
             FiringIsManual = !FiringIsManual;
+            if (FiringIsManual)
+                SignalEvent(Event.AIFiremanSoundOff);
+            else
+                SignalEvent(Event.AIFiremanSoundOn);
         }
 
         public void AIFireOn()

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -6439,6 +6439,7 @@ public void SteamStartGearBoxIncrease()
                             SteamGearRatio = 0.0f;
                             MaxTractiveEffortLbf = 0.0f;
                             MaxIndicatedHorsePowerHP = 0.0f;
+                            SignalEvent(Event.SteamGearLeverToggle);
 
                         }
                         else if (SteamGearPosition == 1.0)
@@ -6447,6 +6448,7 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioLow;
                             MaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioLow;
+                            SignalEvent(Event.SteamGearLeverToggle);
 
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
@@ -6470,6 +6472,7 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioHigh;
                             MaxLocoSpeedMpH = MpS.ToMpH(HighMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioHigh;
+                            SignalEvent(Event.SteamGearLeverToggle);
 
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
@@ -6518,6 +6521,8 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioLow;
                             MaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioLow;
+                            SignalEvent(Event.SteamGearLeverToggle);
+
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
                             // Max IHP = (Max TE x Speed) / 375.0, use a factor of 0.85 to calculate max TE
@@ -6542,6 +6547,7 @@ public void SteamStartGearBoxIncrease()
                             SteamGearRatio = 0.0f;
                             MaxTractiveEffortLbf = 0.0f;
                             MaxIndicatedHorsePowerHP = 0.0f;
+                            SignalEvent(Event.SteamGearLeverToggle);
                         }
                     }
                 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -6439,7 +6439,6 @@ public void SteamStartGearBoxIncrease()
                             SteamGearRatio = 0.0f;
                             MaxTractiveEffortLbf = 0.0f;
                             MaxIndicatedHorsePowerHP = 0.0f;
-                            SignalEvent(Event.SteamGearLeverToggle);
 
                         }
                         else if (SteamGearPosition == 1.0)
@@ -6448,7 +6447,6 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioLow;
                             MaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioLow;
-                            SignalEvent(Event.SteamGearLeverToggle);
 
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
@@ -6472,7 +6470,6 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioHigh;
                             MaxLocoSpeedMpH = MpS.ToMpH(HighMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioHigh;
-                            SignalEvent(Event.SteamGearLeverToggle);
 
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
@@ -6521,8 +6518,6 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioLow;
                             MaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioLow;
-                            SignalEvent(Event.SteamGearLeverToggle);
-
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
                             // Max IHP = (Max TE x Speed) / 375.0, use a factor of 0.85 to calculate max TE
@@ -6547,7 +6542,6 @@ public void SteamStartGearBoxIncrease()
                             SteamGearRatio = 0.0f;
                             MaxTractiveEffortLbf = 0.0f;
                             MaxIndicatedHorsePowerHP = 0.0f;
-                            SignalEvent(Event.SteamGearLeverToggle);
                         }
                     }
                 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -7129,10 +7129,6 @@ public void SteamStartGearBoxIncrease()
     public void ToggleManualFiring()
         {
             FiringIsManual = !FiringIsManual;
-            if (FiringIsManual)
-                SignalEvent(Event.AIFiremanSoundOff);
-            else
-                SignalEvent(Event.AIFiremanSoundOn);
         }
 
         public void AIFireOn()

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -6439,7 +6439,6 @@ public void SteamStartGearBoxIncrease()
                             SteamGearRatio = 0.0f;
                             MaxTractiveEffortLbf = 0.0f;
                             MaxIndicatedHorsePowerHP = 0.0f;
-                            SignalEvent(Event.SteamGearLeverChange);
 
                         }
                         else if (SteamGearPosition == 1.0)
@@ -6448,7 +6447,6 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioLow;
                             MaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioLow;
-                            SignalEvent(Event.SteamGearLeverChange);
 
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
@@ -6472,7 +6470,6 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioHigh;
                             MaxLocoSpeedMpH = MpS.ToMpH(HighMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioHigh;
-                            SignalEvent(Event.SteamGearLeverChange);
 
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
@@ -6521,8 +6518,6 @@ public void SteamStartGearBoxIncrease()
                             MotiveForceGearRatio = SteamGearRatioLow;
                             MaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);
                             SteamGearRatio = SteamGearRatioLow;
-                            SignalEvent(Event.SteamGearLeverChange);
-
                             MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2 * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * TractiveEffortFactor * MotiveForceGearRatio;
 
                             // Max IHP = (Max TE x Speed) / 375.0, use a factor of 0.85 to calculate max TE
@@ -6547,7 +6542,6 @@ public void SteamStartGearBoxIncrease()
                             SteamGearRatio = 0.0f;
                             MaxTractiveEffortLbf = 0.0f;
                             MaxIndicatedHorsePowerHP = 0.0f;
-                            SignalEvent(Event.SteamGearLeverChange);
                         }
                     }
                 }


### PR DESCRIPTION
https://blueprints.launchpad.net/or/+spec/addtional-steam-locomotive-sound-triggers - Add two sound event triggers to separate AI and manual firing sounds in steam locomotives.