### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1906786 - Approach Control doesn't work for non NORMAL signals

### DIFF
--- a/Source/Documentation/Manual/operation.rst
+++ b/Source/Documentation/Manual/operation.rst
@@ -1194,18 +1194,24 @@ has reduced its speed to a specific value. Such control is used for diverging
 routes, to ensure the speed of the train is reduced sufficiently to safely 
 negotiate the switches onto the diverging route.
 
-Two script functions for use in OR have been defined which can be used to 
+Three script functions for use in OR have been defined which can be used to
 control the signal until the train has reached a specific position or has 
 reduced its speed.
 
 These functions are::
 
     APPROACH_CONTROL_POSITION(position)
+    APPROACH_CONTROL_POSITION_FORCED(position)
     APPROACH_CONTROL_SPEED(position, speed)
 
 These functions are Boolean functions: the returned value is 'true' if a train 
-is approaching the signal and is within the required distance of the signal 
-and, for APPROACH_CONTROL_SPEED, has reduced its speed below the required values.
+is approaching the signal and is within the required distance of the signal and,
+for ``APPROACH_CONTROL_SPEED``, has reduced its speed below the required values.
+
+``APPROACH_CONTROL_POSITION_FORCED`` function is similar to
+``APPROACH_CONTROL_POSITION``, but it can be used with any type of signal.
+Meanwhile, ``APPROACH_CONTROL_POSITION`` requires NORMAL signals, and will
+only clear the signal if it is the train's next signal.
 
 Parameters :
 

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -11739,33 +11739,45 @@ namespace Orts.Simulation.Signalling
             }
 
             bool found = false;
+            bool isNormal = isSignalNormal();
             float distance = 0;
             int actDirection = enabledTrain.TrainRouteDirectionIndex;
             Train.TCSubpathRoute routePath = enabledTrain.Train.ValidRoute[actDirection];
             int actRouteIndex = routePath == null ? -1 : routePath.GetRouteIndex(enabledTrain.Train.PresentPosition[actDirection].TCSectionIndex, 0);
             if (actRouteIndex >= 0)
             {
-                float offset = 0;
+                float offset;
                 if (enabledTrain.TrainRouteDirectionIndex == 0)
                     offset = enabledTrain.Train.PresentPosition[0].TCOffset;
                 else
                     offset = signalRef.TrackCircuitList[enabledTrain.Train.PresentPosition[1].TCSectionIndex].Length - enabledTrain.Train.PresentPosition[1].TCOffset;
-                while (!found)
+                while (!found && actRouteIndex < routePath.Count)
                 {
                     Train.TCRouteElement thisElement = routePath[actRouteIndex];
                     TrackCircuitSection thisSection = signalRef.TrackCircuitList[thisElement.TCSectionIndex];
-                    distance += thisSection.Length - offset;
                     if (thisSection.EndSignals[thisElement.Direction] == this)
                     {
+                        distance += thisSection.Length - offset;
                         found = true;
                     }
-                    else
+                    else if (!isNormal)
                     {
+                        TrackCircuitSignalList thisSignalList = thisSection.CircuitItems.TrackCircuitSignals[thisElement.Direction][SignalHeads[0].ORTSsigFunctionIndex];
+                        foreach (TrackCircuitSignalItem thisSignal in thisSignalList.TrackCircuitItem)
+                        {
+                            if (thisSignal.SignalRef == this)
+                            {
+                                distance += thisSignal.SignalLocation - offset;
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!found)
+                    {
+                        distance += thisSection.Length - offset;
                         offset = 0;
-                        int setSection = thisSection.ActivePins[thisElement.OutPin[0], thisElement.OutPin[1]].Link;
                         actRouteIndex++;
-                        if (actRouteIndex >= routePath.Count || setSection < 0)
-                            break;
                     }
                 }
             }


### PR DESCRIPTION
Approach control is only available for NORMAL signals at the moment. This caused some route developers to set level crossing signals (which have to be cleared a fixed distance before the train passes them) as NORMAL signals, but that interferes with signalling logic. With this proposed changes approach_control_position_forced() will work for all signals.

I haven't extended this to approach_control_position() and approach_control_speed(), but if there are use cases I can do it.