### PR TITLE
Further TCS handles to get signal data and to set sound events

### DIFF
--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -128,6 +128,11 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<int, float> NextPostDistanceM;
         /// <summary>
+        /// Distance to end of authority.
+        /// int: direction; 0: forwards; 1: backwards
+        /// </summary>
+        public Func<int, float> EOADistanceM;
+        /// <summary>
         /// Train's length
         /// </summary>
         public Func<float> TrainLengthM;

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -587,6 +587,6 @@ namespace ORTS.Scripting.Api
         public string MainHeadSignalTypeName;
         public Aspect Aspect;
         public float DistanceM;
-        public float SpeedLimit;
+        public float SpeedLimitM;
     }
 }

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -105,7 +105,7 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<string, float> NextGenericSignalDistanceM;
         /// <summary>
-        /// Features of next generic signal. Not for NORMAL signals
+        /// Features of next generic signal. 
         /// string: signal type (DISTANCE etc.)
         /// int: position of signal in the signal sequence along the train route, starting from train front; 0 for first signal;
         /// float: max testing distance
@@ -587,5 +587,6 @@ namespace ORTS.Scripting.Api
         public string MainHeadSignalTypeName;
         public Aspect Aspect;
         public float DistanceM;
+        public float SpeedLimit;
     }
 }

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -18,6 +18,7 @@
 using System;
 using System.IO;
 using ORTS.Common;
+using Orts.Common;
 using Orts.Simulation.RollingStocks;
 
 namespace ORTS.Scripting.Api
@@ -79,6 +80,11 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<bool> DoesNextNormalSignalHaveTwoAspects;
         /// <summary>
+        /// Name of Head 0 of next normal signal.
+        /// int: position of signal in the signal sequence along the train route, starting from train front; 0 for first signal;
+        /// </summary>
+        public Func<int, string> NextNormalSignalMainHeadSignalType;
+        /// <summary>
         /// Aspect of the next DISTANCE signal.
         /// </summary>
         public Func<Aspect> NextDistanceSignalAspect;
@@ -87,17 +93,24 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> NextDistanceSignalDistanceM;
         /// <summary>
-        /// Signal type of main head of hext generic signal.
+        /// Signal type of main head of hext generic signal. Not for NORMAL signals
         /// </summary>
         public Func<string, string> NextGenericSignalMainHeadSignalType;
         /// <summary>
-        /// Aspect of the next generic signal.
+        /// Aspect of the next generic signal. Not for NORMAL signals
         /// </summary>
         public Func<string, Aspect> NextGenericSignalAspect;
         /// <summary>
-        /// Distance to next generic signal.
+        /// Distance to next generic signal. Not for NORMAL signals
         /// </summary>
         public Func<string, float> NextGenericSignalDistanceM;
+        /// <summary>
+        /// Features of next generic signal. Not for NORMAL signals
+        /// string: signal type (DISTANCE etc.)
+        /// int: position of signal in the signal sequence along the train route, starting from train front; 0 for first signal;
+        /// float: max testing distance
+        /// </summary>
+        public Func<string, int, float, SignalFeatures> NextGenericSignalFeatures;
         /// <summary>
         /// Next normal signal has a repeater head
         /// </summary>
@@ -123,21 +136,25 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> SpeedMpS;
         /// <summary>
-        /// Train's direction.
+        /// Locomotive direction.
         /// </summary>
         public Func<Direction> CurrentDirection;
         /// <summary>
-        /// True if train direction is forward.
+        /// True if locomotive direction is forward.
         /// </summary>
         public Func<bool> IsDirectionForward;
         /// <summary>
-        /// True if train direction is neutral.
+        /// True if locomotive direction is neutral.
         /// </summary>
         public Func<bool> IsDirectionNeutral;
         /// <summary>
-        /// True if train direction is reverse.
+        /// True if locomotive direction is reverse.
         /// </summary>
         public Func<bool> IsDirectionReverse;
+        /// <summary>
+        /// Train direction.
+        /// </summary>
+        public Func<Direction> CurrentTrainMUDirection;
         /// <summary>
         /// True if train brake controller is in emergency position, otherwise false.
         /// </summary>
@@ -322,6 +339,10 @@ namespace ORTS.Scripting.Api
         /// Trigger Deactivate sound event
         /// </summary>
         public Action TriggerSoundSystemDeactivate;
+        /// <summary>
+        /// Trigger generic sound event
+        /// </summary>
+        public Action<Event> TriggerGenericSound;
         /// <summary>
         /// Set ALERTER_DISPLAY cabcontrol display's alarm state on or off.
         /// </summary>
@@ -559,5 +580,12 @@ namespace ORTS.Scripting.Api
         /// Red color. Train control system intervention speed. Computer has to apply full service or emergency brake to maintain speed restriction.
         /// </summary>
         Intervention,
+    }
+
+    public struct SignalFeatures
+    {
+        public string MainHeadSignalTypeName;
+        public Aspect Aspect;
+        public float DistanceM;
     }
 }

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -587,6 +587,6 @@ namespace ORTS.Scripting.Api
         public string MainHeadSignalTypeName;
         public Aspect Aspect;
         public float DistanceM;
-        public float SpeedLimitM;
+        public float SpeedLimitMpS;
     }
 }

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -80,11 +80,6 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<bool> DoesNextNormalSignalHaveTwoAspects;
         /// <summary>
-        /// Name of Head 0 of next normal signal.
-        /// int: position of signal in the signal sequence along the train route, starting from train front; 0 for first signal;
-        /// </summary>
-        public Func<int, string> NextNormalSignalMainHeadSignalType;
-        /// <summary>
         /// Aspect of the next DISTANCE signal.
         /// </summary>
         public Func<Aspect> NextDistanceSignalAspect;

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -593,13 +593,15 @@ namespace ORTS.Scripting.Api
         public readonly Aspect Aspect;
         public readonly float DistanceM;
         public readonly float SpeedLimitMpS;
+        public readonly float AltitudeOrLengthM;
 
-        public SignalFeatures(string mainHeadSignalTypeName, Aspect aspect, float distanceM, float speedLimitMpS)
+        public SignalFeatures(string mainHeadSignalTypeName, Aspect aspect, float distanceM, float speedLimitMpS, float altitudeOrLengthM)
         {
             MainHeadSignalTypeName = mainHeadSignalTypeName;
             Aspect = aspect;
             DistanceM = distanceM;
             SpeedLimitMpS = speedLimitMpS;
+            AltitudeOrLengthM = altitudeOrLengthM;
         }
     }
 }

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -593,15 +593,15 @@ namespace ORTS.Scripting.Api
         public readonly Aspect Aspect;
         public readonly float DistanceM;
         public readonly float SpeedLimitMpS;
-        public readonly float AltitudeOrLengthM;
+        public readonly float AltitudeM;
 
-        public SignalFeatures(string mainHeadSignalTypeName, Aspect aspect, float distanceM, float speedLimitMpS, float altitudeOrLengthM)
+        public SignalFeatures(string mainHeadSignalTypeName, Aspect aspect, float distanceM, float speedLimitMpS, float altitudeM)
         {
             MainHeadSignalTypeName = mainHeadSignalTypeName;
             Aspect = aspect;
             DistanceM = distanceM;
             SpeedLimitMpS = speedLimitMpS;
-            AltitudeOrLengthM = altitudeOrLengthM;
+            AltitudeM = altitudeM;
         }
     }
 }

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -584,9 +584,17 @@ namespace ORTS.Scripting.Api
 
     public struct SignalFeatures
     {
-        public string MainHeadSignalTypeName;
-        public Aspect Aspect;
-        public float DistanceM;
-        public float SpeedLimitMpS;
+        public readonly string MainHeadSignalTypeName;
+        public readonly Aspect Aspect;
+        public readonly float DistanceM;
+        public readonly float SpeedLimitMpS;
+
+        public SignalFeatures(string mainHeadSignalTypeName, Aspect aspect, float distanceM, float speedLimitMpS)
+        {
+            MainHeadSignalTypeName = mainHeadSignalTypeName;
+            Aspect = aspect;
+            DistanceM = distanceM;
+            SpeedLimitMpS = speedLimitMpS;
+        }
     }
 }

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -1653,10 +1653,6 @@ namespace Orts.Simulation.Physics
             // check position of train wrt tunnels
             ProcessTunnels();
 
-            // prepare train data for Train Control System
-            if (IsActualPlayerTrain)
-                UpdatePlayerTrainData();
-
             // log train details
 
             if (DatalogTrainSpeed)
@@ -14285,6 +14281,8 @@ namespace Orts.Simulation.Physics
 
         public TrainInfo GetTrainInfo()
         {
+            if (IsActualPlayerTrain && PlayerTrainSignals == null)
+                UpdatePlayerTrainData();
             TrainInfo thisInfo = new TrainInfo();
 
             if (ControlMode == TRAIN_CONTROL.AUTO_NODE || ControlMode == TRAIN_CONTROL.AUTO_SIGNAL)

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -14106,15 +14106,15 @@ namespace Orts.Simulation.Physics
                                 (TrainObjectItem.SpeedItemType)(signalObjectItem.speed_noSpeedReductionOrIsTempSpeedReduction));
                             PlayerTrainSpeedposts[dir].Add(thisItem);
                         }
-                        if (!signalProcessed && NextSignalObject[0] != null && NextSignalObject[0].enabledTrain != null && NextSignalObject[0].enabledTrain.Train == this)
-                        {
-                            TrackMonitorSignalAspect signalAspect =
-                                NextSignalObject[0].TranslateTMAspect(NextSignalObject[0].this_sig_lr(MstsSignalFunction.NORMAL));
-                            ObjectSpeedInfo thisSpeedInfo = NextSignalObject[0].this_sig_speed(MstsSignalFunction.NORMAL);
-                            float validSpeed = thisSpeedInfo == null ? -1 : (IsFreight ? thisSpeedInfo.speed_freight : thisSpeedInfo.speed_pass);
-                            thisItem = new TrainObjectItem(signalAspect, validSpeed, DistanceToSignal, NextSignalObject[0]);
-                            PlayerTrainSignals[0, 0].Add(thisItem);
-                        }
+                    }
+                    if (!signalProcessed && NextSignalObject[0] != null && NextSignalObject[0].enabledTrain != null && NextSignalObject[0].enabledTrain.Train == this)
+                    {
+                        TrackMonitorSignalAspect signalAspect =
+                            NextSignalObject[0].TranslateTMAspect(NextSignalObject[0].this_sig_lr(MstsSignalFunction.NORMAL));
+                        ObjectSpeedInfo thisSpeedInfo = NextSignalObject[0].this_sig_speed(MstsSignalFunction.NORMAL);
+                        float validSpeed = thisSpeedInfo == null ? -1 : (IsFreight ? thisSpeedInfo.speed_freight : thisSpeedInfo.speed_pass);
+                        thisItem = new TrainObjectItem(signalAspect, validSpeed, DistanceToSignal, NextSignalObject[0]);
+                        PlayerTrainSignals[0, 0].Add(thisItem);
                     }
                 }
                 // rear direction, auto mode

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -14376,7 +14376,7 @@ namespace Orts.Simulation.Physics
                                 else if (PlayerTrainTunnels[dir].Count == 0 && (thisTunnel[sectionDirection].TunnelEnd < 0 || thisTunnel[sectionDirection].TunnelEnd > lengthOffset))
                                 {
                                     // Train is in tunnel, compute remaining length
-                                    var remainingLength = thisTunnel[sectionDirection].TotalLength - lengthOffset - (tunnelStartOffset < 0 ? thisTunnel[sectionDirection].TCSStartOffset : tunnelStartOffset);
+                                    var remainingLength = thisTunnel[sectionDirection].TotalLength - lengthOffset + (tunnelStartOffset < 0 ? -thisTunnel[sectionDirection].TCSStartOffset : tunnelStartOffset);
                                     thisItem = new TrainObjectItem(-1, (int)remainingLength, TrainObjectItem.TRAINOBJECTTYPE.TUNNEL);
                                     PlayerTrainTunnels[dir].Add(thisItem);
                                 }

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -14281,6 +14281,7 @@ namespace Orts.Simulation.Physics
 
         public TrainInfo GetTrainInfo()
         {
+            // This may occur just  after player train switching 
             if (IsActualPlayerTrain && PlayerTrainSignals == null)
                 UpdatePlayerTrainData();
             TrainInfo thisInfo = new TrainInfo();

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -14039,11 +14039,12 @@ namespace Orts.Simulation.Physics
             {
                 if (ValidRoute[dir] == null || dir == 1 && PresentPosition[dir].TCSectionIndex < 0)
                     continue;
-                int index = dir == 0 ? PresentPosition[dir].RouteListIndex : ValidRoute[dir].GetRouteIndex(PresentPosition[dir].TCSectionIndex, 0);
-                if (index < 0)
+                int startIndex = dir == 0 ? PresentPosition[dir].RouteListIndex : ValidRoute[dir].GetRouteIndex(PresentPosition[dir].TCSectionIndex, 0);
+                if (startIndex < 0)
                     continue;
                 for (int fn_type = 0; fn_type < signalRef.ORTSSignalTypeCount; fn_type++)
                 {
+                    int index = startIndex;
                     // TODO: NORMAL signals management to be completed
                     // NORMAL signals get data from a different place
                     if (signalRef.ORTSSignalTypes[fn_type] == "NORMAL")

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -55,6 +55,7 @@ using Orts.Formats.Msts;
 using Orts.MultiPlayer;
 using Orts.Simulation.AIs;
 using Orts.Simulation.RollingStocks;
+using Orts.Simulation.RollingStocks.SubSystems;
 using Orts.Simulation.RollingStocks.SubSystems.Brakes;
 using Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS;
 using Orts.Parsers.Msts;
@@ -1648,6 +1649,10 @@ namespace Orts.Simulation.Physics
 
             // check position of train wrt tunnels
             ProcessTunnels();
+
+            // prepare train data for Train Control System
+            if (IsActualPlayerTrain)
+                UpdateTrainData();
 
             // log train details
 
@@ -13982,6 +13987,119 @@ namespace Orts.Simulation.Physics
 
         //================================================================================================//
         /// <summary>
+        /// Generation of Train data useful for TCS and TrackMonitor; player train only
+        /// <\summary>
+
+        public class TrainSignal
+        {
+            public float DistanceToTrainM;
+            public SignalObject ObjectDetails;
+
+            public TrainSignal(float distanceToTrainM, SignalObject objectDetails)
+            {
+                DistanceToTrainM = distanceToTrainM;
+                ObjectDetails = objectDetails;
+            }
+        }
+
+        public List<TrainSignal>[,] TrainSignalLists; // first index 0 forward, 1 backward; second index signal type (NORMAL etc.)
+
+        //================================================================================================//
+        /// <summary>
+        /// Updates the train data for TCS and TrackMonitor
+        /// </summary>
+        /// 
+        public void UpdateTrainData()
+        {
+            UpdateSignalData(10000.0f);
+            //TODO add generation of other train data
+        }
+
+        //================================================================================================//
+        /// <summary>
+        /// Updates the signal data;
+        /// </summary>
+
+        public void UpdateSignalData(float maxDistanceM)
+        {
+            if (!((MSTSLocomotive)Simulator.PlayerLocomotive).TrainControlSystem.CustomTCSScript)
+                return;
+            if (TrainSignalLists == null)
+            {
+                TrainSignalLists = new List<TrainSignal>[2, signalRef.ORTSSignalTypeCount];
+                for (int dir = 0; dir < 2; dir++)
+                    for (int fn_type = 0; fn_type < signalRef.ORTSSignalTypeCount; fn_type++)
+                        TrainSignalLists[dir, fn_type] = new List<TrainSignal>();
+            }
+            else
+                foreach (var trainSignalList in TrainSignalLists)
+                    trainSignalList?.Clear();
+            // fill up the lists
+            for (int dir = 0; dir < 2; dir++)
+            {
+                if (ValidRoute[dir] == null || dir == 1 && PresentPosition[dir].TCSectionIndex < 0)
+                    continue;
+                int index = dir == 0 ? PresentPosition[dir].RouteListIndex : ValidRoute[dir].GetRouteIndex(PresentPosition[dir].TCSectionIndex, 0);
+                if (index < 0)
+                    continue;
+                for (int fn_type = 0; fn_type < signalRef.ORTSSignalTypeCount; fn_type++)
+                {
+                    // TODO: NORMAL signals management to be completed
+                    // NORMAL signals get data from a different place
+                    if (signalRef.ORTSSignalTypes[fn_type] == "NORMAL")
+                    {
+                        if (dir == 0)
+                        {
+                            // we put them all without checking with max distance
+                            foreach (var signalObjectItem in SignalObjectItems)
+                            {
+                                if (signalObjectItem.ObjectType == ObjectItemInfo.ObjectItemType.Signal)
+                                {
+                                    var trainSignal = new TrainSignal(signalObjectItem.distance_to_train, signalObjectItem.ObjectDetails);
+                                }
+                            }
+                        }
+                        else
+                        {
+
+                        }
+                    }
+                    else
+                    {
+                        float lengthOffset = (dir == 1) ? (-PresentPosition[1].TCOffset +
+                                 signalRef.TrackCircuitList[PresentPosition[1].TCSectionIndex].Length) : PresentPosition[0].TCOffset;
+                        float totalLength = 0;
+                        var routePath = ValidRoute[dir];
+                        while (index < routePath.Count && totalLength - lengthOffset < maxDistanceM)
+                        {
+                            var thisElement = routePath[index];
+                            TrackCircuitSection thisSection = signalRef.TrackCircuitList[thisElement.TCSectionIndex];
+                            TrackCircuitSignalList thisSignalList = thisSection.CircuitItems.TrackCircuitSignals[thisElement.Direction][fn_type];
+                            foreach (TrackCircuitSignalItem thisSignal in thisSignalList.TrackCircuitItem)
+                            {
+                                if (thisSignal.SignalLocation > lengthOffset)
+                                {
+                                    var trainSignal = new TrainSignal(thisSignal.SignalLocation - lengthOffset + totalLength, thisSignal.SignalRef);
+                                    TrainSignalLists[dir, fn_type].Add(trainSignal);
+                                }
+                            }
+                            totalLength += (thisSection.Length - lengthOffset);
+                            lengthOffset = 0;
+
+                            // terminate where route not set
+                            int setSection = thisSection.ActivePins[thisElement.OutPin[0], thisElement.OutPin[1]].Link;
+                            index++;
+                            if (setSection < 0)
+                                continue;
+                        }
+                    }
+                }
+            }
+        }
+
+
+        //================================================================================================//
+        /// <summary>
         /// Create TrackInfoObject for information in TrackMonitor window
         /// </summary>
 
@@ -20459,7 +20577,7 @@ namespace Orts.Simulation.Physics
         //================================================================================================//
         /// <summary>
         /// Class for info to TrackMonitor display
-        /// <\summary>
+        /// </summary>
 
         public class TrainInfo
         {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -487,6 +487,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             var aspect = Aspect.None;
             var distanceM = float.MaxValue;
             var speedLimitMpS = -1f;
+            var altitudeOrLengthM = -float.MaxValue;
 
             int dir = Locomotive.Train.MUDirection == Direction.Reverse ? 1 : 0;
 
@@ -514,6 +515,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 {
                     aspect = (Aspect)trainSignal.SignalState;
                     speedLimitMpS = trainSignal.AllowedSpeedMpS;
+                    altitudeOrLengthM = trainSignal.SignalObject.tdbtraveller.Y;
                 }
                 else
                 {
@@ -535,7 +537,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             }
 
         Exit:
-            return new SignalFeatures(mainHeadSignalTypeName: mainHeadSignalTypeName, aspect: aspect, distanceM: distanceM, speedLimitMpS: speedLimitMpS);
+            return new SignalFeatures(mainHeadSignalTypeName: mainHeadSignalTypeName, aspect: aspect, distanceM: distanceM, speedLimitMpS: speedLimitMpS,
+                altitudeOrLengthM: altitudeOrLengthM);
         }
 
         private bool DoesNextNormalSignalHaveRepeaterHead()

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -477,7 +477,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             MainHeadSignalTypeName = ItemFeatures.MainHeadSignalTypeName;
             ItemAspect = ItemFeatures.Aspect;
             ItemDistance = ItemFeatures.DistanceM;
-            ItemSpeedLimit = ItemFeatures.SpeedLimitM;
+            ItemSpeedLimit = ItemFeatures.SpeedLimitMpS;
             return retval;
         }
 
@@ -486,7 +486,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             ItemFeatures.MainHeadSignalTypeName = "";
             ItemFeatures.Aspect = Aspect.None;
             ItemFeatures.DistanceM = float.MaxValue;
-            ItemFeatures.SpeedLimitM = -1.0f;
+            ItemFeatures.SpeedLimitMpS = -1.0f;
 
             int dir = Locomotive.Train.MUDirection == Direction.Reverse ? 1 : 0;
 
@@ -513,7 +513,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 if (signalTypeName == "NORMAL")
                 {
                     ItemFeatures.Aspect = (Aspect)trainSignal.SignalState;
-                    ItemFeatures.SpeedLimitM = trainSignal.AllowedSpeedMpS;
+                    ItemFeatures.SpeedLimitMpS = trainSignal.AllowedSpeedMpS;
                 }
                 else
                 {
@@ -531,7 +531,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
 
                 // All OK, we can retrieve the data for the required speedpost;
                 ItemFeatures.DistanceM = trainSpeedpost.DistanceToTrainM;
-                ItemFeatures.SpeedLimitM = trainSpeedpost.AllowedSpeedMpS;
+                ItemFeatures.SpeedLimitMpS = trainSpeedpost.AllowedSpeedMpS;
             }
 
             return ItemFeatures;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -288,6 +288,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.CurrentPostSpeedLimitMpS = () => Locomotive.Train.allowedMaxSpeedLimitMpS;
                 Script.NextPostSpeedLimitMpS = (value) => NextGenericSignalItem<float>(value, ref ItemSpeedLimit, float.MaxValue, Train.TrainObjectItem.TRAINOBJECTTYPE.SPEEDPOST);
                 Script.NextPostDistanceM = (value) => NextGenericSignalItem<float>(value, ref ItemDistance, float.MaxValue, Train.TrainObjectItem.TRAINOBJECTTYPE.SPEEDPOST);
+                Script.EOADistanceM = (value) => Locomotive.Train.DistanceToEndNodeAuthorityM[value];
                 Script.TrainLengthM = () => Locomotive.Train != null ? Locomotive.Train.Length : 0f;
                 Script.SpeedMpS = () => Math.Abs(Locomotive.SpeedMpS);
                 Script.CurrentDirection = () => Locomotive.Direction; // Direction of locomotive, may be different from direction of train

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -551,11 +551,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems
 
         T NextGenericSignalItem<T>(ref T retval, Train.TrainObjectItem.TRAINOBJECTTYPE type, string signalTypeName)
         {
-            MainHeadSignalTypeName = "";
-            SignalAspect = Aspect.None;
-            SignalDistance = float.MaxValue;
             NextGenericSignalFeatures(signalTypeName, 0, 400);
-            MainHeadSignalTypeName = SignalFeatures.MainHeadSignalTypeName = "";
+            MainHeadSignalTypeName = SignalFeatures.MainHeadSignalTypeName;
             SignalAspect = SignalFeatures.Aspect;
             SignalDistance = SignalFeatures.DistanceM;
             return retval;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -266,7 +266,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.IsSpeedControlEnabled = () => Simulator.Settings.SpeedControl;
                 Script.AlerterSound = () => Locomotive.AlerterSnd;
                 Script.TrainSpeedLimitMpS = () => Math.Min(Locomotive.Train.AllowedMaxSpeedMpS, Locomotive.Train.TrainMaxSpeedMpS);
-                Script.TrainMaxSpeedMpS = () => Locomotive.Train.TrainMaxSpeedMpS;
+                Script.TrainMaxSpeedMpS = () => Locomotive.Train.TrainMaxSpeedMpS; // max speed for train in a specific section, independently from speedpost and signal limits
                 Script.CurrentSignalSpeedLimitMpS = () => Locomotive.Train.allowedMaxSpeedSignalMpS;
                 Script.NextSignalSpeedLimitMpS = (value) => NextGenericSignalItem<float>(value, ref ItemSpeedLimit, float.MaxValue,Train.TrainObjectItem.TRAINOBJECTTYPE.SIGNAL, "NORMAL");
                 Script.NextSignalAspect = (value) => NextGenericSignalItem<Aspect>(value, ref ItemAspect, float.MaxValue, Train.TrainObjectItem.TRAINOBJECTTYPE.SIGNAL, "NORMAL");
@@ -291,11 +291,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.NextPostDistanceM = (value) => NextGenericSignalItem<float>(value, ref ItemDistance, float.MaxValue, Train.TrainObjectItem.TRAINOBJECTTYPE.SPEEDPOST);
                 Script.TrainLengthM = () => Locomotive.Train != null ? Locomotive.Train.Length : 0f;
                 Script.SpeedMpS = () => Math.Abs(Locomotive.SpeedMpS);
-                Script.CurrentDirection = () => Locomotive.Direction;
+                Script.CurrentDirection = () => Locomotive.Direction; // Direction of locomotive, may be different from direction of train
                 Script.IsDirectionForward = () => Locomotive.Direction == Direction.Forward;
                 Script.IsDirectionNeutral = () => Locomotive.Direction == Direction.N;
                 Script.IsDirectionReverse = () => Locomotive.Direction == Direction.Reverse;
-                Script.CurrentTrainMUDirection = () => Locomotive.Train.MUDirection;
+                Script.CurrentTrainMUDirection = () => Locomotive.Train.MUDirection; // Direction of train
                 Script.IsBrakeEmergency = () => Locomotive.TrainBrakeController.EmergencyBraking;
                 Script.IsBrakeFullService = () => Locomotive.TrainBrakeController.TCSFullServiceBraking;
                 Script.PowerAuthorization = () => PowerAuthorization;
@@ -477,7 +477,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             MainHeadSignalTypeName = ItemFeatures.MainHeadSignalTypeName;
             ItemAspect = ItemFeatures.Aspect;
             ItemDistance = ItemFeatures.DistanceM;
-            ItemSpeedLimit = ItemFeatures.SpeedLimit;
+            ItemSpeedLimit = ItemFeatures.SpeedLimitM;
             return retval;
         }
 
@@ -486,7 +486,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             ItemFeatures.MainHeadSignalTypeName = "";
             ItemFeatures.Aspect = Aspect.None;
             ItemFeatures.DistanceM = float.MaxValue;
-            ItemFeatures.SpeedLimit = -1.0f;
+            ItemFeatures.SpeedLimitM = -1.0f;
 
             int dir = Locomotive.Train.MUDirection == Direction.Reverse ? 1 : 0;
 
@@ -513,7 +513,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 if (signalTypeName == "NORMAL")
                 {
                     ItemFeatures.Aspect = (Aspect)trainSignal.SignalState;
-                    ItemFeatures.SpeedLimit = trainSignal.AllowedSpeedMpS;
+                    ItemFeatures.SpeedLimitM = trainSignal.AllowedSpeedMpS;
                 }
                 else
                 {
@@ -531,7 +531,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
 
                 // All OK, we can retrieve the data for the required speedpost;
                 ItemFeatures.DistanceM = trainSpeedpost.DistanceToTrainM;
-                ItemFeatures.SpeedLimit = trainSpeedpost.AllowedSpeedMpS;
+                ItemFeatures.SpeedLimitM = trainSpeedpost.AllowedSpeedMpS;
             }
 
             return ItemFeatures;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -487,7 +487,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             var aspect = Aspect.None;
             var distanceM = float.MaxValue;
             var speedLimitMpS = -1f;
-            var altitudeOrLengthM = -float.MaxValue;
+            var altitudeM = float.MinValue;
 
             int dir = Locomotive.Train.MUDirection == Direction.Reverse ? 1 : 0;
 
@@ -515,7 +515,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 {
                     aspect = (Aspect)trainSignal.SignalState;
                     speedLimitMpS = trainSignal.AllowedSpeedMpS;
-                    altitudeOrLengthM = trainSignal.SignalObject.tdbtraveller.Y;
+                    altitudeM = trainSignal.SignalObject.tdbtraveller.Y;
                 }
                 else
                 {
@@ -538,7 +538,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
 
         Exit:
             return new SignalFeatures(mainHeadSignalTypeName: mainHeadSignalTypeName, aspect: aspect, distanceM: distanceM, speedLimitMpS: speedLimitMpS,
-                altitudeOrLengthM: altitudeOrLengthM);
+                altitudeM: altitudeM);
         }
 
         private bool DoesNextNormalSignalHaveRepeaterHead()

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -620,6 +620,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                     break;
 
                 default:
+                    if (Locomotive == Simulator.PlayerLocomotive)
+                        Locomotive.Train.UpdatePlayerTrainData();
                     if (Script == null)
                     {
                         DisableRestrictions();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -114,6 +114,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
         public MonitoringStatus MonitoringStatus { get; set; }
 
         public bool Activated = false;
+        public bool CustomTCSScript = false;
 
         Train.TrainInfo TrainInfo = new Train.TrainInfo();
 
@@ -212,6 +213,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 {
                     var pathArray = new string[] { Path.Combine(Path.GetDirectoryName(Locomotive.WagFilePath), "Script") };
                     Script = Simulator.ScriptManager.Load(pathArray, ScriptName) as TrainControlSystem;
+                    CustomTCSScript = true;
                 }
 
                 if (ParametersFileName != null)
@@ -552,52 +554,14 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             MainHeadSignalTypeName = "";
             SignalAspect = Aspect.None;
             SignalDistance = float.MaxValue;
-            int fn_type = Locomotive.Train.signalRef.ORTSSignalTypes.IndexOf(signalTypeName);
-            if (fn_type <= 0) // Invalid value or NORMAL signal
-                return retval;
-
-            int dir = Locomotive.Train.MUDirection == Direction.Reverse ? 1 : 0;
-
-            if (Locomotive.Train.ValidRoute[dir] == null || dir == 1 && Locomotive.Train.PresentPosition[dir].TCSectionIndex < 0)
-                return retval;
-
-            int index = dir == 0 ? Locomotive.Train.PresentPosition[dir].RouteListIndex : 
-                Locomotive.Train.ValidRoute[dir].GetRouteIndex(Locomotive.Train.PresentPosition[dir].TCSectionIndex, 0);
-            if (index < 0)
-                return retval;
-
-            float lengthOffset = (dir == 1) ? (-Locomotive.Train.PresentPosition[1].TCOffset +
-                     Locomotive.Train.signalRef.TrackCircuitList[Locomotive.Train.PresentPosition[1].TCSectionIndex].Length) : Locomotive.Train.PresentPosition[0].TCOffset;
-            float totalLength = 0;
-            var routePath = Locomotive.Train.ValidRoute[dir];
-            while (index < routePath.Count && totalLength < 400) // Check only first 400m
-            {
-                var thisElement = routePath[index];
-                TrackCircuitSection thisSection = Locomotive.Train.signalRef.TrackCircuitList[thisElement.TCSectionIndex];
-                TrackCircuitSignalList thisSignalList = thisSection.CircuitItems.TrackCircuitSignals[thisElement.Direction][fn_type];
-                foreach (TrackCircuitSignalItem thisSignal in thisSignalList.TrackCircuitItem)
-                {
-                    if (thisSignal.SignalLocation > lengthOffset)
-                    {
-                        SignalAspect = (Aspect)Locomotive.Train.signalRef.TranslateToTCSAspect(thisSignal.SignalRef.this_sig_lr(fn_type));
-                        SignalDistance = thisSignal.SignalLocation - lengthOffset + totalLength;
-                        MainHeadSignalTypeName = thisSignal.SignalRef.SignalHeads[0].SignalTypeName;
-                        return retval;
-                    }
-                }
-                totalLength += (thisSection.Length - lengthOffset);
-                lengthOffset = 0;
-
-                int setSection = thisSection.ActivePins[thisElement.OutPin[0], thisElement.OutPin[1]].Link;
-                index++;
-                if (setSection < 0)
-                    return retval;
-            }
-
+            NextGenericSignalFeatures(signalTypeName, 0, 400);
+            MainHeadSignalTypeName = SignalFeatures.MainHeadSignalTypeName = "";
+            SignalAspect = SignalFeatures.Aspect;
+            SignalDistance = SignalFeatures.DistanceM;
             return retval;
         }
 
-        SignalFeatures NextGenericSignalFeatures(string signalTypeName, int signalSequenceIndex, float maxDistance)
+        SignalFeatures NextGenericSignalFeatures(string signalTypeName, int signalSequenceIndex, float maxDistanceM)
         {
             SignalFeatures.MainHeadSignalTypeName = "";
             SignalFeatures.Aspect = Aspect.None;
@@ -616,39 +580,17 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             if (index < 0)
                 return SignalFeatures;
 
-            float lengthOffset = (dir == 1) ? (-Locomotive.Train.PresentPosition[1].TCOffset +
-                     Locomotive.Train.signalRef.TrackCircuitList[Locomotive.Train.PresentPosition[1].TCSectionIndex].Length) : Locomotive.Train.PresentPosition[0].TCOffset;
-            float totalLength = 0;
-            var routePath = Locomotive.Train.ValidRoute[dir];
-            int runningSequenceIndex = 0;
-            while (index < routePath.Count && totalLength - lengthOffset < maxDistance) 
-            {
-                var thisElement = routePath[index];
-                TrackCircuitSection thisSection = Locomotive.Train.signalRef.TrackCircuitList[thisElement.TCSectionIndex];
-                TrackCircuitSignalList thisSignalList = thisSection.CircuitItems.TrackCircuitSignals[thisElement.Direction][fn_type];
-                foreach (TrackCircuitSignalItem thisSignal in thisSignalList.TrackCircuitItem)
-                {
-                    if (runningSequenceIndex < signalSequenceIndex)
-                    {
-                        runningSequenceIndex++;
-                        continue;
-                    }
-                    if (thisSignal.SignalLocation > lengthOffset)
-                    {
-                        SignalFeatures.Aspect = (Aspect)Locomotive.Train.signalRef.TranslateToTCSAspect(thisSignal.SignalRef.this_sig_lr(fn_type));
-                        SignalFeatures.DistanceM = thisSignal.SignalLocation - lengthOffset + totalLength;
-                        SignalFeatures.MainHeadSignalTypeName = thisSignal.SignalRef.SignalHeads[0].SignalTypeName;
-                        return SignalFeatures;
-                    }
-                }
-                totalLength += (thisSection.Length - lengthOffset);
-                lengthOffset = 0;
+            var trainSignalList = Locomotive.Train.TrainSignalLists[dir, fn_type];
+            if (signalSequenceIndex > trainSignalList.Count - 1)
+                return SignalFeatures; // no n-th signal available
+            var trainSignal = trainSignalList[signalSequenceIndex];
+            if (trainSignal.DistanceToTrainM > maxDistanceM)
+                return SignalFeatures; // the requested signal is too distant
 
-                int setSection = thisSection.ActivePins[thisElement.OutPin[0], thisElement.OutPin[1]].Link;
-                index++;
-                if (setSection < 0)
-                    return SignalFeatures;
-            }
+            // All OK, we can retrieve the data for the required signal;
+            SignalFeatures.Aspect = (Aspect)Locomotive.Train.signalRef.TranslateToTCSAspect(trainSignal.ObjectDetails.this_sig_lr(fn_type));
+            SignalFeatures.DistanceM = trainSignal.DistanceToTrainM;
+            SignalFeatures.MainHeadSignalTypeName = trainSignal.ObjectDetails.SignalHeads[0].SignalTypeName;
 
             return SignalFeatures;
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -273,7 +273,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.NextSignalDistanceM = (value) => NextGenericSignalItem<float>(value, ref ItemDistance, float.MaxValue, Train.TrainObjectItem.TRAINOBJECTTYPE.SIGNAL, "NORMAL");
                 Script.NextNormalSignalDistanceHeadsAspect = () => NextNormalSignalDistanceHeadsAspect();
                 Script.DoesNextNormalSignalHaveTwoAspects = () => DoesNextNormalSignalHaveTwoAspects();
-                Script.NextNormalSignalMainHeadSignalType = (value) => NextGenericSignalItem<string>(value, ref MainHeadSignalTypeName, float.MaxValue, Train.TrainObjectItem.TRAINOBJECTTYPE.SIGNAL, "NORMAL");
                 Script.NextDistanceSignalAspect = () =>
                     NextGenericSignalItem<Aspect>(0, ref ItemAspect, GenericItemDistance, Train.TrainObjectItem.TRAINOBJECTTYPE.SIGNAL, "DISTANCE");
                 Script.NextDistanceSignalDistanceM = () =>

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -3171,7 +3171,8 @@ namespace Orts.Simulation.Signalling
             float clearedDistanceM = 0.0f;
             Train.END_AUTHORITY endAuthority = Train.END_AUTHORITY.NO_PATH_RESERVED;
             int routeIndex = -1;
-            float maxDistance = Math.Max(thisTrain.Train.AllowedMaxSpeedMpS * thisTrain.Train.maxTimeS, thisTrain.Train.minCheckDistanceM);
+            float maxDistance = Math.Max((thisTrain.Train.IsActualPlayerTrain ? (float)Simulator.TRK.Tr_RouteFile.SpeedLimit : thisTrain.Train.AllowedMaxSpeedMpS)
+                * thisTrain.Train.maxTimeS, thisTrain.Train.minCheckDistanceM);
 
             int lastReserved = thisTrain.Train.LastReservedSection[thisTrain.TrainRouteDirectionIndex];
             int endListIndex = -1;
@@ -3538,8 +3539,8 @@ namespace Orts.Simulation.Signalling
                                 }
                             }
 
-                            if (clearedDistanceM > thisTrain.Train.minCheckDistanceM &&
-                                            clearedDistanceM > (thisTrain.Train.AllowedMaxSpeedMpS * thisTrain.Train.maxTimeS))
+                            if (clearedDistanceM > thisTrain.Train.minCheckDistanceM && clearedDistanceM > (
+                                (thisTrain.Train.IsActualPlayerTrain ? (float)Simulator.TRK.Tr_RouteFile.SpeedLimit : thisTrain.Train.AllowedMaxSpeedMpS) * thisTrain.Train.maxTimeS))
                             {
                                 endAuthority = Train.END_AUTHORITY.MAX_DISTANCE;
                                 furthestRouteCleared = true;

--- a/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
@@ -2812,7 +2812,7 @@ namespace Orts.Simulation.Timetables
 
             // prepare train data for Train Control System
             if (IsActualPlayerTrain)
-                UpdateTrainData();
+                UpdatePlayerTrainData();
 
             // log train details
 

--- a/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
@@ -2810,10 +2810,6 @@ namespace Orts.Simulation.Timetables
             // check position of train wrt tunnels
             ProcessTunnels();
 
-            // prepare train data for Train Control System
-            if (IsActualPlayerTrain)
-                UpdatePlayerTrainData();
-
             // log train details
 
             if (DatalogTrainSpeed)

--- a/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
@@ -2810,6 +2810,10 @@ namespace Orts.Simulation.Timetables
             // check position of train wrt tunnels
             ProcessTunnels();
 
+            // prepare train data for Train Control System
+            if (IsActualPlayerTrain)
+                UpdateTrainData();
+
             // log train details
 
             if (DatalogTrainSpeed)

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -390,6 +390,7 @@ namespace Orts.Viewer3D
 
             if (PlayerLocomotive == null) PlayerLocomotive = Simulator.InitialPlayerLocomotive();
             SelectedTrain = PlayerTrain;
+            PlayerTrain.InitializePlayerTrainData();
             if (PlayerTrain.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING)
             {
                 Simulator.Trains[0].LeadLocomotive = null;


### PR DESCRIPTION
https://trello.com/c/S38d2RoV/482-further-tcs-handles-related-to-signals-and-sound-events
These handles allow to get in a single struct some significant data for any next signal; they allow also to set any sound event and to get the actual direction of the train, that could not coincide with the direction of the player locomotive.