### PR TITLE
Fix annoying startup exception when running with a debugger attached

### DIFF
--- a/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
@@ -290,14 +290,10 @@ namespace Orts.Viewer3D.Debugging
 				  {
 					  foreach (TrPin pin in currNode.TrPins)
 					  {
-						  TrVectorSection item = null;
-						  try
-						  {
-							  if (nodes[pin.Link].TrVectorNode == null || nodes[pin.Link].TrVectorNode.TrVectorSections.Length < 1) continue;
-							  if (pin.Direction == 1) item = nodes[pin.Link].TrVectorNode.TrVectorSections.First();
-							  else item = nodes[pin.Link].TrVectorNode.TrVectorSections.Last();
-						  }
-						  catch { continue; }
+						  var vectorSections = nodes[pin.Link]?.TrVectorNode?.TrVectorSections;
+						  if (vectorSections == null || vectorSections.Length < 1)
+						      continue;
+						  TrVectorSection item = pin.Direction == 1 ? vectorSections.First() : vectorSections.Last();
 						  dVector A = new dVector(currNode.UiD.TileX, currNode.UiD.X, currNode.UiD.TileZ, + currNode.UiD.Z);
 						  dVector B = new dVector(item.TileX, + item.X, item.TileZ, + item.Z);
                           var x = dVector.DistanceSqr(A, B);


### PR DESCRIPTION
Bug report: [RunActivity.exe generates a NullReferenceException at startup with debugger attached](https://bugs.launchpad.net/or/+bug/1883994)

When debugging in Visual Studio, this track node code sometimes generates a NullReferenceException, bringing the startup sequence to a halt. You can continue past it, but it's still irritating. It's also a bad idea to mask all errors with a generic try {} catch {} block.