### PR TITLE
fix to build Test.csproj

### DIFF
--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -51,6 +51,7 @@
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\3rdPartyLibs\xunit.dll</HintPath>
+    </Reference>	  
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
Fix adds missing endtag which stops Appveyor build.