### PR TITLE
Fix invisible forest shadows: https://bugs.launchpad.net/or/+bug/1863217

### DIFF
--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -243,7 +243,8 @@ namespace Orts.Viewer3D
 
         public void SetData(ref Matrix v)
         {
-            sideVector.SetValue(v.Right);
+            var eyeVector = Vector3.Normalize(new Vector3(v.M13, v.M23, v.M33));
+            sideVector.SetValue(Vector3.Normalize(Vector3.Cross(eyeVector, Vector3.Down)));
         }
 
         public void SetData(ref Matrix wvp, Texture2D texture)


### PR DESCRIPTION
A revised, smaller forest shadows patch that merges cleanly into master and Monogame. With a little help from @pzgulyas...