### PR TITLE
Write back to the settings store on quit

### DIFF
--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -407,6 +407,10 @@ namespace ORTS.Settings
         public string TrackMonitorDisplayMode { get; set; }
         [Default(true)]
         public bool Use3DCab { get; set; }
+        [Default(0x7)] // OSDLocations.DisplayState.Auto
+        public int OSDLocationsState { get; set; }
+        [Default(0x1)] // OSDCars.DisplayState.Trains
+        public int OSDCarsState { get; set; }
 
         #endregion
 

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -352,8 +352,6 @@ namespace ORTS.Settings
         [Default(false)]
         public bool DataLogger { get; set; }
         [Default(false)]
-        public bool Letterbox2DCab { get; set; }
-        [Default(false)]
         public bool Profiling { get; set; }
         [Default(0)]
         public int ProfilingFrameCount { get; set; }
@@ -401,6 +399,10 @@ namespace ORTS.Settings
         [Default(false)]
         [DoNotSave]
         public bool MultiplayerServer { get; set; }
+
+        // In-game settings:
+        [Default(false)]
+        public bool Letterbox2DCab { get; set; }
 
         #endregion
 

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -409,6 +409,8 @@ namespace ORTS.Settings
         public int OSDLocationsState { get; set; }
         [Default(0x1)] // OSDCars.DisplayState.Trains
         public int OSDCarsState { get; set; }
+        [Default(0)] // TrackMonitor.DisplayMode.All
+        public int TrackMonitorDisplayMode { get; set; }
 
         #endregion
 

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -403,6 +403,8 @@ namespace ORTS.Settings
         // In-game settings:
         [Default(false)]
         public bool Letterbox2DCab { get; set; }
+        [Default("All")]
+        public string TrackMonitorDisplayMode { get; set; }
 
         #endregion
 

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -403,8 +403,6 @@ namespace ORTS.Settings
         // In-game settings:
         [Default(false)]
         public bool Letterbox2DCab { get; set; }
-        [Default("All")]
-        public string TrackMonitorDisplayMode { get; set; }
         [Default(true)]
         public bool Use3DCab { get; set; }
         [Default(0x7)] // OSDLocations.DisplayState.Auto

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -405,6 +405,8 @@ namespace ORTS.Settings
         public bool Letterbox2DCab { get; set; }
         [Default("All")]
         public string TrackMonitorDisplayMode { get; set; }
+        [Default(true)]
+        public bool Use3DCab { get; set; }
 
         #endregion
 

--- a/Source/RunActivity/Program.cs
+++ b/Source/RunActivity/Program.cs
@@ -64,6 +64,8 @@ namespace Orts
             var game = new Game(settings);
             game.PushState(new GameStateRunActivity(args));
             game.Run();
+
+            settings.Save();
         }
     }
 }

--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -1824,7 +1824,6 @@ namespace Orts.Viewer3D
     public class ThreeDimCabCamera : InsideThreeDimCamera
     {
         public override Styles Style { get { return Styles.ThreeDimCab; } }
-        public bool Enabled { get; set; }
         public override bool IsAvailable
         {
             get
@@ -2043,6 +2042,7 @@ namespace Orts.Viewer3D
                     RotationRatioHorizontal = (float)(0.962314f * 2 * Viewer.DisplaySize.X / Viewer.DisplaySize.Y * Math.Tan(MathHelper.ToRadians(Viewer.Settings.ViewingFOV / 2)) / Viewer.DisplaySize.X);
             }
             InitialiseRotation(attachedCar);
+            ScreenChanged();
         }
 
         protected override void OnActivate(bool sameCamera)

--- a/Source/RunActivity/Viewer3D/Commands.cs
+++ b/Source/RunActivity/Viewer3D/Commands.cs
@@ -290,17 +290,7 @@ namespace Orts.Viewer3D
             Redo();
         }
 
-        public override void Redo()
-        {
-            if (Receiver.ThreeDimCabCamera.Enabled)
-            {
-                Receiver.ThreeDimCabCamera.Activate();
-            }
-            else
-            {
-                Receiver.CabCamera.Activate();
-            }
-        }
+        public override void Redo() => Receiver.ActivateCabCamera();
     }
 
 	[Serializable()]
@@ -313,19 +303,7 @@ namespace Orts.Viewer3D
 			Redo();
 		}
 
-		public override void Redo()
-		{
-            Receiver.ThreeDimCabCamera.Enabled = !Receiver.ThreeDimCabCamera.Enabled;
-
-            if (Receiver.ThreeDimCabCamera.Enabled && Receiver.Camera == Receiver.CabCamera)
-            {
-                Receiver.ThreeDimCabCamera.Activate();
-            }
-            else if (!Receiver.ThreeDimCabCamera.Enabled && Receiver.Camera == Receiver.ThreeDimCabCamera)
-            {
-                Receiver.CabCamera.Activate();
-            }
-        }
+        public override void Redo() => Receiver.ToggleCabCameraView();
 	}
 	
 	[Serializable()]

--- a/Source/RunActivity/Viewer3D/Popups/OSDCars.cs
+++ b/Source/RunActivity/Viewer3D/Popups/OSDCars.cs
@@ -37,7 +37,14 @@ namespace Orts.Viewer3D.Popups
             Trains = 0x1,
             Cars = 0x2,
         }
-        DisplayState State = DisplayState.Trains;
+        private DisplayState State
+        {
+            get => (DisplayState)Owner.Viewer.Settings.OSDCarsState;
+            set
+            {
+                Owner.Viewer.Settings.OSDCarsState = (int)value;
+            }
+        }
 
         Dictionary<TrainCar, LabelPrimitive> Labels = new Dictionary<TrainCar, LabelPrimitive>();
 

--- a/Source/RunActivity/Viewer3D/Popups/OSDLocations.cs
+++ b/Source/RunActivity/Viewer3D/Popups/OSDLocations.cs
@@ -40,7 +40,14 @@ namespace Orts.Viewer3D.Popups
             All = 0x3,
             Auto = 0x7,
         }
-        DisplayState State = DisplayState.Auto;
+        private DisplayState State
+        {
+            get => (DisplayState)Owner.Viewer.Settings.OSDLocationsState;
+            set
+            {
+                Owner.Viewer.Settings.OSDLocationsState = (int)value;
+            }
+        }
 
         Dictionary<TrItemLabel, LabelPrimitive> Labels = new Dictionary<TrItemLabel, LabelPrimitive>();
 

--- a/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
@@ -189,7 +189,36 @@ namespace Orts.Viewer3D.Popups
 
         readonly Viewer Viewer;
         private bool metric => Viewer.MilepostUnitsMetric;
-        private DisplayMode Mode { get; set; } = DisplayMode.All;
+
+        /// <summary>
+        /// Synchronized with the value of
+        /// <see cref="ORTS.Settings.UserSettings.TrackMonitorDisplayMode"/>, which is a string.
+        /// </summary>
+        private DisplayMode _mode = DisplayMode.All;
+        /// <summary>
+        /// Parsing an enum is expensive, so this variable caches the conversion
+        /// from the underlying <see cref="ORTS.Settings.UserSettings.TrackMonitorDisplayMode"/>
+        /// string value.
+        /// </summary>
+        private string _modeString = null;
+        private DisplayMode Mode
+        {
+            get
+            {
+                var setting = Viewer.Settings.TrackMonitorDisplayMode;
+                if (setting != _modeString)
+                {
+                    _modeString = setting;
+                    Enum.TryParse(setting, ignoreCase: true, out _mode);
+                }
+                return _mode;
+            }
+            set
+            {
+                _mode = value;
+                Viewer.Settings.TrackMonitorDisplayMode = _modeString = _mode.ToString();
+            }
+        }
 
         /// <summary>
         /// Different information views for the Track Monitor.

--- a/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
@@ -189,7 +189,14 @@ namespace Orts.Viewer3D.Popups
 
         readonly Viewer Viewer;
         private bool metric => Viewer.MilepostUnitsMetric;
-        private DisplayMode Mode { get; set; } = DisplayMode.All;
+        private DisplayMode Mode
+        {
+            get => (DisplayMode)Viewer.Settings.TrackMonitorDisplayMode;
+            set
+            {
+                Viewer.Settings.TrackMonitorDisplayMode = (int)value;
+            }
+        }
 
         /// <summary>
         /// Different information views for the Track Monitor.
@@ -199,11 +206,11 @@ namespace Orts.Viewer3D.Popups
             /// <summary>
             /// Display all track and routing features.
             /// </summary>
-            All,
+            All = 0,
             /// <summary>
             /// Show only the static features that a train driver would know by memory.
             /// </summary>
-            StaticOnly,
+            StaticOnly = 1,
         }
 
         public static int DbfEvalOverSpeed;//Debrief eval

--- a/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
@@ -189,36 +189,7 @@ namespace Orts.Viewer3D.Popups
 
         readonly Viewer Viewer;
         private bool metric => Viewer.MilepostUnitsMetric;
-
-        /// <summary>
-        /// Synchronized with the value of
-        /// <see cref="ORTS.Settings.UserSettings.TrackMonitorDisplayMode"/>, which is a string.
-        /// </summary>
-        private DisplayMode _mode = DisplayMode.All;
-        /// <summary>
-        /// Parsing an enum is expensive, so this variable caches the conversion
-        /// from the underlying <see cref="ORTS.Settings.UserSettings.TrackMonitorDisplayMode"/>
-        /// string value.
-        /// </summary>
-        private string _modeString = null;
-        private DisplayMode Mode
-        {
-            get
-            {
-                var setting = Viewer.Settings.TrackMonitorDisplayMode;
-                if (setting != _modeString)
-                {
-                    _modeString = setting;
-                    Enum.TryParse(setting, ignoreCase: true, out _mode);
-                }
-                return _mode;
-            }
-            set
-            {
-                _mode = value;
-                Viewer.Settings.TrackMonitorDisplayMode = _modeString = _mode.ToString();
-            }
-        }
+        private DisplayMode Mode { get; set; } = DisplayMode.All;
 
         /// <summary>
         /// Different information views for the Track Monitor.

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -1180,8 +1180,6 @@ namespace Orts.Viewer3D.RollingStock
             #endregion
 
             _Viewer.AdjustCabHeight(_Viewer.DisplaySize.X, _Viewer.DisplaySize.Y);
-
-            _Viewer.CabCamera.ScreenChanged();
         }
 
         public CabRenderer(Viewer viewer, MSTSLocomotive car, CabViewFile CVFFile) //used by 3D cab as a refrence, thus many can be eliminated

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -107,7 +107,14 @@ namespace Orts.Viewer3D
         // Cameras
         public Camera Camera { get; set; } // Current camera
         public Camera AbovegroundCamera { get; private set; } // Previous camera for when automatically switching to cab.
-        public CabCamera CabCamera { get; private set; } // Camera 1
+        /// <summary>
+        /// Camera #1, 2D cab. Swaps with <see cref="ThreeDimCabCamera"/> with Alt+1.
+        /// </summary>
+        private readonly CabCamera CabCamera;
+        /// <summary>
+        /// Camera #1, 3D cab. Swaps with <see cref="CabCamera"/> with Alt+1.
+        /// </summary>
+        private readonly ThreeDimCabCamera ThreeDimCabCamera;
         public HeadOutCamera HeadOutForwardCamera { get; private set; } // Camera 1+Up
         public HeadOutCamera HeadOutBackCamera { get; private set; } // Camera 2+Down
         public TrackingCamera FrontCamera { get; private set; } // Camera 2
@@ -118,7 +125,27 @@ namespace Orts.Viewer3D
         public BrakemanCamera BrakemanCamera { get; private set; } // Camera 6
         public List<FreeRoamCamera> FreeRoamCameraList = new List<FreeRoamCamera>();
         public FreeRoamCamera FreeRoamCamera { get { return FreeRoamCameraList[0]; } } // Camera 8
-        public ThreeDimCabCamera ThreeDimCabCamera; //Camera 0
+
+        /// <summary>
+        /// Activate the 2D or 3D cab camera depending on the current player preference.
+        /// </summary>
+        public void ActivateCabCamera()
+        {
+            if (Settings.Use3DCab && ThreeDimCabCamera.IsAvailable)
+                ThreeDimCabCamera.Activate();
+            else
+                CabCamera.Activate();
+        }
+
+        /// <summary>
+        /// Toggle the 2D/3D cab preference and, if already in the cab camera, switch modes.
+        /// </summary>
+        public void ToggleCabCameraView()
+        {
+            Settings.Use3DCab = !Settings.Use3DCab;
+            if (Camera == CabCamera || Camera == ThreeDimCabCamera)
+                ActivateCabCamera();
+        }
 
         List<Camera> WellKnownCameras; // Providing Camera save functionality by GeorgeS
 
@@ -449,13 +476,10 @@ namespace Orts.Viewer3D
             };
             Simulator.Confirmer.DisplayMessage += (s, e) => MessagesWindow.AddMessage(e.Key, e.Text, e.Duration);
 
-            if (Simulator.PlayerLocomotive.HasFront3DCab || Simulator.PlayerLocomotive.HasRear3DCab)
-            {
-                ThreeDimCabCamera.Enabled = true;
-                ThreeDimCabCamera.Activate();
-            }
-            else if (Simulator.PlayerLocomotive.HasFrontCab || Simulator.PlayerLocomotive.HasRearCab) CabCamera.Activate();
-            else CameraActivate();
+            if (CabCamera.IsAvailable || ThreeDimCabCamera.IsAvailable)
+                ActivateCabCamera();
+            else
+                CameraActivate();
 
             // Prepare the world to be loaded and then load it from the correct thread for debugging/tracing purposes.
             // This ensures that a) we have all the required objects loaded when the 3D view first appears and b) that


### PR DESCRIPTION
Some key commands write to the settings store while in-game. It would be convenient if these change persisted after close, so that players don't have to press the same keys every time to restore their preferences.

I've made sure that at least the cab letterboxing feature and the track monitor immersive mode are saved and restored in this manner. Any suggestions for other in-game modes that should be looked at?

Feature request: https://www.elvastower.com/forums/index.php?/topic/34562-in-game-toggles-that-should-stick-but-dont/