### PR TITLE
build: Add index to PDFs

### DIFF
--- a/Source/Documentation/Manual/index.rst
+++ b/Source/Documentation/Manual/index.rst
@@ -33,9 +33,13 @@ Open Rails Manual
     acknowledgements
     appendices
 
-Indices and tables
-==================
+.. The following section is needed in HTML output but not in PDF
 
-* :ref:`genindex`
-* :ref:`search`
+.. only:: html
+
+    Indices and tables
+    ==================
+
+    * :ref:`genindex`
+    * :ref:`search`
 

--- a/Source/Documentation/Manual/make.bat
+++ b/Source/Documentation/Manual/make.bat
@@ -174,9 +174,7 @@ if "%1" == "latex" (
 if "%1" == "latexpdf" (
 	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
 	cd %BUILDDIR%/latex
-	REM Run pdflatex twice so that the Table of Contents is correct.
-    for %%t in (*.tex) do pdflatex %%t
-	for %%t in (*.tex) do pdflatex %%t
+	make all-pdf
 	cd "%~dp0"
 	echo.
 	echo.Build finished; the PDF files are in %BUILDDIR%/latex.


### PR DESCRIPTION
It turns out that we aren't generating the index for PDF files, so I've fixed that.

I've also removed the explicit index/search entries in the TOC from PDFs, as neither of them was correct for PDFs (they're good for HTML though).