### PR TITLE
add temporary fix

### DIFF
--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -281,10 +281,20 @@ namespace Orts.Simulation.Physics
                 float sectionStart = -offset;
 
                 // Get all track circuit sections in front of the train
-                List<int> sectionIndexes = signalRef.ScanRoute(this, position.TCSectionIndex, position.TCOffset,
-                        position.TCDirection, true, -1, true, false,
-                        false, false, true, false, false, false, false, IsFreight);
-                List<TrackCircuitSection> sections = new List<TrackCircuitSection>();
+                //List<int> sectionIndexes = signalRef.ScanRoute(this, position.TCSectionIndex, position.TCOffset,
+                //        position.TCDirection, true, -1, true, false,
+                //        false, false, true, false, false, false, false, IsFreight);
+                //List<TrackCircuitSection> sections = new List<TrackCircuitSection>();
+
+                var sectionIndexes = new List<int>();
+                var sections = new List<TrackCircuitSection>();
+                if (position.TCSectionIndex >= 0) // Temporary fix for TCSectionIndex == -1 but don't know why that occurs.
+                {
+                    // Get all track circuit sections in front of the train
+                    sectionIndexes = signalRef.ScanRoute(this, position.TCSectionIndex, position.TCOffset,
+                            position.TCDirection, true, -1, true, false,
+                            false, false, true, false, false, false, false, IsFreight);
+                }
 
                 if (sectionIndexes.Count > 0)
                 {


### PR DESCRIPTION
Copy of Carlo's fix for OpenRails_MG_NoWD
In both cases this is temporary as the root cause is not yet known.
Forum thread at http://www.elvastower.com/forums/index.php?/topic/34297-mg71-crash-index-was-out-of-range-must-be-non-negative-and-less-than-the-size-of-the-collection/
Carlo's fix at https://github.com/Csantucci/openrails/commit/540fab09fb6be37ec490461b5974606b13165e3e


PLEASE DO NOT APPROVE THIS PR - it's fine for the Unstable version, but we need a solution to the root cause before making a change to the Testing version.