### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1923946 Variable2 goes negative with electric locos

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs
@@ -34,6 +34,7 @@ using Orts.Simulation.RollingStocks.SubSystems.Controllers;
 using Orts.Simulation.RollingStocks.SubSystems.PowerSupplies;
 using ORTS.Common;
 using ORTS.Scripting.Api;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -232,7 +233,7 @@ namespace Orts.Simulation.RollingStocks
             else
             {
                 float dV2;
-                dV2 = TractiveForceN / MaxForceN * 100f - Variable2;
+                dV2 = Math.Abs(TractiveForceN) / MaxForceN * 100f - Variable2;
                 float max = 2f;
                 if (dV2 > max) dV2 = max;
                 else if (dV2 < -max) dV2 = -max;


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/34147-or-sound-settings/page__view__findpost__p__271104