### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1910154. Log File generates the same header warning message.

### DIFF
--- a/Source/Orts.Simulation/MultiPlayer/Message.cs
+++ b/Source/Orts.Simulation/MultiPlayer/Message.cs
@@ -576,7 +576,7 @@ namespace Orts.MultiPlayer
                                     string wagonFilePath = MPManager.Simulator.BasePath + @"\trains\trainset\" + cars[i];
                                     if (!File.Exists(wagonFilePath))
                                     {
-                                        Trace.TraceWarning("Ignored missing wagon {0}", wagonFilePath);
+                                        Trace.TraceWarning($"Ignored missing {(wagonFilePath.EndsWith(".eng")? "engine" : "wagon")} {wagonFilePath}");
                                         continue;
                                     }
 

--- a/Source/Orts.Simulation/MultiPlayer/Message.cs
+++ b/Source/Orts.Simulation/MultiPlayer/Message.cs
@@ -576,7 +576,7 @@ namespace Orts.MultiPlayer
                                     string wagonFilePath = MPManager.Simulator.BasePath + @"\trains\trainset\" + cars[i];
                                     if (!File.Exists(wagonFilePath))
                                     {
-                                        Trace.TraceWarning($"Ignored missing {(wagonFilePath.EndsWith(".eng")? "engine" : "wagon")} {wagonFilePath}");
+                                        Trace.TraceWarning($"Ignored missing rolling stock {wagonFilePath}");
                                         continue;
                                     }
 

--- a/Source/Orts.Simulation/Simulation/AIs/AI.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AI.cs
@@ -901,7 +901,7 @@ namespace Orts.Simulation.AIs
 
                 if (!File.Exists(wagonFilePath))
                 {
-                    Trace.TraceWarning("Ignored missing wagon {0} in consist {1}", wagonFilePath, consistFileName);
+                    Trace.TraceWarning($"Ignored missing {(wagon.IsEngine ? "engine" : "wagon")} {wagonFilePath} in consist {consistFileName}");
                     continue;
                 }
 

--- a/Source/Orts.Simulation/Simulation/Simulator.cs
+++ b/Source/Orts.Simulation/Simulation/Simulator.cs
@@ -1127,7 +1127,7 @@ namespace Orts.Simulation
                     // First wagon is the player's loco and required, so issue a fatal error message
                     if (wagon == conFile.Train.TrainCfg.WagonList[0])
                         Trace.TraceError("Player's locomotive {0} cannot be loaded in {1}", wagonFilePath, conFileName);
-                    Trace.TraceWarning("Ignored missing wagon {0} in consist {1}", wagonFilePath, conFileName);
+                    Trace.TraceWarning($"Ignored missing {(wagon.IsEngine ? "engine" : "wagon")} {wagonFilePath} in consist {conFileName}");
                     continue;
                 }
 
@@ -1315,7 +1315,7 @@ namespace Orts.Simulation
 
                         if (!File.Exists(wagonFilePath))
                         {
-                            Trace.TraceWarning("Ignored missing wagon {0} in activity definition {1}", wagonFilePath, activityObject.Train_Config.TrainCfg.Name);
+                            Trace.TraceWarning($"Ignored missing {(wagon.IsEngine? "engine" : "wagon")} {wagonFilePath} in activity definition {activityObject.Train_Config.TrainCfg.Name}");
                             continue;
                         }
 

--- a/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
@@ -2463,7 +2463,7 @@ namespace Orts.Simulation.Timetables
 
                     if (!File.Exists(wagonFilePath))
                     {
-                        Trace.TraceWarning("Ignored missing wagon {0} in consist {1}", wagonFilePath, consistFile);
+                        Trace.TraceWarning($"Ignored missing {(wagon.IsEngine ? "engine" : "wagon")} {wagonFilePath} in consist {consistFile}");
                         continue;
                     }
 


### PR DESCRIPTION
This fix allows to differentiate the warning message between wagon and engine.
