### PR TITLE
Add secret button to access launcher arguments for easier debugging

### DIFF
--- a/Source/Menu/Program.cs
+++ b/Source/Menu/Program.cs
@@ -152,14 +152,27 @@ namespace ORTS
                             break;
                     }
 
-                    var processStartInfo = new System.Diagnostics.ProcessStartInfo();
-                    processStartInfo.FileName = MainForm.RunActivityProgram;
-                    processStartInfo.Arguments = String.Join(" ", parameters.ToArray());
-                    processStartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Normal;
-                    processStartInfo.WorkingDirectory = Application.StartupPath;
-
-                    var process = Process.Start(processStartInfo);
-                    process.WaitForExit();
+                    var joinedParameters = string.Join(" ", parameters);
+                    if ((Control.ModifierKeys & Keys.Alt) == Keys.Alt)
+                    {
+                        Clipboard.SetText(joinedParameters);
+                        MessageBox.Show(
+                            "RunActivity.exe arguments have been copied to the clipboard:" +
+                            $"\n\n{joinedParameters}\n\n" +
+                            "This is a debugging aid. If you wanted to start the simulator instead, select Start without holding down the Alt key.");
+                    }
+                    else
+                    {
+                        var processStartInfo = new ProcessStartInfo()
+                        {
+                            FileName = MainForm.RunActivityProgram,
+                            Arguments = joinedParameters,
+                            WindowStyle = ProcessWindowStyle.Normal,
+                            WorkingDirectory = Application.StartupPath,
+                        };
+                        var process = Process.Start(processStartInfo);
+                        process.WaitForExit();
+                    }
                 }
             }
         }


### PR DESCRIPTION
When debugging RunActivity.exe, I often need to copy the launch parameters (`-start -explorer ...`) set by the Open Rails launcher into my Visual Studio project so that I can reproduce a specific test scenario. Now, *yes*, they can be extracted from OpenRailsLog.txt, but this format is not very convenient, because the log file prints the arguments on separate lines and does not escape the spaces with quotes.

Therefore, I propose adding a secret function that copies the exact launch arguments set by the launcher to the clipboard. This function would be activated by holding down the Alt key while clicking on the Start button. Hopefully, no player would do this by accident, but in the event that somebody does, an instructional message is also presented to explain what just happened.

Feature request: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)