### PR TITLE
Resolve Monogame build warnings

### DIFF
--- a/Source/Orts.Simulation/Simulation/Activity.cs
+++ b/Source/Orts.Simulation/Simulation/Activity.cs
@@ -16,7 +16,6 @@
 // along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework;
 using Orts.Formats.Msts;
 using Orts.Simulation.AIs;
 using Orts.Simulation.Physics;

--- a/Source/RunActivity/Viewer3D/DynamicTrack.cs
+++ b/Source/RunActivity/Viewer3D/DynamicTrack.cs
@@ -1117,7 +1117,7 @@ namespace Orts.Viewer3D
             // Create and populate a new ShapePrimitive
             var indexBuffer = new IndexBuffer(viewer.GraphicsDevice, typeof(short), NumIndices, BufferUsage.WriteOnly);
             indexBuffer.SetData(TriangleListIndices);
-            return new ShapePrimitive(lodItem.LODMaterial, new SharedShape.VertexBufferSet(VertexList, viewer.GraphicsDevice), indexBuffer, 0, NumVertices, NumIndices / 3, new[] { -1 }, 0);
+            return new ShapePrimitive(lodItem.LODMaterial, new SharedShape.VertexBufferSet(VertexList, viewer.GraphicsDevice), indexBuffer, NumIndices / 3, new[] { -1 }, 0);
         }
 
         /// <summary>

--- a/Source/RunActivity/Viewer3D/Lights.cs
+++ b/Source/RunActivity/Viewer3D/Lights.cs
@@ -551,7 +551,7 @@ namespace Orts.Viewer3D
         {
             graphicsDevice.SetVertexBuffer(VertexBuffer);
             graphicsDevice.Indices = IndexBuffer;
-            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 6 * State, 0, 6, 0, 2);
+            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 6 * State, startIndex: 0, primitiveCount: 2);
         }
     }
 
@@ -687,14 +687,14 @@ namespace Orts.Viewer3D
             graphicsDevice.DepthStencilState.StencilPass = StencilOperation.Increment;
             graphicsDevice.DepthStencilState.DepthBufferFunction = CompareFunction.Greater;
             graphicsDevice.BlendState = BlendState_SourceZeroDestOne;
-            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, (CircleSegments + 2) * State, 0, CircleSegments + 2, 0, 2 * CircleSegments);
+            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: (CircleSegments + 2) * State, startIndex: 0, primitiveCount: 2 * CircleSegments);
 
             graphicsDevice.RasterizerState = RasterizerState.CullCounterClockwise;
             graphicsDevice.DepthStencilState.StencilFunction = CompareFunction.Less;
             graphicsDevice.DepthStencilState.StencilPass = StencilOperation.Zero;
             graphicsDevice.DepthStencilState.DepthBufferFunction = CompareFunction.LessEqual;
             graphicsDevice.BlendState = BlendState.AlphaBlend;
-            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, (CircleSegments + 2) * State, 0, CircleSegments + 2, 0, 2 * CircleSegments);
+            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: (CircleSegments + 2) * State, startIndex: 0, primitiveCount: 2 * CircleSegments);
 #endif
         }
 

--- a/Source/RunActivity/Viewer3D/MSTSSky.cs
+++ b/Source/RunActivity/Viewer3D/MSTSSky.cs
@@ -342,29 +342,23 @@ namespace Orts.Viewer3D
                 case 1: // Sky dome
                     graphicsDevice.DrawIndexedPrimitives(
                         PrimitiveType.TriangleList,
-                        0,
-                        0,
-                        (numVertices - 4) / 2,
-                        0,
-                        (indexCount - 6) / 6);
+                        baseVertex: 0,
+                        startIndex: 0,
+                        primitiveCount: (indexCount - 6) / 6);
                     break;
                 case 2: // Moon
                     graphicsDevice.DrawIndexedPrimitives(
-                    PrimitiveType.TriangleList,
-                    0,
-                    numVertices - 4,
-                    4,
-                    indexCount - 6,
-                    2);
+                        PrimitiveType.TriangleList,
+                        baseVertex: 4,
+                        startIndex: indexCount - 6,
+                        primitiveCount: 2);
                     break;
                 case 3: // Clouds Dome
                     graphicsDevice.DrawIndexedPrimitives(
                         PrimitiveType.TriangleList,
-                        0,
-                        (numVertices - 4) / 2,
-                        (numVertices - 4) / 2,
-                        (indexCount - 6) / 2,
-                        (indexCount - 6) / 6);
+                        baseVertex: 0,
+                        startIndex: (indexCount - 6) / 2,
+                        primitiveCount: (indexCount - 6) / 6);
                     break;
                 default:
                     break;

--- a/Source/RunActivity/Viewer3D/ParticleEmitter.cs
+++ b/Source/RunActivity/Viewer3D/ParticleEmitter.cs
@@ -439,15 +439,15 @@ namespace Orts.Viewer3D
                     var numParticles = FirstFreeParticle - FirstActiveParticle;
                     // thread safe clause
                     if (numParticles > 0)
-                        graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, FirstActiveParticle * VerticiesPerParticle, numParticles * VerticiesPerParticle, FirstActiveParticle * IndiciesPerParticle, numParticles * PrimitivesPerParticle);
+                        graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: FirstActiveParticle * IndiciesPerParticle, primitiveCount: numParticles * PrimitivesPerParticle);
                 }
                 else
                 {
                     var numParticlesAtEnd = MaxParticles - FirstActiveParticle;
                     if (numParticlesAtEnd > 0)
-                        graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, FirstActiveParticle * VerticiesPerParticle, numParticlesAtEnd * VerticiesPerParticle, FirstActiveParticle * IndiciesPerParticle, numParticlesAtEnd * PrimitivesPerParticle);
+                        graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: FirstActiveParticle * IndiciesPerParticle, primitiveCount: numParticlesAtEnd * PrimitivesPerParticle);
                     if (FirstFreeParticle > 0)
-                        graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, FirstFreeParticle * VerticiesPerParticle, 0, FirstFreeParticle * PrimitivesPerParticle);
+                        graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: 0, primitiveCount: FirstFreeParticle * PrimitivesPerParticle);
                 }
             }
 

--- a/Source/RunActivity/Viewer3D/Popups/Window.cs
+++ b/Source/RunActivity/Viewer3D/Popups/Window.cs
@@ -270,7 +270,7 @@ namespace Orts.Viewer3D.Popups
 
             graphicsDevice.SetVertexBuffer(WindowVertexBuffer);
 			graphicsDevice.Indices = WindowIndexBuffer;
-			graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleStrip, 0, 0, 16, 0, 20);
+			graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleStrip, baseVertex: 0, startIndex: 0, primitiveCount: 20);
 		}
 
         [CallOnThread("Updater")]

--- a/Source/RunActivity/Viewer3D/Popups/Window.cs
+++ b/Source/RunActivity/Viewer3D/Popups/Window.cs
@@ -42,7 +42,6 @@ namespace Orts.Viewer3D.Popups
         readonly string Caption;
         readonly PropertyInfo SettingsProperty;
         ControlLayout WindowLayout;
-        VertexDeclaration WindowVertexDeclaration;
         VertexBuffer WindowVertexBuffer;
         IndexBuffer WindowIndexBuffer;
 

--- a/Source/RunActivity/Viewer3D/Precipitation.cs
+++ b/Source/RunActivity/Viewer3D/Precipitation.cs
@@ -400,15 +400,15 @@ namespace Orts.Viewer3D
                 if (FirstActiveParticle < FirstFreeParticle)
                 {
                     var numParticles = FirstFreeParticle - FirstActiveParticle;
-                    graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, FirstActiveParticle * VerticiesPerParticle, numParticles * VerticiesPerParticle, FirstActiveParticle * IndiciesPerParticle, numParticles * PrimitivesPerParticle);
+                    graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: FirstActiveParticle * IndiciesPerParticle, primitiveCount: numParticles * PrimitivesPerParticle);
                 }
                 else
                 {
                     var numParticlesAtEnd = MaxParticles - FirstActiveParticle;
                     if (numParticlesAtEnd > 0)
-                        graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, FirstActiveParticle * VerticiesPerParticle, numParticlesAtEnd * VerticiesPerParticle, FirstActiveParticle * IndiciesPerParticle, numParticlesAtEnd * PrimitivesPerParticle);
+                        graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: FirstActiveParticle * IndiciesPerParticle, primitiveCount: numParticlesAtEnd * PrimitivesPerParticle);
                     if (FirstFreeParticle > 0)
-                        graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, FirstFreeParticle * VerticiesPerParticle, 0, FirstFreeParticle * PrimitivesPerParticle);
+                        graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: 0, primitiveCount: FirstFreeParticle * PrimitivesPerParticle);
                 }
             }
 

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -590,7 +590,7 @@ namespace Orts.Viewer3D
             IndexBuffer IndexBuffer = new IndexBuffer(viewer.GraphicsDevice, typeof(short),
                                                             NumIndices, BufferUsage.WriteOnly);
             IndexBuffer.SetData(newTList);
-            shapePrimitive = new ShapePrimitive(material, new SharedShape.VertexBufferSet(newVList, viewer.GraphicsDevice), IndexBuffer, 0, NumVertices, NumIndices / 3, new[] { -1 }, 0);
+            shapePrimitive = new ShapePrimitive(material, new SharedShape.VertexBufferSet(newVList, viewer.GraphicsDevice), IndexBuffer, NumIndices / 3, new[] { -1 }, 0);
 
         }
 
@@ -1217,8 +1217,6 @@ namespace Orts.Viewer3D
 
         protected internal VertexBuffer VertexBuffer;
         protected internal IndexBuffer IndexBuffer;
-        protected internal int MinVertexIndex;
-        protected internal int NumVerticies;
         protected internal int PrimitiveCount;
 
         readonly VertexBufferBinding[] VertexBufferBindings;
@@ -1227,13 +1225,11 @@ namespace Orts.Viewer3D
         {
         }
 
-        public ShapePrimitive(Material material, SharedShape.VertexBufferSet vertexBufferSet, IndexBuffer indexBuffer, int minVertexIndex, int numVerticies, int primitiveCount, int[] hierarchy, int hierarchyIndex)
+        public ShapePrimitive(Material material, SharedShape.VertexBufferSet vertexBufferSet, IndexBuffer indexBuffer, int primitiveCount, int[] hierarchy, int hierarchyIndex)
         {
             Material = material;
             VertexBuffer = vertexBufferSet.Buffer;
             IndexBuffer = indexBuffer;
-            MinVertexIndex = minVertexIndex;
-            NumVerticies = numVerticies;
             PrimitiveCount = primitiveCount;
             Hierarchy = hierarchy;
             HierarchyIndex = hierarchyIndex;
@@ -1242,7 +1238,7 @@ namespace Orts.Viewer3D
         }
 
         public ShapePrimitive(Material material, SharedShape.VertexBufferSet vertexBufferSet, IList<ushort> indexData, GraphicsDevice graphicsDevice, int[] hierarchy, int hierarchyIndex)
-            : this(material, vertexBufferSet, null, indexData.Min(), indexData.Max() - indexData.Min() + 1, indexData.Count / 3, hierarchy, hierarchyIndex)
+            : this(material, vertexBufferSet, null, indexData.Count / 3, hierarchy, hierarchyIndex)
         {
             IndexBuffer = new IndexBuffer(graphicsDevice, typeof(short), indexData.Count, BufferUsage.WriteOnly);
             IndexBuffer.SetData(indexData.ToArray());
@@ -1255,7 +1251,7 @@ namespace Orts.Viewer3D
                 // TODO consider sorting by Vertex set so we can reduce the number of SetSources required.
                 graphicsDevice.SetVertexBuffers(VertexBufferBindings);
                 graphicsDevice.Indices = IndexBuffer;
-                graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, MinVertexIndex, NumVerticies, 0, PrimitiveCount);
+                graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: 0, primitiveCount: PrimitiveCount);
             }
         }
 
@@ -1286,8 +1282,6 @@ namespace Orts.Viewer3D
         public void SetVertexData(VertexPositionNormalTexture[] data, int minVertexIndex, int numVertices, int primitiveCount)
         {
             VertexBuffer.SetData(data);
-            MinVertexIndex = minVertexIndex;
-            NumVerticies = numVertices;
             PrimitiveCount = primitiveCount;
         }
 
@@ -1324,8 +1318,6 @@ namespace Orts.Viewer3D
         protected VertexDeclaration VertexDeclaration;
         protected int VertexBufferStride;
         protected IndexBuffer IndexBuffer;
-        protected int MinVertexIndex;
-        protected int NumVerticies;
         protected int PrimitiveCount;
 
         protected VertexBuffer InstanceBuffer;
@@ -1344,8 +1336,6 @@ namespace Orts.Viewer3D
             VertexBuffer = shapePrimitive.VertexBuffer;
             VertexDeclaration = shapePrimitive.VertexBuffer.VertexDeclaration;
             IndexBuffer = shapePrimitive.IndexBuffer;
-            MinVertexIndex = shapePrimitive.MinVertexIndex;
-            NumVerticies = shapePrimitive.NumVerticies;
             PrimitiveCount = shapePrimitive.PrimitiveCount;
 
             InstanceDeclaration = new VertexDeclaration(ShapeInstanceData.SizeInBytes, ShapeInstanceData.VertexElements);
@@ -1360,7 +1350,7 @@ namespace Orts.Viewer3D
         {
             graphicsDevice.Indices = IndexBuffer;
             graphicsDevice.SetVertexBuffers(VertexBufferBindings);
-            graphicsDevice.DrawInstancedPrimitives(PrimitiveType.TriangleList, 0, MinVertexIndex, NumVerticies, 0, PrimitiveCount, InstanceCount);
+            graphicsDevice.DrawInstancedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: 0, PrimitiveCount, InstanceCount);
         }
     }
 

--- a/Source/RunActivity/Viewer3D/Sky.cs
+++ b/Source/RunActivity/Viewer3D/Sky.cs
@@ -255,29 +255,23 @@ namespace Orts.Viewer3D
                 case 1: // Sky dome
                     graphicsDevice.DrawIndexedPrimitives(
                         PrimitiveType.TriangleList,
-                        0,
-                        0,
-                        (numVertices - 4) / 2,
-                        0,
-                        (indexCount - 6) / 6);
+                        baseVertex: 0,
+                        startIndex: 0,
+                        primitiveCount: (indexCount - 6) / 6);
                     break;
                 case 2: // Moon
                     graphicsDevice.DrawIndexedPrimitives(
                     PrimitiveType.TriangleList,
-                    0,
-                    numVertices - 4,
-                    4,
-                    indexCount - 6,
-                    2);
+                    baseVertex: 0,
+                    startIndex: indexCount - 6,
+                    primitiveCount: 2);
                     break;
                 case 3: // Clouds Dome
                     graphicsDevice.DrawIndexedPrimitives(
                         PrimitiveType.TriangleList,
-                        0,
-                        (numVertices - 4) / 2,
-                        (numVertices - 4) / 2,
-                        (indexCount - 6) / 2,
-                        (indexCount - 6) / 6);
+                        baseVertex: 0,
+                        startIndex: (indexCount - 6) / 2,
+                        primitiveCount: (indexCount - 6) / 6);
                     break;
                 default:
                     break;

--- a/Source/RunActivity/Viewer3D/SuperElevation.cs
+++ b/Source/RunActivity/Viewer3D/SuperElevation.cs
@@ -678,7 +678,7 @@ namespace Orts.Viewer3D
             // Create and populate a new ShapePrimitive
             var indexBuffer = new IndexBuffer(viewer.GraphicsDevice, typeof(short), NumIndices, BufferUsage.WriteOnly);
             indexBuffer.SetData(TriangleListIndices);
-            return new ShapePrimitive(lodItem.LODMaterial, new SharedShape.VertexBufferSet(VertexList, viewer.GraphicsDevice), indexBuffer, 0, NumVertices, NumIndices / 3, new[] { -1 }, 0);
+            return new ShapePrimitive(lodItem.LODMaterial, new SharedShape.VertexBufferSet(VertexList, viewer.GraphicsDevice), indexBuffer, NumIndices / 3, new[] { -1 }, 0);
         }
 
         /// <summary>

--- a/Source/RunActivity/Viewer3D/Terrain.cs
+++ b/Source/RunActivity/Viewer3D/Terrain.cs
@@ -265,7 +265,7 @@ namespace Orts.Viewer3D
             graphicsDevice.SetVertexBuffers(VertexBufferBindings);
             if (PatchIndexBuffer != null)
                 graphicsDevice.Indices = PatchIndexBuffer;
-            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, 17 * 17, 0, PatchPrimitiveCount);
+            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: 0, PatchPrimitiveCount);
         }
 
         float Elevation(int x, int z)

--- a/Source/RunActivity/Viewer3D/Transfers.cs
+++ b/Source/RunActivity/Viewer3D/Transfers.cs
@@ -70,7 +70,6 @@ namespace Orts.Viewer3D
     {
         readonly VertexBuffer VertexBuffer;
         readonly IndexBuffer IndexBuffer;
-        readonly int VertexCount;
         readonly int PrimitiveCount;
 
         public TransferPrimitive(Viewer viewer, float width, float height, WorldPosition position)
@@ -131,7 +130,6 @@ namespace Orts.Viewer3D
 
             VertexBuffer = new VertexBuffer(viewer.GraphicsDevice, typeof(VertexPositionTexture), verticies.Length, BufferUsage.WriteOnly);
             VertexBuffer.SetData(verticies);
-            VertexCount = verticies.Length;
 
             IndexBuffer = new IndexBuffer(viewer.GraphicsDevice, typeof(short), indicies.Length, BufferUsage.WriteOnly);
             IndexBuffer.SetData(indicies);
@@ -142,7 +140,7 @@ namespace Orts.Viewer3D
         {
             graphicsDevice.SetVertexBuffer(VertexBuffer);
             graphicsDevice.Indices = IndexBuffer;
-            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, VertexCount, 0, PrimitiveCount);
+            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: 0, PrimitiveCount);
         }
     }
 

--- a/Source/RunActivity/Viewer3D/Water.cs
+++ b/Source/RunActivity/Viewer3D/Water.cs
@@ -79,7 +79,7 @@ namespace Orts.Viewer3D
         {
             graphicsDevice.Indices = IndexBuffer;
             graphicsDevice.SetVertexBuffers(VertexBufferBindings);
-            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, 17 * 17, 0, PrimitiveCount);
+            graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: 0, PrimitiveCount);
         }
 
         void LoadGeometry(GraphicsDevice graphicsDevice, Tile tile, out int primitiveCount, out IndexBuffer indexBuffer, out VertexBuffer vertexBuffer)

--- a/Source/RunActivity/Viewer3D/Wire.cs
+++ b/Source/RunActivity/Viewer3D/Wire.cs
@@ -734,7 +734,7 @@ namespace Orts.Viewer3D
             // Create and populate a new ShapePrimitive
             var indexBuffer = new IndexBuffer(viewer.GraphicsDevice, typeof(short), NumIndices, BufferUsage.WriteOnly);
             indexBuffer.SetData(TriangleListIndices);
-            return new ShapePrimitive(lodItem.LODMaterial, new SharedShape.VertexBufferSet(VertexList, viewer.GraphicsDevice), indexBuffer, 0, NumVertices, NumIndices / 3, new[] { -1 }, 0);
+            return new ShapePrimitive(lodItem.LODMaterial, new SharedShape.VertexBufferSet(VertexList, viewer.GraphicsDevice), indexBuffer, NumIndices / 3, new[] { -1 }, 0);
         }
 
         /// <summary>


### PR DESCRIPTION
Monogame has deprecated the versions of `GraphicsDevice.DrawIndexedPrimitives()` and `GraphicsDevice.DrawInstancedPrimitives()` that take vertex parameters. This PR removes those parameters and resolves the associated build warnings.