### PR TITLE
Remove startup exception in the launcher by refactoring a try-catch

### DIFF
--- a/Source/ORTS.Menu/Consists.cs
+++ b/Source/ORTS.Menu/Consists.cs
@@ -186,25 +186,33 @@ namespace ORTS.Menu
             }
             else if (File.Exists(filePath))
             {
-                var showInList = true;
+                EngineFile engFile;
                 try
                 {
-                    var engFile = new EngineFile(filePath);
-                    showInList = !string.IsNullOrEmpty(engFile.CabViewFile);
-                    Name = engFile.Name.Trim();
-                    Description = engFile.Description.Trim();
+                    engFile = new EngineFile(filePath);
                 }
                 catch
                 {
-                    Name = "<" + catalog.GetString("load error:") + " " + System.IO.Path.GetFileNameWithoutExtension(filePath) + ">";
+                    Name = $"<{catalog.GetString("load error:")} {System.IO.Path.GetFileNameWithoutExtension(filePath)}>";
+                    engFile = null;
                 }
-                if (!showInList) throw new InvalidDataException(catalog.GetStringFmt("Locomotive '{0}' is excluded.", filePath));
-                if (string.IsNullOrEmpty(Name)) Name = "<" + catalog.GetString("unnamed:") + " " + System.IO.Path.GetFileNameWithoutExtension(filePath) + ">";
-                if (string.IsNullOrEmpty(Description)) Description = null;
+                if (engFile != null)
+                {
+                    bool showInList = !string.IsNullOrEmpty(engFile.CabViewFile);
+                    if (!showInList)
+                        throw new InvalidDataException(catalog.GetStringFmt("Locomotive '{0}' is excluded.", filePath));
+
+                    string name = (engFile.Name ?? "").Trim();
+                    Name = name != "" ? name : $"<{catalog.GetString("unnamed:")} {System.IO.Path.GetFileNameWithoutExtension(filePath)}>";
+
+                    string description = (engFile.Description ?? "").Trim();
+                    if (description != "")
+                        Description = description;
+                }
             }
             else
             {
-                Name = "<" + catalog.GetString("missing:") + " " + System.IO.Path.GetFileNameWithoutExtension(filePath) + ">";
+                Name = $"<{catalog.GetString("missing:")} {System.IO.Path.GetFileNameWithoutExtension(filePath)}>";
             }
             FilePath = filePath;
         }


### PR DESCRIPTION
The current code generates a NullReferenceException whenever a locomotive's description is null (i.e., for AI-only equipment). These exceptions interrupt the Visual Studio debugger on startup, making debugging the launcher a rather tedious process with a large content folder.

Bug Report at https://bugs.launchpad.net/or/+bug/1888008