### PR TITLE
Save settings immediately upon changing in RunActivity.exe

### DIFF
--- a/Source/ORTS.Common/SettingsBase.cs
+++ b/Source/ORTS.Common/SettingsBase.cs
@@ -46,6 +46,11 @@ namespace ORTS.Common
         protected readonly Dictionary<string, Source> Sources = new Dictionary<string, Source>();
 
         /// <summary>
+        /// True when the user settings store is in use and will be read from and written to.
+        /// </summary>
+        protected bool AllowUserSettings { get; private set; }
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="settings">The store for the settings</param>
@@ -76,9 +81,8 @@ namespace ORTS.Common
         /// <summary>
         /// Load all settings, possibly partly from the given options
         /// </summary>
-        /// <param name="allowUserSettings">Are user settings allowed?</param>
         /// <param name="optionsDictionary">???</param>
-		protected abstract void Load(bool allowUserSettings, Dictionary<string, string> optionsDictionary);
+		protected abstract void Load(Dictionary<string, string> optionsDictionary);
 
         /// <summary>
         /// Save all settings to the store
@@ -103,7 +107,7 @@ namespace ORTS.Common
 		protected void Load(IEnumerable<string> options)
 		{
 			// This special command-line option prevents the registry values from being used.
-			var allowUserSettings = !options.Contains("skip-user-settings", StringComparer.OrdinalIgnoreCase);
+			AllowUserSettings = !options.Contains("skip-user-settings", StringComparer.OrdinalIgnoreCase);
 
 			// Pull apart the command-line options so we can find them by setting name.
 			var optionsDictionary = new Dictionary<string, string>();
@@ -114,23 +118,22 @@ namespace ORTS.Common
 				optionsDictionary[k] = v;
 			}
 
-			Load(allowUserSettings, optionsDictionary);
+			Load(optionsDictionary);
 		}
 
         /// <summary>
         /// Load a single value from the store, once type of the setting is known
         /// </summary>
-        /// <param name="allowUserSettings">Are user settings allowed for this setting?</param>
         /// <param name="optionsDictionary">???</param>
         /// <param name="name">name of the setting</param>
         /// <param name="type">type of the setting</param>
-		protected void Load(bool allowUserSettings, Dictionary<string, string> optionsDictionary, string name, Type type)
+		protected void Load(Dictionary<string, string> optionsDictionary, string name, Type type)
 		{
 			// Get the default value.
 			var defValue = GetDefaultValue(name);
 
 			// Read in the user setting, if it exists.
-			var userValue = allowUserSettings ? SettingStore.GetUserValue(name, type) : null;
+			var userValue = AllowUserSettings ? SettingStore.GetUserValue(name, type) : null;
 
 			// Read in the command-line option, if it exists into optValue.
 			var propertyNameLower = name.ToLowerInvariant();

--- a/Source/ORTS.Settings/FolderSettings.cs
+++ b/Source/ORTS.Settings/FolderSettings.cs
@@ -53,10 +53,10 @@ namespace ORTS.Settings
                 Folders.Remove(name);
         }
 
-        protected override void Load(bool allowUserSettings, Dictionary<string, string> optionsDictionary)
+        protected override void Load(Dictionary<string, string> optionsDictionary)
         {
             foreach (var name in SettingStore.GetUserNames())
-                Load(allowUserSettings, optionsDictionary, name, typeof(string));
+                Load(optionsDictionary, name, typeof(string));
         }
 
         public override void Save()

--- a/Source/ORTS.Settings/InputSettings.cs
+++ b/Source/ORTS.Settings/InputSettings.cs
@@ -110,10 +110,10 @@ namespace ORTS.Settings
             Commands[(int)GetCommand(name)].PersistentDescriptor = (string)value;
         }
 
-        protected override void Load(bool allowUserSettings, Dictionary<string, string> optionsDictionary)
+        protected override void Load(Dictionary<string, string> optionsDictionary)
         {
             foreach (var command in GetCommands())
-                Load(allowUserSettings, optionsDictionary, command.ToString(), typeof(string));
+                Load(optionsDictionary, command.ToString(), typeof(string));
         }
 
         public override void Save()

--- a/Source/ORTS.Settings/UpdateSettings.cs
+++ b/Source/ORTS.Settings/UpdateSettings.cs
@@ -97,10 +97,10 @@ namespace ORTS.Settings
             GetProperty(name).SetValue(this, value, null);
         }
 
-        protected override void Load(bool allowUserSettings, Dictionary<string, string> optionsDictionary)
+        protected override void Load(Dictionary<string, string> optionsDictionary)
         {
             foreach (var property in GetProperties())
-                Load(allowUserSettings, optionsDictionary, property.Name, property.PropertyType);
+                Load(optionsDictionary, property.Name, property.PropertyType);
         }
 
         public override void Save()

--- a/Source/ORTS.Settings/UpdateState.cs
+++ b/Source/ORTS.Settings/UpdateState.cs
@@ -76,10 +76,10 @@ namespace ORTS.Settings
             GetProperty(name).SetValue(this, value, null);
         }
 
-        protected override void Load(bool allowUserSettings, Dictionary<string, string> optionsDictionary)
+        protected override void Load(Dictionary<string, string> optionsDictionary)
         {
             foreach (var property in GetProperties())
-                Load(allowUserSettings, optionsDictionary, property.Name, property.PropertyType);
+                Load(optionsDictionary, property.Name, property.PropertyType);
         }
 
         public override void Save()

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -470,7 +470,7 @@ namespace ORTS.Settings
             if (property == null)
                 return null;
             else
-                return new SavingProperty<T>(this, property);
+                return new SavingProperty<T>(this, property, AllowUserSettings);
         }
 
         public override object GetDefaultValue(string name)
@@ -506,10 +506,10 @@ namespace ORTS.Settings
             GetProperty(name).SetValue(this, value, null);
         }
 
-        protected override void Load(bool allowUserSettings, Dictionary<string, string> optionsDictionary)
+        protected override void Load(Dictionary<string, string> optionsDictionary)
         {
             foreach (var property in GetProperties())
-                Load(allowUserSettings, optionsDictionary, property.Name, property.PropertyType);
+                Load(optionsDictionary, property.Name, property.PropertyType);
         }
 
         public override void Save()
@@ -562,11 +562,13 @@ namespace ORTS.Settings
     {
         private readonly UserSettings Settings;
         private readonly PropertyInfo Property;
+        private readonly bool DoSave;
 
-        internal SavingProperty(UserSettings settings, PropertyInfo property)
+        internal SavingProperty(UserSettings settings, PropertyInfo property, bool allowSave = true)
         {
             Settings = settings;
             Property = property;
+            DoSave = allowSave;
         }
 
         /// <summary>
@@ -592,7 +594,8 @@ namespace ORTS.Settings
             if (!GetValue().Equals(value))
             {
                 Property.SetValue(Settings, value);
-                Settings.Save(Property.Name);
+                if (DoSave)
+                    Settings.Save(Property.Name);
             }
         }
     }

--- a/Source/RunActivity/Program.cs
+++ b/Source/RunActivity/Program.cs
@@ -64,8 +64,6 @@ namespace Orts
             var game = new Game(settings);
             game.PushState(new GameStateRunActivity(args));
             game.Run();
-
-            settings.Save();
         }
     }
 }

--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -31,6 +31,7 @@ using Orts.Simulation.RollingStocks;
 using Orts.Simulation.Signalling;
 using ORTS.Common;
 using ORTS.Common.Input;
+using ORTS.Settings;
 
 namespace Orts.Viewer3D
 {
@@ -1973,6 +1974,7 @@ namespace Orts.Viewer3D
 
     public class CabCamera : NonTrackingCamera
     {
+        private readonly SavingProperty<bool> LetterboxProperty;
         protected int sideLocation;
         public int SideLocation { get { return sideLocation; } }
 
@@ -2001,6 +2003,7 @@ namespace Orts.Viewer3D
         public CabCamera(Viewer viewer)
             : base(viewer)
         {
+            LetterboxProperty = viewer.Settings.GetSavingProperty<bool>("Letterbox2DCab");
         }
 
         protected internal override void Save(BinaryWriter outf)
@@ -2212,7 +2215,7 @@ namespace Orts.Viewer3D
                 ScrollRight(false, speed);
             if (UserInput.IsPressed(UserCommand.CameraToggleLetterboxCab))
             {
-                Viewer.Settings.Letterbox2DCab = !Viewer.Settings.Letterbox2DCab;
+                LetterboxProperty.Value = !LetterboxProperty.Value;
                 Viewer.AdjustCabHeight(Viewer.DisplaySize.X, Viewer.DisplaySize.Y);
                 if (attachedCar != null)
                     Initialize();

--- a/Source/RunActivity/Viewer3D/Popups/OSDCars.cs
+++ b/Source/RunActivity/Viewer3D/Popups/OSDCars.cs
@@ -21,6 +21,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Orts.Simulation.RollingStocks;
 using ORTS.Common;
+using ORTS.Settings;
 using System.Collections.Generic;
 
 namespace Orts.Viewer3D.Popups
@@ -37,12 +38,13 @@ namespace Orts.Viewer3D.Popups
             Trains = 0x1,
             Cars = 0x2,
         }
+        private readonly SavingProperty<int> StateProperty;
         private DisplayState State
         {
-            get => (DisplayState)Owner.Viewer.Settings.OSDCarsState;
+            get => (DisplayState)StateProperty.Value;
             set
             {
-                Owner.Viewer.Settings.OSDCarsState = (int)value;
+                StateProperty.Value = (int)value;
             }
         }
 
@@ -51,6 +53,7 @@ namespace Orts.Viewer3D.Popups
         public OSDCars(WindowManager owner)
             : base(owner, 0, 0, "OSD Cars")
         {
+            StateProperty = owner.Viewer.Settings.GetSavingProperty<int>("OSDCarsState");
         }
 
         public override bool Interactive

--- a/Source/RunActivity/Viewer3D/Popups/OSDLocations.cs
+++ b/Source/RunActivity/Viewer3D/Popups/OSDLocations.cs
@@ -47,7 +47,7 @@ namespace Orts.Viewer3D.Popups
             get => (DisplayState)StateProperty.Value;
             set
             {
-                StateProperty.Value =(int)value;
+                StateProperty.Value = (int)value;
             }
         }
 

--- a/Source/RunActivity/Viewer3D/Popups/OSDLocations.cs
+++ b/Source/RunActivity/Viewer3D/Popups/OSDLocations.cs
@@ -65,7 +65,6 @@ namespace Orts.Viewer3D.Popups
         {
             StateProperty = owner.Viewer.Settings.GetSavingProperty<int>("OSDLocationsState");
             UpdateLabelLists();
-            if (Platforms.Count + Sidings.Count == 0) State = DisplayState.All;
         }
 
         void UpdateLabelLists()

--- a/Source/RunActivity/Viewer3D/Popups/OSDLocations.cs
+++ b/Source/RunActivity/Viewer3D/Popups/OSDLocations.cs
@@ -21,6 +21,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Orts.Simulation;
 using ORTS.Common;
+using ORTS.Settings;
 using System.Collections.Generic;
 
 namespace Orts.Viewer3D.Popups
@@ -40,12 +41,13 @@ namespace Orts.Viewer3D.Popups
             All = 0x3,
             Auto = 0x7,
         }
+        private readonly SavingProperty<int> StateProperty;
         private DisplayState State
         {
-            get => (DisplayState)Owner.Viewer.Settings.OSDLocationsState;
+            get => (DisplayState)StateProperty.Value;
             set
             {
-                Owner.Viewer.Settings.OSDLocationsState = (int)value;
+                StateProperty.Value =(int)value;
             }
         }
 
@@ -61,6 +63,7 @@ namespace Orts.Viewer3D.Popups
         public OSDLocations(WindowManager owner)
             : base(owner, 0, 0, "OSD Locations")
         {
+            StateProperty = owner.Viewer.Settings.GetSavingProperty<int>("OSDLocationsState");
             UpdateLabelLists();
             if (Platforms.Count + Sidings.Count == 0) State = DisplayState.All;
         }

--- a/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
@@ -21,6 +21,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Orts.Simulation.Physics;
 using ORTS.Common;
+using ORTS.Settings;
 using System;
 using System.Collections.Generic;
 
@@ -189,12 +190,13 @@ namespace Orts.Viewer3D.Popups
 
         readonly Viewer Viewer;
         private bool metric => Viewer.MilepostUnitsMetric;
+        private readonly SavingProperty<int> StateProperty;
         private DisplayMode Mode
         {
-            get => (DisplayMode)Viewer.Settings.TrackMonitorDisplayMode;
+            get => (DisplayMode)StateProperty.Value;
             set
             {
-                Viewer.Settings.TrackMonitorDisplayMode = (int)value;
+                StateProperty.Value = (int)value;
             }
         }
 
@@ -313,6 +315,7 @@ namespace Orts.Viewer3D.Popups
                 TrackMonitorImages = SharedTextureManager.Get(owner.Viewer.RenderProcess.GraphicsDevice, System.IO.Path.Combine(owner.Viewer.ContentPath, "TrackMonitorImages.png"));
 
             Viewer = owner.Viewer;
+            StateProperty = Viewer.Settings.GetSavingProperty<int>("TrackMonitorDisplayMode");
             Font = owner.TextFontSmall;
 
             ScaleDesign(ref additionalInfoHeight);

--- a/Source/RunActivity/Viewer3D/Popups/Window.cs
+++ b/Source/RunActivity/Viewer3D/Popups/Window.cs
@@ -20,9 +20,9 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using ORTS.Common;
+using ORTS.Settings;
 using System;
 using System.IO;
-using System.Reflection;
 
 namespace Orts.Viewer3D.Popups
 {
@@ -40,7 +40,7 @@ namespace Orts.Viewer3D.Popups
         Rectangle location;
 
         readonly string Caption;
-        readonly PropertyInfo SettingsProperty;
+        readonly SavingProperty<int[]> SettingsProperty;
         ControlLayout WindowLayout;
         VertexBuffer WindowVertexBuffer;
         IndexBuffer WindowIndexBuffer;
@@ -51,10 +51,10 @@ namespace Orts.Viewer3D.Popups
             // We need to correct the window height for the ACTUAL font size, so that the title bar is shown correctly.
             location = new Rectangle(0, 0, width, height - BaseFontSize + owner.TextFontDefault.Height);
 
-            SettingsProperty = Owner.Viewer.Settings.GetType().GetProperty("WindowPosition_" + GetType().Name.Replace("Window", ""));
+            SettingsProperty = Owner.Viewer.Settings.GetSavingProperty<int[]>("WindowPosition_" + GetType().Name.Replace("Window", ""));
             if (SettingsProperty != null)
             {
-                var value = SettingsProperty.GetValue(Owner.Viewer.Settings, null) as int[];
+                var value = SettingsProperty.Value;
                 if ((value != null) && (value.Length >= 2))
                 {
                     location.X = (int)Math.Round((float)value[0] * (Owner.ScreenSize.X - location.Width) / 100);
@@ -104,11 +104,7 @@ namespace Orts.Viewer3D.Popups
 
         protected virtual void LocationChanged()
         {
-            if (SettingsProperty != null)
-            {
-                SettingsProperty.SetValue(Owner.Viewer.Settings, new[] { (int)Math.Round(100f * location.X / (Owner.ScreenSize.X - location.Width)), (int)Math.Round(100f * location.Y / (Owner.ScreenSize.Y - location.Height)) }, null);
-                Owner.Viewer.Settings.Save(SettingsProperty.Name);
-            }
+            SettingsProperty?.SetValue(new[] { (int)Math.Round(100f * location.X / (Owner.ScreenSize.X - location.Width)), (int)Math.Round(100f * location.Y / (Owner.ScreenSize.Y - location.Height)) });
 
             XNAWorld = Matrix.CreateWorld(new Vector3(location.X, location.Y, 0), -Vector3.UnitZ, Vector3.UnitY);
         }

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -53,6 +53,7 @@ namespace Orts.Viewer3D
         public static Random Random { get; private set; }
         // User setups.
         public UserSettings Settings { get; private set; }
+        private readonly SavingProperty<bool> Use3DCabProperty;
         // Multi-threaded processes
         public LoaderProcess LoaderProcess { get; private set; }
         public UpdaterProcess UpdaterProcess { get; private set; }
@@ -142,7 +143,7 @@ namespace Orts.Viewer3D
         /// </summary>
         public void ToggleCabCameraView()
         {
-            Settings.Use3DCab = !Settings.Use3DCab;
+            Use3DCabProperty.Value = !Use3DCabProperty.Value;
             if (Camera == CabCamera || Camera == ThreeDimCabCamera)
                 ActivateCabCamera();
         }
@@ -270,6 +271,7 @@ namespace Orts.Viewer3D
             Simulator = simulator;
             Game = game;
             Settings = simulator.Settings;
+            Use3DCabProperty = Settings.GetSavingProperty<bool>("Use3DCab");
 
             RenderProcess = game.RenderProcess;
             UpdaterProcess = game.UpdaterProcess;


### PR DESCRIPTION
Changes the code to save whitelisted settings immediately upon change. Also changes the code to respect the skip-user-settings command-line flag.

Bug report: https://github.com/openrails/openrails/pull/306#issuecomment-803592877