### PR TITLE
Fix calculation issues with TE and Speed

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -1544,6 +1544,7 @@ iii. `Testing Resources for Open Rails Steam Locomotives
    single: ORTSRigidWheelBase
    single: ORTSSteamGearRatio
    single: ORTSSteamMaxGearPistonRate
+   single: ORTSGearedTractiveEffortFactor
    single: ORTSBoilerEvaporationRate
    single: ORTSBurnRate
    single: ORTSCylinderEfficiencyRate
@@ -1701,6 +1702,9 @@ iii. `Testing Resources for Open Rails Steam Locomotives
 +-----------------------------------------------------------+-------------------+-------------------+-------------------+
 |ORTS |-| Steam |-| Gear |-| Type ( x )                     |Fixed gearing or   |Fixed,             || (Fixed)          |
 |                                                           |selectable gearing |Select             || (Select)         |
++-----------------------------------------------------------+-------------------+-------------------+-------------------+
+|ORTS |-| Geared |-| Tractive |-| Effort |-| Factor ( x )   |Factor to include  |Fixed              || (Fixed)          |
+|                                                           | in TE calculation |                   ||                  |
 +-----------------------------------------------------------+-------------------+-------------------+-------------------+
 |**Locomotive Performance Adjustments (Engine section -- Optional, for experienced modellers)**                         |
 +-----------------------------------------------------------+-------------------+-------------------+-------------------+

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -1280,7 +1280,6 @@ namespace Orts.Simulation.RollingStocks
                     // Calculate maximum locomotive speed - based upon the number of revs for the drive shaft, geared to wheel shaft, and then circumference of drive wheel
                     // Max Geared speed = ((MaxPistonSpeedFt/m / Gear Ratio) x DrvWheelCircumference) / Feet in mile - miles per min
                     LowMaxGearedSpeedMpS = (Me.FromFt(pS.FrompM(MaxSteamGearPistonRateFtpM / SteamGearRatioLow))) * 2.0f * MathHelper.Pi * DriverWheelRadiusM / (2.0f * CylinderStrokeM);
-//                    LowMaxGearedSpeedMpS = pS.FrompM(MaxSteamGearPistonRateFtpM / SteamGearRatio * MathHelper.Pi * DriverWheelRadiusM * 2.0f);
                     MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2.0f * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * GearedTractiveEffortFactor * MotiveForceGearRatio * CylinderEfficiencyRate;
                     MaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);
                     DisplayMaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -571,7 +571,7 @@ namespace Orts.Simulation.RollingStocks
         float absStartTractiveEffortN = 0.0f;      // Record starting tractive effort
         float TractiveEffortLbsF;           // Current sim calculated tractive effort
         const float TractiveEffortFactor = 0.85f;  // factor for calculating Theoretical Tractive Effort for non-geared locomotives
-        const float GearedTractiveEffortFactor = 0.7f;  // factor for calculating Theoretical Tractive Effort for geared locomotives
+        float GearedTractiveEffortFactor = 0.7f;  // factor for calculating Theoretical Tractive Effort for geared locomotives
         float NeutralGearedDavisAN; // Davis A value adjusted for neutral gearing
         const float DavisMechanicalResistanceFactor = 20.0f;
         float GearedRetainedDavisAN; // Remembers the Davis A value
@@ -827,6 +827,7 @@ namespace Orts.Simulation.RollingStocks
                     stf.SkipRestOfBlock();
                     break;
                 case "engine(ortssteammaxgearpistonrate": MaxSteamGearPistonRateFtpM = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;
+                case "engine(ortsgearedtractiveeffortfactor": GearedTractiveEffortFactor = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;
                 case "engine(ortssteamlocomotivetype":
                     stf.MustMatch("(");
                     var steamengineType = stf.ReadString();
@@ -883,6 +884,7 @@ namespace Orts.Simulation.RollingStocks
             EjectorSmallSteamConsumptionLbpS = locoCopy.EjectorSmallSteamConsumptionLbpS;
             EjectorLargeSteamConsumptionLbpS = locoCopy.EjectorLargeSteamConsumptionLbpS;
             ShovelMassKG = locoCopy.ShovelMassKG;
+            GearedTractiveEffortFactor = locoCopy.GearedTractiveEffortFactor;
             MaxTenderCoalMassKG = locoCopy.MaxTenderCoalMassKG;
             MaxLocoTenderWaterMassKG = locoCopy.MaxLocoTenderWaterMassKG;
             MaxFiringRateKGpS = locoCopy.MaxFiringRateKGpS;
@@ -1277,7 +1279,8 @@ namespace Orts.Simulation.RollingStocks
                     SteamGearPosition = 1.0f; // set starting gear position 
                     // Calculate maximum locomotive speed - based upon the number of revs for the drive shaft, geared to wheel shaft, and then circumference of drive wheel
                     // Max Geared speed = ((MaxPistonSpeedFt/m / Gear Ratio) x DrvWheelCircumference) / Feet in mile - miles per min
-                    LowMaxGearedSpeedMpS = pS.FrompM(MaxSteamGearPistonRateFtpM / SteamGearRatio * MathHelper.Pi * DriverWheelRadiusM * 2.0f);
+                    LowMaxGearedSpeedMpS = (Me.FromFt(pS.FrompM(MaxSteamGearPistonRateFtpM / SteamGearRatioLow))) * 2.0f * MathHelper.Pi * DriverWheelRadiusM / (2.0f * CylinderStrokeM);
+//                    LowMaxGearedSpeedMpS = pS.FrompM(MaxSteamGearPistonRateFtpM / SteamGearRatio * MathHelper.Pi * DriverWheelRadiusM * 2.0f);
                     MaxTractiveEffortLbf = (NumCylinders / 2.0f) * (Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / (2.0f * Me.ToIn(DriverWheelRadiusM))) * MaxBoilerPressurePSI * GearedTractiveEffortFactor * MotiveForceGearRatio * CylinderEfficiencyRate;
                     MaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);
                     DisplayMaxLocoSpeedMpH = MpS.ToMpH(LowMaxGearedSpeedMpS);


### PR DESCRIPTION
 For fixed geared steam locomotives - https://bugs.launchpad.net/or/+bug/1899443