### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1919354 In isolated locos rear brakeman view is not available

### DIFF
--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -1549,6 +1549,12 @@ namespace Orts.Viewer3D
             LastCar();
         }
 
+        public override void LastCar()
+        {
+            base.LastCar();
+            attachedToRear = true;
+        }
+
     }
 
     public class InsideThreeDimCamera : NonTrackingCamera


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/34936-no-6-rear-camera-for-player-locomotive/