### PR TITLE
Fix advanced adhesion wheelslip upon resuming from save: https://bugs.launchpad.net/or/+bug/1294410

### DIFF
--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -647,8 +647,8 @@ namespace Orts.Simulation.Physics
             Number = inf.ReadInt32();
             TotalNumber = Math.Max(Number + 1, TotalNumber);
             Name = inf.ReadString();
-            SpeedMpS = inf.ReadSingle();
-            AccelerationMpSpS.ForceSmoothValue(0f);
+            SpeedMpS = LastSpeedMpS = inf.ReadSingle();
+            AccelerationMpSpS.ForceSmoothValue(inf.ReadSingle());
             TrainType = (TRAINTYPE)inf.ReadInt32();
             if (TrainType == TRAINTYPE.STATIC) ColdStart = true;
             MUDirection = (Direction)inf.ReadInt32();
@@ -986,6 +986,7 @@ namespace Orts.Simulation.Physics
             outf.Write(Number);
             outf.Write(Name);
             outf.Write(SpeedMpS);
+            outf.Write(AccelerationMpSpS.SmoothedValue);
             outf.Write((int)TrainType);
             outf.Write((int)MUDirection);
             outf.Write(MUThrottlePercent);

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -648,6 +648,7 @@ namespace Orts.Simulation.Physics
             TotalNumber = Math.Max(Number + 1, TotalNumber);
             Name = inf.ReadString();
             SpeedMpS = inf.ReadSingle();
+            AccelerationMpSpS.ForceSmoothValue(0f);
             TrainType = (TRAINTYPE)inf.ReadInt32();
             if (TrainType == TRAINTYPE.STATIC) ColdStart = true;
             MUDirection = (Direction)inf.ReadInt32();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1026,6 +1026,7 @@ namespace Orts.Simulation.RollingStocks
             base.Save(outf);
 
             TrainControlSystem.Save(outf);
+            LocomotiveAxle.Save(outf);
         }
 
         /// <summary>
@@ -1068,6 +1069,7 @@ namespace Orts.Simulation.RollingStocks
             base.Restore(inf);
 
             TrainControlSystem.Restore(inf);
+            LocomotiveAxle = new Axle(inf);
         }
 
         public bool IsLeadLocomotive()

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
@@ -17,6 +17,7 @@
 
 using ORTS.Common;
 using System;
+using System.IO;
 
 namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
 {
@@ -580,6 +581,26 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                     totalInertiaKgm2 = inertiaKgm2;
                     break;
             }
+        }
+
+        /// <summary>
+        /// A constructor that restores the game state.
+        /// </summary>
+        /// <param name="inf">The save stream to read from.</param>
+        public Axle(BinaryReader inf) : this()
+        {
+            previousSlipPercent = inf.ReadSingle();
+            previousSlipSpeedMpS = inf.ReadSingle();
+        }
+
+        /// <summary>
+        /// Save the game state.
+        /// </summary>
+        /// <param name="outf">The save stream to write to.</param>
+        public void Save(BinaryWriter outf)
+        {
+            outf.Write(previousSlipPercent);
+            outf.Write(previousSlipSpeedMpS);
         }
 
         /// <summary>


### PR DESCRIPTION
On steep grades and at slow speeds, advanced adhesion physics can cause a wheelslip upon resuming from a save. This is because the state of the wheelslip model is not being properly restored.

This PR also includes a fix for the projected speed display on the Track Monitor, which displays "NaN" for a short time after resuming due to an initial acceleration calculation that comes out to "negative infinity." I have chosen to fix this by fixing the acceleration to 0 m/s/s^2 upon resume, but @peternewell has also [proposed](https://www.trainsim.com/vbts/showthread.php?333695-Resuming-Activity-From-Save-Locomotive-Wheelslip-and-Power-Reduction-Occurs!&p=1970175#post1970175) saving the state of the Track Monitor's acceleration projection. Perhaps another developer could chime in on which alternative seems more proper for Open Rails.