### PR TITLE
Battery and PowerKey cab controls, on behalf of Paolo

### DIFF
--- a/Source/Documentation/Manual/cabs.rst
+++ b/Source/Documentation/Manual/cabs.rst
@@ -266,15 +266,18 @@ Further OR cab controls
 -----------------------
 
 OR supports the cabview control to open/close the left doors, the right doors 
-and the mirrors.
+and the mirrors. Moreover it supports the controls for the battery state and for 
+the key state; these two controls have no effect on the state of the locomotive.
 
 .. index::
    single: ORTS_LEFTDOOR
    single: ORTS_RIGHTDOOR
    single: ORTS_MIRRORS
+   single: ORTS_BATTERY
+   single: ORTS_POWERKEY
 
 The control blocks are like the one shown for the cab light. The Type strings 
-are ORTS_LEFTDOOR, ORTS_RIGHTDOOR and ORTS_MIRRORS.
+are ORTS_LEFTDOOR, ORTS_RIGHTDOOR, ORTS_MIRRORS, ORTS_BATTERY and ORTS_POWERKEY.
 
 
 High-resolution Cab Backgrounds and Controls

--- a/Source/Documentation/Manual/sound.rst
+++ b/Source/Documentation/Manual/sound.rst
@@ -280,6 +280,10 @@ Trigger       Function
 174           HotBoxBearingOff
 175           BoilerBlowdownOn
 176           BoilerBlowdownOff
+177           BatteryOn
+178           BatteryOff
+179           PowerKeyOn
+180           PowerKeyOff
 =========     =====================================
 
 

--- a/Source/ORTS.Common/Input/UserCommand.cs
+++ b/Source/ORTS.Common/Input/UserCommand.cs
@@ -199,5 +199,7 @@
         [GetString("Control AI Fire On")] ControlAIFireOn,
         [GetString("Control AI Fire Off")] ControlAIFireOff,
         [GetString("Control AI Fire Reset")] ControlAIFireReset,
+        [GetString("Control Battery")] ControlBattery,
+        [GetString("Control PowerKey")] ControlPowerKey,
     }
 }

--- a/Source/ORTS.Settings/InputSettings.cs
+++ b/Source/ORTS.Settings/InputSettings.cs
@@ -345,6 +345,7 @@ namespace ORTS.Settings
             Commands[(int)UserCommand.ControlAlerter] = new UserCommandKeyInput(0x2C);
             Commands[(int)UserCommand.ControlBackwards] = new UserCommandKeyInput(0x1F);
             Commands[(int)UserCommand.ControlBailOff] = new UserCommandKeyInput(0x35);
+            Commands[(int)UserCommand.ControlBattery] = new UserCommandKeyInput(0x30, KeyModifiers.Control);
             Commands[(int)UserCommand.ControlBell] = new UserCommandKeyInput(0x30);
             Commands[(int)UserCommand.ControlBellToggle] = new UserCommandKeyInput(0x30, KeyModifiers.Shift);
             Commands[(int)UserCommand.ControlBlowerDecrease] = new UserCommandKeyInput(0x31, KeyModifiers.Shift);
@@ -408,6 +409,7 @@ namespace ORTS.Settings
             Commands[(int)UserCommand.ControlPantograph2] = new UserCommandKeyInput(0x19, KeyModifiers.Shift);
             Commands[(int)UserCommand.ControlPantograph3] = new UserCommandKeyInput(0x19, KeyModifiers.Control);
             Commands[(int)UserCommand.ControlPantograph4] = new UserCommandKeyInput(0x19, KeyModifiers.Shift | KeyModifiers.Control);
+            Commands[(int)UserCommand.ControlPowerKey] = new UserCommandKeyInput(0x25, KeyModifiers.Control);
             Commands[(int)UserCommand.ControlOdoMeterShowHide] = new UserCommandKeyInput(0x2C, KeyModifiers.Shift);
             Commands[(int)UserCommand.ControlOdoMeterReset] = new UserCommandKeyInput(0x2C, KeyModifiers.Control);
             Commands[(int)UserCommand.ControlOdoMeterDirection] = new UserCommandKeyInput(0x2C, KeyModifiers.Control | KeyModifiers.Shift);

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -181,6 +181,8 @@ namespace Orts.Formats.Msts
         ORTS_BAILOFF,
         ORTS_QUICKRELEASE,
         ORTS_OVERCHARGE,
+        ORTS_BATTERY,
+        ORTS_POWERKEY,
 
         // TCS Controls
         ORTS_TCS1,

--- a/Source/Orts.Simulation/Common/Commands.cs
+++ b/Source/Orts.Simulation/Common/Commands.cs
@@ -994,7 +994,42 @@ namespace Orts.Common
             // Report();
         }
     }
-    
+
+    [Serializable()]
+    public sealed class ToggleBatteryCommand : Command
+    {
+        public static MSTSLocomotive Receiver { get; set; }
+
+        public ToggleBatteryCommand(CommandLog log)
+            : base(log)
+        {
+            Redo();
+        }
+
+        public override void Redo()
+        {
+            Receiver.ToggleBattery();
+            // Report();
+        }
+    }
+
+    [Serializable()]
+    public sealed class TogglePowerKeyCommand : Command
+    {
+        public static MSTSLocomotive Receiver { get; set; }
+
+        public TogglePowerKeyCommand(CommandLog log)
+            : base(log)
+        {
+            Redo();
+        }
+
+        public override void Redo()
+        {
+            Receiver.TogglePowerKey();
+            // Report();
+        }
+    }
     // Steam controls
     [Serializable()]
     public sealed class ContinuousSteamHeatCommand : ContinuousCommand

--- a/Source/Orts.Simulation/Common/Events.cs
+++ b/Source/Orts.Simulation/Common/Events.cs
@@ -27,6 +27,8 @@ namespace Orts.Common
     public enum Event
     {
         None,
+        BatteryOff,
+        BatteryOn,
         BellOff,
         BellOn,
         BlowerChange,
@@ -101,6 +103,8 @@ namespace Orts.Common
         PermissionDenied,
         PermissionGranted,
         PermissionToDepart,
+        PowerKeyOff,
+        PowerKeyOn,
         ReverserChange,
         ReverserToForwardBackward,
         ReverserToNeutral,
@@ -400,11 +404,11 @@ namespace Orts.Common
                         case 175: return Event.BoilerBlowdownOn;
                         case 176: return Event.BoilerBlowdownOff;
 
-                        // These triggers have been released in MG????
-                    //    case 177: return Event.ORTS_BATTERY;
-                    //    case 178: return Event.ORTS_BATTERY;
-                    //    case 179: return Event.ORTS_POWERKEY;
-                    //    case 180: return Event.ORTS_POWERKEY;
+                        case 177: return Event.BatteryOn;
+                        case 178: return Event.BatteryOff;
+
+                        case 179: return Event.PowerKeyOn;
+                        case 180: return Event.PowerKeyOff;
 
                         case 181: return Event.GenericEvent1;
                         case 182: return Event.GenericEvent2;

--- a/Source/Orts.Simulation/Simulation/Confirmer.cs
+++ b/Source/Orts.Simulation/Simulation/Confirmer.cs
@@ -97,6 +97,8 @@ namespace Orts.Simulation
       , Wipers
       , ChangeCab
       , Odometer
+      , Battery
+      , PowerKey
       // Train Devices
       , DoorsLeft
       , DoorsRight
@@ -239,6 +241,8 @@ namespace Orts.Simulation
                 , new string [] { GetString("Wipers"), GetString("off"), null, GetString("on") } 
                 , new string [] { GetString("Cab"), null, null, GetParticularString("Cab", "change"), null, null, GetString("changing is not available"), GetString("changing disabled. Close throttle, set reverser to neutral, stop train then re-try.") } 
                 , new string [] { GetString("Odometer"), null, null, GetParticularString("Odometer", "reset"), GetParticularString("Odometer", "counting down"), GetParticularString("Odometer", "counting up") }
+                , new string [] { GetString("Battery"), GetString("off"), null, GetString("on") }
+                , new string [] { GetString("PowerKey"), GetString("off"), null, GetString("on")}
                 // Train Devices
                 , new string [] { GetString("Doors Left"), GetString("close"), null, GetString("open") } 
                 , new string [] { GetString("Doors Right"), GetString("close"), null, GetString("open") } 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -143,6 +143,8 @@ namespace Orts.Simulation.RollingStocks
         public bool CabRadioOn;
         public bool OnLineCabRadio;
         public string OnLineCabRadioURL;
+        public bool Battery;
+        public bool PowerKey;
 
         // Water trough filling
         public bool HasWaterScoop = false; // indicates whether loco + tender have a water scoop or not
@@ -1100,6 +1102,8 @@ namespace Orts.Simulation.RollingStocks
             ControllerFactory.Save(SteamHeatController, outf);
             outf.Write(AcceptMUSignals);
             outf.Write(PowerReduction);
+            outf.Write(Battery);
+            outf.Write(PowerKey);
             outf.Write(ScoopIsBroken);
             outf.Write(IsWaterScoopDown);
             outf.Write(CurrentTrackSandBoxCapacityM3);
@@ -1142,6 +1146,8 @@ namespace Orts.Simulation.RollingStocks
             ControllerFactory.Restore(SteamHeatController, inf);
             AcceptMUSignals = inf.ReadBoolean();
             PowerReduction = inf.ReadSingle();
+            Battery = inf.ReadBoolean();
+            PowerKey = inf.ReadBoolean();
             ScoopIsBroken = inf.ReadBoolean();
             IsWaterScoopDown = inf.ReadBoolean();
             CurrentTrackSandBoxCapacityM3 = inf.ReadSingle();
@@ -3883,6 +3889,20 @@ namespace Orts.Simulation.RollingStocks
             Simulator.Confirmer.Confirm(CabControl.CabLight, CabLightOn ? CabSetting.On : CabSetting.Off);
         }
 
+        public void ToggleBattery()
+        {
+            Battery = !Battery;
+            if (Battery) SignalEvent(Event.BatteryOn);
+            else SignalEvent(Event.BatteryOff);
+            if (Simulator.PlayerLocomotive == this) Simulator.Confirmer.Confirm(CabControl.Battery, Battery ? CabSetting.On : CabSetting.Off);
+        }
+        public void TogglePowerKey()
+        {
+            PowerKey = !PowerKey;
+            if (PowerKey) SignalEvent(Event.PowerKeyOn);
+            else SignalEvent(Event.PowerKeyOff);
+            if (Simulator.PlayerLocomotive == this) Simulator.Confirmer.Confirm(CabControl.PowerKey, PowerKey ? CabSetting.On : CabSetting.Off);
+        }
         public void ToggleCabRadio( bool newState)
         {
             CabRadioOn = newState;
@@ -4834,6 +4854,12 @@ namespace Orts.Simulation.RollingStocks
                     break;
                 case CABViewControlTypes.ORTS_MIRRORS:
                     data = MirrorOpen ? 1 : 0;
+                    break;
+                case CABViewControlTypes.ORTS_BATTERY:
+                    data = Battery ? 1 : 0;
+                    break;
+                case CABViewControlTypes.ORTS_POWERKEY:
+                    data = PowerKey ? 1 : 0;
                     break;
                 case CABViewControlTypes.ORTS_HOURDIAL:
                     float hour = (float)(Simulator.ClockTime / 3600) % 12;

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -179,6 +179,8 @@ namespace Orts.Viewer3D.RollingStock
             UserInputCommands.Add(UserCommand.ControlOdoMeterDirection, new Action[] { Noop, () => new ToggleOdometerDirectionCommand(Viewer.Log) });
             UserInputCommands.Add(UserCommand.ControlCabRadio, new Action[] { Noop, () => new CabRadioCommand(Viewer.Log, !Locomotive.CabRadioOn) });
             UserInputCommands.Add(UserCommand.ControlDieselHelper, new Action[] { Noop, () => new ToggleHelpersEngineCommand(Viewer.Log) });
+            UserInputCommands.Add(UserCommand.ControlBattery, new Action[] { Noop, () => new ToggleBatteryCommand(Viewer.Log) });
+            UserInputCommands.Add(UserCommand.ControlPowerKey, new Action[] { Noop, () => new TogglePowerKeyCommand(Viewer.Log) });
             UserInputCommands.Add(UserCommand.ControlGeneric1, new Action[] {
                 () => new TCSButtonCommand(Viewer.Log, false, 0),
                 () => {
@@ -1943,6 +1945,8 @@ namespace Orts.Viewer3D.RollingStock
                 case CABViewControlTypes.ORTS_LEFTDOOR:
                 case CABViewControlTypes.ORTS_RIGHTDOOR:
                 case CABViewControlTypes.ORTS_MIRRORS:
+                case CABViewControlTypes.ORTS_BATTERY:
+                case CABViewControlTypes.ORTS_POWERKEY:
                     index = (int)data;
                     break;
 
@@ -2154,6 +2158,10 @@ namespace Orts.Viewer3D.RollingStock
                          != ChangedValue(Locomotive.GetCabFlipped() ? (Locomotive.DoorLeftOpen ? 1 : 0) : Locomotive.DoorRightOpen ? 1 : 0)) new ToggleDoorsRightCommand(Viewer.Log); break;
                 case CABViewControlTypes.ORTS_MIRRORS:
                     if ((Locomotive.MirrorOpen ? 1 : 0) != ChangedValue(Locomotive.MirrorOpen ? 1 : 0)) new ToggleMirrorsCommand(Viewer.Log); break;
+                case CABViewControlTypes.ORTS_BATTERY:
+                    if ((Locomotive.Battery ? 1 : 0) != ChangedValue(Locomotive.Battery ? 1 : 0)) new ToggleBatteryCommand(Viewer.Log); break;
+                case CABViewControlTypes.ORTS_POWERKEY:
+                    if ((Locomotive.PowerKey ? 1 : 0) != ChangedValue(Locomotive.PowerKey ? 1 : 0)) new TogglePowerKeyCommand(Viewer.Log); break;
 
                 // Train Control System controls
                 case CABViewControlTypes.ORTS_TCS1:

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -585,6 +585,8 @@ namespace Orts.Viewer3D
             ToggleHelpersEngineCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
             TCSButtonCommand.Receiver = ((MSTSLocomotive)PlayerLocomotive).TrainControlSystem;
             TCSSwitchCommand.Receiver = ((MSTSLocomotive)PlayerLocomotive).TrainControlSystem;
+            ToggleBatteryCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
+            TogglePowerKeyCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
         }
 
         public void ChangeToPreviousFreeRoamCamera()


### PR DESCRIPTION
Battery and PowerKey cab controls, https://trello.com/c/G4tuC0wc/468-ortsbattery https://trello.com/c/JbeOzUT7/247-power-key-cab-view-control . See also http://www.elvastower.com/forums/index.php?/topic/34095-orts-battery-and-orts-powerkey/ .
Manual will be updated after code accepted. 
Feature already present in OR NewYear MG.
Original PR generated by Paolo had conflicts. Actual PR generated with his consent.