### PR TITLE
Improvements for EP and air braking systems

### DIFF
--- a/Source/Documentation/Manual/cabs.rst
+++ b/Source/Documentation/Manual/cabs.rst
@@ -188,6 +188,39 @@ Here is an example of a cab light control block within the .cvf file::
 			      MouseControl ( 1 )
             )
 
+Dedicated buttons for brake controllers
+---------------------------------------
+
+.. index::
+    single: ORTS_BAILOFF
+
+In addition to the BailOff keyboard command, a cabview control named
+ORTS_BAILOFF is available. It is used to release the brakes of the engine
+while keeping the train brakes applied.
+
+.. index::
+    single: ORTS_QUICKRELEASE
+
+In some brake controllers, there is a button that provides a full and quick
+release of the train brake when pressed. OR supports this via the
+ORTS_QUICKRELEASE cabview control.
+
+.. index::
+    single: ORTS_OVERCHARGE
+
+Some brake controllers have a dedicated button to overcharge the brake pipe.
+The ORTS_OVERCHARGE cabview control can be used for this purpose.
+
+Here is an example of one of this controls within the .cvf file::
+
+			TwoState (
+            Type ( ORTS_BAILOFF TWO_STATE )
+			      Position ( 120 425 30 21 )
+			      Graphic ( BailOff.ace )
+			      NumFrames ( 2 2 1 )
+			      Style ( PRESSED )
+			      MouseControl ( 1 )
+            )
 
 Signed Traction Braking control
 -------------------------------

--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -1922,32 +1922,31 @@ Open Rails software has implemented its own braking physics in the
 current release. It is based on the Westinghouse 26C and 26F air brake
 and controller system. Open Rails braking will parse the type of braking
 from the .eng file to determine if the braking physics uses passenger or
-freight standards, self-lapping or not. This is controlled within the
-Options menu as shown in :ref:`General Options <options-general>` above.
+freight standards, self-lapping or not. 
 
-Selecting :ref:`Graduated Release Air Brakes <options-general>` in *Menu >
-Options* allows partial release of the brakes. Some 26C brake valves have a
-cut-off valve that has three positions: passenger, freight and cut-out. Checked
-is equivalent to passenger standard and unchecked is equivalent to freight
-standard.
+There are two different features regarding graduated release of brakes.
+If the train brake controller has a self-lapping notch that provides
+graduated release, then the amount of brake pressure can be adjusted up
+or down by changing the control in this notch. If the notch does not
+provide graduated release, then the brakes can only be increased in 
+this notch and one of the release positions is required to release the brakes.
+The list of notches that have graduated release can be found :ref:`here <physics-brake-controller>`.
 
-The *Graduated Release Air Brakes* option controls two different features.
-If the train brake controller has a self-lapping notch and the *Graduated
-Release Air Brakes* box is checked, then the amount of brake pressure can
-be adjusted up or down by changing the control in this notch. If the
-*Graduated Release Air Brakes* option is not checked, then the brakes can
-only be increased in this notch and one of the release positions is
-required to release the brakes.
-
-Another capability controlled by the *Graduated Release Air Brakes*
-checkbox is the behavior of the brakes on each car in the train. If the
-*Graduated Release Air Brakes* box is checked, then the brake cylinder
-pressure is regulated to keep it proportional to the difference between
-the emergency reservoir pressure and the brake pipe pressure. If the
-*Graduated Release Air Brakes* box is not checked and the brake pipe
-pressure rises above the auxiliary reservoir pressure, then the brake
+To achieve a graduated release, the brake valves in the train cars must
+have this capability. If the BrakeEquipmentType() parameter in the Wagon()
+section contains "Graduated_release_triple_valve" or "Distributor", then the 
+brake cylinder pressure is regulated to keep it proportional to the difference 
+between the emergency reservoir pressure and the brake pipe pressure. If the
+brake valve is a "Triple_valve" instead, when the brake pipe
+pressure rises above the auxiliary reservoir pressure, the brake
 cylinder pressure is released completely at a rate determined by the
 retainer setting.
+
+Selecting :ref:`Graduated Release Air Brakes <options-general>` in *Menu >
+Options* will force self-lapping notches in the brake controller to have
+graduated release. It will also force graduated release of brakes in triple
+valves. This option should be unchecked, except for compatibility problems
+with old MSTS stock.
 
 The following brake types are implemented in OR:
 
@@ -2291,6 +2290,7 @@ MaxAuxilaryChargingRate and EmergencyResChargingRate.
    single: ORTSEngineBrakeReleaseRate
    single: ORTSEngineBrakeApplicationRate
    single: ORTSBrakePipeChargingRate
+   single: ORTSBrakePipeQuickChargingRate
    single: ORTSBrakeServiceTimeFactor
    single: ORTSBrakeEmergencyTimeFactor
    single: ORTSBrakePipeTimeFactor
@@ -2317,6 +2317,9 @@ MaxAuxilaryChargingRate and EmergencyResChargingRate.
   (default 12.5).
 - ``Engine(ORTSBrakePipeChargingRate`` -- Rate of lead engine brake pipe
   pressure increase in PSI per second (default 21).
+- ``Engine(ORTSBrakePipeQuickChargingRate`` -- Rate of lead engine brake pipe
+  pressure increase in PSI per second during a quick release (by default
+  will be equal to ORTSBrakePipeChargingRate).
 - ``Engine(ORTSBrakeServiceTimeFactor`` -- Time in seconds for lead engine
   brake pipe pressure to drop to about 1/3 for service application
   (default 1.009).

--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -2005,10 +2005,12 @@ The following notch positions can be defined for the train brake at ``Engine(Eng
 .. index::
    single: TrainBrakesControllerFullQuickReleaseStart
    single: TrainBrakesControllerReleaseStart
-   single: TrainBrakesControllerOverchageStart
+   single: TrainBrakesControllerOverchargeStart
    single: TrainBrakesControllerApplyStart
+   single: TrainBrakesControllerSlowServiceStart
    single: TrainBrakesControllerFullServiceStart
    single: TrainBrakesControllerHoldStart
+   single: TrainBrakesControllerEPHoldStart
    single: TrainBrakesControllerSelfLapStart
    single: TrainBrakesControllerRunningStart
    single: TrainBrakesControllerMinimalReductionStart
@@ -2019,30 +2021,501 @@ The following notch positions can be defined for the train brake at ``Engine(Eng
    single: TrainBrakesControllerGraduatedSelfLapLimitedHoldingStart
    single: TrainBrakesControllerSuppressionStart
    single: TrainBrakesControllerContinuousServiceStart
-   single: EPApply
+   single: TrainBrakesControllerEPApplyStart
+   single: TrainBrakesControllerEPFullServiceStart
+   single: TrainBrakesControllerEPOnlyStart
    single: TrainBrakesControllerEmergencyStart
    single: Dummy
    single: ORTSTrainBrakesControllerMaxOverchargePressure
    single: ORTSTrainBrakesControllerOverchargeEliminationRate
-   single: TrainBrakesControllerMaxApplicationRate
-   single: TrainBrakesControllerMaxQuickReleaseRate
-   single: TrainBrakesControllerMaxReleaseRate
-   single: TrainBrakesControllerMinPressureReduction
-   single: TrainBrakesControllerMaxSystemPressure
+   single: ORTSTrainBrakesControllerSlowApplicationRate
 
-- ``FullQuickReleaseStart`` -- Increases pressure in equalizing reservoir (EQ) at a rate proportional to ``TrainBrakesControllerMaxQuickReleaseRate`` and controller position, releasing the brakes.
-- ``ReleaseStart`` -- same as above, but with a rate of ``TrainBrakesControllerMaxReleaseRate``.
-- ``OverchageStart`` -- Increases pressure in EQ over the maximum (``TrainBrakesControllerMaxSystemPressure``), up to ``ORTSTrainBrakesControllerMaxOverchargePressure``, to release stuck distributors. Setting the controller back to a release position will slowly return pressure to nominal value at a rate of ``ORTSTrainBrakesControllerOverchargeEliminationRate``.
-- ``ApplyStart`` -- Starts decreasing pressure in EQ at a rate proportional to ``TrainBrakesControllerMaxApplicationRate`` and controller position, down to full service pressure.
-- ``FullServiceStart`` -- Same as above, but also applies EP brakes if available.
-- ``HoldStart``, ``SelfLapStart`` and ``RunningStart`` -- Keep EQ pressure constant, maintaining brake pipe pressure.
-- ``MinimalReductionStart`` -- If previous notch position was Running, Release or QuickRelease, applies a minimal reduction to brake pipe pressure (defined by ``TrainBrakesControllerMinPressureReduction``).
-- ``HoldLappedStart`` -- Same as above, but isolates brake pipe from EQ reservoir. Brake pipe leakage is not compensated.
-- ``VaccumContinuousServiceStart`` and ``VaccumApplyContinuousService`` -- Set EQ pressure to a value from MaxPressure to 0, proportional to controller position.
-- ``GraduatedSelfLapStart``, ``GraduatedSelfLapHoldingStart`` and ``SuppressionStart`` -- Adjust EQ pressure to a value from (MaxPressure-MinimalReduction) to FullServicePressure, proportional to controller position. Depending on :ref:`Graduated Release Air Brakes <options-general>` option, EQ pressure can be increased to reduce brake application. ``Suppression`` should be a non-smooth notch used to suppress TCS brake application.
-- ``ContinuousServiceStart`` and ``EPApply`` -- Same as above, but also apply EP brakes if available.
-- ``EmergencyStart`` -- Quickly decreases EQ pressure and connects brake pipe to atmosphere, applying maximum braking.
-- ``Dummy`` -- Adjusts EQ pressure to a value from MaxPressure to FullServicePressure, proportional to controller position.
+.. table:: Brake Controller Tokens
+    :widths: 20 45 20 15
+
+    +-----------------+-----------------+-----------------+-----------+
+    | OR Brake Token  | Description     | Brake Systems   | Operation |
+    +-----------------+-----------------+-----------------+-----------+
+    | **RELEASE and RUNNING tokens**                                  |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | RELEASE or      | Air single pipe | Air       |
+    | Brakes |-|      | OVERCHARGE      |                 |           |
+    | Controller |-|  |                 | Air twin pipe   |           |
+    | Overcharge |-|  | Rapidly         |                 |           |
+    | Start           | releases air    | EP              |           |
+    |                 | brakes and      |                 |           |
+    |                 | charges air     |                 |           |
+    |                 | reservoirs.     |                 |           |
+    |                 |                 |                 |           |
+    |                 | Train brake     |                 |           |
+    |                 | pipe may be     |                 |           |
+    |                 | overcharged (up |                 |           |
+    |                 | to ORTS |-|     |                 |           |
+    |                 | Train |-|       |                 |           |
+    |                 | Brakes |-|      |                 |           |
+    |                 | Controller |-|  |                 |           |
+    |                 | Max |-|         |                 |           |
+    |                 | Overcharge |-|  |                 |           |
+    |                 | Pressure |-|    |                 |           |
+    |                 | and will        |                 |           |
+    |                 | gradually       |                 |           |
+    |                 | return to       |                 |           |
+    |                 | normal working  |                 |           |
+    |                 | pressure when   |                 |           |
+    |                 | the controller  |                 |           |
+    |                 | is moved to a   |                 |           |
+    |                 | release         |                 |           |
+    |                 | position (the   |                 |           |
+    |                 | rate will be    |                 |           |
+    |                 | determined by   |                 |           |
+    |                 | ORTS |-| Train  |                 |           |
+    |                 | Brakes |-|      |                 |           |
+    |                 | Controller |-|  |                 |           |
+    |                 | Overcharge |-|. |                 |           |
+    |                 | Elimination |-| |                 |           |
+    |                 | Rate            |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | RELEASE or      | Air single pipe | Air       |
+    | Brakes |-|      | QUICK RELEASE   |                 |           |
+    | Controller |-|  |                 | Air twin pipe   | EP        |
+    | Full |-| Quick  | Air brakes:     |                 |           |
+    | |-| Release |-| | Rapidly         | EP              | Vacuum    |
+    | Start           | releases air    |                 |           |
+    |                 | brakes and      | Vacuum single   |           |
+    |                 | charges air     | pipe            |           |
+    |                 | reservoirs,     |                 |           |
+    |                 | without         |                 |           |
+    |                 | overcharging    |                 |           |
+    |                 | the train pipe. |                 |           |
+    |                 |                 |                 |           |
+    |                 | EP brakes:      |                 |           |
+    |                 | Rapidly         |                 |           |
+    |                 | releases EP     |                 |           |
+    |                 | brakes.         |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes – |                 |           |
+    |                 | diesel and      |                 |           |
+    |                 | electric loco:  |                 |           |
+    |                 | Operates        |                 |           |
+    |                 | exhauster at    |                 |           |
+    |                 | fast speed.     |                 |           |
+    |                 | Rapidly         |                 |           |
+    |                 | releases vacuum |                 |           |
+    |                 | brakes and      |                 |           |
+    |                 | charges vacuum  |                 |           |
+    |                 | reservoirs.     |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes – |                 |           |
+    |                 | steam with      |                 |           |
+    |                 | combination     |                 |           |
+    |                 | ejector:        |                 |           |
+    |                 | Operates large  |                 |           |
+    |                 | ejector at full |                 |           |
+    |                 | power. Rapidly  |                 |           |
+    |                 | releases vacuum |                 |           |
+    |                 | brakes and      |                 |           |
+    |                 | charges vacuum  |                 |           |
+    |                 | reservoirs.     |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes – |                 |           |
+    |                 | steam with      |                 |           |
+    |                 | separate        |                 |           |
+    |                 | ejector:        |                 |           |
+    |                 | Connects brake  |                 |           |
+    |                 | pipe to         |                 |           |
+    |                 | ejector(s)      |                 |           |
+    |                 | and/or vacuum   |                 |           |
+    |                 | pump. Brakes    |                 |           |
+    |                 | may be released |                 |           |
+    |                 | by operating    |                 |           |
+    |                 | large or small  |                 |           |
+    |                 | ejector.        |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | RUNNING or      | Air single pipe | Air       |
+    | Brakes |-|      | RELEASE         |                 |           |
+    | Controller |-|  |                 | Air twin pipe   | EP        |
+    | Release |-|     | Air brakes:     |                 |           |
+    | Start           | Maintains       | EP              | Vacuum    |
+    |                 | working         |                 |           |
+    |                 | pressure in     | Vacuum single   |           |
+    |                 | train pipe.     | pipe            |           |
+    |                 | Slowly releases |                 |           |
+    |                 | brakes.         |                 |           |
+    |                 |                 |                 |           |
+    |                 | EP brakes:      |                 |           |
+    |                 | Releases        |                 |           |
+    |                 | brakes.         |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes – |                 |           |
+    |                 | diesel and      |                 |           |
+    |                 | electric loco:  |                 |           |
+    |                 | Connects brake  |                 |           |
+    |                 | pipe to         |                 |           |
+    |                 | exhauster.      |                 |           |
+    |                 | Maintains       |                 |           |
+    |                 | vacuum in train |                 |           |
+    |                 | pipe. Slowly    |                 |           |
+    |                 | releases        |                 |           |
+    |                 | brakes.         |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes – |                 |           |
+    |                 | steam with      |                 |           |
+    |                 | combination     |                 |           |
+    |                 | ejector:        |                 |           |
+    |                 | Operates large  |                 |           |
+    |                 | ejector at full |                 |           |
+    |                 | power. Rapidly  |                 |           |
+    |                 | releases vacuum |                 |           |
+    |                 | brakes and      |                 |           |
+    |                 | charges vacuum  |                 |           |
+    |                 | reservoirs.     |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes – |                 |           |
+    |                 | steam with      |                 |           |
+    |                 | separate        |                 |           |
+    |                 | ejector:        |                 |           |
+    |                 | Connects brake  |                 |           |
+    |                 | pipe to         |                 |           |
+    |                 | ejector(s)      |                 |           |
+    |                 | and/or vacuum   |                 |           |
+    |                 | pump. Brakes    |                 |           |
+    |                 | may be released |                 |           |
+    |                 | by operating    |                 |           |
+    |                 | large or small  |                 |           |
+    |                 | ejector.        |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | **LAP, HOLDING and NEUTRAL tokens**                             |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | LAP or RUNNING  | Air single pipe | Air       |
+    | Brakes |-|      |                 |                 |           |
+    | Controller |-|  | Air brakes:     | Air twin pipe   | EP        |
+    | Running |-|     | Train pipe      |                 |           |
+    | Start           | pressure is     | EP              | Vacuum    |
+    |                 | held at any     |                 |           |
+    |                 | pressure with   | Vacuum single   |           |
+    |                 | compensation    | pipe            |           |
+    |                 | for leakage.    |                 |           |
+    |                 |                 |                 |           |
+    |                 | EP brakes:      |                 |           |
+    |                 | Brake           |                 |           |
+    |                 | application is  |                 |           |
+    |                 | held at any     |                 |           |
+    |                 | value.          |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes – |                 |           |
+    |                 | diesel and      |                 |           |
+    |                 | electric loco:  |                 |           |
+    |                 | Train pipe      |                 |           |
+    |                 | vacuum is held  |                 |           |
+    |                 | at any value    |                 |           |
+    |                 | with            |                 |           |
+    |                 | compensation    |                 |           |
+    |                 | for leakage.    |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes – |                 |           |
+    |                 | steam with      |                 |           |
+    |                 | combination     |                 |           |
+    |                 | ejector:        |                 |           |
+    |                 | Connects brake  |                 |           |
+    |                 | pipe to small   |                 |           |
+    |                 | ejector and/or  |                 |           |
+    |                 | vacuum pump.    |                 |           |
+    |                 | Maintains       |                 |           |
+    |                 | vacuum. Brakes  |                 |           |
+    |                 | may be released |                 |           |
+    |                 | by operating    |                 |           |
+    |                 | small ejector.  |                 |           |
+    |                 |                 |                 |           |
+    |                 | (Vacuum brakes  |                 |           |
+    |                 | – steam with    |                 |           |
+    |                 | separate        |                 |           |
+    |                 | ejector:        |                 |           |
+    |                 | Connects brake  |                 |           |
+    |                 | pipe only to    |                 |           |
+    |                 | small ejector   |                 |           |
+    |                 | and/or vacuum   |                 |           |
+    |                 | pump.)          |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | LAP             | Air single pipe | Air       |
+    | Brakes |-|      |                 |                 |           |
+    | Controller |-|  | Air brakes:     | Air twin pipe   | EP        |
+    | Self |-| Lap    | Train pipe      |                 |           |
+    | |-| Start       | pressure is     | EP              | Vacuum    |
+    |                 | held at any     |                 |           |
+    |                 | pressure with   | Vacuum single   |           |
+    |                 | compensation    | pipe            |           |
+    |                 | for leakage.    |                 |           |
+    |                 |                 |                 |           |
+    |                 | EP brakes:      |                 |           |
+    |                 | Brake           |                 |           |
+    |                 | application is  |                 |           |
+    |                 | held at any     |                 |           |
+    |                 | value.          |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes:  |                 |           |
+    |                 | Train pipe      |                 |           |
+    |                 | vacuum is held  |                 |           |
+    |                 | with            |                 |           |
+    |                 | compensation    |                 |           |
+    |                 | for leakage.    |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | LAP – all brake | Air single pipe | Air       |
+    | Brakes |-|      | types held      |                 |           |
+    | Controller |-|  | without change  | Air twin pipe   | EP        |
+    | Hold |-| Start  | – legacy MSTS   |                 |           |
+    |                 | token           | EP              | Vacuum    |
+    |                 |                 |                 |           |
+    |                 |                 | Vacuum single   |           |
+    |                 |                 | pipe            |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train\ |-|\     | HOLD EP – EP    | EP              | EP        |
+    | Brakes\ |-|\    | brake setting   |                 |           |
+    | Controller\     | is held without |                 |           |
+    | |-|\ EP\ Hold   | influence on    |                 |           |
+    | |-|  Start      | train air pipe. |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | LAP or NEUTRAL  | Air single pipe | Air       |
+    | Brakes |-|      |                 |                 |           |
+    | Controller |-|  | Air brakes:     | Air twin pipe   | EP        |
+    | Hold |-| Lapped | Train pipe      |                 |           |
+    | |-| Start       | pressure is     | EP              | Vacuum    |
+    |                 | held without    |                 |           |
+    |                 | compensation    | Vacuum single   |           |
+    |                 | for leakage.    | pipe            |           |
+    |                 |                 |                 |           |
+    |                 | EP brakes:      |                 |           |
+    |                 | Brake           |                 |           |
+    |                 | application is  |                 |           |
+    |                 | held at any     |                 |           |
+    |                 | value.          |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes:  |                 |           |
+    |                 | Train pipe      |                 |           |
+    |                 | vacuum is held  |                 |           |
+    |                 | without         |                 |           |
+    |                 | compensation    |                 |           |
+    |                 | for leakage.    |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | LAP or NEUTRAL  | Air single pipe | Air       |
+    | Brakes |-|      |                 |                 |           |
+    | Controller |-|  | Air brakes:     | Air twin pipe   | EP        |
+    | Neutral |-|     | Train pipe      |                 |           |
+    | Handle |-| Off  | pressure is     | EP              | Vacuum    |
+    | |-| Start       | held without    |                 |           |
+    |                 | compensation    | Vacuum single   |           |
+    |                 | for leakage.    | pipe            |           |
+    |                 |                 |                 |           |
+    |                 | EP brakes:      |                 |           |
+    |                 | Brake           |                 |           |
+    |                 | application is  |                 |           |
+    |                 | held at any     |                 |           |
+    |                 | value.          |                 |           |
+    |                 |                 |                 |           |
+    |                 | Vacuum brakes:  |                 |           |
+    |                 | Train pipe      |                 |           |
+    |                 | vacuum is held  |                 |           |
+    |                 | without         |                 |           |
+    |                 | compensation    |                 |           |
+    |                 | for leakage.    |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | **SELF LAPPING APPLY tokens**                                   |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | INITIAL / FIRST | Air single pipe | Air       |
+    | Brakes |-|      | SERVICE         |                 |           |
+    | Controller |-|  |                 | Air twin pipe   | Vacuum    |
+    | Minimal |-|     | Notch. Train    |                 |           |
+    | Reduction |-|   | pipe pressure   | Vacuum single   |           |
+    | Start           | or vacuum is    | pipe            |           |
+    |                 | held at Minimum |                 |           |
+    |                 | Reduction       |                 |           |
+    |                 | value.          |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | INITIAL / FIRST | Air single pipe | Air       |
+    | Brakes |-|      | SERVICE << >>   |                 |           |
+    | Controller |-|  | FULL SERVICE    | Air twin pipe   |           |
+    | Graduated |-|   |                 |                 |           |
+    | Self |-| Lap    | Graduated       |                 |           |
+    | |-| Limited |-| | service         |                 |           |
+    | Start           | application and |                 |           |
+    |                 | release of air  |                 |           |
+    |                 | brakes only.    |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | INITIAL / FIRST | Air single pipe | Air       |
+    | Brakes |-|      | SERVICE >>>>    |                 |           |
+    | Controller |-|  | FULL SERVICE    | Air twin pipe   |           |
+    | Graduated |-|   |                 |                 |           |
+    | Self |-| Lap    | Graduated       |                 |           |
+    | |-| Limited |-| | service         |                 |           |
+    | Holding |-|     | application of  |                 |           |
+    | Start           | air brakes      |                 |           |
+    |                 | only. (Release  |                 |           |
+    |                 | is not          |                 |           |
+    |                 | graduable.)     |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | INITIAL / FIRST | Air single pipe | Air       |
+    | Brakes |-|      | SERVICE << >>   |                 |           |
+    | Controller |-|  | FULL SERVICE    | Air twin pipe   | EP        |
+    | EPApply |-|     |                 |                 |           |
+    | Start           | Graduated       | EP              |           |
+    |                 | service         |                 |           |
+    |                 | application and |                 |           |
+    |                 | release of air  |                 |           |
+    |                 | brakes and EP   |                 |           |
+    |                 | brakes.         |                 |           |
+    |                 |                 |                 |           |
+    |                 | Can be used for |                 |           |
+    |                 | notched         |                 |           |
+    |                 | controllers.    |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | INITIAL / FIRST | Air single pipe | Air       |
+    | Brakes |-|      | SERVICE >>>>    |                 |           |
+    | Controller |-|  | FULL SERVICE    | Air twin pipe   | EP        |
+    | Continuous |-|  |                 |                 |           |
+    | Service |-|     | Graduated       | EP              |           |
+    | Start           | service         |                 |           |
+    |                 | application of  |                 |           |
+    |                 | air brakes and  |                 |           |
+    |                 | EP brakes.      |                 |           |
+    |                 | (Release is not |                 |           |
+    |                 | graduable.)     |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | INITIAL / FIRST | EP              | EP        |
+    | Brakes |-|      | SERVICE << >>   |                 |           |
+    | Controller |-|  | FULL SERVICE    |                 |           |
+    | EPOnly |-|      |                 |                 |           |
+    | Start           | Graduated       |                 |           |
+    |                 | service         |                 |           |
+    |                 | application and |                 |           |
+    |                 | release of EP   |                 |           |
+    |                 | brakes only     |                 |           |
+    |                 | without         |                 |           |
+    |                 | reduction in    |                 |           |
+    |                 | air train pipe  |                 |           |
+    |                 | pressure.       |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | RUNNING << >>   | Vacuum single   | Vacuum    |
+    | Brakes |-|      | FULL SERVICE /  | pipe            |           |
+    | Controller |-|  | EMERGENCY       |                 |           |
+    | Vacuum |-|      |                 |                 |           |
+    | Continuous |-|  | Graduated       |                 |           |
+    | Service |-|     | application and |                 |           |
+    | Start           | release of      |                 |           |
+    |                 | vacuum brakes.  |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Dummy           | Train pipe      | Air single pipe | Air       |
+    |                 | pressure of     |                 |           |
+    |                 | vacuum can be   | Air twin pipe   | Vacuum    |
+    |                 | held at any     |                 |           |
+    |                 | value.          | Vacuum single   |           |
+    |                 |                 | pipe            |           |
+    |                 | Can be used for |                 |           |
+    |                 | notched         |                 |           |
+    |                 | controllers.    |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | **NON SELF LAPPING APPLY tokens**                               |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | FIRST SERVICE   | Air single pipe | Air       |
+    | Brakes |-|      | or SLOW APPLY   |                 |           |
+    | Controller |-|  |                 | Air twin pipe   | EP        |
+    | Slow |-|        | Notch. Train    |                 |           |
+    | Service |-|     | brakes are      | EP              |           |
+    | Start           | applied at a    |                 |           |
+    |                 | slow rate from  |                 |           |
+    |                 | minimal         |                 |           |
+    |                 | application     |                 |           |
+    |                 | until full      |                 |           |
+    |                 | service         |                 |           |
+    |                 | application.    |                 |           |
+    |                 | The rate is     |                 |           |
+    |                 | determined by   |                 |           |
+    |                 | ORTS |-| Train  |                 |           |
+    |                 | |-| Brakes |-|  |                 |           |
+    |                 | Controller |-|  |                 |           |
+    |                 | Slow |-|        |                 |           |
+    |                 | Application |-| |                 |           |
+    |                 | Rate in the     |                 |           |
+    |                 | .eng file.      |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | APPLY           | Air single pipe | Air       |
+    | Brakes |-|      |                 |                 |           |
+    | Controller |-|  | Notch. Train    | Air twin pipe   | EP        |
+    | Full |-|        | brakes are      |                 |           |
+    | Service |-|     | applied at the  | EP              |           |
+    | Start           | normal service  |                 |           |
+    |                 | rate from       |                 |           |
+    |                 | minimal         |                 |           |
+    |                 | application     |                 |           |
+    |                 | until full      |                 |           |
+    |                 | service         |                 |           |
+    |                 | application.    |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | EP APPLY        | EP              | EP        |
+    | Brakes |-|      |                 |                 |           |
+    | Controller |-|  | Notch. EP       |                 |           |
+    | EP |-| Full |-| | brakes are      |                 |           |
+    | Service |-|     | applied at the  |                 |           |
+    | Start           | normal service  |                 |           |
+    |                 | rate without    |                 |           |
+    |                 | reduction in    |                 |           |
+    |                 | air train pipe  |                 |           |
+    |                 | pressure.       |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | APPLY           | Air single pipe | Air       |
+    | Brakes |-|      |                 |                 |           |
+    | Controller |-|  | Notch. Train    | Air twin pipe   | EP        |
+    | Apply |-| Start | brakes are      |                 |           |
+    |                 | applied at the  | EP              | Vacuum    |
+    |                 | normal service  |                 |           |
+    |                 | rate from       | Vacuum single   |           |
+    |                 | minimal         | pipe            |           |
+    |                 | application     |                 |           |
+    |                 | until emergency |                 |           |
+    |                 | application.    |                 |           |
+    |                 |                 |                 |           |
+    |                 | (Vacuum brakes  |                 |           |
+    |                 | – steam: MSTS   |                 |           |
+    |                 | legacy          |                 |           |
+    |                 | controller is   |                 |           |
+    |                 | now replaced by |                 |           |
+    |                 | Train |-|       |                 |           |
+    |                 | Brakes |-|      |                 |           |
+    |                 | Controller |-|  |                 |           |
+    |                 | Vaccuum |-|     |                 |           |
+    |                 | Apply |-|       |                 |           |
+    |                 | Continuous |-|  |                 |           |
+    |                 | Service |-|     |                 |           |
+    |                 | Start)          |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | APPLY           | Vacuum single   | Vacuum    |
+    | Brakes |-|      |                 | pipe            |           |
+    | Controller |-|  | Range. The rate |                 |           |
+    | Vacuum |-|      | of the brake    |                 |           |
+    | Apply |-|       | application is  |                 |           |
+    | Continuous |-|  | determined by   |                 |           |
+    | ServiceStart    | the position of |                 |           |
+    |                 | the valve.      |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | EMERGENCY       | Air single pipe | Air       |
+    | Brakes |-|      |                 |                 |           |
+    | Controller |-|  | Notch. Makes a  | Air twin pipe   | EP        |
+    | Emergency |-|   | full emergency  |                 |           |
+    | Start           | application of  | EP              | Vacuum    |
+    |                 | brakes at the   |                 |           |
+    |                 | fastest         | Vacuum single   |           |
+    |                 | possible rate.  | pipe            |           |
+    +-----------------+-----------------+-----------------+-----------+
+    | **OTHER train brake controller tokens**                         |
+    +-----------------+-----------------+-----------------+-----------+
+    | Train |-|       | Cancels effect  | Air single pipe | Air       |
+    | Brakes |-|      | of penalty      |                 |           |
+    | Controller |-|  | brake           | Air twin pipe   | EP        |
+    | Suppression |-| | application by  |                 |           |
+    | Start           | TCS and         | EP              |           |
+    |                 | restores        |                 |           |
+    |                 | control of      |                 |           |
+    |                 | brakes to       |                 |           |
+    |                 | driver.         |                 |           |
+    +-----------------+-----------------+-----------------+-----------+
 
 .. _physics-hud-brake:
 

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -178,6 +178,9 @@ namespace Orts.Formats.Msts
         ORTS_SECONDDIAL,
 		ORTS_SIGNED_TRACTION_BRAKING,
         ORTS_SIGNED_TRACTION_TOTAL_BRAKING,
+        ORTS_BAILOFF,
+        ORTS_QUICKRELEASE,
+        ORTS_OVERCHARGE,
 
         // TCS Controls
         ORTS_TCS1,

--- a/Source/Orts.Simulation/Common/Commands.cs
+++ b/Source/Orts.Simulation/Common/Commands.cs
@@ -553,6 +553,52 @@ namespace Orts.Common
     }
 
     [Serializable()]
+    public sealed class QuickReleaseCommand : BooleanCommand
+    {
+        public static MSTSLocomotive Receiver { get; set; }
+
+        public QuickReleaseCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
+            Redo();
+        }
+
+        public override void Redo()
+        {
+            Receiver.TrainBrakeController.QuickReleaseButtonPressed = ToState;
+            // Report();
+        }
+
+        public override string ToString()
+        {
+            return base.ToString() + " - " + (ToState ? "off" : "on");
+        }
+    }
+
+    [Serializable()]
+    public sealed class BrakeOverchargeCommand : BooleanCommand
+    {
+        public static MSTSLocomotive Receiver { get; set; }
+
+        public BrakeOverchargeCommand(CommandLog log, bool toState)
+            : base(log, toState)
+        {
+            Redo();
+        }
+
+        public override void Redo()
+        {
+            Receiver.TrainBrakeController.OverchargeButtonPressed = ToState;
+            // Report();
+        }
+
+        public override string ToString()
+        {
+            return base.ToString() + " - " + (ToState ? "off" : "on");
+        }
+    }
+
+    [Serializable()]
     public sealed class HandbrakeCommand : BooleanCommand {
         public static MSTSLocomotive Receiver { get; set; }
 

--- a/Source/Orts.Simulation/Common/Scripting/BrakeController.cs
+++ b/Source/Orts.Simulation/Common/Scripting/BrakeController.cs
@@ -37,6 +37,14 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<bool> TCSFullServiceBraking;
         /// <summary>
+        /// True if the driver has pressed the Quick Release button
+        /// </summary>
+        public Func<bool> QuickReleaseButtonPressed;
+        /// <summary>
+        /// True if the driver has pressed the Overcharge button
+        /// </summary>
+        public Func<bool> OverchargeButtonPressed;
+        /// <summary>
         /// Main reservoir pressure
         /// </summary>
         public Func<float> MainReservoirPressureBar;

--- a/Source/Orts.Simulation/Common/Scripting/BrakeController.cs
+++ b/Source/Orts.Simulation/Common/Scripting/BrakeController.cs
@@ -222,10 +222,12 @@ namespace ORTS.Scripting.Api
         EBPB,               // Emergency Braking Push Button
         TCSEmergency,       // TCS Emergency Braking
         TCSFullServ,        // TCS Full Service Braking
-        VacContServ,         // TrainBrakesControllerVacuumContinuousServiceStart
-        VacApplyContServ,    // TrainBrakesControllerVacuumApplyContinuousServiceStart
-        ManualBraking,        // BrakemanBrakesControllerManualBraking
-        BrakeNotch           // EngineBrakesControllerBrakeNotchStart
+        VacContServ,        // TrainBrakesControllerVacuumContinuousServiceStart
+        VacApplyContServ,   // TrainBrakesControllerVacuumApplyContinuousServiceStart
+        ManualBraking,      // BrakemanBrakesControllerManualBraking
+        BrakeNotch,         // EngineBrakesControllerBrakeNotchStart
+        EPOnly,             // TrainBrakesControllerEPOnlyStart
+        EPFullServ,         // TrainBrakesControllerEPFullServiceStart
     };
 
     public static class ControllerStateDictionary
@@ -258,7 +260,9 @@ namespace ORTS.Scripting.Api
             {ControllerState.VacContServ, Catalog.GetString("Vac. Cont. Service")},
             {ControllerState.VacApplyContServ, Catalog.GetString("Vac. Apply Cont. Service")},
             {ControllerState.ManualBraking, Catalog.GetString("Manual Braking")},
-            {ControllerState.BrakeNotch, Catalog.GetString("Notch")}
+            {ControllerState.BrakeNotch, Catalog.GetString("Notch")},
+            {ControllerState.EPOnly, Catalog.GetString("EP Service")},
+            {ControllerState.EPFullServ, Catalog.GetString("EP Full Service")}
         };
     }
 }

--- a/Source/Orts.Simulation/Common/Scripting/BrakeController.cs
+++ b/Source/Orts.Simulation/Common/Scripting/BrakeController.cs
@@ -61,6 +61,10 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> OverchargeEliminationRateBarpS;
         /// <summary>
+        /// Slow application rate of the equalizing reservoir
+        /// </summary>
+        public Func<float> SlowApplicationRateBarpS;
+        /// <summary>
         /// Apply rate of the equalizing reservoir
         /// </summary>
         public Func<float> ApplyRateBarpS;
@@ -228,6 +232,7 @@ namespace ORTS.Scripting.Api
         BrakeNotch,         // EngineBrakesControllerBrakeNotchStart
         EPOnly,             // TrainBrakesControllerEPOnlyStart
         EPFullServ,         // TrainBrakesControllerEPFullServiceStart
+        SlowService,        // TrainBrakesControllerSlowServiceStart
     };
 
     public static class ControllerStateDictionary
@@ -262,7 +267,8 @@ namespace ORTS.Scripting.Api
             {ControllerState.ManualBraking, Catalog.GetString("Manual Braking")},
             {ControllerState.BrakeNotch, Catalog.GetString("Notch")},
             {ControllerState.EPOnly, Catalog.GetString("EP Service")},
-            {ControllerState.EPFullServ, Catalog.GetString("EP Full Service")}
+            {ControllerState.EPFullServ, Catalog.GetString("EP Full Service")},
+            {ControllerState.SlowService, Catalog.GetString("Slow service")}
         };
     }
 }

--- a/Source/Orts.Simulation/Common/Scripting/BrakeController.cs
+++ b/Source/Orts.Simulation/Common/Scripting/BrakeController.cs
@@ -113,6 +113,10 @@ namespace ORTS.Scripting.Api
         /// Sets the state of the brake pressure (1 = increasing, -1 = decreasing)
         /// </summary>
         public Action<float> SetUpdateValue;
+        /// <summary>
+        /// Sets the dynamic brake intervention value
+        /// </summary>
+        public Action<float> SetDynamicBrakeIntervention;
 
         /// <summary>
         /// Called once at initialization time.

--- a/Source/Orts.Simulation/Common/Scripting/Common.cs
+++ b/Source/Orts.Simulation/Common/Scripting/Common.cs
@@ -36,6 +36,10 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> DistanceM;
         /// <summary>
+        /// Train's actual absolute speed.
+        /// </summary>
+        public Func<float> SpeedMpS;
+        /// <summary>
         /// Confirms a command done by the player with a pre-set message on the screen.
         /// </summary>
         public Action<CabControl, CabSetting> Confirm;

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -143,10 +143,6 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<float> TrainLengthM;
         /// <summary>
-        /// Train's actual absolute speed.
-        /// </summary>
-        public Func<float> SpeedMpS;
-        /// <summary>
         /// Locomotive direction.
         /// </summary>
         public Func<Direction> CurrentDirection;

--- a/Source/Orts.Simulation/Simulation/Confirmer.cs
+++ b/Source/Orts.Simulation/Simulation/Confirmer.cs
@@ -84,6 +84,8 @@ namespace Orts.Simulation
       , Handbrake
       , Retainers
       , BrakeHose
+      , QuickRelease
+      , Overcharge
       // Cab Devices
       , Sander
       , Alerter
@@ -223,7 +225,9 @@ namespace Orts.Simulation
                 , new string [] { GetString("Brakes"), GetString("initialize"), null, null, null, null, GetString("cannot initialize. Stop train then re-try.") } 
                 , new string [] { GetString("Handbrake"), GetString("none"), null, GetString("full") } 
                 , new string [] { GetString("Retainers"), GetString("off"), null, GetString("on"), null, null, null, null, GetString("Exhaust"), GetString("High Pressure"), GetString("Low Pressure"), GetString("Slow Direct") } 
-                , new string [] { GetString("Brake Hose"), GetString("disconnect"), null, GetString("connect") } 
+                , new string [] { GetString("Brake Hose"), GetString("disconnect"), null, GetString("connect") }
+                , new string [] { GetString("Quick Release"), GetString("off"), null, GetString("on") }
+                , new string [] { GetString("Overcharge"), GetString("off"), null, GetString("on") }
                 // Cab Devices
                 , new string [] { GetString("Sander"), GetString("off"), null, GetString("on") } 
                 , new string [] { GetString("Alerter"), GetString("acknowledge"), null, GetParticularString("Alerter", "sound") } 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -311,6 +311,7 @@ namespace Orts.Simulation.RollingStocks
         public float BrakeServiceTimeFactorS;
         public float BrakeEmergencyTimeFactorS;
         public float BrakePipeChargingRatePSIorInHgpS;
+        public float BrakePipeQuickChargingRatePSIpS;
         public InterpolatorDiesel2D TractiveForceCurves;
         public InterpolatorDiesel2D DynamicBrakeForceCurves;
         public float DynamicBrakeSpeed1MpS = MpS.FromKpH(5);
@@ -818,6 +819,7 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(ortsbrakeservicetimefactor": BrakeServiceTimeFactorS = stf.ReadFloatBlock(STFReader.UNITS.Time, null); break;
                 case "engine(ortsbrakeemergencytimefactor": BrakeEmergencyTimeFactorS = stf.ReadFloatBlock(STFReader.UNITS.Time, null); break;
                 case "engine(ortsbrakepipechargingrate": BrakePipeChargingRatePSIorInHgpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null); break;
+                case "engine(ortsbrakepipequickchargingrate": BrakePipeQuickChargingRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null); break;
                 case "engine(ortsbrakepipedischargetimemult": BrakePipeDischargeTimeFactor = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;
                 case "engine(ortsmaxtractiveforcecurves": TractiveForceCurves = new InterpolatorDiesel2D(stf, false); TractiveForceCurves.HasNegativeValue();  break;
                 case "engine(ortstractioncharacteristics": TractiveForceCurves = new InterpolatorDiesel2D(stf, true); break;
@@ -1272,6 +1274,8 @@ namespace Orts.Simulation.RollingStocks
                     BrakePipeChargingRatePSIorInHgpS = Simulator.Settings.BrakePipeChargingRate; // Air brakes
                 }
             }
+            // Initialise Brake Pipe Quick Charging Rate
+            if (BrakePipeQuickChargingRatePSIpS == 0) BrakePipeQuickChargingRatePSIpS = BrakePipeChargingRatePSIorInHgpS;
 
             // Initialise Exhauster Charging rate in diesel and electric locomotives. The equivalent ejector charging rates are set in the steam locomotive.
             if (this is MSTSDieselLocomotive || this is MSTSElectricLocomotive)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -2823,7 +2823,7 @@ namespace Orts.Simulation.RollingStocks
 
         public void StartThrottleIncrease()
         {
-            if (DynamicBrakePercent >= 0 || !(DynamicBrakePercent == -1 && !DynamicBrake || DynamicBrakePercent >= 0 && DynamicBrake))
+            if (DynamicBrakeController != null && DynamicBrakeController.CurrentValue >= 0 && (DynamicBrakePercent >= 0 || !(DynamicBrakePercent == -1 && !DynamicBrake || DynamicBrakePercent >= 0 && DynamicBrake)))
             {
                 if (!(CombinedControlType == CombinedControl.ThrottleDynamic
                     || CombinedControlType == CombinedControl.ThrottleAir && TrainBrakeController.CurrentValue > 0))

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -4438,6 +4438,21 @@ namespace Orts.Simulation.RollingStocks
                         data = (TrainBrakeController == null) ? 0.0f : TrainBrakeController.CurrentValue;
                         break;
                     }
+                case CABViewControlTypes.ORTS_BAILOFF:
+                    {
+                        data = BailOff ? 1 : 0;
+                        break;
+                    }
+                case CABViewControlTypes.ORTS_QUICKRELEASE:
+                    {
+                        data = (TrainBrakeController == null || !TrainBrakeController.QuickReleaseButtonPressed) ? 0 : 1;
+                        break;
+                    }
+                case CABViewControlTypes.ORTS_OVERCHARGE:
+                    {
+                        data = (TrainBrakeController == null || !TrainBrakeController.OverchargeButtonPressed) ? 0 : 1;
+                        break;
+                    }
                 case CABViewControlTypes.FRICTION_BRAKING:
                     {
                         data = (BrakeSystem == null) ? 0.0f : BrakeSystem.GetCylPressurePSI();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -767,6 +767,7 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(trainbrakescontrolleremergencyapplicationrate":
                 case "engine(trainbrakescontrollerfullservicepressuredrop":
                 case "engine(trainbrakescontrollerminpressurereduction":
+                case "engine(ortstrainbrakescontrollerslowapplicationrate":
                 case "engine(ortstrainbrakecontroller":
                 case "engine(enginecontrollers(brake_train":
                     TrainBrakeController.Parse(lowercasetoken, stf);
@@ -780,6 +781,7 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(enginebrakescontrolleremergencyapplicationrate":
                 case "engine(enginebrakescontrollerfullservicepressuredrop":
                 case "engine(enginebrakescontrollerminpressurereduction":
+                case "engine(ortsenginebrakescontrollerslowapplicationrate":
                 case "engine(enginecontrollers(brake_engine":
                 case "engine(ortsenginebrakecontroller":
                     EngineBrakeController.Parse(lowercasetoken, stf);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -619,54 +619,57 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
                     if (lead != null)
                     {
-                            // Allow for leaking train air brakepipe
-                            if (lead.BrakeSystem.BrakeLine1PressurePSI - TrainPipeLeakLossPSI > 0 && lead.TrainBrakePipeLeakPSIorInHgpS != 0) // if train brake pipe has pressure in it, ensure result will not be negative if loss is subtracted
-                            {
-                                lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipeLeakLossPSI;
-                            }
-
-                            // Charge train brake pipe - adjust main reservoir pressure, and lead brake pressure line to maintain brake pipe equal to equalising resevoir pressure - release brakes
-                        if (lead.BrakeSystem.BrakeLine1PressurePSI < train.EqualReservoirPressurePSIorInHg)
+                        // Allow for leaking train air brakepipe
+                        if (lead.BrakeSystem.BrakeLine1PressurePSI - TrainPipeLeakLossPSI > 0 && lead.TrainBrakePipeLeakPSIorInHgpS != 0) // if train brake pipe has pressure in it, ensure result will not be negative if loss is subtracted
                         {
-                            // Calculate change in brake pipe pressure between equalising reservoir and lead brake pipe
-                            float PressureDiffEqualToPipePSI = TrainPipeTimeVariationS * lead.BrakePipeChargingRatePSIorInHgpS; // default condition - if EQ Res is higher then Brake Pipe Pressure
-
-                            if (lead.BrakeSystem.BrakeLine1PressurePSI + PressureDiffEqualToPipePSI > train.EqualReservoirPressurePSIorInHg) 
-                                PressureDiffEqualToPipePSI = train.EqualReservoirPressurePSIorInHg - lead.BrakeSystem.BrakeLine1PressurePSI;
-
-                            if (lead.BrakeSystem.BrakeLine1PressurePSI + PressureDiffEqualToPipePSI > lead.MainResPressurePSI)
-                                PressureDiffEqualToPipePSI = lead.MainResPressurePSI - lead.BrakeSystem.BrakeLine1PressurePSI;
-
-                            if (PressureDiffEqualToPipePSI < 0)
-                                PressureDiffEqualToPipePSI = 0;
-
-                            // Adjust brake pipe pressure based upon pressure differential
-                            if (lead.TrainBrakePipeLeakPSIorInHgpS == 0)  // Train pipe leakage disabled (ie. No Train Leakage parameter present in ENG file)
-                            {
-                                lead.BrakeSystem.BrakeLine1PressurePSI += PressureDiffEqualToPipePSI;
-                                lead.MainResPressurePSI -= PressureDiffEqualToPipePSI * lead.BrakeSystem.BrakePipeVolumeM3 / lead.MainResVolumeM3;
-                            }
-                            else
-                            // Train pipe leakage is enabled (ie. ENG file parameter present)
-                            {
-                                // If pipe leakage and brake control valve is in LAP position then pipe is connected to main reservoir and maintained at equalising pressure from reservoir
-                                // All other brake states will have the brake pipe connected to the main reservoir, and therefore leakage will be compenstaed by air from main reservoir
-                                // Modern self lap brakes will maintain pipe pressure using air from main reservoir
-
-                                if (lead.TrainBrakeController.TrainBrakeControllerState != ControllerState.Lap)
-                                {
-                                    lead.BrakeSystem.BrakeLine1PressurePSI += PressureDiffEqualToPipePSI;  // Increase brake pipe pressure to cover loss
-                                    lead.MainResPressurePSI = lead.MainResPressurePSI - (PressureDiffEqualToPipePSI * lead.BrakeSystem.BrakePipeVolumeM3 / lead.MainResVolumeM3);   // Decrease main reservoir pressure
-                                }
-                                    // else in LAP psoition brake pipe is isolated, and thus brake pipe pressure decreases, but reservoir remains at same pressure
-                            }
+                            lead.BrakeSystem.BrakeLine1PressurePSI -= TrainPipeLeakLossPSI;
                         }
-                        // reduce pressure in lead brake line if brake pipe pressure is above equalising pressure - apply brakes
-                        else if (lead.BrakeSystem.BrakeLine1PressurePSI > train.EqualReservoirPressurePSIorInHg)
+
+                        if (lead.TrainBrakeController.TrainBrakeControllerState != ControllerState.Neutral)
                         {
-                            float ServiceVariationFactor = (1 - TrainPipeTimeVariationS / serviceTimeFactor);
-                            ServiceVariationFactor = MathHelper.Clamp(ServiceVariationFactor, 0.05f, 1.0f); // Keep factor within acceptable limits - prevent value from going negative
-                            lead.BrakeSystem.BrakeLine1PressurePSI *= ServiceVariationFactor;
+                            // Charge train brake pipe - adjust main reservoir pressure, and lead brake pressure line to maintain brake pipe equal to equalising resevoir pressure - release brakes
+                            if (lead.BrakeSystem.BrakeLine1PressurePSI < train.EqualReservoirPressurePSIorInHg)
+                            {
+                                // Calculate change in brake pipe pressure between equalising reservoir and lead brake pipe
+                                float PressureDiffEqualToPipePSI = TrainPipeTimeVariationS * lead.BrakePipeChargingRatePSIorInHgpS; // default condition - if EQ Res is higher then Brake Pipe Pressure
+
+                                if (lead.BrakeSystem.BrakeLine1PressurePSI + PressureDiffEqualToPipePSI > train.EqualReservoirPressurePSIorInHg)
+                                    PressureDiffEqualToPipePSI = train.EqualReservoirPressurePSIorInHg - lead.BrakeSystem.BrakeLine1PressurePSI;
+
+                                if (lead.BrakeSystem.BrakeLine1PressurePSI + PressureDiffEqualToPipePSI > lead.MainResPressurePSI)
+                                    PressureDiffEqualToPipePSI = lead.MainResPressurePSI - lead.BrakeSystem.BrakeLine1PressurePSI;
+
+                                if (PressureDiffEqualToPipePSI < 0)
+                                    PressureDiffEqualToPipePSI = 0;
+
+                                // Adjust brake pipe pressure based upon pressure differential
+                                if (lead.TrainBrakePipeLeakPSIorInHgpS == 0)  // Train pipe leakage disabled (ie. No Train Leakage parameter present in ENG file)
+                                {
+                                    lead.BrakeSystem.BrakeLine1PressurePSI += PressureDiffEqualToPipePSI;
+                                    lead.MainResPressurePSI -= PressureDiffEqualToPipePSI * lead.BrakeSystem.BrakePipeVolumeM3 / lead.MainResVolumeM3;
+                                }
+                                else
+                                // Train pipe leakage is enabled (ie. ENG file parameter present)
+                                {
+                                    // If pipe leakage and brake control valve is in LAP position then pipe is connected to main reservoir and maintained at equalising pressure from reservoir
+                                    // All other brake states will have the brake pipe connected to the main reservoir, and therefore leakage will be compenstaed by air from main reservoir
+                                    // Modern self lap brakes will maintain pipe pressure using air from main reservoir
+
+                                    if (lead.TrainBrakeController.TrainBrakeControllerState != ControllerState.Lap)
+                                    {
+                                        lead.BrakeSystem.BrakeLine1PressurePSI += PressureDiffEqualToPipePSI;  // Increase brake pipe pressure to cover loss
+                                        lead.MainResPressurePSI = lead.MainResPressurePSI - (PressureDiffEqualToPipePSI * lead.BrakeSystem.BrakePipeVolumeM3 / lead.MainResVolumeM3);   // Decrease main reservoir pressure
+                                    }
+                                    // else in LAP psoition brake pipe is isolated, and thus brake pipe pressure decreases, but reservoir remains at same pressure
+                                }
+                            }
+                            // reduce pressure in lead brake line if brake pipe pressure is above equalising pressure - apply brakes
+                            else if (lead.BrakeSystem.BrakeLine1PressurePSI > train.EqualReservoirPressurePSIorInHg)
+                            {
+                                float ServiceVariationFactor = (1 - TrainPipeTimeVariationS / serviceTimeFactor);
+                                ServiceVariationFactor = MathHelper.Clamp(ServiceVariationFactor, 0.05f, 1.0f); // Keep factor within acceptable limits - prevent value from going negative
+                                lead.BrakeSystem.BrakeLine1PressurePSI *= ServiceVariationFactor;
+                            }
                         }
 
                         train.LeadPipePressurePSI = lead.BrakeSystem.BrakeLine1PressurePSI;  // Keep a record of current train pipe pressure in lead locomotive

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -398,6 +398,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     dp = MaxCylPressurePSI - AutoCylPressurePSI;
                 if (BrakeLine1PressurePSI > AuxResPressurePSI - dp / AuxCylVolumeRatio && !BleedOffValveOpen)
                     dp = (AuxResPressurePSI - BrakeLine1PressurePSI) * AuxCylVolumeRatio;
+                if (dp < 0)
+                    dp = 0;
 
                 AuxResPressurePSI -= dp / AuxCylVolumeRatio;
                 AutoCylPressurePSI += dp;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -88,7 +88,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             DebugType = "1P";
 
             // Force graduated releasable brakes. Workaround for MSTS with bugs preventing to set eng/wag files correctly for this.
-            (Car as MSTSWagon).DistributorPresent = Car.Simulator.Settings.GraduatedRelease;
+            (Car as MSTSWagon).DistributorPresent |= Car.Simulator.Settings.GraduatedRelease;
 
             if (Car.Simulator.Settings.RetainersOnAllCars && !(Car is MSTSLocomotive))
                 (Car as MSTSWagon).RetainerPositions = 4;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -633,7 +633,12 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                             if (lead.BrakeSystem.BrakeLine1PressurePSI < train.EqualReservoirPressurePSIorInHg)
                             {
                                 // Calculate change in brake pipe pressure between equalising reservoir and lead brake pipe
-                                float PressureDiffEqualToPipePSI = TrainPipeTimeVariationS * lead.BrakePipeChargingRatePSIorInHgpS; // default condition - if EQ Res is higher then Brake Pipe Pressure
+                                float chargingRatePSIpS = lead.BrakePipeChargingRatePSIorInHgpS;
+                                if (lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.FullQuickRelease || lead.TrainBrakeController.TrainBrakeControllerState == ControllerState.Overcharge)
+                                {
+                                    chargingRatePSIpS = lead.BrakePipeQuickChargingRatePSIpS;
+                                }
+                                float PressureDiffEqualToPipePSI = TrainPipeTimeVariationS * chargingRatePSIpS; // default condition - if EQ Res is higher then Brake Pipe Pressure
 
                                 if (lead.BrakeSystem.BrakeLine1PressurePSI + PressureDiffEqualToPipePSI > train.EqualReservoirPressurePSIorInHg)
                                     PressureDiffEqualToPipePSI = train.EqualReservoirPressurePSIorInHg - lead.BrakeSystem.BrakeLine1PressurePSI;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/EPBrakeSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/EPBrakeSystem.cs
@@ -43,7 +43,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             }
             else
             {
-                demandedAutoCylPressurePSI = Math.Min(Math.Max(Car.Train.BrakeLine4, 0), 1) * FullServPressurePSI;
+                demandedAutoCylPressurePSI = Math.Min(Math.Max(Car.Train.BrakeLine4, 0), 1) * MaxCylPressurePSI;
                 HoldingValve = AutoCylPressurePSI <= demandedAutoCylPressurePSI ? ValveState.Lap : ValveState.Release;
             }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/EPBrakeSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/EPBrakeSystem.cs
@@ -32,9 +32,20 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
         public override void Update(float elapsedClockSeconds)
         {
-            var demandedAutoCylPressurePSI = Math.Min(Math.Max(Car.Train.BrakeLine4, 0), 1) * FullServPressurePSI;
-            if (BrakeLine3PressurePSI >= 1000f) demandedAutoCylPressurePSI = 0;
-            HoldingValve = AutoCylPressurePSI <= demandedAutoCylPressurePSI ? ValveState.Lap : ValveState.Release;
+            float demandedAutoCylPressurePSI = 0;
+            if (BrakeLine3PressurePSI >= 1000f || Car.Train.BrakeLine4 < 0)
+            {
+                HoldingValve = ValveState.Release;
+            }
+            else if (Car.Train.BrakeLine4 == 0)
+            {
+                HoldingValve = ValveState.Lap;
+            }
+            else
+            {
+                demandedAutoCylPressurePSI = Math.Min(Math.Max(Car.Train.BrakeLine4, 0), 1) * FullServPressurePSI;
+                HoldingValve = AutoCylPressurePSI <= demandedAutoCylPressurePSI ? ValveState.Lap : ValveState.Release;
+            }
 
             base.Update(elapsedClockSeconds);
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
@@ -153,6 +153,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             QuickReleaseRatePSIpS = 10;
             OverchargeEliminationRatePSIpS = 0.036f;
             ApplyRatePSIpS = 2;
+            SlowApplicationRatePSIpS = 1;
             EmergencyRatePSIpS = 10;
             FullServReductionPSI = 26;
             MinReductionPSI = 6;
@@ -170,6 +171,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             QuickReleaseRatePSIpS = controller.QuickReleaseRatePSIpS;
             OverchargeEliminationRatePSIpS = controller.OverchargeEliminationRatePSIpS;
             ApplyRatePSIpS = controller.ApplyRatePSIpS;
+            SlowApplicationRatePSIpS = controller.SlowApplicationRatePSIpS;
             EmergencyRatePSIpS = controller.EmergencyRatePSIpS;
             FullServReductionPSI = controller.FullServReductionPSI;
             MinReductionPSI = controller.MinReductionPSI;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
@@ -125,7 +125,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
         {
             get
             {
-                return Notches.Count > 0 ? Notches[CurrentNotch].Type : ControllerState.Dummy;
+                if (Script is MSTSBrakeController)
+                    return Notches.Count > 0 ? Notches[CurrentNotch].Type : ControllerState.Dummy;
+                else
+                    return Script.GetState();
             }
         }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
@@ -302,6 +302,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 Script.ClockTime = () => (float)Simulator.ClockTime;
                 Script.GameTime = () => (float)Simulator.GameTime;
                 Script.DistanceM = () => Locomotive.DistanceM;
+                Script.SpeedMpS = () => Math.Abs(Locomotive.SpeedMpS);
 
                 // BrakeController
                 Script.EmergencyBrakingPushButton = () => EmergencyBrakingPushButton;
@@ -334,6 +335,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
 
                 Script.SetCurrentValue = (value) => CurrentValue = value;
                 Script.SetUpdateValue = (value) => UpdateValue = value;
+
+                Script.SetDynamicBrakeIntervention = (value) =>
+                {
+                    // TODO: Set dynamic brake intervention instead of controller position
+                    // There are some issues that need to be identified and fixed before setting the intervention directly
+                    if (Locomotive.DynamicBrakeController == null) return;
+                    Locomotive.DynamicBrakeChangeActiveState(value > 0);
+                    Locomotive.DynamicBrakeController.SetValue(value);
+                };
 
                 Script.Initialize();
             }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
@@ -106,6 +106,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
         public float ReleaseRatePSIpS { get; private set; }
         public float QuickReleaseRatePSIpS { get; private set; }
         public float OverchargeEliminationRatePSIpS { get; private set; }
+        public float SlowApplicationRatePSIpS { get; private set; }
         public float ApplyRatePSIpS { get; private set; }
         public float EmergencyRatePSIpS { get; private set; }
         public float FullServReductionPSI { get; private set; }
@@ -242,6 +243,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                     MinReductionPSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, null);
                     break;
 
+                case "engine(ortstrainbrakescontrollerslowapplicationrate":
+                case "engine(ortsenginebrakescontrollerslowapplicationrate":
+                    SlowApplicationRatePSIpS = stf.ReadFloatBlock(STFReader.UNITS.PressureRateDefaultPSIpS, null);
+                    break;
+
                 case "engine(enginecontrollers(brake_train":
                 case "engine(enginecontrollers(brake_engine":
                 case "engine(enginecontrollers(brake_brakeman":
@@ -314,6 +320,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 Script.ReleaseRateBarpS = () => BarpS.FromPSIpS(ReleaseRatePSIpS);
                 Script.QuickReleaseRateBarpS = () => BarpS.FromPSIpS(QuickReleaseRatePSIpS);
                 Script.OverchargeEliminationRateBarpS = () => BarpS.FromPSIpS(OverchargeEliminationRatePSIpS);
+                Script.SlowApplicationRateBarpS = () => BarpS.FromPSIpS(SlowApplicationRatePSIpS);
                 Script.ApplyRateBarpS = () => BarpS.FromPSIpS(ApplyRatePSIpS);
                 Script.EmergencyRateBarpS = () => BarpS.FromPSIpS(EmergencyRatePSIpS);
                 Script.FullServReductionBar = () => Bar.FromPSI(FullServReductionPSI);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
@@ -38,6 +38,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
         private bool emergencyBrakingPushButton = false;
         private bool tcsEmergencyBraking = false;
         private bool tcsFullServiceBraking = false;
+        private bool overchargeButtonPressed = false;
+        private bool quickReleaseButtonPressed = false;
         public bool EmergencyBraking
         {
             get
@@ -98,6 +100,44 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 }
 
                 tcsFullServiceBraking = value;
+            }
+        }
+        public bool QuickReleaseButtonPressed
+        {
+            get
+            {
+                return quickReleaseButtonPressed;
+            }
+            set
+            {
+                if (Simulator.Confirmer != null)
+                {
+                    if (value && !quickReleaseButtonPressed)
+                        Simulator.Confirmer.Confirm(CabControl.QuickRelease, CabSetting.On);
+                    else if (!value && quickReleaseButtonPressed)
+                        Simulator.Confirmer.Confirm(CabControl.QuickRelease, CabSetting.Off);
+                }
+
+                quickReleaseButtonPressed = value;
+            }
+        }
+        public bool OverchargeButtonPressed
+        {
+            get
+            {
+                return overchargeButtonPressed;
+            }
+            set
+            {
+                if (Simulator.Confirmer != null)
+                {
+                    if (value && !overchargeButtonPressed)
+                        Simulator.Confirmer.Confirm(CabControl.Overcharge, CabSetting.On);
+                    else if (!value && overchargeButtonPressed)
+                        Simulator.Confirmer.Confirm(CabControl.Overcharge, CabSetting.Off);
+                }
+
+                overchargeButtonPressed = value;
             }
         }
 
@@ -310,6 +350,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 Script.EmergencyBrakingPushButton = () => EmergencyBrakingPushButton;
                 Script.TCSEmergencyBraking = () => TCSEmergencyBraking;
                 Script.TCSFullServiceBraking = () => TCSFullServiceBraking;
+                Script.QuickReleaseButtonPressed = () => QuickReleaseButtonPressed;
+                Script.OverchargeButtonPressed = () => OverchargeButtonPressed;
 
                 Script.MainReservoirPressureBar = () =>
                 {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
@@ -118,11 +118,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                             IncreasePressure(ref pressureBar, Math.Min(MaxOverchargePressureBar(), MainReservoirPressureBar()), QuickReleaseRateBarpS(), elapsedClockSeconds);
                             epState = -1;
                             break;
+                        case ControllerState.SlowService:
+                            pressureBar -= x * SlowApplicationRateBarpS() * elapsedClockSeconds;
+                            break;
                         case ControllerState.Apply:
                             pressureBar -= x * ApplyRateBarpS() * elapsedClockSeconds;
                             break;
                         case ControllerState.FullServ:
                             epState = x;
+                            DecreasePressure(ref pressureBar, MaxPressureBar() - MinReductionBar(), ReleaseRateBarpS(), elapsedClockSeconds);
                             DecreasePressure(ref pressureBar, MaxPressureBar()-FullServReductionBar(), ApplyRateBarpS(), elapsedClockSeconds);
                             break;
                         case ControllerState.Lap:
@@ -156,6 +160,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                             if (notch.Type == ControllerState.EPApply || notch.Type == ControllerState.ContServ)
                             {
                                 x = MaxPressureBar() - MinReductionBar() * (1 - x) - FullServReductionBar() * x;
+                                DecreasePressure(ref pressureBar, MaxPressureBar() - MinReductionBar(), ReleaseRateBarpS(), elapsedClockSeconds);
                                 DecreasePressure(ref pressureBar, x, ApplyRateBarpS(), elapsedClockSeconds);
                                 if (ForceControllerReleaseGraduated || notch.Type == ControllerState.EPApply)
                                     IncreasePressure(ref pressureBar, x, ReleaseRateBarpS(), elapsedClockSeconds);
@@ -165,6 +170,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                         case ControllerState.Suppression:
                         case ControllerState.GSelfLap:
                             x = MaxPressureBar() - MinReductionBar() * (1 - x) - FullServReductionBar() * x;
+                            DecreasePressure(ref pressureBar, MaxPressureBar() - MinReductionBar(), ReleaseRateBarpS(), elapsedClockSeconds);
                             DecreasePressure(ref pressureBar, x, ApplyRateBarpS(), elapsedClockSeconds);
                             if (ForceControllerReleaseGraduated || notch.Type == ControllerState.GSelfLap)
                                 IncreasePressure(ref pressureBar, x, ReleaseRateBarpS(), elapsedClockSeconds);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
@@ -119,15 +119,16 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                             epState = -1;
                             break;
                         case ControllerState.SlowService:
-                            pressureBar -= x * SlowApplicationRateBarpS() * elapsedClockSeconds;
+                            if (pressureBar > MaxPressureBar() - MinReductionBar()) pressureBar = MaxPressureBar() - MinReductionBar();
+                            else DecreasePressure(ref pressureBar, MaxPressureBar() - FullServReductionBar(), SlowApplicationRateBarpS(), elapsedClockSeconds);
                             break;
                         case ControllerState.Apply:
                             pressureBar -= x * ApplyRateBarpS() * elapsedClockSeconds;
                             break;
                         case ControllerState.FullServ:
                             epState = x;
-                            DecreasePressure(ref pressureBar, MaxPressureBar() - MinReductionBar(), ReleaseRateBarpS(), elapsedClockSeconds);
-                            DecreasePressure(ref pressureBar, MaxPressureBar()-FullServReductionBar(), ApplyRateBarpS(), elapsedClockSeconds);
+                            if (pressureBar > MaxPressureBar() - MinReductionBar()) pressureBar = MaxPressureBar() - MinReductionBar();
+                            else DecreasePressure(ref pressureBar, MaxPressureBar()-FullServReductionBar(), ApplyRateBarpS(), elapsedClockSeconds);
                             break;
                         case ControllerState.Lap:
                             // Lap position applies min service reduction when first selected, and previous contoller position was Running, then no change in pressure occurs 
@@ -160,8 +161,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                             if (notch.Type == ControllerState.EPApply || notch.Type == ControllerState.ContServ)
                             {
                                 x = MaxPressureBar() - MinReductionBar() * (1 - x) - FullServReductionBar() * x;
-                                DecreasePressure(ref pressureBar, MaxPressureBar() - MinReductionBar(), ReleaseRateBarpS(), elapsedClockSeconds);
-                                DecreasePressure(ref pressureBar, x, ApplyRateBarpS(), elapsedClockSeconds);
+                                if (pressureBar > MaxPressureBar() - MinReductionBar()) pressureBar = MaxPressureBar() - MinReductionBar();
+                                else DecreasePressure(ref pressureBar, x, ApplyRateBarpS(), elapsedClockSeconds);
                                 if (ForceControllerReleaseGraduated || notch.Type == ControllerState.EPApply)
                                     IncreasePressure(ref pressureBar, x, ReleaseRateBarpS(), elapsedClockSeconds);
                             }
@@ -170,8 +171,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                         case ControllerState.Suppression:
                         case ControllerState.GSelfLap:
                             x = MaxPressureBar() - MinReductionBar() * (1 - x) - FullServReductionBar() * x;
-                            DecreasePressure(ref pressureBar, MaxPressureBar() - MinReductionBar(), ReleaseRateBarpS(), elapsedClockSeconds);
-                            DecreasePressure(ref pressureBar, x, ApplyRateBarpS(), elapsedClockSeconds);
+                            if (pressureBar > MaxPressureBar() - MinReductionBar()) pressureBar = MaxPressureBar() - MinReductionBar();
+                            else DecreasePressure(ref pressureBar, x, ApplyRateBarpS(), elapsedClockSeconds);
                             if (ForceControllerReleaseGraduated || notch.Type == ControllerState.GSelfLap)
                                 IncreasePressure(ref pressureBar, x, ReleaseRateBarpS(), elapsedClockSeconds);
                             break;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
@@ -120,7 +120,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                             break;
                         case ControllerState.SlowService:
                             if (pressureBar > MaxPressureBar() - MinReductionBar()) pressureBar = MaxPressureBar() - MinReductionBar();
-                            else DecreasePressure(ref pressureBar, MaxPressureBar() - FullServReductionBar(), SlowApplicationRateBarpS(), elapsedClockSeconds);
+                            DecreasePressure(ref pressureBar, MaxPressureBar() - FullServReductionBar(), SlowApplicationRateBarpS(), elapsedClockSeconds);
                             break;
                         case ControllerState.Apply:
                             pressureBar -= x * ApplyRateBarpS() * elapsedClockSeconds;
@@ -128,7 +128,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                         case ControllerState.FullServ:
                             epState = x;
                             if (pressureBar > MaxPressureBar() - MinReductionBar()) pressureBar = MaxPressureBar() - MinReductionBar();
-                            else DecreasePressure(ref pressureBar, MaxPressureBar()-FullServReductionBar(), ApplyRateBarpS(), elapsedClockSeconds);
+                            DecreasePressure(ref pressureBar, MaxPressureBar()-FullServReductionBar(), ApplyRateBarpS(), elapsedClockSeconds);
                             break;
                         case ControllerState.Lap:
                             // Lap position applies min service reduction when first selected, and previous contoller position was Running, then no change in pressure occurs 
@@ -162,7 +162,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                             {
                                 x = MaxPressureBar() - MinReductionBar() * (1 - x) - FullServReductionBar() * x;
                                 if (pressureBar > MaxPressureBar() - MinReductionBar()) pressureBar = MaxPressureBar() - MinReductionBar();
-                                else DecreasePressure(ref pressureBar, x, ApplyRateBarpS(), elapsedClockSeconds);
+                                DecreasePressure(ref pressureBar, x, ApplyRateBarpS(), elapsedClockSeconds);
                                 if (ForceControllerReleaseGraduated || notch.Type == ControllerState.EPApply)
                                     IncreasePressure(ref pressureBar, x, ReleaseRateBarpS(), elapsedClockSeconds);
                             }
@@ -172,7 +172,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                         case ControllerState.GSelfLap:
                             x = MaxPressureBar() - MinReductionBar() * (1 - x) - FullServReductionBar() * x;
                             if (pressureBar > MaxPressureBar() - MinReductionBar()) pressureBar = MaxPressureBar() - MinReductionBar();
-                            else DecreasePressure(ref pressureBar, x, ApplyRateBarpS(), elapsedClockSeconds);
+                            DecreasePressure(ref pressureBar, x, ApplyRateBarpS(), elapsedClockSeconds);
                             if (ForceControllerReleaseGraduated || notch.Type == ControllerState.GSelfLap)
                                 IncreasePressure(ref pressureBar, x, ReleaseRateBarpS(), elapsedClockSeconds);
                             break;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSNotchController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSNotchController.cs
@@ -67,6 +67,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 case "manualbrakingstart": Type = ControllerState.ManualBraking; break;
                 case "brakenotchstart": Type = ControllerState.BrakeNotch; break;
                 case "overchargestart": Type = ControllerState.Overcharge; break;
+                case "slowservicestart": Type = ControllerState.SlowService; break;
                 default:
                     STFException.TraceInformation(stf, "Skipped unknown notch type " + type);
                     break;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSNotchController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSNotchController.cs
@@ -59,6 +59,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 case "emergencystart": Type = ControllerState.Emergency; break;
                 case "minimalreductionstart": Type = ControllerState.MinimalReduction; break;
                 case "epapplystart": Type = ControllerState.EPApply; break;
+                case "eponlystart": Type = ControllerState.EPOnly; break;
+                case "epfullservicestart": Type = ControllerState.EPFullServ; break;
                 case "epholdstart": Type = ControllerState.SelfLap; break;
                 case "vacuumcontinuousservicestart": Type = ControllerState.VacContServ; break;
                 case "vacuumapplycontinuousservicestart": Type = ControllerState.VacApplyContServ; break;
@@ -447,7 +449,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             MSTSNotch notch = Notches[CurrentNotch];
             if (!notch.Smooth)
                 // Respect British 3-wire EP brake configurations
-                return notch.Type == ControllerState.EPApply ? CurrentValue : 1;
+                return (notch.Type == ControllerState.EPApply || notch.Type == ControllerState.EPOnly) ? CurrentValue : 1;
             float x = 1;
             if (CurrentNotch + 1 < Notches.Count)
                 x = Notches[CurrentNotch + 1].Value;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/CircuitBreaker.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/CircuitBreaker.cs
@@ -138,6 +138,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 Script.ClockTime = () => (float)Simulator.ClockTime;
                 Script.GameTime = () => (float)Simulator.GameTime;
                 Script.DistanceM = () => Locomotive.DistanceM;
+                Script.SpeedMpS = () => Math.Abs(Locomotive.SpeedMpS);
                 Script.Confirm = Locomotive.Simulator.Confirmer.Confirm;
                 Script.Message = Locomotive.Simulator.Confirmer.Message;
                 Script.SignalEvent = Locomotive.SignalEvent;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricPowerSupply.cs
@@ -18,6 +18,7 @@
 using Orts.Parsers.Msts;
 using ORTS.Common;
 using ORTS.Scripting.Api;
+using System;
 using System.IO;
 
 namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
@@ -118,6 +119,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 Script.ClockTime = () => (float)Simulator.ClockTime;
                 Script.GameTime = () => (float)Simulator.GameTime;
                 Script.DistanceM = () => Locomotive.DistanceM;
+                Script.SpeedMpS = () => Math.Abs(Locomotive.SpeedMpS);
                 Script.Confirm = Locomotive.Simulator.Confirmer.Confirm;
                 Script.Message = Locomotive.Simulator.Confirmer.Message;
                 Script.SignalEvent = Locomotive.SignalEvent;

--- a/Source/Orts.Simulation/Simulation/Simulator.cs
+++ b/Source/Orts.Simulation/Simulation/Simulator.cs
@@ -1192,8 +1192,9 @@ namespace Orts.Simulation
             else
                 train.TrainMaxSpeedMpS = Math.Min((float)TRK.Tr_RouteFile.SpeedLimit, conFile.Train.TrainCfg.MaxVelocity.A);
 
-
+            float prevEQres = train.EqualReservoirPressurePSIorInHg;
             train.AITrainBrakePercent = 100; //<CSComment> This seems a tricky way for the brake modules to test if it is an AI train or not
+            train.EqualReservoirPressurePSIorInHg = prevEQres; // The previous command modifies EQ reservoir pressure, causing issues with EP brake systems, so restore to prev value
             return (train);
         }
 

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2091,6 +2091,9 @@ namespace Orts.Viewer3D.RollingStock
                 case CABViewControlTypes.ORTS_CIRCUIT_BREAKER_DRIVER_OPENING_ORDER: new CircuitBreakerOpeningOrderButtonCommand(Viewer.Log, ChangedValue(UserInput.IsMouseLeftButtonPressed ? 1 : 0) > 0); break;
                 case CABViewControlTypes.ORTS_CIRCUIT_BREAKER_DRIVER_CLOSING_AUTHORIZATION: new CircuitBreakerClosingAuthorizationCommand(Viewer.Log, ChangedValue((Locomotive as MSTSElectricLocomotive).PowerSupply.CircuitBreaker.DriverClosingAuthorization ? 1 : 0) > 0); break;
                 case CABViewControlTypes.EMERGENCY_BRAKE: if ((Locomotive.EmergencyButtonPressed ? 1 : 0) != ChangedValue(Locomotive.EmergencyButtonPressed ? 1 : 0)) new EmergencyPushButtonCommand(Viewer.Log); break;
+                case CABViewControlTypes.ORTS_BAILOFF: new BailOffCommand(Viewer.Log, ChangedValue(Locomotive.BailOff ? 1 : 0) > 0); break;
+                case CABViewControlTypes.ORTS_QUICKRELEASE: new QuickReleaseCommand(Viewer.Log, ChangedValue(Locomotive.TrainBrakeController.QuickReleaseButtonPressed ? 1 : 0) > 0); break;
+                case CABViewControlTypes.ORTS_OVERCHARGE: new BrakeOverchargeCommand(Viewer.Log, ChangedValue(Locomotive.TrainBrakeController.OverchargeButtonPressed ? 1 : 0) > 0); break;
                 case CABViewControlTypes.RESET: new AlerterCommand(Viewer.Log, ChangedValue(Locomotive.TrainControlSystem.AlerterButtonPressed ? 1 : 0) > 0); break;
                 case CABViewControlTypes.CP_HANDLE: Locomotive.SetCombinedHandleValue(ChangedValue(Locomotive.GetCombinedHandleValue(true))); break;
                 // Steam locomotives only:

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -493,6 +493,8 @@ namespace Orts.Viewer3D
             EmergencyPushButtonCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
             HandbrakeCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
             BailOffCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
+            QuickReleaseCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
+            BrakeOverchargeCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
             RetainersCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
             BrakeHoseConnectCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
             ToggleWaterScoopCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;


### PR DESCRIPTION
There are some issues with the behaviour of some of the brake controller notches, which have been corrected:
- Full service position decreases pressure to 0, instead of using the full service pressure drop parameter
- Neutral position should isolate the EQ reservoir from the brake pipe, so no leakage is compensated.

Additionally, two new notches have been added:
- EPOnly: this token applies EP brakes without reducing pressure in brake pipe.
- EPFullService: this is used for non self lapping EP systems. The brake controller should have three positions: Release, EPHold and EPFullService, to increase or reduce application of EP brakes.
 
Another feature added is graduated release of the brakes without the need of the "Graduated release on all cars" option. In order to not having to create more brake tokens, the existing ones have been modified, so there will be a slightly different behaviour for this tokens. If it's better to create new tokens rather than modifying existing ones, I'll do that. These are the modified notches:
- EPApply: applies both EP and air brakes with graduated release. The continuous service position does the same as EPApply but without graduated release.
- GraduatedSelfLap: applies air brakes with graduated release. There's another (already existing) function, GraduatedSelfLapLimitedHolding that doesn't provide graduated release. IIRC this was the behaviour in MSTS.

Still have to add a slow pressure reduction notch for AWS and include some documentation provided by darwins from Elvas Tower.

@peternewell what do you think about this changes?

Discussion: http://www.elvastower.com/forums/index.php?/topic/34527-wishes-for-improvement-of-braking-systems/
Related trello card: https://trello.com/c/0SvMICQt/485-air-brake-and-ep-brake-options
