### PR TITLE
ci: Disable artifacts as we're over-quota and don't use them

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,6 @@ install:
 build_script:
 - cmd: Build.cmd unstable
 test: off
-artifacts:
-- path: OpenRails-Unstable.zip
-- path: OpenRails-Unstable-Source.zip
+# artifacts:
+# - path: OpenRails-Unstable.zip
+# - path: OpenRails-Unstable-Source.zip


### PR DESCRIPTION
Unfortunately, we're again gone over-quota with AppVeyor. They keep artifacts for 6 months and have a fixed 75 GB limit (which we already had raised from the default 50 GB limit), but do not provide a way of managing this storage in any way.

Instead of asking for the quota to be raised again, I'm going to turn off the collection of artifacts on the AppVeyor builds. This means that you will have to build a PR yourself instead of simply downloading AppVeyor's version, but it will also mean AppVeyor is not duplicating the Unstable and Testing Version artifacts, which are already build elsewhere for the official downloads.