### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1921615 No brake HUD after entering a new cab

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1042,6 +1042,9 @@ namespace Orts.Simulation.RollingStocks
             LocomotiveName = locoCopy.LocomotiveName;
             MaxVaccuumMaxPressurePSI = locoCopy.MaxVaccuumMaxPressurePSI;
             VacuumBrakeEQFitted = locoCopy.VacuumBrakeEQFitted;
+            TrainBrakeFitted = locoCopy.TrainBrakeFitted;
+            EngineBrakeFitted = locoCopy.EngineBrakeFitted;
+            BrakemanBrakeFitted = locoCopy.BrakemanBrakeFitted;
             SteamEngineBrakeFitted = locoCopy.SteamEngineBrakeFitted;
             HasWaterScoop = locoCopy.HasWaterScoop;
             WaterScoopFillElevationM = locoCopy.WaterScoopFillElevationM;


### PR DESCRIPTION
See here http://www.elvastower.com/forums/index.php?/topic/34572-new-player-trains-dont-show-train-brakes-in-hud/ and here http://www.elvastower.com/forums/index.php?/topic/35017-open-rails-x-131-323-f5-brake-information-not-displayed-for-helper-locomotives/ . Switching from the player loco cab to the cab of another loco of same type leads to HUD brake info missing.