### PR TITLE
Extend <br> from train to timetable briefing

### DIFF
--- a/Source/Orts.Formats.OR/TimetableFile.cs
+++ b/Source/Orts.Formats.OR/TimetableFile.cs
@@ -175,7 +175,9 @@ namespace Orts.Formats.OR
                     if (String.Compare(Parts[0], "#briefing", true) == 0)
                     {
                         briefingFound = true;
-                        Briefing = String.Copy(Parts[1]);
+
+                        // Newlines "\n" cannot be emdedded in CSV files, so HTML breaks "<br>" are used instead.
+                        Briefing = String.Copy(Parts[1].Replace("<br>", "\n"));
                         foreach (TrainInformation train in Trains)
                             train.Briefing = String.Copy(Parts[train.Column]).Replace("<br>", "\n");
                     }


### PR DESCRIPTION
https://blueprints.launchpad.net/or/+spec/timetable-briefing

Fix for Timetable-briefing-ingame #263 which failed to embed newlines into the timetable briefing.