### PR TITLE
feat: Cache build tools to improve reliability

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,13 @@
 version: AV1.3.1-{build}
 skip_branch_with_pr: true
 image: Visual Studio 2017
+cache:
+  - C:\ProgramData\chocolatey\bin -> .appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> .appveyor.yml
+  - C:\lazarus -> .appveyor.yml
+  - C:\Program Files (x86)\Common Files\Microsoft Shared\XNA -> .appveyor.yml
+  - C:\Windows\assembly\GAC_32\Microsoft.Xna.Framework -> .appveyor.yml
+  - C:\Windows\assembly\GAC_32\Microsoft.Xna.Framework.Game -> .appveyor.yml
 install:
 - ps: >-
     $ErrorActionPreference = "Stop"


### PR DESCRIPTION
[Due to (we suspect) SourceForge blocking downloads of Lazarus into the AppVeyor build environment](http://www.elvastower.com/forums/index.php?/topic/34274-ci-failure-due-to-lazarus-download/page__view__findpost__p__261384), this PR caches the installed software needed for the build.