### PR TITLE
fix: Allow building the manual without the rest of Open Rails

### DIFF
--- a/Source/Documentation/Manual/conf.py
+++ b/Source/Documentation/Manual/conf.py
@@ -25,8 +25,11 @@ author = 'Open Rails Team'
 version = ''
 revision = ''
 
-# Load current version and revision information
-exec(open("./version.py").read())
+# Load current version and revision information (ignoring errors)
+try:
+    exec(open("./version.py").read())
+except:
+    pass
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This is a slight change which allows you to compile the manual (HTML or PDF) without compiling the rest of Open Rails, which saves on a lot of time and dependencies (or messing with configuration files).