### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1905957 - Locomotives with only a rear 3D cab aren't managed properly

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -714,7 +714,14 @@ namespace Orts.Simulation.RollingStocks
             if (!(this is MSTSSteamLocomotive))
                 InitializeFromORTSSpecific(cvfFilePath, extendedCVF);
 
-            return new CabView3D(cvfFile, CabViewpoints, extendedCVF, CabViewType.Front, noseAhead, shapeFilePath);
+            var cabViewType = CabViewType.Front;
+            if (CabViewpoints.Count == 1 && ((CabViewpoints[0].StartDirection.Y >= 90 && CabViewpoints[0].StartDirection.Y <= 270)
+                 || (CabViewpoints[0].StartDirection.Y <= -90 && CabViewpoints[0].StartDirection.Y >= -270)))
+            {
+                CabViewpoints.Insert(0, new PassengerViewPoint());
+                cabViewType = CabViewType.Rear;
+            }
+            return new CabView3D(cvfFile, CabViewpoints, extendedCVF, cabViewType, noseAhead, shapeFilePath);
         }
 
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -714,13 +714,13 @@ namespace Orts.Simulation.RollingStocks
             if (!(this is MSTSSteamLocomotive))
                 InitializeFromORTSSpecific(cvfFilePath, extendedCVF);
 
-            var cabViewType = CabViewType.Front;
-            if (CabViewpoints.Count == 1 && ((CabViewpoints[0].StartDirection.Y >= 90 && CabViewpoints[0].StartDirection.Y <= 270)
-                 || (CabViewpoints[0].StartDirection.Y <= -90 && CabViewpoints[0].StartDirection.Y >= -270)))
-            {
+            var cabViewAngle = CabViewpoints[0].StartDirection.Y;
+            var cabViewType = (cabViewAngle >= 90 && cabViewAngle <= 270) || (cabViewAngle <= -90 && cabViewAngle >= -270) ? CabViewType.Rear : CabViewType.Front;
+
+            // only one cabview, and it looks rear; insert a void one at first place to maintain fast indexing
+            if (CabViewpoints.Count == 1 && cabViewType == CabViewType.Rear)
                 CabViewpoints.Insert(0, new PassengerViewPoint());
-                cabViewType = CabViewType.Rear;
-            }
+
             return new CabView3D(cvfFile, CabViewpoints, extendedCVF, cabViewType, noseAhead, shapeFilePath);
         }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -1639,7 +1639,7 @@ namespace Orts.Simulation.RollingStocks
             {
                 var loco = this as MSTSLocomotive;
                 var i = (int)CabViewType.Front;
-                if (loco == null || loco.CabView3D == null) return false;
+                if (loco == null || loco.CabView3D == null || loco.CabView3D.CabViewType != CabViewType.Front) return false;
                 return (loco.CabView3D.ViewPointList.Count > i);
             }
         }


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/24040-3d-cabs/page__view__findpost__p__264525
When a locomotive has only a 3D cab in rear but not in front, the cab change procedure handles the rear cab as a frontal cab, not setting the variable UsingRearCab correctly, so direction dependent controls like reverser aren't inverted.