### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1910746. By Buttercup.

### DIFF
--- a/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
@@ -3741,7 +3741,7 @@ namespace Orts.Simulation.Timetables
                         FormType = formType;
                         FormTrain = true;
 
-                        if (trainCommands.CommandQualifiers != null && formType == TTTrain.FormCommand.TerminationFormed)
+                        if (trainCommands.CommandQualifiers != null && (formType == TTTrain.FormCommand.TerminationFormed || formType == TTTrain.FormCommand.TerminationTriggered))
                         {
                             foreach (TTTrainCommands.TTTrainComQualifiers formedTrainQualifiers in trainCommands.CommandQualifiers)
                             {


### PR DESCRIPTION
Timetable, /closeup qualifier not working with $triggers dispose command.