### PR TITLE
Fix lack of friction for wagons using freight animations with Davis values: https://bugs.launchpad.net/or/+bug/1889448

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -471,7 +471,6 @@ namespace Orts.Simulation.RollingStocks
             MaxHandbrakeForceN = InitialMaxHandbrakeForceN;
             MaxBrakeForceN = InitialMaxBrakeForceN;
             CentreOfGravityM = InitialCentreOfGravityM;
-            IsDavisFriction = DavisAN != 0 && DavisBNSpM != 0 && DavisCNSSpMM != 0; // test to see if OR thinks that Davis Values have been entered in WG file.
 
             if (FreightAnimations != null)
             {
@@ -819,6 +818,9 @@ namespace Orts.Simulation.RollingStocks
 #endif
 
             }
+
+            // Determine whether or not to use the Davis friction model. Must come after freight animations are initialized.
+            IsDavisFriction = DavisAN != 0 && DavisBNSpM != 0 && DavisCNSSpMM != 0;
 
             if (BrakeSystem == null)
                 BrakeSystem = MSTSBrakeSystem.Create(CarBrakeSystemType, this);


### PR DESCRIPTION
We need to move the "are we using Davis friction?" decision again, this time to a position following the initialization of the freight animation properties.