### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1910684 Crash selecting height entry in altitude file

### DIFF
--- a/Source/RunActivity/Viewer3D/Tiles.cs
+++ b/Source/RunActivity/Viewer3D/Tiles.cs
@@ -251,8 +251,8 @@ namespace Orts.Viewer3D
             {
                 var ux2 = (int)((x + 2048 * (tile.TileX - otherTile.TileX)) / otherTile.SampleSize);
                 var uz2 = -(int)((z + 2048 * (tile.TileZ - otherTile.TileZ - otherTile.Size)) / otherTile.SampleSize);
-                ux2 = ux2 <= otherTile.SampleCount - 1 ? ux2 : otherTile.SampleCount - 1;
-                uz2 = uz2 <= otherTile.SampleCount - 1 ? uz2 : otherTile.SampleCount - 1;
+                ux2 = Math.Min(ux2, otherTile.SampleCount - 1);
+                uz2 = Math.Min(uz2, otherTile.SampleCount - 1);
                 return otherTile.GetElevation(ux2, uz2);
             }
 
@@ -408,4 +408,3 @@ namespace Orts.Viewer3D
         }
     }
 }
-

--- a/Source/RunActivity/Viewer3D/Tiles.cs
+++ b/Source/RunActivity/Viewer3D/Tiles.cs
@@ -251,6 +251,8 @@ namespace Orts.Viewer3D
             {
                 var ux2 = (int)((x + 2048 * (tile.TileX - otherTile.TileX)) / otherTile.SampleSize);
                 var uz2 = -(int)((z + 2048 * (tile.TileZ - otherTile.TileZ - otherTile.Size)) / otherTile.SampleSize);
+                ux2 = ux2 <= otherTile.SampleCount - 1 ? ux2 : otherTile.SampleCount - 1;
+                uz2 = uz2 <= otherTile.SampleCount - 1 ? uz2 : otherTile.SampleCount - 1;
                 return otherTile.GetElevation(ux2, uz2);
             }
 


### PR DESCRIPTION
See here https://www.trainsim.com/vbts/showthread.php?335911-GN-Hi-Line . The log shows that the uz2 index sometimes is 256 and even 257, while it should be less than 256. This is assumed to be a rounding problem. Due to the fact that there are no known cases where the ux2 and uz2 indices were below 0, only the check for the max values has been introduced.