### PR TITLE
Bug fix for ttps://bugs.launchpad.net/or/+bug/1918921 Crash after restore in timetable mode

### DIFF
--- a/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
@@ -319,6 +319,7 @@ namespace Orts.Simulation.AIs
 
         public override void Save(BinaryWriter outf)
         {
+            // if something changes in this list, it must be changed also in Save(BinaryWriter outf) within TTTrain.cs
             outf.Write("AI");
             base.Save(outf);
             outf.Write(UiD);

--- a/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
@@ -644,6 +644,8 @@ namespace Orts.Simulation.Timetables
             outf.Write(UncondAttach);
             outf.Write(doorCloseAdvance);
             outf.Write(doorOpenDelay);
+            // dummy for level crossing horn pattern
+            outf.Write(-1);
 
             // dummy for service list count
             outf.Write(-1);


### PR DESCRIPTION
An additional parameter related to AI trains horn blow has been added in the AI train save method. In this case, the same parameter must be added for in the Save method for TTTrains, because AI trains and TTTrains share the restore method, but don't share the save method. Apart correcting the bug, now a warning message has been added in the AITrain save method.