### PR TITLE
fix: Make AppVeyor fail the build if a pre-req fails to install

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,11 @@ skip_branch_with_pr: true
 image: Visual Studio 2017
 install:
 - ps: >-
+    $ErrorActionPreference = "Stop"
+
     choco install --yes --no-progress lazarus 7zip.portable xna31
+
+    if ($LASTEXITCODE -ne 0) { throw "Chocolatey failed to install all required packages - use the 're-build' option to try again" }
 
     (New-Object Net.WebClient).DownloadFile('https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x86.exe', 'rcedit-x86.exe')
 


### PR DESCRIPTION
This update makes sure that, should the "choco install" command fail, the AppVeyor build stops with a useful error messages - instead of continuing until it fails due to something missing.