### PR TITLE
Adjust hotbox code

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -2296,7 +2296,7 @@ namespace Orts.Simulation.RollingStocks
             // The model uses the Newton Law of Heating and cooling to model the time taken for temperature rise and fall - ie of the form T(t) = Ts + (T0 - Ts)exp(kt)
 
             // Keep track of Activity details if an activity, setup random wagon, and start time for hotbox
-            if (Simulator.ActivityRun != null)
+            if (Simulator.ActivityRun != null && IsPlayerTrain)
             {
                 if (ActivityElapsedDurationS<HotBoxStartTimeS)
                 {


### PR DESCRIPTION
Set hotboxes so that they only activate on player trains. - https://bugs.launchpad.net/or/+bug/1900762