### PR TITLE
Fix ReadTheDocs by adding an optional configuration option back

### DIFF
--- a/Source/Documentation/Manual/conf.py
+++ b/Source/Documentation/Manual/conf.py
@@ -57,6 +57,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # is enabled with language, an equivalent format for the selected locale).
 today_fmt = '%d %B %Y'
 
+# NOTE: This is needed because ReadTheDocs uses an old version of Sphinx.
+# The master toctree document.
+master_doc = 'index'
+
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
This was easier than getting ReadTheDocs to use a newer version of Sphinx, which seems to involve adding a RTD cofig file and a complete Python `requirements.txt`