### PR TITLE
Some locomotive related TCS script hooks, see https://blueprints.launchpad.net/or/+spec/locomotive-related-tcs-hooks

### DIFF
--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -204,13 +204,13 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> AccelerationMpSS;
         /// <summary>
-        /// Locomotive elevation.
+        /// Locomotive altitude.
         /// </summary>
-        public Func<float> ElevationM;
+        public Func<float> AltitudeM;
         /// <summary>
         /// Track gradient percent at the locomotive's location.
         /// </summary>
-        public Func<float> CurrentGradientPercent;
+        public Func<float> CurrentElevationPercent;
         /// <summary>
         /// Line speed taken from .trk file.
         /// </summary>

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -292,11 +292,15 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Action SetPantographsDown;
         /// <summary>
-        /// Cut power by pull all pantographs down.
-        /// PowerSupplyEvent: may be LowerPantograph or RaisePantograph
+        /// Raise specified pantograph
         /// int: pantographID, from 1 to 4
         /// </summary>
-        public Action<PowerSupplyEvent, int> SetPantograph;
+        public Action<int> SetPantographUp;
+        /// <summary>
+        /// Lower specified pantograph
+        /// int: pantographID, from 1 to 4
+        /// </summary>
+        public Action<int> SetPantographDown;
         /// <summary>
         /// Set the circuit breaker or power contactor closing authorization.
         /// </summary>

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -172,6 +172,10 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> ThrottlePercent;
         /// <summary>
+        /// Returns dynamic brake percent
+        /// </summary>
+        public Func<float> DynamicBrakePercent;
+        /// <summary>
         /// True if traction is authorized.
         /// </summary>
         public Func<bool> TractionAuthorization;
@@ -192,9 +196,21 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> BrakeCutsPowerAtBrakeCylinderPressureBar;
         /// <summary>
-        /// Elevation percent at the locomotive's location.
+        /// Track slope percent at the locomotive's location.
         /// </summary>
-        public Func<float> CurrentElevationPercent;
+        public Func<ControllerState> TrainBrakeControllerState;
+        /// <summary>
+        /// Locomotive acceleration.
+        /// </summary>
+        public Func<float> AccelerationMpSS;
+        /// <summary>
+        /// Locomotive elevation.
+        /// </summary>
+        public Func<float> ElevationM;
+        /// <summary>
+        /// Track slope percent at the locomotive's location.
+        /// </summary>
+        public Func<float> CurrentSlopePercent;
         /// <summary>
         /// Line speed taken from .trk file.
         /// </summary>

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -162,7 +162,7 @@ namespace ORTS.Scripting.Api
         /// Checks the state of any pantograph
         /// int: pantograph ID (1 for first pantograph)
         /// </summary>
-        public Func<int, PantographState> PantographState;
+        public Func<int, PantographState> GetPantographState;
         /// <summary>
         /// True if all pantographs are down.
         /// </summary>

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -158,6 +158,10 @@ namespace ORTS.Scripting.Api
         /// True if circuit breaker or power contactor opening order is true.
         /// </summary>
         public Func<bool> CircuitBreakerOpeningOrder;
+         /// <summary>
+        /// Returns the number of pantographs on the locomotive.
+        /// </summary>
+        public Func<int> PantographCount;
         /// <summary>
         /// Checks the state of any pantograph
         /// int: pantograph ID (1 for first pantograph)
@@ -208,9 +212,9 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> AltitudeM;
         /// <summary>
-        /// Track gradient percent at the locomotive's location.
+        /// Track gradient percent at the locomotive's location (positive = uphill).
         /// </summary>
-        public Func<float> CurrentElevationPercent;
+        public Func<float> CurrentGradientPercent;
         /// <summary>
         /// Line speed taken from .trk file.
         /// </summary>

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -208,9 +208,9 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> ElevationM;
         /// <summary>
-        /// Track slope percent at the locomotive's location.
+        /// Track gradient percent at the locomotive's location.
         /// </summary>
-        public Func<float> CurrentSlopePercent;
+        public Func<float> CurrentGradientPercent;
         /// <summary>
         /// Line speed taken from .trk file.
         /// </summary>

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -139,6 +139,14 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<bool> IsDirectionReverse;
         /// <summary>
+        /// True if locomotive is flipped.
+        /// </summary>
+        public Func<bool> IsFlipped;
+        /// <summary>
+        /// True if player is in rear cab.
+        /// </summary>
+        public Func<bool> IsRearCab;
+        /// <summary>
         /// True if train brake controller is in emergency position, otherwise false.
         /// </summary>
         public Func<bool> IsBrakeEmergency;

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -159,6 +159,19 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<bool> CircuitBreakerOpeningOrder;
         /// <summary>
+        /// Checks the state of any pantograph
+        /// int: pantograph ID (1 for first pantograph)
+        /// </summary>
+        public Func<int, PantographState> PantographState;
+        /// <summary>
+        /// True if all pantographs are down.
+        /// </summary>
+        public Func<bool> ArePantographsDown;
+        /// <summary>
+        /// Returns throttle percent
+        /// </summary>
+        public Func<float> ThrottlePercent;
+        /// <summary>
         /// True if traction is authorized.
         /// </summary>
         public Func<bool> TractionAuthorization;
@@ -178,6 +191,10 @@ namespace ORTS.Scripting.Api
         /// Train brake pressure value which triggers the power cut-off.
         /// </summary>
         public Func<float> BrakeCutsPowerAtBrakeCylinderPressureBar;
+        /// <summary>
+        /// Elevation percent at the locomotive's location.
+        /// </summary>
+        public Func<float> CurrentElevationPercent;
         /// <summary>
         /// Line speed taken from .trk file.
         /// </summary>
@@ -258,6 +275,12 @@ namespace ORTS.Scripting.Api
         /// Cut power by pull all pantographs down.
         /// </summary>
         public Action SetPantographsDown;
+        /// <summary>
+        /// Cut power by pull all pantographs down.
+        /// PowerSupplyEvent: may be LowerPantograph or RaisePantograph
+        /// int: pantographID, from 1 to 4
+        /// </summary>
+        public Action<PowerSupplyEvent, int> SetPantograph;
         /// <summary>
         /// Set the circuit breaker or power contactor closing authorization.
         /// </summary>

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -196,7 +196,7 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> BrakeCutsPowerAtBrakeCylinderPressureBar;
         /// <summary>
-        /// Track slope percent at the locomotive's location.
+        /// State of the train brake controller.
         /// </summary>
         public Func<ControllerState> TrainBrakeControllerState;
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/Pantograph.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/Pantograph.cs
@@ -28,6 +28,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 {
     public class Pantographs
     {
+        public static readonly int MinPantoID = 1; // minimum value of PantoID, applies to Pantograph 1
+        public static readonly int MaxPantoID = 4; // maximum value of PantoID, applies to Pantograph 4
         readonly MSTSWagon Wagon;
 
         public List<Pantograph> List = new List<Pantograph>();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -303,12 +303,16 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.PantographState = (pantoID) => Locomotive.Pantographs[pantoID].State;
                 Script.ArePantographsDown = () => Locomotive.Pantographs.State == PantographState.Down;
                 Script.ThrottlePercent = () => Locomotive.ThrottleController.CurrentValue * 100;
+                Script.DynamicBrakePercent = () => Locomotive.DynamicBrakeController == null ? 0 : Locomotive.DynamicBrakeController.CurrentValue * 100;
                 Script.TractionAuthorization = () => TractionAuthorization;
                 Script.BrakePipePressureBar = () => Locomotive.BrakeSystem != null ? Bar.FromPSI(Locomotive.BrakeSystem.BrakeLine1PressurePSI) : float.MaxValue;
                 Script.LocomotiveBrakeCylinderPressureBar = () => Locomotive.BrakeSystem != null ? Bar.FromPSI(Locomotive.BrakeSystem.GetCylPressurePSI()) : float.MaxValue;
                 Script.DoesBrakeCutPower = () => Locomotive.DoesBrakeCutPower;
                 Script.BrakeCutsPowerAtBrakeCylinderPressureBar = () => Bar.FromPSI(Locomotive.BrakeCutsPowerAtBrakeCylinderPressurePSI);
-                Script.CurrentElevationPercent = () => Locomotive.CurrentElevationPercent;
+                Script.TrainBrakeControllerState = () => Locomotive.TrainBrakeController.TrainBrakeControllerState;
+                Script.AccelerationMpSS = () => Locomotive.AccelerationMpSS;
+                Script.ElevationM = () => Locomotive.WorldPosition.Location.Y;
+                Script.CurrentSlopePercent = () => Locomotive.CurrentElevationPercent;
                 Script.LineSpeedMpS = () => (float)Simulator.TRK.Tr_RouteFile.SpeedLimit;
                 Script.DoesStartFromTerminalStation = () => DoesStartFromTerminalStation();
                 Script.IsColdStart = () => Locomotive.Train.ColdStart;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -295,6 +295,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.IsDirectionForward = () => Locomotive.Direction == Direction.Forward;
                 Script.IsDirectionNeutral = () => Locomotive.Direction == Direction.N;
                 Script.IsDirectionReverse = () => Locomotive.Direction == Direction.Reverse;
+                Script.IsFlipped = () => Locomotive.Flipped;
+                Script.IsRearCab = () => Locomotive.UsingRearCab;
                 Script.IsBrakeEmergency = () => Locomotive.TrainBrakeController.EmergencyBraking;
                 Script.IsBrakeFullService = () => Locomotive.TrainBrakeController.TCSFullServiceBraking;
                 Script.PowerAuthorization = () => PowerAuthorization;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -300,7 +300,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.PowerAuthorization = () => PowerAuthorization;
                 Script.CircuitBreakerClosingOrder = () => CircuitBreakerClosingOrder;
                 Script.CircuitBreakerOpeningOrder = () => CircuitBreakerOpeningOrder;
-                Script.PantographState = (pantoID) => Locomotive.Pantographs[pantoID].State;
+                Script.GetPantographState = (pantoID) => Locomotive.Pantographs[pantoID].State;
                 Script.ArePantographsDown = () => Locomotive.Pantographs.State == PantographState.Down;
                 Script.ThrottlePercent = () => Locomotive.ThrottleController.CurrentValue * 100;
                 Script.DynamicBrakePercent = () => Locomotive.DynamicBrakeController == null ? 0 : Locomotive.DynamicBrakeController.CurrentValue * 100;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -300,7 +300,19 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.PowerAuthorization = () => PowerAuthorization;
                 Script.CircuitBreakerClosingOrder = () => CircuitBreakerClosingOrder;
                 Script.CircuitBreakerOpeningOrder = () => CircuitBreakerOpeningOrder;
-                Script.GetPantographState = (pantoID) => Locomotive.Pantographs[pantoID].State;
+                Script.PantographCount = () => Locomotive.Pantographs.Count;
+                Script.GetPantographState = (pantoID) =>
+                {
+                   if (pantoID > 0 && pantoID <= 4)
+                    {
+                        return Locomotive.Pantographs[pantoID].State;
+                    }
+                    else
+                    {
+                        Trace.TraceError($"TCS script used bad pantograph ID {pantoID}");
+                        return PantographState.Down;
+                    }
+                };
                 Script.ArePantographsDown = () => Locomotive.Pantographs.State == PantographState.Down;
                 Script.ThrottlePercent = () => Locomotive.ThrottleController.CurrentValue * 100;
                 Script.DynamicBrakePercent = () => Locomotive.DynamicBrakeController == null ? 0 : Locomotive.DynamicBrakeController.CurrentValue * 100;
@@ -312,7 +324,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.TrainBrakeControllerState = () => Locomotive.TrainBrakeController.TrainBrakeControllerState;
                 Script.AccelerationMpSS = () => Locomotive.AccelerationMpSS;
                 Script.AltitudeM = () => Locomotive.WorldPosition.Location.Y;
-                Script.CurrentElevationPercent = () => Locomotive.CurrentElevationPercent;
+                Script.CurrentGradientPercent = () => -Locomotive.CurrentElevationPercent;
                 Script.LineSpeedMpS = () => (float)Simulator.TRK.Tr_RouteFile.SpeedLimit;
                 Script.DoesStartFromTerminalStation = () => DoesStartFromTerminalStation();
                 Script.IsColdStart = () => Locomotive.Train.ColdStart;
@@ -368,8 +380,24 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                         Locomotive.Train.SignalEvent(PowerSupplyEvent.LowerPantograph);
                     }
                 };
-                Script.SetPantographUp = (pantoID) => Locomotive.Train.SignalEvent(PowerSupplyEvent.RaisePantograph, pantoID);
-                Script.SetPantographDown = (pantoID) => Locomotive.Train.SignalEvent(PowerSupplyEvent.LowerPantograph, pantoID);
+                Script.SetPantographUp = (pantoID) =>
+                {
+                    if (pantoID < 1 || pantoID > 4)
+                    {
+                        Trace.TraceError($"TCS script used bad pantograph ID {pantoID}");
+                        return;
+                    }
+                    Locomotive.Train.SignalEvent(PowerSupplyEvent.RaisePantograph, pantoID);
+                };               
+                Script.SetPantographDown = (pantoID) =>
+                {
+                    if (pantoID < 1 || pantoID > 4)
+                    {
+                        Trace.TraceError($"TCS script used bad pantograph ID {pantoID}");
+                        return;
+                    }
+                    Locomotive.Train.SignalEvent(PowerSupplyEvent.LowerPantograph, pantoID);
+                };
                 Script.SetPowerAuthorization = (value) => PowerAuthorization = value;
                 Script.SetCircuitBreakerClosingOrder = (value) => CircuitBreakerClosingOrder = value;
                 Script.SetCircuitBreakerOpeningOrder = (value) => CircuitBreakerOpeningOrder = value;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -311,8 +311,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.BrakeCutsPowerAtBrakeCylinderPressureBar = () => Bar.FromPSI(Locomotive.BrakeCutsPowerAtBrakeCylinderPressurePSI);
                 Script.TrainBrakeControllerState = () => Locomotive.TrainBrakeController.TrainBrakeControllerState;
                 Script.AccelerationMpSS = () => Locomotive.AccelerationMpSS;
-                Script.ElevationM = () => Locomotive.WorldPosition.Location.Y;
-                Script.CurrentGradientPercent = () => Locomotive.CurrentElevationPercent;
+                Script.AltitudeM = () => Locomotive.WorldPosition.Location.Y;
+                Script.CurrentElevationPercent = () => Locomotive.CurrentElevationPercent;
                 Script.LineSpeedMpS = () => (float)Simulator.TRK.Tr_RouteFile.SpeedLimit;
                 Script.DoesStartFromTerminalStation = () => DoesStartFromTerminalStation();
                 Script.IsColdStart = () => Locomotive.Train.ColdStart;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -368,7 +368,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                         Locomotive.Train.SignalEvent(PowerSupplyEvent.LowerPantograph);
                     }
                 };
-                Script.SetPantograph = (pantoCommand, pantoID) => Locomotive.Train.SignalEvent(pantoCommand, pantoID);
+                Script.SetPantographUp = (pantoID) => Locomotive.Train.SignalEvent(PowerSupplyEvent.RaisePantograph, pantoID);
+                Script.SetPantographDown = (pantoID) => Locomotive.Train.SignalEvent(PowerSupplyEvent.LowerPantograph, pantoID);
                 Script.SetPowerAuthorization = (value) => PowerAuthorization = value;
                 Script.SetCircuitBreakerClosingOrder = (value) => CircuitBreakerClosingOrder = value;
                 Script.SetCircuitBreakerOpeningOrder = (value) => CircuitBreakerOpeningOrder = value;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -300,11 +300,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.PowerAuthorization = () => PowerAuthorization;
                 Script.CircuitBreakerClosingOrder = () => CircuitBreakerClosingOrder;
                 Script.CircuitBreakerOpeningOrder = () => CircuitBreakerOpeningOrder;
+                Script.PantographState = (pantoID) => Locomotive.Pantographs[pantoID].State;
+                Script.ArePantographsDown = () => Locomotive.Pantographs.State == PantographState.Down;
+                Script.ThrottlePercent = () => Locomotive.ThrottleController.CurrentValue * 100;
                 Script.TractionAuthorization = () => TractionAuthorization;
                 Script.BrakePipePressureBar = () => Locomotive.BrakeSystem != null ? Bar.FromPSI(Locomotive.BrakeSystem.BrakeLine1PressurePSI) : float.MaxValue;
                 Script.LocomotiveBrakeCylinderPressureBar = () => Locomotive.BrakeSystem != null ? Bar.FromPSI(Locomotive.BrakeSystem.GetCylPressurePSI()) : float.MaxValue;
                 Script.DoesBrakeCutPower = () => Locomotive.DoesBrakeCutPower;
                 Script.BrakeCutsPowerAtBrakeCylinderPressureBar = () => Bar.FromPSI(Locomotive.BrakeCutsPowerAtBrakeCylinderPressurePSI);
+                Script.CurrentElevationPercent = () => Locomotive.CurrentElevationPercent;
                 Script.LineSpeedMpS = () => (float)Simulator.TRK.Tr_RouteFile.SpeedLimit;
                 Script.DoesStartFromTerminalStation = () => DoesStartFromTerminalStation();
                 Script.IsColdStart = () => Locomotive.Train.ColdStart;
@@ -360,6 +364,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                         Locomotive.Train.SignalEvent(PowerSupplyEvent.LowerPantograph);
                     }
                 };
+                Script.SetPantograph = (pantoCommand, pantoID) => Locomotive.Train.SignalEvent(pantoCommand, pantoID);
                 Script.SetPowerAuthorization = (value) => PowerAuthorization = value;
                 Script.SetCircuitBreakerClosingOrder = (value) => CircuitBreakerClosingOrder = value;
                 Script.SetCircuitBreakerOpeningOrder = (value) => CircuitBreakerOpeningOrder = value;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -22,6 +22,7 @@ using Orts.Common;
 using Orts.Parsers.Msts;
 using Orts.Simulation.Physics;
 using Orts.Simulation.Signalling;
+using Orts.Simulation.RollingStocks.SubSystems.PowerSupplies;
 using ORTS.Common;
 using ORTS.Scripting.Api;
 using System;
@@ -305,7 +306,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.PantographCount = () => Locomotive.Pantographs.Count;
                 Script.GetPantographState = (pantoID) =>
                 {
-                   if (pantoID > 0 && pantoID <= 4)
+                   if (pantoID >= Pantographs.MinPantoID && pantoID <= Pantographs.MaxPantoID)
                     {
                         return Locomotive.Pantographs[pantoID].State;
                     }
@@ -384,7 +385,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 };
                 Script.SetPantographUp = (pantoID) =>
                 {
-                    if (pantoID < 1 || pantoID > 4)
+                    if (pantoID < Pantographs.MinPantoID || pantoID > Pantographs.MaxPantoID)
                     {
                         Trace.TraceError($"TCS script used bad pantograph ID {pantoID}");
                         return;
@@ -393,7 +394,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 };               
                 Script.SetPantographDown = (pantoID) =>
                 {
-                    if (pantoID < 1 || pantoID > 4)
+                    if (pantoID < Pantographs.MinPantoID || pantoID > Pantographs.MaxPantoID)
                     {
                         Trace.TraceError($"TCS script used bad pantograph ID {pantoID}");
                         return;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -312,7 +312,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.TrainBrakeControllerState = () => Locomotive.TrainBrakeController.TrainBrakeControllerState;
                 Script.AccelerationMpSS = () => Locomotive.AccelerationMpSS;
                 Script.ElevationM = () => Locomotive.WorldPosition.Location.Y;
-                Script.CurrentSlopePercent = () => Locomotive.CurrentElevationPercent;
+                Script.CurrentGradientPercent = () => Locomotive.CurrentElevationPercent;
                 Script.LineSpeedMpS = () => (float)Simulator.TRK.Tr_RouteFile.SpeedLimit;
                 Script.DoesStartFromTerminalStation = () => DoesStartFromTerminalStation();
                 Script.IsColdStart = () => Locomotive.Train.ColdStart;


### PR DESCRIPTION
Hooks include:
- pantograph state (both read and write)
- throttle percent (read)
- current elevation percent.
