### PR TITLE
Extend path up to 5 km or first signal, and clear depending on SNCA

### DIFF
--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -247,6 +247,7 @@ namespace Orts.Simulation.Physics
         public float maxTimeS = 120;                     // check ahead for distance covered in 2 mins.
         public float minCheckDistanceM = 5000;           // minimum distance to check ahead
         public float minCheckDistanceManualM = 3000;     // minimum distance to check ahead in manual mode
+        public float minCheckDistanceExplorerM => Math.Max(AllowedMaxSpeedMpS * 240, 5000);      // minimum distance to check ahead in explorer mode
 
         public float standardOverlapM = 15.0f;           // standard overlap on clearing sections
         public float junctionOverlapM = 75.0f;           // standard overlap on clearing sections
@@ -9012,7 +9013,7 @@ namespace Orts.Simulation.Physics
                 List<int> tempSections = new List<int>();
 
                 tempSections = signalRef.ScanRoute(this, requiredPosition.TCSectionIndex, requiredPosition.TCOffset,
-                        requiredPosition.TCDirection, forward, minCheckDistanceM, true, false,
+                        requiredPosition.TCDirection, forward, minCheckDistanceExplorerM, true, false,
                         true, false, true, false, false, false, false, IsFreight);
 
                 if (tempSections.Count > 0)
@@ -9098,10 +9099,10 @@ namespace Orts.Simulation.Physics
 
             // if route does not end with signal and is too short, extend
 
-            if (!endWithSignal && totalLengthM < minCheckDistanceM)
+            if (!endWithSignal && totalLengthM < minCheckDistanceExplorerM)
             {
 
-                float extendedDistanceM = minCheckDistanceM - totalLengthM;
+                float extendedDistanceM = minCheckDistanceExplorerM - totalLengthM;
                 TCRouteElement lastElement = newRoute[newRoute.Count - 1];
 
                 int lastSectionIndex = lastElement.TCSectionIndex;
@@ -9327,7 +9328,7 @@ namespace Orts.Simulation.Physics
                         int numCleared = 0;
                         totalLengthM = 0;
                         offsetM = direction == 0 ? requiredPosition.TCOffset : thisSection.Length - requiredPosition.TCOffset;
-                        for (int iindex = 0; iindex < newRoute.Count && (firstSignalPassed || totalLengthM < minCheckDistanceM) && (!firstSignalPassed || numCleared != 0); iindex++)
+                        for (int iindex = 0; iindex < newRoute.Count && (firstSignalPassed || totalLengthM < minCheckDistanceExplorerM) && (!firstSignalPassed || numCleared != 0); iindex++)
                         {
 
                             thisSection = signalRef.TrackCircuitList[newRoute[iindex].TCSectionIndex];

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -9313,10 +9313,8 @@ namespace Orts.Simulation.Physics
                     // remove invalid sections from route
                     if (lastValidSectionIndex < newRoute.Count - 1)
                     {
-                        for (int iindex = newRoute.Count - 1; iindex > lastValidSectionIndex; iindex--)
-                        {
-                            newRoute.RemoveAt(iindex);
-                        }
+                        signalRef.BreakDownRouteList(newRoute, lastValidSectionIndex + 1, thisRouted);
+                        newRoute.RemoveRange(lastValidSectionIndex + 1, newRoute.Count - lastValidSectionIndex - 1);
                     }
                 }
 
@@ -9630,8 +9628,7 @@ namespace Orts.Simulation.Physics
 
         public void ProcessExplorerSwitch(int routeDirectionIndex, TrackCircuitSection switchSection, Direction direction)
         {
-            //<CSComment> Probably also in singleplayer the logic of multiplayer should be used, but it's unwise to modify it just before a release
-            TrainRouted thisRouted = direction == Direction.Reverse ^ !MPManager.IsMultiPlayer() ? routedBackward : routedForward;
+            TrainRouted thisRouted = direction == Direction.Reverse ? routedBackward : routedForward;
             TCSubpathRoute selectedRoute = ValidRoute[routeDirectionIndex];
 
             // store required position

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -9327,8 +9327,9 @@ namespace Orts.Simulation.Physics
                         int numCleared = 0;
                         totalLengthM = 0;
                         offsetM = direction == 0 ? requiredPosition.TCOffset : thisSection.Length - requiredPosition.TCOffset;
-                        for (int iindex = 0; iindex < newRoute.Count && (firstSignalPassed || totalLengthM < minCheckDistanceM); iindex++)
+                        for (int iindex = 0; iindex < newRoute.Count && (firstSignalPassed || totalLengthM < minCheckDistanceM) && (!firstSignalPassed || numCleared != 0); iindex++)
                         {
+
                             thisSection = signalRef.TrackCircuitList[newRoute[iindex].TCSectionIndex];
                             int actDirection = newRoute[iindex].Direction;
 
@@ -9346,34 +9347,23 @@ namespace Orts.Simulation.Physics
                                     firstSignalPassed = true;
                                     if (thisSignal == reqSignal)
                                     {
-                                        for (int i = newRoute.Count - 1; i >= iindex + 1; i--)
-                                        {
-                                            thisSection = signalRef.TrackCircuitList[newRoute[i].TCSectionIndex];
-                                            thisSection.RemoveTrain(this, true);
-                                            newRoute.RemoveAt(i);
-                                        }
+                                        signalRef.BreakDownRouteList(newRoute, iindex + 1, thisRouted);
+                                        newRoute.RemoveRange(iindex + 1, newRoute.Count - iindex - 1);
                                         newRoute = thisSignal.requestClearSignalExplorer(newRoute, thisRouted, false, 0);
                                         break;
                                     }
-                                    int num = thisSignal.SignalNumClearAhead_MSTS;
-                                    if (num <= -2)
-                                        num = thisSignal.SignalNumClearAheadActive;
-                                    numCleared = Math.Max(num - thisSignal.SignalNumNormalHeads, 0);
+                                    numCleared = thisSignal.GetReqNumClearAheadExplorer(false, 0);
                                 }
                                 else
                                 {
-                                    if (thisSignal == reqSignal && numCleared > 0)
+                                    if (thisSignal == reqSignal)
                                     {
-                                        for (int i = newRoute.Count - 1; i >= iindex + 1; i--)
-                                        {
-                                            thisSection = signalRef.TrackCircuitList[newRoute[i].TCSectionIndex];
-                                            thisSection.RemoveTrain(this, true);
-                                            newRoute.RemoveAt(i);
-                                        }
+                                        signalRef.BreakDownRouteList(newRoute, iindex + 1, thisRouted);
+                                        newRoute.RemoveRange(iindex + 1, newRoute.Count - iindex - 1);
                                         newRoute = thisSignal.requestClearSignalExplorer(newRoute, thisRouted, true, numCleared);
                                         break;
                                     }
-                                    numCleared = Math.Max(numCleared - thisSignal.SignalNumNormalHeads, 0);
+                                    numCleared = thisSignal.GetReqNumClearAheadExplorer(true, numCleared);
                                 }
                             }
                         }

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -10369,30 +10369,14 @@ namespace Orts.Simulation.Signalling
 
         public int GetReqNumClearAheadExplorer(bool isPropagated, int signalNumClearAhead)
         {
-            int ReqNumClearAhead = 0;
-
             if (SignalNumClearAhead_MSTS > -2)
-            {
-                ReqNumClearAhead = propagated ?
-                    signalNumClearAhead - SignalNumNormalHeads : SignalNumClearAhead_MSTS - SignalNumNormalHeads;
-            }
+                return propagated ? signalNumClearAhead - SignalNumNormalHeads : SignalNumClearAhead_MSTS - SignalNumNormalHeads;
+            else if (SignalNumClearAheadActive == -1)
+                return propagated ? signalNumClearAhead : 1;
+            else if (SignalNumClearAheadActive == 0)
+                return 0;
             else
-            {
-                if (SignalNumClearAheadActive == -1)
-                {
-                    ReqNumClearAhead = propagated ? signalNumClearAhead : 1;
-                }
-                else if (SignalNumClearAheadActive == 0)
-                {
-                    ReqNumClearAhead = 0;
-                }
-                else
-                {
-                    ReqNumClearAhead = isPropagated ? signalNumClearAhead - 1 : SignalNumClearAheadActive - 1;
-                }
-            }
-
-            return ReqNumClearAhead;
+                return isPropagated ? signalNumClearAhead - 1 : SignalNumClearAheadActive - 1;
         }
         //================================================================================================//
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -10347,30 +10347,7 @@ namespace Orts.Simulation.Signalling
             if (extendRoute && fullRoute)
             {
                 isPropagated = propagated;
-                int ReqNumClearAhead = 0;
-
-                if (SignalNumClearAhead_MSTS > -2)
-                {
-                    ReqNumClearAhead = propagated ?
-                        signalNumClearAhead - SignalNumNormalHeads : SignalNumClearAhead_MSTS - SignalNumNormalHeads;
-                }
-                else
-                {
-                    if (SignalNumClearAheadActive == -1)
-                    {
-                        ReqNumClearAhead = propagated ? signalNumClearAhead : 1;
-                    }
-                    else if (SignalNumClearAheadActive == 0)
-                    {
-                        ReqNumClearAhead = 0;
-                    }
-                    else
-                    {
-                        ReqNumClearAhead = isPropagated ? signalNumClearAhead - 1 : SignalNumClearAheadActive - 1;
-                    }
-                }
-
-
+                int ReqNumClearAhead = GetReqNumClearAheadExplorer(isPropagated, signalNumClearAhead);
                 if (ReqNumClearAhead > 0)
                 {
                     int nextSignalIndex = sigfound[(int)MstsSignalFunction.NORMAL];
@@ -10383,6 +10360,39 @@ namespace Orts.Simulation.Signalling
             }
 
             return (newRoute);
+        }
+
+        //================================================================================================//
+        /// <summary>
+        /// number of remaining signals to clear
+        /// </summary>
+
+        public int GetReqNumClearAheadExplorer(bool isPropagated, int signalNumClearAhead)
+        {
+            int ReqNumClearAhead = 0;
+
+            if (SignalNumClearAhead_MSTS > -2)
+            {
+                ReqNumClearAhead = propagated ?
+                    signalNumClearAhead - SignalNumNormalHeads : SignalNumClearAhead_MSTS - SignalNumNormalHeads;
+            }
+            else
+            {
+                if (SignalNumClearAheadActive == -1)
+                {
+                    ReqNumClearAhead = propagated ? signalNumClearAhead : 1;
+                }
+                else if (SignalNumClearAheadActive == 0)
+                {
+                    ReqNumClearAhead = 0;
+                }
+                else
+                {
+                    ReqNumClearAhead = isPropagated ? signalNumClearAhead - 1 : SignalNumClearAheadActive - 1;
+                }
+            }
+
+            return ReqNumClearAhead;
         }
         //================================================================================================//
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -10292,6 +10292,10 @@ namespace Orts.Simulation.Signalling
             // build output route from input route
             Train.TCSubpathRoute newRoute = new Train.TCSubpathRoute(thisRoute);
 
+            // don't clear if enabled for another train
+            if (enabledTrain != null && enabledTrain != thisTrain)
+                return newRoute;
+
             // if signal has fixed route, use that else build route
             if (fixedRoute != null && fixedRoute.Count > 0)
             {


### PR DESCRIPTION
https://bugs.launchpad.net/or/+bug/1903196
There are some issues with the calculation of ValidRoute in explorer mode. In some cases, path is too short and there is no information in TrackMonitor and TCS scripts. In other situations, path is extended up to hundreds of kilometers, which will cause signals 100 km away to be cleared, making difficult multiplayer operations.
I mentioned it some time ago here: http://www.elvastower.com/forums/index.php?/topic/33930-improving-calculation-of-train-path-in-explorer-mode/