### PR TITLE
Fix translations not displaying for the HUD Dispatcher Information tab: https://bugs.launchpad.net/or/+bug/1891066

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -913,7 +913,7 @@ namespace Orts.Viewer3D.Popups
                 }
             }
 
-            TextPageHeading(table, Viewer.Catalog.GetString("DISPATCHER INFORMATION : active trains : " + totalactive));
+            TextPageHeading(table, $"{Viewer.Catalog.GetString("DISPATCHER INFORMATION : active trains : ")}{totalactive}");
 
             TableSetCells(table, 0,
                 Viewer.Catalog.GetString("Train"),


### PR DESCRIPTION
The Dispatcher Information header, which displays the number of active trains, is not being properly translated into other languages. Discovered by @Weter-ORTS during his work on the Russian translation (#248).