### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1912388 Crash with $attach and $detach in timetable mode

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -691,7 +691,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                     break;
 
                 default:
-                    if (Locomotive == Simulator.PlayerLocomotive)
+                    if (Locomotive == Simulator.PlayerLocomotive || Locomotive.Train.PlayerTrainSignals == null)
                         Locomotive.Train.UpdatePlayerTrainData();
                     if (Script == null)
                     {


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/34801-tt-crash-when-player-attaches-train/