### PR TITLE
Brake pipe overcharge

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -2098,9 +2098,11 @@ For example, in a lot of normal Westinghouse brake systems, a minimum pressure r
 Train Brake Pipe Losses
 -----------------------
 
-The train brake pipe on a train is subject to air losses through leakage at joints, etc. Typically when the brake controller is in the RUNNING position, air pressure is maintained in the pipe from the reservoir. However on some brake systems, especially older ones such as the A6-ET, when the brake controller is in the LAP position the train brkae pipe is isolated from the air reservoir, and hence over time the pipe will suffer pressure drops due to leakages. This will result in the brakes being gradually applied.
+The train brake pipe on a train is subject to air losses through leakage at joints, etc. Typically when the brake controller is in the RUNNING position, air pressure is maintained in the pipe from the reservoir. However on some brake systems, especially older ones such as the A6-ET, when the brake controller is in the LAP position the train brake pipe is isolated from the air reservoir, and hence over time the pipe will suffer pressure drops due to leakages. This will result in the brakes being gradually applied.
 
-More modern brake systems have a self lapping feature which compensates for train brake pipe leakage regardless of the position that the brake controller is in.
+Some brake systems allow small leakage to happen without applying brakes. This can be regulated with the parameter ``ORTSBrakeInsensitivity`` in the WAG file. UIC vehicles are usually insensitive to pressure drop rates lower than 0.3 bar/min. This parameter also prevents brakes being applied while an overcharge in the brake pipe is being eliminated.
+
+More modern systems have a self lapping feature which compensates for train brake pipe leakage regardless of the position that the brake controller is in.
 
 Open Rails models this feature whenever the ``TrainPipeLeakRate`` parameter is defined in the engine section of the ENG file. Typically most railway companies accepted leakage rates of around 5 psi/min in the train brake pipe before some remedial action needed to be undertaken.
 

--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -1990,6 +1990,55 @@ brake features.
 Brake system charging time depends on the train length as it should, but
 at the moment there is no modeling of main reservoirs and compressors.
 
+.. _physics-brake-controller:
+
+Train Brake Controller Positions
+--------------------------------
+
+The following notch positions can be defined for the train brake at ``Engine(EngineControllers(Brake_Train``:
+
+.. index::
+   single: TrainBrakesControllerFullQuickReleaseStart
+   single: TrainBrakesControllerReleaseStart
+   single: TrainBrakesControllerOverchageStart
+   single: TrainBrakesControllerApplyStart
+   single: TrainBrakesControllerFullServiceStart
+   single: TrainBrakesControllerHoldStart
+   single: TrainBrakesControllerSelfLapStart
+   single: TrainBrakesControllerRunningStart
+   single: TrainBrakesControllerMinimalReductionStart
+   single: TrainBrakesControllerHoldLappedStart
+   single: TrainBrakesControllerVaccumContinuousServiceStart
+   single: TrainBrakesControllerVaccumApplyContinuousService
+   single: TrainBrakesControllerGraduatedSelfLapLimitedStart
+   single: TrainBrakesControllerGraduatedSelfLapLimitedHoldingStart
+   single: TrainBrakesControllerSuppressionStart
+   single: TrainBrakesControllerContinuousServiceStart
+   single: EPApply
+   single: TrainBrakesControllerEmergencyStart
+   single: Dummy
+   single: ORTSTrainBrakesControllerMaxOverchargePressure
+   single: ORTSTrainBrakesControllerOverchargeEliminationRate
+   single: TrainBrakesControllerMaxApplicationRate
+   single: TrainBrakesControllerMaxQuickReleaseRate
+   single: TrainBrakesControllerMaxReleaseRate
+   single: TrainBrakesControllerMinPressureReduction
+   single: TrainBrakesControllerMaxSystemPressure
+
+- ``FullQuickReleaseStart`` -- Increases pressure in equalizing reservoir (EQ) at a rate proportional to ``TrainBrakesControllerMaxQuickReleaseRate`` and controller position, releasing the brakes.
+- ``ReleaseStart`` -- same as above, but with a rate of ``TrainBrakesControllerMaxReleaseRate``.
+- ``OverchageStart`` -- Increases pressure in EQ over the maximum (``TrainBrakesControllerMaxSystemPressure``), up to ``ORTSTrainBrakesControllerMaxOverchargePressure``, to release stuck distributors. Setting the controller back to a release position will slowly return pressure to nominal value at a rate of ``ORTSTrainBrakesControllerOverchargeEliminationRate``.
+- ``ApplyStart`` -- Starts decreasing pressure in EQ at a rate proportional to ``TrainBrakesControllerMaxApplicationRate`` and controller position, down to full service pressure.
+- ``FullServiceStart`` -- Same as above, but also applies EP brakes if available.
+- ``HoldStart``, ``SelfLapStart`` and ``RunningStart`` -- Keep EQ pressure constant, maintaining brake pipe pressure.
+- ``MinimalReductionStart`` -- If previous notch position was Running, Release or QuickRelease, applies a minimal reduction to brake pipe pressure (defined by ``TrainBrakesControllerMinPressureReduction``).
+- ``HoldLappedStart`` -- Same as above, but isolates brake pipe from EQ reservoir. Brake pipe leakage is not compensated.
+- ``VaccumContinuousServiceStart`` and ``VaccumApplyContinuousService`` -- Set EQ pressure to a value from MaxPressure to 0, proportional to controller position.
+- ``GraduatedSelfLapStart``, ``GraduatedSelfLapHoldingStart`` and ``SuppressionStart`` -- Adjust EQ pressure to a value from (MaxPressure-MinimalReduction) to FullServicePressure, proportional to controller position. Depending on :ref:`Graduated Release Air Brakes <options-general>` option, EQ pressure can be increased to reduce brake application. ``Suppression`` should be a non-smooth notch used to suppress TCS brake application.
+- ``ContinuousServiceStart`` and ``EPApply`` -- Same as above, but also apply EP brakes if available.
+- ``EmergencyStart`` -- Quickly decreases EQ pressure and connects brake pipe to atmosphere, applying maximum braking.
+- ``Dummy`` -- Adjusts EQ pressure to a value from MaxPressure to FullServicePressure, proportional to controller position.
+
 .. _physics-hud-brake:
 
 Brake Shoe Adhesion

--- a/Source/Orts.Simulation/Common/Scripting/BrakeController.cs
+++ b/Source/Orts.Simulation/Common/Scripting/BrakeController.cs
@@ -45,6 +45,10 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> MaxPressureBar;
         /// <summary>
+        /// Maximum pressure in the brake pipes when they are overcharged
+        /// </summary>
+        public Func<float> MaxOverchargePressureBar;
+        /// <summary>
         /// Release rate of the equalizing reservoir
         /// </summary>
         public Func<float> ReleaseRateBarpS;
@@ -52,6 +56,10 @@ namespace ORTS.Scripting.Api
         /// Quick release rate of the equalizing reservoir
         /// </summary>
         public Func<float> QuickReleaseRateBarpS;
+        /// <summary>
+        /// Pressure decrease rate of equalizing reservoir when eliminating overcharge
+        /// </summary>
+        public Func<float> OverchargeEliminationRateBarpS;
         /// <summary>
         /// Apply rate of the equalizing reservoir
         /// </summary>

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -3906,9 +3906,10 @@ namespace Orts.Simulation.Physics
                 MSTSLocomotive lead = (MSTSLocomotive)Cars[LeadLocomotiveIndex];
                 if (lead.TrainBrakeController != null)
                 {
-                    lead.TrainBrakeController.UpdatePressure(ref EqualReservoirPressurePSIorInHg, 1000, ref BrakeLine4);
                     maxPressurePSI = lead.TrainBrakeController.MaxPressurePSI;
                     fullServPressurePSI = lead.BrakeSystem is VacuumSinglePipe ? 16 : maxPressurePSI - lead.TrainBrakeController.FullServReductionPSI;
+                    EqualReservoirPressurePSIorInHg = Math.Min(maxPressurePSI, EqualReservoirPressurePSIorInHg);
+                    lead.TrainBrakeController.UpdatePressure(ref EqualReservoirPressurePSIorInHg, 1000, ref BrakeLine4);
                     EqualReservoirPressurePSIorInHg =
                             MathHelper.Max(EqualReservoirPressurePSIorInHg, fullServPressurePSI);
                 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -752,8 +752,10 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(enginecontrollers(brake_dynamic": DynamicBrakeController.Parse(stf); break;
 
                 case "engine(trainbrakescontrollermaxsystempressure":
+                case "engine(trainbrakescontrollermaxoverchargepressure":
                 case "engine(trainbrakescontrollermaxreleaserate":
                 case "engine(trainbrakescontrollermaxquickreleaserate":
+                case "engine(trainbrakescontrolleroverchargeeliminationrate":
                 case "engine(trainbrakescontrollermaxapplicationrate":
                 case "engine(trainbrakescontrolleremergencyapplicationrate":
                 case "engine(trainbrakescontrollerfullservicepressuredrop":

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -752,10 +752,10 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(enginecontrollers(brake_dynamic": DynamicBrakeController.Parse(stf); break;
 
                 case "engine(trainbrakescontrollermaxsystempressure":
-                case "engine(trainbrakescontrollermaxoverchargepressure":
+                case "engine(ortstrainbrakescontrollermaxoverchargepressure":
                 case "engine(trainbrakescontrollermaxreleaserate":
                 case "engine(trainbrakescontrollermaxquickreleaserate":
-                case "engine(trainbrakescontrolleroverchargeeliminationrate":
+                case "engine(ortstrainbrakescontrolleroverchargeeliminationrate":
                 case "engine(trainbrakescontrollermaxapplicationrate":
                 case "engine(trainbrakescontrolleremergencyapplicationrate":
                 case "engine(trainbrakescontrollerfullservicepressuredrop":

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -709,19 +709,22 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                             if (car.BrakeSystem.AngleCockAOpen) //  AND Front brake cock opened
                             {
                                 car.BrakeSystem.BrakeLine1PressurePSI -= TrainPipeTimeVariationS * p1 / brakePipeTimeFactorS;
-
+                                if (car.BrakeSystem.BrakeLine1PressurePSI < 0)
+                                    car.BrakeSystem.BrakeLine1PressurePSI = 0;
                             }
 
                             if (car0.BrakeSystem.AngleCockBOpen && car != car0) //  AND Rear cock of wagon opened, and car is not the first wagon
                             {
                                 car0.BrakeSystem.BrakeLine1PressurePSI -= TrainPipeTimeVariationS * p0 / brakePipeTimeFactorS;
-
+                                if (car.BrakeSystem.BrakeLine1PressurePSI < 0)
+                                    car.BrakeSystem.BrakeLine1PressurePSI = 0;
                             }
                         }
                         if (car == train.Cars[train.Cars.Count - 1] && car.BrakeSystem.AngleCockBOpen) // Last car in train and rear cock of wagon open
                         {
                             car.BrakeSystem.BrakeLine1PressurePSI -= TrainPipeTimeVariationS * p1 / brakePipeTimeFactorS;
-
+                            if (car.BrakeSystem.BrakeLine1PressurePSI < 0)
+                                car.BrakeSystem.BrakeLine1PressurePSI = 0;
                         }
                         p0 = car.BrakeSystem.BrakeLine1PressurePSI;
                         car0 = car;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -695,7 +695,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                             // Based on the principle of pressure equualization between adjacent cars
                             // First, we define a variable storing the pressure diff between cars, but limited to a maximum flow rate depending on pipe characteristics
                             // The sign in the equation determines the direction of air flow.
-                            float TrainPipePressureDiffPropogationPSI = (p0>p1 ? -1 : 1) * Math.Min (TrainPipeTimeVariationS * Math.Abs(p1 - p0) / brakePipeTimeFactorS, Math.Abs(p1 - p0));
+                            float TrainPipePressureDiffPropogationPSI = (p0>p1 ? -1 : 1) * Math.Min(TrainPipeTimeVariationS * Math.Abs(p1 - p0) / brakePipeTimeFactorS, Math.Abs(p1 - p0));
 
                             // Air flows from high pressure to low pressure, until pressure is equal in both cars.
                             // Brake pipe volumes of both cars are taken into account, so pressure increase/decrease is proportional to relative volumes.

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -48,7 +48,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         protected float MaxReleaseRatePSIpS = 1.86f;
         protected float MaxApplicationRatePSIpS = .9f;
         protected float MaxAuxilaryChargingRatePSIpS = 1.684f;
-        protected float MaxAuxilaryOverchargeEliminationRatePSIpS = 0.05f; // Allows overcharge elimination of 0.4 bar in 2 minutes
+        protected float BrakeInsensitivityPSIpS = 0;
         protected float EmergResChargingRatePSIpS = 1.684f;
         protected float EmergAuxVolumeRatio = 1.4f;
         protected string DebugType = string.Empty;
@@ -112,6 +112,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             MaxReleaseRatePSIpS = thiscopy.MaxReleaseRatePSIpS;
             MaxApplicationRatePSIpS = thiscopy.MaxApplicationRatePSIpS;
             MaxAuxilaryChargingRatePSIpS = thiscopy.MaxAuxilaryChargingRatePSIpS;
+            BrakeInsensitivityPSIpS = thiscopy.BrakeInsensitivityPSIpS;
             EmergResChargingRatePSIpS = thiscopy.EmergResChargingRatePSIpS;
             EmergAuxVolumeRatio = thiscopy.EmergAuxVolumeRatio;
             TwoPipes = thiscopy.TwoPipes;
@@ -234,6 +235,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 
                 // OpenRails specific parameters
                 case "wagon(brakepipevolume": BrakePipeVolumeM3 = Me3.FromFt3(stf.ReadFloatBlock(STFReader.UNITS.VolumeDefaultFT3, null)); break;
+                case "wagon(ortsbrakeinsensitivity": BrakeInsensitivityPSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null); break;
             }
         }
 
@@ -449,9 +451,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     AuxResPressurePSI += dp;
                     BrakeLine1PressurePSI -= dp * AuxBrakeLineVolumeRatio;  // Adjust the train brake pipe pressure
                 }
-                if (AuxResPressurePSI > BrakeLine1PressurePSI) // Allow small flow from auxiliary reservoir to brake pipe to restore normal pressure after overcharge
+                if (AuxResPressurePSI > BrakeLine1PressurePSI) // Allow small flow from auxiliary reservoir to brake pipe so the triple valve is not sensible to small pressure variations when in release position
                 {
-                    float dp = elapsedClockSeconds * MaxAuxilaryOverchargeEliminationRatePSIpS;
+                    float dp = elapsedClockSeconds * BrakeInsensitivityPSIpS;
                     if (AuxResPressurePSI - dp < BrakeLine1PressurePSI + dp * AuxBrakeLineVolumeRatio)
                         dp = (AuxResPressurePSI - BrakeLine1PressurePSI) / (1 + AuxBrakeLineVolumeRatio);
                     AuxResPressurePSI -= dp;
@@ -688,13 +690,16 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         train.TotalTrainBrakePipeVolumeM3 += car.BrakeSystem.BrakePipeVolumeM3; // Calculate total brake pipe volume of train
 
                         float p1 = car.BrakeSystem.BrakeLine1PressurePSI;
-                        if (car == train.Cars[0] || car.BrakeSystem.FrontBrakeHoseConnected && car.BrakeSystem.AngleCockAOpen && car0.BrakeSystem.AngleCockBOpen)
+                        if (car != train.Cars[0] && car.BrakeSystem.FrontBrakeHoseConnected && car.BrakeSystem.AngleCockAOpen && car0.BrakeSystem.AngleCockBOpen)
                         {
+                            // Based on the principle of pressure equualization between adjacent cars
+                            // First, we define a variable storing the pressure diff between cars, but limited to a maximum flow rate depending on pipe characteristics
+                            // The sign in the equation determines the direction of air flow.
+                            float TrainPipePressureDiffPropogationPSI = (p0>p1 ? -1 : 1) * Math.Min (TrainPipeTimeVariationS * Math.Abs(p1 - p0) / brakePipeTimeFactorS, Math.Abs(p1 - p0));
 
-                            float TrainPipePressureDiffPropogationPSI = Math.Min (TrainPipeTimeVariationS * (p1 - p0) / brakePipeTimeFactorS, p1 - p0);
-                            // Appears to work on the principle of pressure equalisation, ie trailing car pressure will drop by fraction of total volume determined by lead car.
-
-                            // TODO - Confirm logic - it appears to allow for air flow to coupled car by reducing (increasing) preceeding car brake pipe - this allows time for the train to "recharge".
+                            // Air flows from high pressure to low pressure, until pressure is equal in both cars.
+                            // Brake pipe volumes of both cars are taken into account, so pressure increase/decrease is proportional to relative volumes.
+                            // If TrainPipePressureDiffPropagationPSI equals to p1-p0 the equalization is achieved in one step.
                             car.BrakeSystem.BrakeLine1PressurePSI -= TrainPipePressureDiffPropogationPSI * brakePipeVolumeM30 / (brakePipeVolumeM30 + car.BrakeSystem.BrakePipeVolumeM3);
                             car0.BrakeSystem.BrakeLine1PressurePSI += TrainPipePressureDiffPropogationPSI * car.BrakeSystem.BrakePipeVolumeM3 / (brakePipeVolumeM30 + car.BrakeSystem.BrakePipeVolumeM3);
                         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -48,6 +48,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         protected float MaxReleaseRatePSIpS = 1.86f;
         protected float MaxApplicationRatePSIpS = .9f;
         protected float MaxAuxilaryChargingRatePSIpS = 1.684f;
+        protected float MaxAuxilaryOverchargeEliminationRatePSIpS = 0.05f; // Allows overcharge elimination of 0.4 bar in 2 minutes
         protected float EmergResChargingRatePSIpS = 1.684f;
         protected float EmergAuxVolumeRatio = 1.4f;
         protected string DebugType = string.Empty;
@@ -450,7 +451,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 }
                 if (AuxResPressurePSI > BrakeLine1PressurePSI) // Allow small flow from auxiliary reservoir to brake pipe to restore normal pressure after overcharge
                 {
-                    float dp = elapsedClockSeconds * 0.05f;
+                    float dp = elapsedClockSeconds * MaxAuxilaryOverchargeEliminationRatePSIpS;
                     if (AuxResPressurePSI - dp < BrakeLine1PressurePSI + dp * AuxBrakeLineVolumeRatio)
                         dp = (AuxResPressurePSI - BrakeLine1PressurePSI) / (1 + AuxBrakeLineVolumeRatio);
                     AuxResPressurePSI -= dp;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
@@ -102,8 +102,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
         }
 
         public float MaxPressurePSI { get; set; }
+        public float MaxOverchargePressurePSI { get; private set; }
         public float ReleaseRatePSIpS { get; private set; }
         public float QuickReleaseRatePSIpS { get; private set; }
+        public float OverchargeEliminationRatePSIpS { get; private set; }
         public float ApplyRatePSIpS { get; private set; }
         public float EmergencyRatePSIpS { get; private set; }
         public float FullServReductionPSI { get; private set; }
@@ -142,8 +144,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             Locomotive = locomotive;
 
             MaxPressurePSI = 90;
+            MaxOverchargePressurePSI = 95;
             ReleaseRatePSIpS = 5;
             QuickReleaseRatePSIpS = 10;
+            OverchargeEliminationRatePSIpS = 0.036f;
             ApplyRatePSIpS = 2;
             EmergencyRatePSIpS = 10;
             FullServReductionPSI = 26;
@@ -157,8 +161,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
 
             ScriptName = controller.ScriptName;
             MaxPressurePSI = controller.MaxPressurePSI;
+            MaxOverchargePressurePSI = controller.MaxOverchargePressurePSI;
             ReleaseRatePSIpS = controller.ReleaseRatePSIpS;
             QuickReleaseRatePSIpS = controller.QuickReleaseRatePSIpS;
+            OverchargeEliminationRatePSIpS = controller.OverchargeEliminationRatePSIpS;
             ApplyRatePSIpS = controller.ApplyRatePSIpS;
             EmergencyRatePSIpS = controller.EmergencyRatePSIpS;
             FullServReductionPSI = controller.FullServReductionPSI;
@@ -195,6 +201,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                     MaxPressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, null);
                     break;
 
+                case "engine(trainbrakescontrollermaxoverchargepressure":
+                    MaxOverchargePressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, null);
+                    break;
+
                 case "engine(trainbrakescontrollermaxreleaserate":
                 case "engine(enginebrakescontrollermaxreleaserate":    
                     ReleaseRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null);
@@ -203,6 +213,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 case "engine(trainbrakescontrollermaxquickreleaserate":
                 case "engine(enginebrakescontrollermaxquickreleaserate":
                     QuickReleaseRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null);
+                    break;
+
+                case "engine(trainbrakescontrolleroverchargeeliminationrate":
+                    OverchargeEliminationRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null);
                     break;
 
                 case "engine(trainbrakescontrollermaxapplicationrate":
@@ -293,8 +307,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                         return float.MaxValue;
                 };
                 Script.MaxPressureBar = () => Bar.FromPSI(MaxPressurePSI);
+                Script.MaxOverchargePressureBar = () => Bar.FromPSI(MaxOverchargePressurePSI);
                 Script.ReleaseRateBarpS = () => BarpS.FromPSIpS(ReleaseRatePSIpS);
                 Script.QuickReleaseRateBarpS = () => BarpS.FromPSIpS(QuickReleaseRatePSIpS);
+                Script.OverchargeEliminationRateBarpS = () => BarpS.FromPSIpS(OverchargeEliminationRatePSIpS);
                 Script.ApplyRateBarpS = () => BarpS.FromPSIpS(ApplyRatePSIpS);
                 Script.EmergencyRateBarpS = () => BarpS.FromPSIpS(EmergencyRatePSIpS);
                 Script.FullServReductionBar = () => Bar.FromPSI(FullServReductionPSI);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
@@ -201,7 +201,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                     MaxPressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, null);
                     break;
 
-                case "engine(trainbrakescontrollermaxoverchargepressure":
+                case "engine(ortstrainbrakescontrollermaxoverchargepressure":
                     MaxOverchargePressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, null);
                     break;
 
@@ -215,7 +215,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                     QuickReleaseRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null);
                     break;
 
-                case "engine(trainbrakescontrolleroverchargeeliminationrate":
+                case "engine(ortstrainbrakescontrolleroverchargeeliminationrate":
                     OverchargeEliminationRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null);
                     break;
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
@@ -105,11 +105,13 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                     switch (notch.Type)
                     {
                         case ControllerState.Release:
+                            IncreasePressure(ref pressureBar, MaxPressureBar(), ReleaseRateBarpS(), elapsedClockSeconds);
+                            DecreasePressure(ref pressureBar, MaxPressureBar(), OverchargeEliminationRateBarpS(), elapsedClockSeconds);
+                            epState = -1;
+                            break;
                         case ControllerState.FullQuickRelease:
-                            if (pressureBar <= MaxPressureBar())
-                                IncreasePressure(ref pressureBar, MaxPressureBar(), notch.Type == ControllerState.FullQuickRelease ? QuickReleaseRateBarpS() : ReleaseRateBarpS(), elapsedClockSeconds);
-                            else
-                                DecreasePressure(ref pressureBar, MaxPressureBar(), OverchargeEliminationRateBarpS(), elapsedClockSeconds);
+                            IncreasePressure(ref pressureBar, MaxPressureBar(), QuickReleaseRateBarpS(), elapsedClockSeconds);
+                            DecreasePressure(ref pressureBar, MaxPressureBar(), OverchargeEliminationRateBarpS(), elapsedClockSeconds);
                             epState = -1;
                             break;
                         case ControllerState.Overcharge:

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
@@ -16,6 +16,7 @@
 // along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 
 using ORTS.Scripting.Api;
+using System;
 using System.Diagnostics;
 
 namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
@@ -104,12 +105,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                     switch (notch.Type)
                     {
                         case ControllerState.Release:
-                            pressureBar += x * ReleaseRateBarpS() * elapsedClockSeconds;
+                        case ControllerState.FullQuickRelease:
+                            if (pressureBar <= MaxPressureBar())
+                                IncreasePressure(ref pressureBar, MaxPressureBar(), notch.Type == ControllerState.FullQuickRelease ? QuickReleaseRateBarpS() : ReleaseRateBarpS(), elapsedClockSeconds);
+                            else
+                                DecreasePressure(ref pressureBar, MaxPressureBar(), OverchargeEliminationRateBarpS(), elapsedClockSeconds);
                             epState = -1;
                             break;
-                        case ControllerState.FullQuickRelease:
-                            pressureBar += x * QuickReleaseRateBarpS() * elapsedClockSeconds;
-                            epState = -1;
+                        case ControllerState.Overcharge:
+                            IncreasePressure(ref pressureBar, Math.Min(MaxOverchargePressureBar(), MainReservoirPressureBar()), QuickReleaseRateBarpS(), elapsedClockSeconds);
                             break;
                         case ControllerState.Apply:
                         case ControllerState.FullServ:
@@ -168,8 +172,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 }
             }
 
-            if (pressureBar > MaxPressureBar())
-                pressureBar = MaxPressureBar();
             if (pressureBar < 0)
                 pressureBar = 0;
             epControllerState = epState;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSNotchController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSNotchController.cs
@@ -64,6 +64,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 case "vacuumapplycontinuousservicestart": Type = ControllerState.VacApplyContServ; break;
                 case "manualbrakingstart": Type = ControllerState.ManualBraking; break;
                 case "brakenotchstart": Type = ControllerState.BrakeNotch; break;
+                case "overchargestart": Type = ControllerState.Overcharge; break;
                 default:
                     STFException.TraceInformation(stf, "Skipped unknown notch type " + type);
                     break;


### PR DESCRIPTION
https://trello.com/c/nHJrSDA9/486-brake-pipe-overcharge

Adds "overcharge" brake controller position, which increases brake pipe pressure above the maximum to fully release all brakes.

See http://www.elvastower.com/forums/index.php?/topic/34536-brake-pipe-overcharge/