### PR TITLE
Enforce EQ pressure minimal reduction at service rate

### DIFF
--- a/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
@@ -6264,6 +6264,7 @@ namespace Orts.Simulation.AIs
                 j++;
             }
             MSTSLocomotive lead = (MSTSLocomotive)Simulator.PlayerLocomotive;
+            EqualReservoirPressurePSIorInHg = Math.Min(EqualReservoirPressurePSIorInHg, lead.TrainBrakeController.MaxPressurePSI);
             foreach (TrainCar car in Cars)
             {
                 if (car.BrakeSystem is AirSinglePipe)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
@@ -107,14 +107,17 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                     if (OverchargeButtonPressed()) type = ControllerState.Overcharge;
                     else if (QuickReleaseButtonPressed()) type = ControllerState.FullQuickRelease;
 
-                    if (type == ControllerState.Hold || type == ControllerState.Lap || type == ControllerState.MinimalReduction)
+                    switch (type)
                     {
-                        if (EnforceMinimalReduction)
-                            DecreasePressure(ref pressureBar, MaxPressureBar() - MinReductionBar(), ApplyRateBarpS(), elapsedClockSeconds);
-                    }
-                    else
-                    {
-                        EnforceMinimalReduction = false;
+                        case ControllerState.Hold:
+                        case ControllerState.Lap:
+                        case ControllerState.MinimalReduction:
+                            if (EnforceMinimalReduction)
+                                DecreasePressure(ref pressureBar, MaxPressureBar() - MinReductionBar(), ApplyRateBarpS(), elapsedClockSeconds);
+                            break;
+                        default:
+                            EnforceMinimalReduction = false;
+                            break;
                     }
 
                     switch (type)


### PR DESCRIPTION
Currently the "minimal reduction" pressure drop is performed instantly. With this changes the pressure drops at MaxApplicationRate as expected, and ensures that the valve is not lapped before completing the minimal reduction.

See http://www.elvastower.com/forums/index.php?/topic/34853-equalizing-reservoir-unexpected-behavior/

Bug report: https://bugs.launchpad.net/or/+bug/1915432