### PR TITLE
Replace for loops with explicit array copies and comparisons

### DIFF
--- a/Source/Orts.Formats.Msts/ShapeFile.cs
+++ b/Source/Orts.Formats.Msts/ShapeFile.cs
@@ -901,8 +901,7 @@ namespace Orts.Formats.Msts
         {
             flags = copy.flags;
             ishader = copy.ishader;
-            tex_idxs = new int[copy.tex_idxs.Length];
-            for (var i = 0; i < copy.tex_idxs.Length; ++i) tex_idxs[i] = copy.tex_idxs[i];
+            tex_idxs = (int[])copy.tex_idxs.Clone();
             ZBias = copy.ZBias;
             ivtx_state = copy.ivtx_state;
             alphatestmode = copy.alphatestmode;
@@ -915,7 +914,7 @@ namespace Orts.Formats.Msts
             if (flags != prim_state.flags) return false;
             if (ishader != prim_state.ishader) return false;
             if (tex_idxs.Length != prim_state.tex_idxs.Length) return false;
-            for (var i = 0; i < tex_idxs.Length; ++i) if (tex_idxs[i] != prim_state.tex_idxs[i]) return false;
+            if (!tex_idxs.SequenceEqual(prim_state.tex_idxs)) return false;
             if (ZBias != prim_state.ZBias) return false;
             if (ivtx_state != prim_state.ivtx_state) return false;
             if (alphatestmode != prim_state.alphatestmode) return false;
@@ -1246,8 +1245,7 @@ namespace Orts.Formats.Msts
             inormal = copy.inormal;
             Color1 = copy.Color1;
             Color2 = copy.Color2;
-            vertex_uvs = new int[copy.vertex_uvs.Length];
-            for (var i = 0; i < copy.vertex_uvs.Length; ++i) vertex_uvs[i] = copy.vertex_uvs[i];
+            vertex_uvs = (int[])copy.vertex_uvs.Clone();
         }
 
         public vertex()
@@ -1268,8 +1266,7 @@ namespace Orts.Formats.Msts
             if (inormal != vertex.inormal) return false;
             if (Color1 != vertex.Color1) return false;
             if (Color2 != vertex.Color2) return false;
-            if (vertex_uvs.Length != vertex.vertex_uvs.Length) return false;
-            for (var i = 0; i < vertex_uvs.Length; ++i) if (vertex_uvs[i] != vertex.vertex_uvs[i]) return false;
+            if (!vertex_uvs.SequenceEqual(vertex.vertex_uvs)) return false;
             return true;
         }
     }

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -583,10 +583,10 @@ namespace Orts.Viewer3D
                 id = SpeedPostObj.GetTrItemID(idlocation);
             }
             //create the shape primitive
-            short[] newTList = new short[NumIndices];
-            for (i = 0; i < NumIndices; i++) newTList[i] = TriangleListIndices[i];
-            VertexPositionNormalTexture[] newVList = new VertexPositionNormalTexture[NumVertices];
-            for (i = 0; i < NumVertices; i++) newVList[i] = VertexList[i];
+            var newTList = new short[NumIndices];
+            Array.Copy(TriangleListIndices, newTList, NumIndices);
+            var newVList = new VertexPositionNormalTexture[NumVertices];
+            Array.Copy(VertexList, newVList, NumVertices);
             IndexBuffer IndexBuffer = new IndexBuffer(viewer.GraphicsDevice, typeof(short),
                                                             NumIndices, BufferUsage.WriteOnly);
             IndexBuffer.SetData(newTList);


### PR DESCRIPTION
Replaces `for (i = 0; i < length; i++)` with `Array.Copy()`, `Array.Clone(),` and `Enumerable.SequenceEqual()`.

Array.Copy() and and Array.Clone(), in addition to being easier to read, are also an order of magnitude [faster](https://stackoverflow.com/a/18639042) than looping by index.