### PR TITLE
build: Add xunit to AppVeyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,13 +12,13 @@ install:
 - ps: >-
     $ErrorActionPreference = "Stop"
 
-    choco install --yes --no-progress lazarus 7zip.portable xna31
+    choco install --yes --no-progress lazarus 7zip.portable xunit xna31
 
     if ($LASTEXITCODE -ne 0) { throw "Chocolatey failed to install all required packages - use the 're-build' option to try again" }
 
     (New-Object Net.WebClient).DownloadFile('https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x86.exe', 'rcedit-x86.exe')
 
-    $env:PATH="$env:PATH;C:\lazarus;$((Get-ChildItem -Recurse C:\lazarus\fpc\strip.exe).DirectoryName);C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin"
+    $env:PATH="C:\ProgramData\chocolatey\bin;$env:PATH;C:\lazarus;$((Get-ChildItem -Recurse C:\lazarus\fpc\strip.exe).DirectoryName);C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin"
 build_script:
 - cmd: Build.cmd unstable
 test: off


### PR DESCRIPTION
[As was pointed out](http://www.elvastower.com/forums/index.php?/topic/34274-ci-failure-due-to-lazarus-download/page__view__findpost__p__264908), because we don't have the same AppVeyor configuration nor Chocolatey packages on different branches, the cache feature is not really effective.

This PR adds XUnit to the configuration which, combined with https://github.com/openrails/openrails/pull/230/commits/88ce21f9a0a8e330fdb3ee056cdc265e3437dcd4, should allow the AppVeyor configuration to match on `master` and `unstable` thus allowing the use of the cache.

Any open PRs can, if they absolutely need it, merge `master` into their PR (after this one is merged) to also align with the configuration and cache.