### PR TITLE
Adds the signal ID and the aspect (including text aspect) of each signal head to the signalling debug window

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/SignallingDebugWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/SignallingDebugWindow.cs
@@ -215,11 +215,14 @@ namespace Orts.Viewer3D.Popups
                             }
                             else if (signalObj != null)
                             {
+                                string aspects = string.Join(" / ", signalObj.Signal.SignalHeads.Select(
+                                    x => x.state.ToString() + (x.TextSignalAspect.Length > 0 ? $" ({x.TextSignalAspect})" : string.Empty)
+                                    ));
                                 primitives.Add(new DispatcherLabel(currentPosition.WorldLocation,
                                            GetAspect(signalObj.Signal) == DebugWindowSignalAspect.Stop ? Color.Red :
                                                GetAspect(signalObj.Signal) == DebugWindowSignalAspect.Warning ? Color.Yellow :
                                                Color.Green,
-                                           String.Format("Signal ({0})", signalObj.Signal.this_sig_lr(MstsSignalFunction.NORMAL)),
+                                           String.Format("Signal {0} ({1})", signalObj.Signal.thisRef, aspects),
                                            Owner.TextFontDefaultOutlined));
                             }
 

--- a/Source/RunActivity/Viewer3D/Popups/SignallingDebugWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/SignallingDebugWindow.cs
@@ -215,14 +215,14 @@ namespace Orts.Viewer3D.Popups
                             }
                             else if (signalObj != null)
                             {
-                                string aspects = string.Join(" / ", signalObj.Signal.SignalHeads.Select(
-                                    x => x.state.ToString() + (x.TextSignalAspect.Length > 0 ? $" ({x.TextSignalAspect})" : string.Empty)
+                                var aspects = string.Join(" / ", signalObj.Signal.SignalHeads.Select(
+                                    head => $"{head.state}" + (head.TextSignalAspect.Length > 0 ? $" ({head.TextSignalAspect})" : string.Empty)
                                     ));
                                 primitives.Add(new DispatcherLabel(currentPosition.WorldLocation,
                                            GetAspect(signalObj.Signal) == DebugWindowSignalAspect.Stop ? Color.Red :
                                                GetAspect(signalObj.Signal) == DebugWindowSignalAspect.Warning ? Color.Yellow :
                                                Color.Green,
-                                           String.Format("Signal {0} ({1})", signalObj.Signal.thisRef, aspects),
+                                           $"Signal {signalObj.Signal.thisRef} ({aspects})",
                                            Owner.TextFontDefaultOutlined));
                             }
 


### PR DESCRIPTION
To make signal debugging easier.

Feature request: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)