### PR TITLE
Ignore VS Code preferences (again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,15 +17,7 @@
 /Source/Locales/**/*.bak
 
 ## Ignore Visual Studio Code configuration files.
-##
-## Get latest from https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore
-
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-*.code-workspace
+.vscode/
 
 # Local History for Visual Studio Code
 .history/


### PR DESCRIPTION
Turns out GitHub's gitignore template is for projects that would like to unify VS Code preferences among all of their developers. We don't do that here, so just ignore the .vscode directory entirely.