### PR TITLE
fix: Remove VS2015 from supported build environments

### DIFF
--- a/Website/openrails.org/contribute/developing-code/index.php
+++ b/Website/openrails.org/contribute/developing-code/index.php
@@ -64,7 +64,7 @@ The main folders in the repository are:
 To compile and debug the Open Rails source code, ensure you have the following Microsoft products installed:
       </p>
       <ul>
-        <li>Visual Studio 2015/17/19, any edition. The 
+        <li>Visual Studio 2017 or 2019, any edition. The 
           <a href="https://www.visualstudio.com/downloads/">Community Edition</a> 
          is free
 		 <br />(Note 1: To save on disk space, all you need is the option Windows > .NET Development)


### PR DESCRIPTION
We haven't actually supported VS2015 since Mar 2019, so let's remove it from the website. 🙂