### PR TITLE
Display shadow only behind text in on-screen messages

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/MessagesWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/MessagesWindow.cs
@@ -121,8 +121,8 @@ namespace Orts.Viewer3D.Popups
             foreach( var message in messages )
             {
                 var hbox = vbox.AddLayoutHorizontal(TextSize);
-                var width = hbox.RemainingWidth;
-                hbox.Add(message.LabelShadow = new LabelShadow(hbox.RemainingWidth, hbox.RemainingHeight));
+                var width = Owner.Viewer.WindowManager.TextFontDefault.MeasureString(message.Text);
+                hbox.Add(message.LabelShadow = new LabelShadow(width, hbox.RemainingHeight));
                 hbox.Add(message.LabelText = new Label(-width, 0, width, TextSize, message.Text));
             }
             return vbox;


### PR DESCRIPTION
As of now shadows of on-screen messages cover the whole width of the screen, even if the string is very short. This is not nice to see and can also partially hide the cabview controls. The patch displays the shadow only behind of the text. See http://www.elvastower.com/forums/index.php?/topic/34709-shadow-behind-on-screen-messages/
Trello box https://trello.com/c/FaitVFxc/489-shadow-only-behind-text-in-on-screen-messages