### PR TITLE
Adjust water scoop sounds

### DIFF
--- a/Source/Documentation/Manual/sound.rst
+++ b/Source/Documentation/Manual/sound.rst
@@ -265,6 +265,21 @@ Trigger       Function
 172           Pantograph4Down
 =========     =====================================
 
+Additional triggers:
+
+=========     =====================================
+Trigger       Function
+=========     =====================================
+173           HotBoxBearingOn
+174           HotBoxBearingOff
+175           BoilerBlowdownOn
+176           BoilerBlowdownOff
+177           WaterScoopRaiseLower
+178           WaterScoopBrocken
+=========     =====================================
+
+
+
 The following triggers are used to activate the gear positions:
 
 =========     =====================================

--- a/Source/Documentation/Manual/sound.rst
+++ b/Source/Documentation/Manual/sound.rst
@@ -196,6 +196,12 @@ Trigger       Function
 143           BrakePipePressureStoppedChanging : for rolling stock equipped with train brakes, triggered when brake pipe/brakeline pressure stops changing
 =========     ============================================================================================================================================================================
 
+=========     =====================================
+Trigger       Function
+=========     =====================================
+145           WaterScoopRaiseLower
+146           WaterScoopBroken
+=========     =====================================
 
 =========     ======================================================================
 Trigger       Function
@@ -274,8 +280,6 @@ Trigger       Function
 174           HotBoxBearingOff
 175           BoilerBlowdownOn
 176           BoilerBlowdownOff
-177           WaterScoopRaiseLower
-178           WaterScoopBroken
 =========     =====================================
 
 

--- a/Source/Documentation/Manual/sound.rst
+++ b/Source/Documentation/Manual/sound.rst
@@ -275,7 +275,7 @@ Trigger       Function
 175           BoilerBlowdownOn
 176           BoilerBlowdownOff
 177           WaterScoopRaiseLower
-178           WaterScoopBrocken
+178           WaterScoopBroken
 =========     =====================================
 
 

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -184,6 +184,9 @@ namespace Orts.Common
         BoilerBlowdownOn,
         BoilerBlowdownOff,
 
+        WaterScoopRaiseLower,
+        WaterScoopBroken,
+
         SteamGearLeverToggle,
         AIFiremanSoundOn,
         AIFiremanSoundOff,
@@ -389,6 +392,9 @@ namespace Orts.Common
 
                         case 175: return Event.BoilerBlowdownOn;
                         case 176: return Event.BoilerBlowdownOff;
+
+                        case 177: return Event.WaterScoopRaiseLower;
+                        case 178: return Event.WaterScoopBroken;
 
                         case 181: return Event.GenericEvent1;
                         case 182: return Event.GenericEvent2;

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -354,6 +354,9 @@ namespace Orts.Common
                         case 142: return Event.BrakePipePressureDecrease;
                         case 143: return Event.BrakePipePressureStoppedChanging;
 
+                        case 145: return Event.WaterScoopRaiseLower;
+                        case 146: return Event.WaterScoopBroken;
+
                         case 147: return Event.SteamGearLeverToggle;
                         case 148: return Event.AIFiremanSoundOn;
                         case 149: return Event.AIFiremanSoundOff;
@@ -393,8 +396,11 @@ namespace Orts.Common
                         case 175: return Event.BoilerBlowdownOn;
                         case 176: return Event.BoilerBlowdownOff;
 
-                        case 177: return Event.WaterScoopRaiseLower;
-                        case 178: return Event.WaterScoopBroken;
+                        // These triggers have been released in MG????
+                    //    case 177: return Event.ORTS_BATTERY;
+                    //    case 178: return Event.ORTS_BATTERY;
+                    //    case 179: return Event.ORTS_POWERKEY;
+                    //    case 180: return Event.ORTS_POWERKEY;
 
                         case 181: return Event.GenericEvent1;
                         case 182: return Event.GenericEvent2;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -2403,13 +2403,11 @@ namespace Orts.Simulation.RollingStocks
                         WaterScoopNotFittedFlag = true;
                     }
                     RefillingFromTrough = false;
-                    return;
                 }
                 else if (ScoopIsBroken)
                 {
                     Simulator.Confirmer.Message(ConfirmLevel.Error, Simulator.Catalog.GetString("Scoop is broken, can't refill"));
-                    RefillingFromTrough = false;
-                    return;
+                    RefillingFromTrough = false;       
                 }
                 else if (IsOverJunction())
                 {
@@ -2419,8 +2417,7 @@ namespace Orts.Simulation.RollingStocks
                     }
                     ScoopIsBroken = true;
                     RefillingFromTrough = false;
-                    SignalEvent(Event.WaterScoopBroken);
-                    return;
+                    SignalEvent(Event.WaterScoopBroken);       
                 }
                 else if (!IsOverTrough())
                 {
@@ -2432,7 +2429,6 @@ namespace Orts.Simulation.RollingStocks
                         MSTSWagon.RefillProcess.ActivePickupObjectUID = 0;
                     }
                     RefillingFromTrough = false;
-                    return;
                 }
                 else if (IsTenderRequired == 1 && Direction == Direction.Reverse) // Locomotives with tenders cannot go in reverse
                 {
@@ -2442,7 +2438,6 @@ namespace Orts.Simulation.RollingStocks
                         WaterScoopDirectionFlag = true;
                     }
                     RefillingFromTrough = false;
-                    return;
                 }
                 else if (absSpeedMpS < WaterScoopMinSpeedMpS)
                 {
@@ -2455,12 +2450,10 @@ namespace Orts.Simulation.RollingStocks
                         MSTSWagon.RefillProcess.ActivePickupObjectUID = 0;
                     }
                     RefillingFromTrough = false;
-                    return;
                 }
                 else if (fraction > 1.0)
                 {
                     Simulator.Confirmer.Message(ConfirmLevel.None, Simulator.Catalog.GetStringFmt("Refill: Water supply now replenished."));
-                    return;
                 }
                 else
                 {
@@ -2476,7 +2469,6 @@ namespace Orts.Simulation.RollingStocks
                 MSTSWagon.RefillProcess.OkToRefill = false;
                 MSTSWagon.RefillProcess.ActivePickupObjectUID = 0;
                 RefillingFromTrough = false;
-                return;
             }
 
 
@@ -2554,10 +2546,7 @@ namespace Orts.Simulation.RollingStocks
                     WaterScoopSoundOn = false;
                     SignalEvent(Event.WaterScoopUp);
                 }
-
             }
-
-
         }
 
         #region Calculate Friction Coefficient

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -167,6 +167,7 @@ namespace Orts.Simulation.RollingStocks
         bool WaterScoopSlowSpeedFlag = false;
         bool WaterScoopDirectionFlag = false;
         public bool IsWaterScoopPlayerLocomotive = false;
+        bool WaterScoopSoundOn = false;
         public float MaxTotalCombinedWaterVolumeUKG;
         public MSTSNotchController WaterController = new MSTSNotchController(0, 1, 0.01f);
         public float CombinedTenderWaterVolumeUKG          // Decreased by running injectors and increased by refilling
@@ -2418,6 +2419,7 @@ namespace Orts.Simulation.RollingStocks
                     }
                     ScoopIsBroken = true;
                     RefillingFromTrough = false;
+                    SignalEvent(Event.WaterScoopBroken);
                     return;
                 }
                 else if (!IsOverTrough())
@@ -2457,6 +2459,11 @@ namespace Orts.Simulation.RollingStocks
                 }
                 else if (fraction > 1.0)
                 {
+                    if (WaterScoopSoundOn)
+                    {
+                        WaterScoopSoundOn = false;
+                        SignalEvent(Event.WaterScoopUp);
+                    }
                     Simulator.Confirmer.Message(ConfirmLevel.None, Simulator.Catalog.GetStringFmt("Refill: Water supply now replenished."));
                     return;
                 }
@@ -2466,6 +2473,11 @@ namespace Orts.Simulation.RollingStocks
                     MSTSWagon.RefillProcess.ActivePickupObjectUID = -1;
                     RefillingFromTrough = true;
                     WaterScoopOverTroughFlag = false; // Reset flag so that message will come up again
+                    if ( !WaterScoopSoundOn)
+                    {
+                        WaterScoopSoundOn = true;
+                        SignalEvent(Event.WaterScoopDown);
+                    }
                 }
 
             }
@@ -2978,16 +2990,14 @@ namespace Orts.Simulation.RollingStocks
             if (Simulator.PlayerLocomotive == this)
             {
                 WaterScoopDown = !WaterScoopDown;
-                SignalEvent(Event.WaterScoopDown);
+                SignalEvent(Event.WaterScoopRaiseLower);
                 if (WaterScoopDown)
                 {
                     IsWaterScoopDown = true; // Set flag to potentially fill from water trough
-                    SignalEvent(Event.WaterScoopDown);
                 }
                 else
                 {
                     IsWaterScoopDown = false;
-                    SignalEvent(Event.WaterScoopUp);
                     WaterScoopOverTroughFlag = false; // Reset flags so that message will come up again
                     WaterScoopNotFittedFlag = false;
                     WaterScoopSlowSpeedFlag = false;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -2432,6 +2432,11 @@ namespace Orts.Simulation.RollingStocks
                         MSTSWagon.RefillProcess.ActivePickupObjectUID = 0;
                     }
                     RefillingFromTrough = false;
+                    if (WaterScoopSoundOn)
+                    {
+                        WaterScoopSoundOn = false;
+                        SignalEvent(Event.WaterScoopUp);
+                    }
                     return;
                 }
                 else if (IsTenderRequired == 1 && Direction == Direction.Reverse) // Locomotives with tenders cannot go in reverse
@@ -2442,6 +2447,11 @@ namespace Orts.Simulation.RollingStocks
                         WaterScoopDirectionFlag = true;
                     }
                     RefillingFromTrough = false;
+                    if (WaterScoopSoundOn)
+                    {
+                        WaterScoopSoundOn = false;
+                        SignalEvent(Event.WaterScoopUp);
+                    }
                     return;
                 }
                 else if (absSpeedMpS < WaterScoopMinSpeedMpS)
@@ -2455,6 +2465,11 @@ namespace Orts.Simulation.RollingStocks
                         MSTSWagon.RefillProcess.ActivePickupObjectUID = 0;
                     }
                     RefillingFromTrough = false;
+                    if (WaterScoopSoundOn)
+                    {
+                        WaterScoopSoundOn = false;
+                        SignalEvent(Event.WaterScoopUp);
+                    }
                     return;
                 }
                 else if (fraction > 1.0)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -2432,11 +2432,6 @@ namespace Orts.Simulation.RollingStocks
                         MSTSWagon.RefillProcess.ActivePickupObjectUID = 0;
                     }
                     RefillingFromTrough = false;
-                    if (WaterScoopSoundOn)
-                    {
-                        WaterScoopSoundOn = false;
-                        SignalEvent(Event.WaterScoopUp);
-                    }
                     return;
                 }
                 else if (IsTenderRequired == 1 && Direction == Direction.Reverse) // Locomotives with tenders cannot go in reverse
@@ -2447,11 +2442,6 @@ namespace Orts.Simulation.RollingStocks
                         WaterScoopDirectionFlag = true;
                     }
                     RefillingFromTrough = false;
-                    if (WaterScoopSoundOn)
-                    {
-                        WaterScoopSoundOn = false;
-                        SignalEvent(Event.WaterScoopUp);
-                    }
                     return;
                 }
                 else if (absSpeedMpS < WaterScoopMinSpeedMpS)
@@ -2465,20 +2455,10 @@ namespace Orts.Simulation.RollingStocks
                         MSTSWagon.RefillProcess.ActivePickupObjectUID = 0;
                     }
                     RefillingFromTrough = false;
-                    if (WaterScoopSoundOn)
-                    {
-                        WaterScoopSoundOn = false;
-                        SignalEvent(Event.WaterScoopUp);
-                    }
                     return;
                 }
                 else if (fraction > 1.0)
                 {
-                    if (WaterScoopSoundOn)
-                    {
-                        WaterScoopSoundOn = false;
-                        SignalEvent(Event.WaterScoopUp);
-                    }
                     Simulator.Confirmer.Message(ConfirmLevel.None, Simulator.Catalog.GetStringFmt("Refill: Water supply now replenished."));
                     return;
                 }
@@ -2488,11 +2468,6 @@ namespace Orts.Simulation.RollingStocks
                     MSTSWagon.RefillProcess.ActivePickupObjectUID = -1;
                     RefillingFromTrough = true;
                     WaterScoopOverTroughFlag = false; // Reset flag so that message will come up again
-                    if ( !WaterScoopSoundOn)
-                    {
-                        WaterScoopSoundOn = true;
-                        SignalEvent(Event.WaterScoopDown);
-                    }
                 }
 
             }
@@ -2554,6 +2529,12 @@ namespace Orts.Simulation.RollingStocks
                 float ScoopFluidDensityKgpM3 = 998.2f; // Fuild density of water @ 20c
                 WaterScoopDragForceN = 0.5f * ScoopDragCoeff * ScoopFluidDensityKgpM3 * ScoopDragAreaM * absSpeedMpS * absSpeedMpS;
 
+                // Turn water scoop sound on
+                if (!WaterScoopSoundOn)
+                {
+                    WaterScoopSoundOn = true;
+                    SignalEvent(Event.WaterScoopDown);
+                }
             }
             else // Ensure water scoop values are zero if not taking water.
             {
@@ -2566,6 +2547,14 @@ namespace Orts.Simulation.RollingStocks
                 {
                     WaterScoopTotalWaterL = 0.0f; // Reset amount of water picked up by water sccop.
                 }
+
+                // Turn water scoop sound off
+                if (WaterScoopSoundOn)
+                {
+                    WaterScoopSoundOn = false;
+                    SignalEvent(Event.WaterScoopUp);
+                }
+
             }
 
 


### PR DESCRIPTION
https://blueprints.launchpad.net/or/+spec/water-trough-filling - Adjust water scoop sounds so that they only come on when over trough, add extra sound events for water scoop broken, and raise/lower