### PR TITLE
adds Manual.pdf in Spanish

### DIFF
--- a/Source/Documentation/Manual/es/README.TXT
+++ b/Source/Documentation/Manual/es/README.TXT
@@ -1,0 +1,2 @@
+This is a temporary arrangement to make the Spanish manual maintained by Javier (Xavivilla) available to all users.
+The intention is to get Javier to update his rst files using GitHub and make them part of the build that delivers the English manual.

--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -231,21 +231,19 @@ namespace ORTS
                 var path = dir + @"\Documentation\";
                 if (Directory.Exists(path))
                 {
-                    foreach (string entry in Directory.GetFiles(path))
+                    // Load English documents
+                    LoadDocuments(docs, path, null);
+
+                    // Find any non-English documents by looking in \Documentation\<language code>\, e.g. \Documentation\es\
+                    foreach (var codePath in Directory.GetDirectories(path))
                     {
-                        // These are the following formats that can be selected.
-                        if (entry.Contains(".pdf") || entry.Contains(".doc") || entry.Contains(".docx") || entry.Contains(".pptx") || entry.Contains(".txt"))
-                        {
-                            var i = entry.LastIndexOf("\\");
-                            docs.Add(new ToolStripMenuItem(entry.Substring(i + 1), null, (Object sender2, EventArgs e2) =>
-                            {
-                                var docPath = (sender2 as ToolStripItem).Tag as string;
-                                Process.Start(docPath);
-                             }) { Tag = entry });
-                        }
-                        contextMenuStripDocuments.Items.AddRange((from tool in docs
-                                                                  orderby tool.Text
-                                                                  select tool).ToArray());
+                        // Extract the last folder in the path - the language code, e.g. "es"
+                        var i = codePath.LastIndexOf(@"\");
+                        var code = codePath.Substring(i + 1);
+
+                        // include any non-English documents that match the chosen language
+                        if (code == Settings.Language)
+                            LoadDocuments(docs, codePath, code);
                     }
                 }
                 else
@@ -261,6 +259,31 @@ namespace ORTS
             {
                 LoadFolderList();
                 Initialized = true;
+            }
+        }
+
+        private void LoadDocuments(List<ToolStripItem> docs, string folderPath, string code)
+        {
+            foreach (var filePath in Directory.GetFiles(folderPath))
+            {
+                var ext = System.IO.Path.GetExtension(filePath);
+                var name = System.IO.Path.GetFileNameWithoutExtension(filePath);
+                // These are the following formats that can be selected.
+                if (".pdf .doc .docx .pptx .txt".Contains(ext))
+                {
+                    var codeLabel = "";
+                    if (code != null)
+                        codeLabel = $" [{code}]";
+                    docs.Add(new ToolStripMenuItem($"{name}{ext}{codeLabel}", null, (Object sender2, EventArgs e2) =>
+                    {
+                        var docPath = (sender2 as ToolStripItem).Tag as string;
+                        Process.Start(docPath);
+                    })
+                    { Tag = filePath });
+                }
+                contextMenuStripDocuments.Items.AddRange((from tool in docs
+                                                          orderby tool.Text
+                                                          select tool).ToArray());
             }
         }
 

--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -232,14 +232,13 @@ namespace ORTS
                 if (Directory.Exists(path))
                 {
                     // Load English documents
-                    LoadDocuments(docs, path, null);
+                    LoadDocuments(docs, path);
 
                     // Find any non-English documents by looking in \Documentation\<language code>\, e.g. \Documentation\es\
                     foreach (var codePath in Directory.GetDirectories(path))
                     {
                         // Extract the last folder in the path - the language code, e.g. "es"
-                        var i = codePath.LastIndexOf(@"\");
-                        var code = codePath.Substring(i + 1);
+                        var code = System.IO.Path.GetFileName(codePath);
 
                         // include any non-English documents that match the chosen language
                         if (code == Settings.Language)
@@ -262,19 +261,17 @@ namespace ORTS
             }
         }
 
-        private void LoadDocuments(List<ToolStripItem> docs, string folderPath, string code)
+        private void LoadDocuments(List<ToolStripItem> docs, string folderPath, string code = null)
         {
             foreach (var filePath in Directory.GetFiles(folderPath))
             {
                 var ext = System.IO.Path.GetExtension(filePath);
                 var name = System.IO.Path.GetFileNameWithoutExtension(filePath);
-                // These are the following formats that can be selected.
-                if (".pdf .doc .docx .pptx .txt".Contains(ext))
+                // These are the formats that can be selected.
+                if (new[] { ".pdf", ".doc", ".docx", ".pptx", ".txt" }.Contains(ext.ToLowerInvariant()))
                 {
-                    var codeLabel = "";
-                    if (code != null)
-                        codeLabel = $" [{code}]";
-                    docs.Add(new ToolStripMenuItem($"{name}{ext}{codeLabel}", null, (Object sender2, EventArgs e2) =>
+                    var codeLabel = string.IsNullOrEmpty(code) ? "" : $" [{code}]";
+                    docs.Add(new ToolStripMenuItem($"{name}{ext}{codeLabel}", null, (object sender2, EventArgs e2) =>
                     {
                         var docPath = (sender2 as ToolStripItem).Tag as string;
                         Process.Start(docPath);

--- a/Source/Menu/Menu.csproj
+++ b/Source/Menu/Menu.csproj
@@ -198,6 +198,13 @@
     </PreBuildEvent>
     <PostBuildEvent>echo $Revision: 000 $&gt;Revision.txt
 date /t&gt;&gt;Revision.txt
-time /t&gt;&gt;Revision.txt</PostBuildEvent>
+time /t&gt;&gt;Revision.txt
+
+REM Copy Spanish manual until we can make its RST files part of the build.
+CD ..\
+IF EXIST "Program\Documentation\es" RMDIR "Program\Documentation\es" /S /Q
+IF NOT EXIST "Program\Documentation\es" MKDIR "Program\Documentation\es"
+COPY "Source\Documentation\Manual\es\Manual.pdf" "Program\Documentation\es\"
+</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
https://blueprints.launchpad.net/or/+spec/non-english-documents
Adds a Spanish version of the Manual.pdf provided by Javier (Xavivilla) to the distribution.
Also extends the Menu.exe to automatically add any non-English documents into the Documents drop-down if that language has been selected.