### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1882397. Consist engine info shows bad.…

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
@@ -760,7 +760,7 @@ namespace Orts.Viewer3D.Popups
                             int ncountdiesel = cEnginetype.Where(s => s == "Diesel").Count();
                             int ncountsteam = cEnginetype.Where(s => s == "Steam").Count();
                             int ncountelectric = cEnginetype.Where(s => s == "Electric").Count();
-                            labeltext = "  Consist engine=" + (ncountdiesel > 0 ? ncountdiesel + Viewer.Catalog.GetString(" Diesel. ") : "") + (ncountsteam > 0 ? ncountsteam + Viewer.Catalog.GetString(" Steam.") : "") + (ncountelectric > 0 ? ncountelectric + Viewer.Catalog.GetString(" Electric.") : "");
+                            labeltext = "  Consist engine=" + (ncountdiesel > 0 ? ncountdiesel + " " + Viewer.Catalog.GetString("Diesel.") + " " : "") + (ncountsteam > 0 ? ncountsteam + " " + Viewer.Catalog.GetString("Steam.") + " " : "") + (ncountelectric > 0 ? ncountelectric + " " + Viewer.Catalog.GetString("Electric.") : "");
                             outmesssage(labeltext, colWidth * 3, true, 0);
 
                             if (lDiesel)//Fuel Diesel


### PR DESCRIPTION
The Debrief-Eval report, shows the consist engine information, incorrectly when the English language was not used.