### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1916525. TimeTable mode, #settings for storage area, fails.

### DIFF
--- a/Source/Orts.Simulation/Simulation/Timetables/TTPool.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTPool.cs
@@ -487,8 +487,8 @@ namespace Orts.Simulation.Timetables
                                     default:
                                         break;
                                 }
-                                nextfield++;
                             }
+                            nextfield++;
                         }
                         lineindex++;
                         break;


### PR DESCRIPTION
The code related to the #settings for storage area, does not work correctly if there is an empty field in that string.