### PR TITLE
Refactor try-catch blocks in RunActivity

### DIFF
--- a/Source/RunActivity/Processes/Profiler.cs
+++ b/Source/RunActivity/Processes/Profiler.cs
@@ -60,15 +60,15 @@ namespace Orts.Processes
             // This is so that you can identify threads from debuggers like Visual Studio.
             try
             {
-                Thread.CurrentThread.Name = Name + " Process";
+                Thread.CurrentThread.Name += " Process";
             }
-            catch { }
+            catch (InvalidOperationException) { }
 
             // This is so that you can identify threads from programs like Process Monitor. The call
             // should always fail but will appear in Process Monitor's log against the correct thread.
             try
             {
-                File.ReadAllBytes(@"DEBUG\THREAD\" + Name + " Process");
+                File.ReadAllBytes($@"DEBUG\THREAD\{Name} Process");
             }
             catch { }
 

--- a/Source/RunActivity/Processes/Profiler.cs
+++ b/Source/RunActivity/Processes/Profiler.cs
@@ -60,7 +60,7 @@ namespace Orts.Processes
             // This is so that you can identify threads from debuggers like Visual Studio.
             try
             {
-                Thread.CurrentThread.Name += " Process";
+                Thread.CurrentThread.Name = $"{Name} Process";
             }
             catch (InvalidOperationException) { }
 

--- a/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
@@ -601,12 +601,12 @@ namespace Orts.Viewer3D.Debugging
 				  int i = AvatarView.SelectedIndices.Cast<int>().Min();
 				  string name = (AvatarView.Items[i].Text ?? "").Split(' ').First().Trim();
 				  if (MultiPlayer.MPManager.OnlineTrains.Players.TryGetValue(name, out MultiPlayer.OnlinePlayer player))
-					  pos = player?.Train?.Cars?.First()?.WorldPosition;
+					  pos = player?.Train?.Cars?.FirstOrDefault()?.WorldPosition;
 				  else if (MultiPlayer.MPManager.Instance().lostPlayer.TryGetValue(name, out MultiPlayer.OnlinePlayer lost))
-					  pos = lost?.Train?.Cars?.First()?.WorldPosition;
+					  pos = lost?.Train?.Cars?.FirstOrDefault()?.WorldPosition;
 			  }
 			  if (pos == null)
-				  pos = PickedTrain?.Cars?.First()?.WorldPosition;
+				  pos = PickedTrain?.Cars?.FirstOrDefault()?.WorldPosition;
 			  if (pos != null)
 			  {
 				  var ploc = new PointF(pos.TileX * 2048 + pos.Location.X, pos.TileZ * 2048 + pos.Location.Z);

--- a/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
@@ -593,41 +593,26 @@ namespace Orts.Viewer3D.Debugging
 			  else { rmvButton.Visible = false; chkAllowNew.Visible = false; chkAllowUserSwitch.Visible = false; chkBoxPenalty.Visible = false; chkPreferGreen.Visible = false; }
 		  }
 		  if (firstShow || followTrain) {
-			  WorldPosition pos;
 			  //see who should I look at:
 			  //if the player is selected in the avatar list, show the player, otherwise, show the one with the lowest index
-			  if (Program.Simulator.PlayerLocomotive != null) pos = Program.Simulator.PlayerLocomotive.WorldPosition;
-			  else pos = Program.Simulator.Trains[0].Cars[0].WorldPosition;
-			  bool hasSelectedTrain = false;
+			  WorldPosition pos = Program.Simulator.PlayerLocomotive == null ? Program.Simulator.Trains.First().Cars.First().WorldPosition : Program.Simulator.PlayerLocomotive.WorldPosition;
 			  if (AvatarView.SelectedIndices.Count > 0 && !AvatarView.SelectedIndices.Contains(0))
 			  {
-					  try
-					  {
-						  var i = 10000;
-						  foreach (var index in AvatarView.SelectedIndices)
-						  {
-							  if ((int)index < i) i = (int)index;
-						  }
-						  var name = AvatarView.Items[i].Text.Split(' ')[0].Trim() ;
-						  if (MultiPlayer.MPManager.OnlineTrains.Players.ContainsKey(name))
-						  {
-							  pos = MultiPlayer.MPManager.OnlineTrains.Players[name].Train.Cars[0].WorldPosition;
-						  }
-						  else if (MultiPlayer.MPManager.Instance().lostPlayer.ContainsKey(name))
-						  {
-							  pos = MultiPlayer.MPManager.Instance().lostPlayer[name].Train.Cars[0].WorldPosition;
-						  }
-						  hasSelectedTrain = true;
-					  }
-					  catch { }
+				  int i = AvatarView.SelectedIndices.Cast<int>().Min();
+				  string name = (AvatarView.Items[i].Text ?? "").Split(' ').First().Trim();
+				  if (MultiPlayer.MPManager.OnlineTrains.Players.TryGetValue(name, out MultiPlayer.OnlinePlayer player))
+					  pos = player?.Train?.Cars?.First()?.WorldPosition;
+				  else if (MultiPlayer.MPManager.Instance().lostPlayer.TryGetValue(name, out MultiPlayer.OnlinePlayer lost))
+					  pos = lost?.Train?.Cars?.First()?.WorldPosition;
 			  }
-			  if (hasSelectedTrain == false && PickedTrain != null && PickedTrain.Cars != null && PickedTrain.Cars.Count > 0)
+			  if (pos == null)
+				  pos = PickedTrain?.Cars?.First()?.WorldPosition;
+			  if (pos != null)
 			  {
-				  pos = PickedTrain.Cars[0].WorldPosition;
+				  var ploc = new PointF(pos.TileX * 2048 + pos.Location.X, pos.TileZ * 2048 + pos.Location.Z);
+				  ViewWindow.X = ploc.X - minX - ViewWindow.Width / 2; ViewWindow.Y = ploc.Y - minY - ViewWindow.Width / 2;
+				  firstShow = false;
 			  }
-			  var ploc = new PointF(pos.TileX * 2048 + pos.Location.X, pos.TileZ * 2048 + pos.Location.Z);
-			  ViewWindow.X = ploc.X - minX - ViewWindow.Width / 2; ViewWindow.Y = ploc.Y - minY - ViewWindow.Width / 2;
-			  firstShow = false;
 		  }
 
 		  try

--- a/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
@@ -2114,21 +2114,40 @@ namespace Orts.Viewer3D.Debugging
 		   Item = item;
 		   Signal = signal;
 		   hasDir = false;
-		   Location.X = item.TileX * 2048 + item.X; Location.Y = item.TileZ * 2048 + item.Z;
-		   try
+		   Location.X = item.TileX * 2048 + item.X;
+		   Location.Y = item.TileZ * 2048 + item.Z;
+		   var node = Program.Simulator.TDB.TrackDB.TrackNodes?[signal.trackNode];
+		   Vector2 v2;
+		   if (node?.TrVectorNode != null)
 		   {
-			   var node = Program.Simulator.TDB.TrackDB.TrackNodes[signal.trackNode];
-			   Vector2 v2;
-			   if (node.TrVectorNode != null) { var ts = node.TrVectorNode.TrVectorSections[0]; v2 = new Vector2(ts.TileX * 2048 + ts.X, ts.TileZ * 2048 + ts.Z); }
-			   else if (node.TrJunctionNode != null) { var ts = node.UiD; v2 = new Vector2(ts.TileX * 2048 + ts.X, ts.TileZ * 2048 + ts.Z); }
-			   else throw new Exception();
-			   var v1 = new Vector2(Location.X, Location.Y); var v3 = v1 - v2; v3.Normalize(); v2 = v1 - Vector2.Multiply(v3, signal.direction == 0 ? 12f : -12f);
-			   Dir.X = v2.X; Dir.Y = v2.Y;
-               v2 = v1 - Vector2.Multiply(v3, signal.direction == 0 ? 1.5f : -1.5f);//shift signal along the dir for 2m, so signals will not be overlapped
-               Location.X = v2.X; Location.Y = v2.Y;
-			   hasDir = true;
+			   var ts = node.TrVectorNode.TrVectorSections?.FirstOrDefault();
+			   if (ts == null)
+				   return;
+			   v2 = new Vector2(ts.TileX * 2048 + ts.X, ts.TileZ * 2048 + ts.Z);
 		   }
-		   catch {  }
+		   else if (node?.TrJunctionNode != null)
+		   {
+			   var ts = node?.UiD;
+			   if (ts == null)
+				   return;
+			   v2 = new Vector2(ts.TileX * 2048 + ts.X, ts.TileZ * 2048 + ts.Z);
+		   }
+		   else
+		   {
+			   return;
+		   }
+		   var v1 = new Vector2(Location.X, Location.Y);
+		   var v3 = v1 - v2;
+		   v3.Normalize();
+		   void copyTo(Vector2 input, ref PointF output)
+		   {
+			   output.X = input.X;
+			   output.Y = input.Y;
+		   }
+		   copyTo(v1 - Vector2.Multiply(v3, signal.direction == 0 ? 12f : -12f), ref Dir);
+		   //shift signal along the dir for 2m, so signals will not be overlapped
+		   copyTo(v1 - Vector2.Multiply(v3, signal.direction == 0 ? 1.5f : -1.5f), ref Location);
+		   hasDir = true;
 	   }
    }
    #endregion

--- a/Source/RunActivity/Viewer3D/Debugging/MessageViewer.Designer.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/MessageViewer.Designer.cs
@@ -33,7 +33,7 @@
 		  this.messages = new System.Windows.Forms.ListBox();
 		  this.MSG = new System.Windows.Forms.TextBox();
 		  this.compose = new System.Windows.Forms.Button();
-		  this.compose.Click += new System.EventHandler(this.composeClick);
+		  this.compose.Click += new System.EventHandler(this.ComposeClick);
 		  this.SuspendLayout();
 		  // 
 		  // clearAll
@@ -45,7 +45,7 @@
 		  this.clearAll.TabIndex = 2;
 		  this.clearAll.Text = "Clear All";
 		  this.clearAll.UseVisualStyleBackColor = true;
-		  this.clearAll.Click += new System.EventHandler(this.clearAllClick);
+		  this.clearAll.Click += new System.EventHandler(this.ClearAllClick);
 		  // 
 		  // replySelected
 		  // 
@@ -56,7 +56,7 @@
 		  this.replySelected.TabIndex = 4;
 		  this.replySelected.Text = "Reply Selected";
 		  this.replySelected.UseVisualStyleBackColor = true;
-		  this.replySelected.Click += new System.EventHandler(this.replySelectedClick);
+		  this.replySelected.Click += new System.EventHandler(this.ReplySelectedClick);
 		  // 
 		  // messages
 		  // 

--- a/Source/RunActivity/Viewer3D/MSTSSky.cs
+++ b/Source/RunActivity/Viewer3D/MSTSSky.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Orts.Common;
+using Orts.MultiPlayer;
 using Orts.Viewer3D.Common;
 using Orts.Viewer3D.Processes;
 using ORTS.Common;
@@ -157,29 +158,23 @@ namespace Orts.Viewer3D
                 mstsskyfogDistance = MSTSSkyViewer.Simulator.Weather.FogDistance;
             }
 
-            if (Orts.MultiPlayer.MPManager.IsClient() && Orts.MultiPlayer.MPManager.Instance().weatherChanged)
+            MPManager manager = MPManager.Instance();
+            if (MPManager.IsClient() && manager.weatherChanged)
             {
                 //received message about weather change
-                if (Orts.MultiPlayer.MPManager.Instance().overcastFactor >= 0)
-                {
-                    mstsskyovercastFactor = Orts.MultiPlayer.MPManager.Instance().overcastFactor;
-                }
-                //received message about weather change
-                if (Orts.MultiPlayer.MPManager.Instance().fogDistance > 0)
-                {
-                    mstsskyfogDistance = Orts.MultiPlayer.MPManager.Instance().fogDistance;
-                }
-                try
-                {
-                    if (Orts.MultiPlayer.MPManager.Instance().overcastFactor >= 0 || Orts.MultiPlayer.MPManager.Instance().fogDistance > 0)
-                    {
-                        Orts.MultiPlayer.MPManager.Instance().weatherChanged = false;
-                        Orts.MultiPlayer.MPManager.Instance().overcastFactor = -1;
-                        Orts.MultiPlayer.MPManager.Instance().fogDistance = -1;
-                    }
-                }
-                catch { }
+                if (manager.overcastFactor >= 0)
+                    mstsskyovercastFactor = manager.overcastFactor;
 
+                //received message about weather change
+                if (manager.fogDistance > 0)
+                    mstsskyfogDistance = manager.fogDistance;
+
+                if (manager.overcastFactor >= 0 || manager.fogDistance > 0)
+                {
+                    manager.weatherChanged = false;
+                    manager.overcastFactor = -1;
+                    manager.fogDistance = -1;
+                }
             }
 
             ////////////////////// T E M P O R A R Y ///////////////////////////
@@ -188,7 +183,7 @@ namespace Orts.Viewer3D
             // Control- and Control+ for overcast, Shift- and Shift+ for fog and - and + for time.
 
             // Don't let multiplayer clients adjust the weather.
-            if (!Orts.MultiPlayer.MPManager.IsClient())
+            if (!MPManager.IsClient())
             {
                 // Overcast ranges from 0 (completely clear) to 1 (completely overcast).
                 if (UserInput.IsDown(UserCommand.DebugOvercastIncrease)) mstsskyovercastFactor = MathHelper.Clamp(mstsskyovercastFactor + elapsedTime.RealSeconds / 10, 0, 1);
@@ -198,19 +193,19 @@ namespace Orts.Viewer3D
                 if (UserInput.IsDown(UserCommand.DebugFogDecrease)) mstsskyfogDistance = MathHelper.Clamp(mstsskyfogDistance + elapsedTime.RealSeconds * mstsskyfogDistance, 10, 100000);
             }
             // Don't let clock shift if multiplayer.
-            if (!Orts.MultiPlayer.MPManager.IsMultiPlayer())
+            if (!MPManager.IsMultiPlayer())
             {
                 // Shift the clock forwards or backwards at 1h-per-second.
                 if (UserInput.IsDown(UserCommand.DebugClockForwards)) MSTSSkyViewer.Simulator.ClockTime += elapsedTime.RealSeconds * 3600;
                 if (UserInput.IsDown(UserCommand.DebugClockBackwards)) MSTSSkyViewer.Simulator.ClockTime -= elapsedTime.RealSeconds * 3600;
             }
             // Server needs to notify clients of weather changes.
-            if (Orts.MultiPlayer.MPManager.IsServer())
+            if (MPManager.IsServer())
             {
                 if (UserInput.IsReleased(UserCommand.DebugOvercastIncrease) || UserInput.IsReleased(UserCommand.DebugOvercastDecrease) || UserInput.IsReleased(UserCommand.DebugFogIncrease) || UserInput.IsReleased(UserCommand.DebugFogDecrease))
                 {
-                    Orts.MultiPlayer.MPManager.Instance().SetEnvInfo(mstsskyovercastFactor, mstsskyfogDistance);
-                    Orts.MultiPlayer.MPManager.Notify((new Orts.MultiPlayer.MSGWeather(-1, mstsskyovercastFactor, -1, mstsskyfogDistance)).ToString());
+                    manager.SetEnvInfo(mstsskyovercastFactor, mstsskyfogDistance);
+                    MPManager.Notify(new MSGWeather(-1, mstsskyovercastFactor, -1, mstsskyfogDistance).ToString());
                 }
             }
 

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -98,23 +98,45 @@ namespace Orts.Viewer3D
                         }
                         else
                         {
-                            try //in case of no texture in wintersnow etc, go up one level
+                            Texture2D missing()
                             {
-                                var p = System.IO.Directory.GetParent(path);//returns the current level of dir
-
-                                p = System.IO.Directory.GetParent(p.FullName);//go up one level
-                                var s = p.FullName + "\\" + Path.GetFileName(path);
-                                if (File.Exists(s) &&  s.ToLower().Contains("texture")) //in texure and exists
+                                if (required)
+                                    Trace.TraceWarning("Missing texture {0} replaced with default texture", path);
+                                return defaultTexture;
+                            }
+                            Texture2D invalid()
+                            {
+                                if (required)
+                                    Trace.TraceWarning("Invalid texture {0} replaced with default texture", path);
+                                return defaultTexture;
+                            }
+                            //in case of no texture in wintersnow etc, go up one level
+                            DirectoryInfo currentDir;
+                            string searchPath;
+                            try
+                            {
+                                currentDir = Directory.GetParent(path);//returns the current level of dir
+                                searchPath = $"{Directory.GetParent(currentDir.FullName).FullName}\\{Path.GetFileName(path)}";
+                            }
+                            catch
+                            {
+                                return missing();
+                            }
+                            if (File.Exists(searchPath) && searchPath.ToLower().Contains("texture")) //in texture and exists
+                            {
+                                try
                                 {
-                                    texture = Orts.Formats.Msts.AceFile.Texture2DFromFile(GraphicsDevice, s);
+                                    texture = Formats.Msts.AceFile.Texture2DFromFile(GraphicsDevice, searchPath);
                                 }
-                                else {
-                                    if (required)
-                                        Trace.TraceWarning("Missing texture {0} replaced with default texture", path);
-                                    return defaultTexture;
+                                catch
+                                {
+                                    return invalid();
                                 }
                             }
-                            catch { texture = defaultTexture; return defaultTexture; }
+                            else
+                            {
+                                return missing();
+                            }
                         }
                     }
                     else

--- a/Source/RunActivity/Viewer3D/Popups/ComposeMessage.cs
+++ b/Source/RunActivity/Viewer3D/Popups/ComposeMessage.cs
@@ -20,7 +20,6 @@
 using Microsoft.Xna.Framework.Input;
 using Orts.MultiPlayer;
 using ORTS.Common;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Orts.Viewer3D.Popups

--- a/Source/RunActivity/Viewer3D/Popups/ComposeMessage.cs
+++ b/Source/RunActivity/Viewer3D/Popups/ComposeMessage.cs
@@ -119,9 +119,12 @@ namespace Orts.Viewer3D.Popups
                     MPManager.Notify(msgText);
                 }
                 catch { }
-                Visible = false;
-                UserInput.ComposingMessage = false;
-                Message.Text = "";
+                finally
+                {
+                    Visible = false;
+                    UserInput.ComposingMessage = false;
+                    Message.Text = "";
+                }
             }
         }
         protected override ControlLayout Layout(ControlLayout layout)

--- a/Source/RunActivity/Viewer3D/Popups/ComposeMessage.cs
+++ b/Source/RunActivity/Viewer3D/Popups/ComposeMessage.cs
@@ -18,7 +18,9 @@
 // This file is the responsibility of the 3D & Environment Team. 
 
 using Microsoft.Xna.Framework.Input;
+using Orts.MultiPlayer;
 using ORTS.Common;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Orts.Viewer3D.Popups
@@ -93,46 +95,34 @@ namespace Orts.Viewer3D.Popups
             //we need to send message out
             if (EnterReceived == true)
             {
+                string user = "";
+                if (MPManager.Instance().lastSender == "") //server will broadcast the message to everyone
+                    user = MPManager.IsServer() ? string.Join("", MPManager.OnlineTrains.Players.Keys.Select((string k) => $"{k}\r")) + "0END" : "0Server\r0END";
+
+                int index = Message.Text.IndexOf(':');
+                string msg = Message.Text;
+                if (index > 0)
+                {
+                    msg = Message.Text.Remove(0, index + 1);
+                    var onlinePlayers = Message.Text.Substring(0, index)
+                        .Split(',')
+                        .Select((string n) => n.Trim())
+                        .Where((string nt) => MPManager.OnlineTrains.Players.ContainsKey(nt))
+                        .Select((string nt) => $"{nt}\r");
+                    string newUser = string.Join("", onlinePlayers);
+                    if (newUser != "")
+                        user = newUser;
+                    user += "0END";
+                }
+                string msgText = new MSGText(MPManager.GetUserName(), user, msg).ToString();
                 try
                 {
-                    var user = "";
-                    if (Orts.MultiPlayer.MPManager.Instance().lastSender == "")
-                    {
-                        //server will broadcast the message to everyone
-                        if (Orts.MultiPlayer.MPManager.IsServer())
-                        {
-                            foreach (var p in Orts.MultiPlayer.MPManager.OnlineTrains.Players)
-                            {
-                                user += p.Key + "\r";
-                            }
-                            user += "0END";
-
-                        }
-                        else user = "0Server\r0END";
-                    }
-                    var index = Message.Text.IndexOf(':');
-                    var msg = Message.Text;
-                    if (index > 0)
-                    {
-                        msg = Message.Text.Remove(0, index + 1);
-                        var str = Message.Text.Substring(0, index);
-                        var names = str.Split(',');
-                        var first = true;
-                        foreach (var n in names)
-                        {
-                            if (Orts.MultiPlayer.MPManager.OnlineTrains.Players.ContainsKey(n.Trim()))
-                            {
-                                if (first) { user = ""; first = false; }
-                                user += n.Trim() + "\r";
-                            }
-                        }
-                        user += "0END";
-                    }
-                    Orts.MultiPlayer.MPManager.Notify((new Orts.MultiPlayer.MSGText(Orts.MultiPlayer.MPManager.GetUserName(), user, msg)).ToString());
-                    this.Visible = false;
-                    UserInput.ComposingMessage = false; Message.Text = "";
+                    MPManager.Notify(msgText);
                 }
                 catch { }
+                Visible = false;
+                UserInput.ComposingMessage = false;
+                Message.Text = "";
             }
         }
         protected override ControlLayout Layout(ControlLayout layout)

--- a/Source/RunActivity/Viewer3D/Processes/Game.cs
+++ b/Source/RunActivity/Viewer3D/Processes/Game.cs
@@ -215,7 +215,7 @@ namespace Orts.Viewer3D.Processes
                 {
                     CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(Settings.Language);
                 }
-                catch { }
+                catch (CultureNotFoundException) { }
             }
         }
 

--- a/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
+++ b/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
@@ -21,6 +21,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Orts.Common;
+using Orts.Formats.Msts;
 using Orts.MultiPlayer;
 using Orts.Simulation;
 using Orts.Viewer3D.Debugging;
@@ -1087,89 +1088,93 @@ namespace Orts.Viewer3D.Processes
 
         string GetRouteName(string path)
         {
+            if (!HasExtension(path, ".act") && !HasExtension(path, ".pat"))
+                return null;
+
+            RouteFile trk = null;
             try
             {
-                if (Path.GetExtension(path).Equals(".act", StringComparison.OrdinalIgnoreCase) || Path.GetExtension(path).Equals(".pat", StringComparison.OrdinalIgnoreCase))
-                {
-                    var trk = new Orts.Formats.Msts.RouteFile(MSTS.MSTSPath.GetTRKFileName(Path.GetDirectoryName(Path.GetDirectoryName(path))));
-                    return trk.Tr_RouteFile.Name;
-                }
+                trk = new RouteFile(MSTS.MSTSPath.GetTRKFileName(Path.GetDirectoryName(Path.GetDirectoryName(path))));
             }
             catch { }
-            return null;
+            return trk?.Tr_RouteFile?.Name;
         }
 
         string GetActivityName(string path)
         {
+            if (!HasExtension(path, ".act"))
+                return null;
+            
+            ActivityFile act = null;
             try
             {
-                if (Path.GetExtension(path).Equals(".act", StringComparison.OrdinalIgnoreCase))
-                {
-                    var act = new Orts.Formats.Msts.ActivityFile(path);
-                    return act.Tr_Activity.Tr_Activity_Header.Name;
-                }
+                act = new ActivityFile(path);
             }
             catch { }
-            return null;
+            return act?.Tr_Activity?.Tr_Activity_Header?.Name;
         }
 
         string GetPathName(string path)
         {
+            if (!HasExtension(path, ".pat"))
+                return null;
+
+            PathFile pat = null;
             try
             {
-                if (Path.GetExtension(path).Equals(".pat", StringComparison.OrdinalIgnoreCase))
-                {
-                    var pat = new Orts.Formats.Msts.PathFile(path);
-                    return pat.Name;
-                }
+                pat = new PathFile(path);
             }
             catch { }
-            return null;
+            return pat?.Name;
         }
 
         string GetConsistName(string path)
         {
+            if (!HasExtension(path, ".con"))
+                return null;
+
+            ConsistFile con = null;
             try
             {
-                if (Path.GetExtension(path).Equals(".con", StringComparison.OrdinalIgnoreCase))
-                {
-                    var con = new Orts.Formats.Msts.ConsistFile(path);
-                    return con.Name;
-                }
+                con = new ConsistFile(path);
             }
             catch { }
-            return null;
+            return con?.Name;
         }
+
+        private bool HasExtension(string path, string ext) => Path.GetExtension(path).Equals(ext, StringComparison.OrdinalIgnoreCase);
 
         string GetTime(string timeString)
         {
+            string[] time = timeString.Split(':');
+            if (time.Length == 0)
+                return null;
+
+            string ts = null;
             try
             {
-                var time = timeString.Split(':');
-                return new TimeSpan(int.Parse(time[0]), time.Length > 1 ? int.Parse(time[1]) : 0, time.Length > 2 ? int.Parse(time[2]) : 0).ToString();
+                ts = new TimeSpan(int.Parse(time[0]), time.Length > 1 ? int.Parse(time[1]) : 0, time.Length > 2 ? int.Parse(time[2]) : 0).ToString();
             }
-            catch { }
-            return null;
+            catch (ArgumentOutOfRangeException) { }
+            catch (FormatException) { }
+            catch (OverflowException) { }
+            return ts;
         }
 
         string GetSeason(string season)
         {
-            try
-            {
-                return Enum.Parse(typeof(Orts.Formats.Msts.SeasonType), season).ToString();
-            }
-            catch { }
-            return null;
+            if (Enum.TryParse(season, out SeasonType value))
+                return value.ToString();
+            else
+                return null;
         }
 
         string GetWeather(string weather)
         {
-            try
-            {
-                return Enum.Parse(typeof(Orts.Formats.Msts.WeatherType), weather).ToString();
-            }
-            catch { }
-            return null;
+            if (Enum.TryParse(weather, out WeatherType value))
+                return value.ToString();
+            else
+                return null;
         }
 
         void LogSeparator()

--- a/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
+++ b/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
@@ -730,12 +730,15 @@ namespace Orts.Viewer3D.Processes
         {
             if (settings.Logging && (settings.LoggingPath.Length > 0) && Directory.Exists(settings.LoggingPath))
             {
-                var fileName = settings.LoggingFilename;
+                string fileName;
                 try
                 {
-                    fileName = String.Format(fileName, Application.ProductName, VersionInfo.VersionOrBuild, VersionInfo.Version, VersionInfo.Build, DateTime.Now);
+                    fileName = string.Format(settings.LoggingFilename, Application.ProductName, VersionInfo.VersionOrBuild, VersionInfo.Version, VersionInfo.Build, DateTime.Now);
                 }
-                catch { }
+                catch (FormatException)
+                {
+                    fileName = settings.LoggingFilename;
+                }
                 foreach (var ch in Path.GetInvalidFileNameChars())
                     fileName = fileName.Replace(ch, '.');
 

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2510,7 +2510,6 @@ namespace Orts.Viewer3D.RollingStock
             DigitParts3D = new Dictionary<int, ThreeDimCabDigit>();
             Gauges = new Dictionary<int, ThreeDimCabGaugeNative>();
             OnDemandAnimateParts = new Dictionary<int, AnimatedPart>();
-            CABViewControlTypes type;
             // Find the animated parts
             if (TrainCarShape != null && TrainCarShape.SharedShape.Animations != null)
             {
@@ -2524,33 +2523,43 @@ namespace Orts.Viewer3D.RollingStock
                     //     ASPECT_SIGNAL:0:0-2: first ASPECT_SIGNAL, parameter is 0, this component is part 2 of this cab control
                     //     ASPECT_SIGNAL:1:0  second ASPECT_SIGNAL, parameter is 0, this component is the only one for this cab control
                     typeName = matrixName.Split('-')[0]; //a part may have several sub-parts, like ASPECT_SIGNAL:0:0-1, ASPECT_SIGNAL:0:0-2
-                    type = CABViewControlTypes.NONE;
                     tmpPart = null;
                     int order, key;
                     string parameter1 = "0", parameter2 = "";
                     CabViewControlRenderer style = null;
                     //ASPECT_SIGNAL:0:0
                     var tmp = typeName.Split(':');
-                    try
+                    if (tmp.Length < 2 || !int.TryParse(tmp[1].Trim(), out order))
                     {
-                        order = int.Parse(tmp[1].Trim());
-                        if (tmp.Length >= 3) parameter1 = tmp[2].Trim();
-                        if (tmp.Length == 4) parameter2 = tmp[3].Trim();//we can get max two parameters per part
-                    }
-                    catch { continue; }
-                    try
-                    {
-                        type = (CABViewControlTypes)Enum.Parse(typeof(CABViewControlTypes), tmp[0].Trim(), true); //convert from string to enum
-                        key = 1000 * (int)type + order;
-                        if (type != CABViewControlTypes.EXTERNALWIPERS && type != CABViewControlTypes.MIRRORS && type != CABViewControlTypes.LEFTDOOR && type != CABViewControlTypes.RIGHTDOOR)
-                            style = locoViewer.ThreeDimentionCabRenderer.ControlMap[key]; //cvf file has no external wipers, left door, right door and mirrors key word
-                    }
-                    catch
-                    {
-                        type = CABViewControlTypes.NONE;
                         continue;
                     }
+                    else if (tmp.Length >= 3)
+                    {
+                        parameter1 = tmp[2].Trim();
+                        if (tmp.Length == 4) //we can get max two parameters per part
+                            parameter2 = tmp[3].Trim();
+                    }
 
+                    if (Enum.TryParse(tmp[0].Trim(), true, out CABViewControlTypes type))
+                    {
+                        key = 1000 * (int)type + order;
+                        switch (type)
+                        {
+                            case CABViewControlTypes.EXTERNALWIPERS:
+                            case CABViewControlTypes.MIRRORS:
+                            case CABViewControlTypes.LEFTDOOR:
+                            case CABViewControlTypes.RIGHTDOOR:
+                                break;
+                            default:
+                                //cvf file has no external wipers, left door, right door and mirrors key word
+                                style = locoViewer.ThreeDimentionCabRenderer.ControlMap[key];
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        continue;
+                    }
 
                     key = 1000 * (int)type + order;
                     if (style != null && style is CabViewDigitalRenderer)//digits?
@@ -3256,22 +3265,14 @@ namespace Orts.Viewer3D.RollingStock
         /// </summary>
         public void Update(MSTSLocomotiveViewer locoViewer, ElapsedTime elapsedTime)
         {
-            if (MatrixIndexes.Count == 0 || !locoViewer._has3DCabRenderer) return;
+            if (MatrixIndexes.Count == 0 || !locoViewer._has3DCabRenderer)
+                return;
 
-            CabViewControlRenderer cvfr;
-            float index;
-            try
+            if (locoViewer.ThreeDimentionCabRenderer.ControlMap.TryGetValue(Key, out CabViewControlRenderer cvfr))
             {
-                cvfr = locoViewer.ThreeDimentionCabRenderer.ControlMap[Key];
-                if (cvfr is CabViewDiscreteRenderer)
-                {
-                    index = (cvfr as CabViewDiscreteRenderer).GetDrawIndex();
-                }
-                else index = cvfr.GetRangeFraction() * this.FrameCount;
+                float index = cvfr is CabViewDiscreteRenderer renderer ? renderer.GetDrawIndex() : cvfr.GetRangeFraction() * FrameCount;
+                SetFrameClamp(index);
             }
-            catch { cvfr = null; index = 0; }
-            if (cvfr == null) return;
-            this.SetFrameClamp(index);
         }
     }
 }

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -1122,29 +1122,23 @@ namespace Orts.Viewer3D
                 if (Program.DebugViewer != null && Program.DebugViewer.Enabled && (Program.DebugViewer.switchPickedItem != null || Program.DebugViewer.signalPickedItem != null))
                 {
                     WorldLocation wos;
-                    try
+                    TrJunctionNode nextSwitchTrack = Program.DebugViewer.switchPickedItem?.Item?.TrJunctionNode;
+                    if (nextSwitchTrack != null)
                     {
-                        if (Program.DebugViewer.switchPickedItem != null)
-                        {
-                            TrJunctionNode nextSwitchTrack = Program.DebugViewer.switchPickedItem.Item.TrJunctionNode;
-                            wos = new WorldLocation(nextSwitchTrack.TN.UiD.TileX, nextSwitchTrack.TN.UiD.TileZ, nextSwitchTrack.TN.UiD.X, nextSwitchTrack.TN.UiD.Y + 8, nextSwitchTrack.TN.UiD.Z);
-                        }
-                        else
-                        {
-                            var s = Program.DebugViewer.signalPickedItem.Item;
-                            wos = new WorldLocation(s.TileX, s.TileZ, s.X, s.Y + 8, s.Z);
-                        }
-                        if (FreeRoamCameraList.Count == 0)
-                        {
-                            new UseFreeRoamCameraCommand(Log);
-                        }
-                        FreeRoamCamera.SetLocation(wos);
-                        //FreeRoamCamera
-                        FreeRoamCamera.Activate();
+                        wos = new WorldLocation(nextSwitchTrack.TN.UiD.TileX, nextSwitchTrack.TN.UiD.TileZ, nextSwitchTrack.TN.UiD.X, nextSwitchTrack.TN.UiD.Y + 8, nextSwitchTrack.TN.UiD.Z);
                     }
-                    catch { }
-
-
+                    else
+                    {
+                        var s = Program.DebugViewer.signalPickedItem.Item;
+                        wos = new WorldLocation(s.TileX, s.TileZ, s.X, s.Y + 8, s.Z);
+                    }
+                    if (FreeRoamCameraList.Count == 0)
+                    {
+                        new UseFreeRoamCameraCommand(Log);
+                    }
+                    FreeRoamCamera.SetLocation(wos);
+                    //FreeRoamCamera
+                    FreeRoamCamera.Activate();
                 }
             }
 

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -1809,34 +1809,39 @@ namespace Orts.Viewer3D
         [CallOnThread("Render")]
         void SaveScreenshotToFile(GraphicsDevice graphicsDevice, string fileName, bool silent)
         {
-            var screenshot = new ResolveTexture2D(graphicsDevice, graphicsDevice.PresentationParameters.BackBufferWidth, graphicsDevice.PresentationParameters.BackBufferHeight, 1, SurfaceFormat.Color);
-            graphicsDevice.ResolveBackBuffer(screenshot);
+            int width, height;
+            uint[] image;
+            using (var screenshot = new ResolveTexture2D(graphicsDevice, graphicsDevice.PresentationParameters.BackBufferWidth, graphicsDevice.PresentationParameters.BackBufferHeight, 1, SurfaceFormat.Color))
+            {
+                graphicsDevice.ResolveBackBuffer(screenshot);
+                width = screenshot.Width;
+                height = screenshot.Height;
+                image = new uint[width * height];
+                screenshot.GetData(image);
+            }
             new Thread(() =>
             {
+                // Unfortunately, the back buffer includes an alpha channel. Although saving this might seem okay,
+                // it actually ruins the picture - nothing in the back buffer is seen on-screen according to its
+                // alpha, it's only used for blending (if at all). We'll remove the alpha here.
+                foreach (int i in Enumerable.Range(0, image.Length))
+                    image[i] |= 0xFF000000;
+                var texture = new Texture2D(graphicsDevice, width, height);
+                texture.SetData(image);
                 try
                 {
-                    // Unfortunately, the back buffer includes an alpha channel. Although saving this might seem okay,
-                    // it actually ruins the picture - nothing in the back buffer is seen on-screen according to its
-                    // alpha, it's only used for blending (if at all). We'll remove the alpha here.
-                    var data = new uint[screenshot.Width * screenshot.Height];
-                    screenshot.GetData(data);
-                    for (var i = 0; i < data.Length; i++)
-                        data[i] |= 0xFF000000;
-                    screenshot.SetData(data);
-
-                    // Now save the modified image.
-                    screenshot.Save(fileName, ImageFileFormat.Png);
-                    screenshot.Dispose();
-
-                    if (!silent)
-                        MessagesWindow.AddMessage(String.Format("Saving screenshot to '{0}'.", fileName), 10);
-
-                    Visibility = VisibilityState.Visible;
-                    // Reveal MessageWindow
-                    MessagesWindow.Visible = true;
+                    texture.Save(fileName, ImageFileFormat.Png);
                 }
                 catch { }
+                finally
+                {
+                    Visibility = VisibilityState.Visible; // Notify the caller the screenshot has finished saving.
+                }
             }).Start();
+
+            if (!silent)
+                MessagesWindow.AddMessage($"Saving screenshot to '{fileName}'.", 10);
+            MessagesWindow.Visible = true; // Reveal MessageWindow
         }
     }
 }

--- a/Source/RunActivity/Viewer3D/Weather.cs
+++ b/Source/RunActivity/Viewer3D/Weather.cs
@@ -331,28 +331,35 @@ namespace Orts.Viewer3D
         public virtual void Update(ElapsedTime elapsedTime)
         {
             Time += elapsedTime.ClockSeconds;
+            var manager = MPManager.Instance();
 
-            if (MPManager.IsClient() && MPManager.Instance().weatherChanged)
+            if (MPManager.IsClient() && manager.weatherChanged)
             {
                 // Multiplayer weather has changed so we need to update our state to match weather, overcastFactor, pricipitationIntensity and fogDistance.
-                if (MPManager.Instance().weather >= 0 && MPManager.Instance().weather != (int)Viewer.Simulator.WeatherType) { Viewer.Simulator.WeatherType = (Orts.Formats.Msts.WeatherType)MPManager.Instance().weather; UpdateWeatherParameters(); }
-                if (MPManager.Instance().overcastFactor >= 0) Weather.OvercastFactor = MPManager.Instance().overcastFactor;
-                if (MPManager.Instance().pricipitationIntensity >= 0) { Weather.PricipitationIntensityPPSPM2 = MPManager.Instance().pricipitationIntensity; UpdateVolume(); }
-                if (MPManager.Instance().fogDistance >= 0) Weather.FogDistance = MPManager.Instance().fogDistance;
+                if (manager.weather >= 0 && manager.weather != (int)Viewer.Simulator.WeatherType)
+                {
+                    Viewer.Simulator.WeatherType = (Orts.Formats.Msts.WeatherType)manager.weather;
+                    UpdateWeatherParameters();
+                }
+                if (manager.overcastFactor >= 0)
+                    Weather.OvercastFactor = manager.overcastFactor;
+                if (manager.pricipitationIntensity >= 0)
+                {
+                    Weather.PricipitationIntensityPPSPM2 = manager.pricipitationIntensity;
+                    UpdateVolume();
+                }
+                if (manager.fogDistance >= 0)
+                    Weather.FogDistance = manager.fogDistance;
 
                 // Reset the message now that we've applied all the changes.
-                try
+                if ((manager.weather >= 0 && manager.weather != (int)Viewer.Simulator.WeatherType) || manager.overcastFactor >= 0 || manager.pricipitationIntensity >= 0 || manager.fogDistance >= 0)
                 {
-                    if ((MPManager.Instance().weather >= 0 && MPManager.Instance().weather != (int)Viewer.Simulator.WeatherType) || MPManager.Instance().overcastFactor >= 0 || MPManager.Instance().pricipitationIntensity >= 0 || MPManager.Instance().fogDistance >= 0)
-                    {
-                        MPManager.Instance().weatherChanged = false;
-                        MPManager.Instance().weather = -1;
-                        MPManager.Instance().overcastFactor = -1;
-                        MPManager.Instance().pricipitationIntensity = -1;
-                        MPManager.Instance().fogDistance = -1;
-                    }
+                    manager.weatherChanged = false;
+                    manager.weather = -1;
+                    manager.overcastFactor = -1;
+                    manager.pricipitationIntensity = -1;
+                    manager.fogDistance = -1;
                 }
-                catch { }
             }
 
             else if (!MPManager.IsClient())
@@ -500,7 +507,7 @@ namespace Orts.Viewer3D
                     || UserInput.IsReleased(UserCommand.DebugPrecipitationIncrease) || UserInput.IsReleased(UserCommand.DebugPrecipitationDecrease)
                     || UserInput.IsReleased(UserCommand.DebugFogIncrease) || UserInput.IsReleased(UserCommand.DebugFogDecrease))
                 {
-                    MPManager.Instance().SetEnvInfo(Weather.OvercastFactor, Weather.FogDistance);
+                    manager.SetEnvInfo(Weather.OvercastFactor, Weather.FogDistance);
                     MPManager.Notify((new MSGWeather(-1, Weather.OvercastFactor, Weather.PricipitationIntensityPPSPM2, Weather.FogDistance)).ToString());
                 }
             }


### PR DESCRIPTION
Many sections of the code are wrapped in catch-all try-catch blocks, which is very bad practice as this masks any potential runtime or logic errors. Following up on #214, which resolved the most obnoxious case, this pull request would continue the work for the rest of RunActivity.

I have attempted to delete, or at least minimize, the try-catch blocks wherever possible. Hopefully, I've translated the logic correctly and haven't introduced any new bugs.