### PR TITLE
Add a video options setting for MultiSampleCount anti-aliasing

### DIFF
--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -367,6 +367,17 @@ Ambient daylight brightness
 
 With this slider you can set the daylight brightness.
 
+Anti-aliasing
+-------------
+
+Controls the anti-aliasing method used by Open Rails. Anti-aliasing is a
+computer graphics technique that smooths any harsh edges, otherwise known as
+"jaggies," present in the video image. Currently, Open Rails only supports the
+multisample anti-aliasing (MSAA) method. Higher applications of anti-aliasing
+will require exponentially more graphics computing power.
+
+The default setting is MSAA with 2x sampling.
+
 .. _options-simulation:
 
 Simulation Options

--- a/Source/Menu/Options.Designer.cs
+++ b/Source/Menu/Options.Designer.cs
@@ -77,6 +77,9 @@
             this.numericSoundDetailLevel = new System.Windows.Forms.NumericUpDown();
             this.checkMSTSBINSound = new System.Windows.Forms.CheckBox();
             this.tabPageVideo = new System.Windows.Forms.TabPage();
+            this.labelAntiAliasingValue = new System.Windows.Forms.Label();
+            this.labelAntiAliasing = new System.Windows.Forms.Label();
+            this.trackAntiAliasing = new System.Windows.Forms.TrackBar();
             this.checkShadowAllShapes = new System.Windows.Forms.CheckBox();
             this.checkDoubleWire = new System.Windows.Forms.CheckBox();
             this.label15 = new System.Windows.Forms.Label();
@@ -225,6 +228,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericSoundVolumePercent)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericSoundDetailLevel)).BeginInit();
             this.tabPageVideo.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.trackAntiAliasing)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackDayAmbientLight)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericDistantMountainsViewingDistance)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericViewingDistance)).BeginInit();
@@ -835,6 +839,9 @@
             // 
             // tabPageVideo
             // 
+            this.tabPageVideo.Controls.Add(this.labelAntiAliasingValue);
+            this.tabPageVideo.Controls.Add(this.labelAntiAliasing);
+            this.tabPageVideo.Controls.Add(this.trackAntiAliasing);
             this.tabPageVideo.Controls.Add(this.checkShadowAllShapes);
             this.tabPageVideo.Controls.Add(this.checkDoubleWire);
             this.tabPageVideo.Controls.Add(this.label15);
@@ -867,6 +874,44 @@
             this.tabPageVideo.TabIndex = 4;
             this.tabPageVideo.Text = "Video";
             this.tabPageVideo.UseVisualStyleBackColor = true;
+            // 
+            // labelAntiAliasingValue
+            // 
+            this.labelAntiAliasingValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelAntiAliasingValue.Location = new System.Drawing.Point(376, 352);
+            this.labelAntiAliasingValue.Margin = new System.Windows.Forms.Padding(3);
+            this.labelAntiAliasingValue.Name = "labelAntiAliasingValue";
+            this.labelAntiAliasingValue.Size = new System.Drawing.Size(220, 13);
+            this.labelAntiAliasingValue.TabIndex = 23;
+            this.labelAntiAliasingValue.Text = "XXX";
+            this.labelAntiAliasingValue.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // labelAntiAliasing
+            // 
+            this.labelAntiAliasing.AutoSize = true;
+            this.labelAntiAliasing.Location = new System.Drawing.Point(304, 352);
+            this.labelAntiAliasing.Margin = new System.Windows.Forms.Padding(3);
+            this.labelAntiAliasing.Name = "labelAntiAliasing";
+            this.labelAntiAliasing.Size = new System.Drawing.Size(66, 13);
+            this.labelAntiAliasing.TabIndex = 22;
+            this.labelAntiAliasing.Text = "Anti-aliasing:";
+            // 
+            // trackAntiAliasing
+            // 
+            this.trackAntiAliasing.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.trackAntiAliasing.AutoSize = false;
+            this.trackAntiAliasing.BackColor = System.Drawing.SystemColors.Window;
+            this.trackAntiAliasing.LargeChange = 2;
+            this.trackAntiAliasing.Location = new System.Drawing.Point(304, 371);
+            this.trackAntiAliasing.Margin = new System.Windows.Forms.Padding(6, 3, 6, 3);
+            this.trackAntiAliasing.Maximum = 6;
+            this.trackAntiAliasing.Minimum = 1;
+            this.trackAntiAliasing.Name = "trackAntiAliasing";
+            this.trackAntiAliasing.Size = new System.Drawing.Size(292, 26);
+            this.trackAntiAliasing.TabIndex = 24;
+            this.toolTip1.SetToolTip(this.trackAntiAliasing, "Default is 2x MSAA");
+            this.trackAntiAliasing.Value = 2;
+            this.trackAntiAliasing.ValueChanged += new System.EventHandler(this.trackAntiAliasing_ValueChanged);
             // 
             // checkShadowAllShapes
             // 
@@ -2524,6 +2569,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericSoundDetailLevel)).EndInit();
             this.tabPageVideo.ResumeLayout(false);
             this.tabPageVideo.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.trackAntiAliasing)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackDayAmbientLight)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericDistantMountainsViewingDistance)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericViewingDistance)).EndInit();
@@ -2742,5 +2788,8 @@
         private System.Windows.Forms.PictureBox pbWebServer;
         private System.Windows.Forms.PictureBox pbDisableTcs;
         private System.Windows.Forms.PictureBox pbOverspeedMonitor;
+        private System.Windows.Forms.TrackBar trackAntiAliasing;
+        private System.Windows.Forms.Label labelAntiAliasingValue;
+        private System.Windows.Forms.Label labelAntiAliasing;
     }
 }

--- a/Source/Menu/Options.cs
+++ b/Source/Menu/Options.cs
@@ -636,7 +636,7 @@ namespace ORTS
             switch ((UserSettings.AntiAliasingMethod)trackAntiAliasing.Value)
             {
                 case UserSettings.AntiAliasingMethod.None:
-                    method = "None";
+                    method = "Disabled";
                     break;
                 case UserSettings.AntiAliasingMethod.MSAA2x:
                     method = "2x MSAA";

--- a/Source/Menu/Options.cs
+++ b/Source/Menu/Options.cs
@@ -179,6 +179,8 @@ namespace ORTS
             comboWindowSize.Text = Settings.WindowSize;
             trackDayAmbientLight.Value = Settings.DayAmbientLight;
             trackDayAmbientLight_ValueChanged(null, null);
+            trackAntiAliasing.Value = Settings.AntiAliasing;
+            trackAntiAliasing_ValueChanged(null, null);
             checkDoubleWire.Checked = Settings.DoubleWire;
 
             // Simulation tab
@@ -467,6 +469,7 @@ namespace ORTS
 
             Settings.DayAmbientLight = (int)trackDayAmbientLight.Value;
             Settings.DoubleWire = checkDoubleWire.Checked;
+            Settings.AntiAliasing = trackAntiAliasing.Value;
 
             // Simulation tab
             Settings.SimpleControlPhysics = checkSimpleControlsPhysics.Checked;
@@ -625,6 +628,36 @@ namespace ORTS
         private void trackDayAmbientLight_ValueChanged(object sender, EventArgs e)
         {
             labelDayAmbientLight.Text = catalog.GetStringFmt("{0}%", trackDayAmbientLight.Value * 5);
+        }
+
+        private void trackAntiAliasing_ValueChanged(object sender, EventArgs e)
+        {
+            string method;
+            switch ((UserSettings.AntiAliasingMethod)trackAntiAliasing.Value)
+            {
+                case UserSettings.AntiAliasingMethod.None:
+                    method = "None";
+                    break;
+                case UserSettings.AntiAliasingMethod.MSAA2x:
+                    method = "2x MSAA";
+                    break;
+                case UserSettings.AntiAliasingMethod.MSAA4x:
+                    method = "4x MSAA";
+                    break;
+                case UserSettings.AntiAliasingMethod.MSAA8x:
+                    method = "8x MSAA";
+                    break;
+                case UserSettings.AntiAliasingMethod.MSAA16x:
+                    method = "16x MSAA";
+                    break;
+                case UserSettings.AntiAliasingMethod.MSAA32x:
+                    method = "32x MSAA";
+                    break;
+                default:
+                    method = "";
+                    break;
+            }
+            labelAntiAliasingValue.Text = method;
         }
 
         private void trackLODBias_ValueChanged(object sender, EventArgs e)

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -90,6 +90,37 @@ namespace ORTS.Settings
         }
         #endregion
 
+        /// <summary>
+        /// Specifies an anti-aliasing method. Currently, Monogame's MSAA is the only supported method.
+        /// </summary>
+        public enum AntiAliasingMethod
+        {
+            /// <summary>
+            /// No antialiasing
+            /// </summary>
+            None = 1,
+            /// <summary>
+            /// 2x multisampling
+            /// </summary>
+            MSAA2x = 2,
+            /// <summary>
+            /// 4x multisampling
+            /// </summary>
+            MSAA4x = 3,
+            /// <summary>
+            /// 8x multisampling
+            /// </summary>
+            MSAA8x = 4,
+            /// <summary>
+            /// 16x multisampling
+            /// </summary>
+            MSAA16x = 5,
+            /// <summary>
+            /// 32x multisampling
+            /// </summary>
+            MSAA32x = 6,
+        }
+
         public enum DirectXFeature
         {
             Level9_1,
@@ -195,6 +226,8 @@ namespace ORTS.Settings
         public string WindowSize { get; set; }
         [Default(20)]
         public int DayAmbientLight { get; set; }
+        [Default(AntiAliasingMethod.MSAA2x)]
+        public int AntiAliasing { get; set; }
 
         // Simulation settings:
 


### PR DESCRIPTION
Now that Monogame has landed, we can introduce proper anti-aliasing support. This PR adds a 6-step slider that ranges from no anti-aliasing to 32x MSAA. It is based on the equivalent feature already present in NewYear MG, except this patch is agnostic to different methods of anti-aliasing - which would make it easier to introduce FXAA, SSAA, and other alternative methods in the future. I have also located the slider at the bottom of the video tab, next to the ambient brightness slider.

![image](https://user-images.githubusercontent.com/4701008/112235361-b71b3d80-8bfb-11eb-835b-e7f7e07c3dac.png)

Feature request: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)