### PR TITLE
Record current speed limit in the data logger

### DIFF
--- a/Source/RunActivity/Viewer3D/InfoDisplay.cs
+++ b/Source/RunActivity/Viewer3D/InfoDisplay.cs
@@ -268,24 +268,31 @@ namespace Orts.Viewer3D
                         Logger.Data((Viewer.PlayerLocomotive as MSTSLocomotive).LocomotiveAxle.AxleForceN.ToString("F2"));
                         Logger.Data((Viewer.PlayerLocomotive as MSTSLocomotive).LocomotiveAxle.SlipSpeedPercent.ToString("F1"));
 
-                        switch (Viewer.Settings.DataLogSpeedUnits)
+                        void logSpeed(float speedMpS)
                         {
-                            case "route":
-                                Logger.Data(FormatStrings.FormatSpeed(Viewer.PlayerLocomotive.SpeedMpS, Viewer.MilepostUnitsMetric));
-                                break;
-                            case "mps":
-                                Logger.Data(Viewer.PlayerLocomotive.SpeedMpS.ToString("F1"));
-                                break;
-                            case "mph":
-                                Logger.Data(MpS.FromMpS(Viewer.PlayerLocomotive.SpeedMpS, false).ToString("F1"));
-                                break;
-                            case "kmph":
-                                Logger.Data(MpS.FromMpS(Viewer.PlayerLocomotive.SpeedMpS, true).ToString("F1"));
-                                break;
-                            default:
-                                Logger.Data(FormatStrings.FormatSpeed(Viewer.PlayerLocomotive.SpeedMpS, Viewer.MilepostUnitsMetric));
-                                break;
+                            string result;
+                            switch (Viewer.Settings.DataLogSpeedUnits)
+                            {
+                                case "route":
+                                    result = FormatStrings.FormatSpeed(speedMpS, Viewer.MilepostUnitsMetric);
+                                    break;
+                                case "mps":
+                                    result = speedMpS.ToString("F1");
+                                    break;
+                                case "mph":
+                                    result = MpS.FromMpS(speedMpS, false).ToString("F1");
+                                    break;
+                                case "kmph":
+                                    result = MpS.FromMpS(speedMpS, true).ToString("F1");
+                                    break;
+                                default:
+                                    result = FormatStrings.FormatSpeed(speedMpS, Viewer.MilepostUnitsMetric);
+                                    break;
+                            }
+                            Logger.Data(result);
                         }
+                        logSpeed(Viewer.PlayerLocomotive.SpeedMpS);
+                        logSpeed(Viewer.PlayerTrain.AllowedMaxSpeedMpS);
 
                         Logger.Data((Viewer.PlayerLocomotive.DistanceM.ToString("F0")));
                         Logger.Data((Viewer.PlayerLocomotive.GravityForceN.ToString("F0")));
@@ -437,7 +444,8 @@ namespace Orts.Viewer3D
                                 "Player Brake Force [N]",
                                 "Player Axle Force [N]",
                                 "Player Wheelslip",
-                                "Player Speed [" + settings.DataLogSpeedUnits + "]",
+                                $"Player Speed [{settings.DataLogSpeedUnits}]",
+                                $"Speed Limit [{settings.DataLogSpeedUnits}]",
                                 "Distance [m]",
                                 "Player Gravity Force [N]",
                                 "Train Brake",


### PR DESCRIPTION
Log the current speed limit to make it easy to judge your driving performance. Implemented at the request of an Elvas Tower member.

Feature request: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)