### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1905146 On restore panto 1 is always risen

### DIFF
--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -91,6 +91,7 @@ namespace Orts.Common
         MirrorOpen, 
         Pantograph1Down,
         PantographToggle,
+        // Don't modify order of next 7 events
         Pantograph1Up,
         Pantograph2Down,
         Pantograph2Up,
@@ -98,6 +99,7 @@ namespace Orts.Common
         Pantograph3Up,
         Pantograph4Down,
         Pantograph4Up,
+        //
         PermissionDenied,
         PermissionGranted,
         PermissionToDepart,

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -91,7 +91,6 @@ namespace Orts.Common
         MirrorOpen, 
         Pantograph1Down,
         PantographToggle,
-        // Don't modify order of next 7 events
         Pantograph1Up,
         Pantograph2Down,
         Pantograph2Up,
@@ -99,7 +98,6 @@ namespace Orts.Common
         Pantograph3Up,
         Pantograph4Down,
         Pantograph4Up,
-        //
         PermissionDenied,
         PermissionGranted,
         PermissionToDepart,

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSElectricLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSElectricLocomotiveViewer.cs
@@ -38,8 +38,19 @@ namespace Orts.Viewer3D.RollingStock
             if (ElectricLocomotive.Train != null && (car.Train.TrainType == Train.TRAINTYPE.AI ||
                 ((car.Train.TrainType == Train.TRAINTYPE.PLAYER || car.Train.TrainType == Train.TRAINTYPE.AI_PLAYERDRIVEN || car.Train.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING) &&
                 (car.Train.MUDirection != Direction.N && ElectricLocomotive.PowerOn))))
+                // following reactivates the sound triggers related to certain states
+                // for pantos the sound trigger related to the raised panto must be reactivated, else SignalEvent() would raise also another panto
             {
-                ElectricLocomotive.SignalEvent(Event.Pantograph1Up);
+                var iPanto = 0;
+                foreach (var panto in ElectricLocomotive.Pantographs.List)
+                {
+                    if (panto.State == ORTS.Scripting.Api.PantographState.Up)
+                    {
+                        ElectricLocomotive.SignalEvent((Event)((int)Event.Pantograph1Up + 2 * iPanto));
+                        break;
+                    }
+                    iPanto++;
+                }
                 ElectricLocomotive.SignalEvent(Event.EnginePowerOn);
                 ElectricLocomotive.SignalEvent(Event.ReverserToForwardBackward);
                 ElectricLocomotive.SignalEvent(Event.ReverserChange);

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSElectricLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSElectricLocomotiveViewer.cs
@@ -42,12 +42,20 @@ namespace Orts.Viewer3D.RollingStock
                 // for pantos the sound trigger related to the raised panto must be reactivated, else SignalEvent() would raise also another panto
             {
                 var iPanto = 0;
+                Event evt;
                 foreach (var panto in ElectricLocomotive.Pantographs.List)
                 {
                     if (panto.State == ORTS.Scripting.Api.PantographState.Up)
                     {
-                        ElectricLocomotive.SignalEvent((Event)((int)Event.Pantograph1Up + 2 * iPanto));
-                        break;
+                        switch (iPanto)
+                        {
+                            case 0: evt = Event.Pantograph1Up; break;
+                            case 1: evt = Event.Pantograph2Up; break;
+                            case 2: evt = Event.Pantograph3Up; break;
+                            case 3: evt = Event.Pantograph4Up; break;
+                            default: evt = Event.Pantograph1Up; break;
+                        }
+                        ElectricLocomotive.SignalEvent(evt);
                     }
                     iPanto++;
                 }
@@ -57,11 +65,14 @@ namespace Orts.Viewer3D.RollingStock
             }
         }
 
-        /// <summary>
-        /// A keyboard or mouse click has occured. Read the UserInput
-        /// structure to determine what was pressed.
-        /// </summary>
-        public override void HandleUserInput(ElapsedTime elapsedTime)
+        Event evt;
+
+
+    /// <summary>
+    /// A keyboard or mouse click has occured. Read the UserInput
+    /// structure to determine what was pressed.
+    /// </summary>
+    public override void HandleUserInput(ElapsedTime elapsedTime)
         {
             base.HandleUserInput(elapsedTime);
         }

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSElectricLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSElectricLocomotiveViewer.cs
@@ -65,14 +65,12 @@ namespace Orts.Viewer3D.RollingStock
             }
         }
 
-        Event evt;
 
-
-    /// <summary>
-    /// A keyboard or mouse click has occured. Read the UserInput
-    /// structure to determine what was pressed.
-    /// </summary>
-    public override void HandleUserInput(ElapsedTime elapsedTime)
+        /// <summary>
+        /// A keyboard or mouse click has occurred. Read the UserInput
+        /// structure to determine what was pressed.
+        /// </summary>
+        public override void HandleUserInput(ElapsedTime elapsedTime)
         {
             base.HandleUserInput(elapsedTime);
         }


### PR DESCRIPTION
Launching event of a panto rise is needed when you meet an AI train or after restore of a moving player train, because it restarts the related sound event. Up to now always the event for panto 1 was launched. However launching the event not only triggers the related sound trigger, but also physically rises the panto if it it was down, and another one was up; so panto 1 was risen even if it hat to be down, because another panto was up. With the patch the first up panto is selected, and the event is launched for that one.
