### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1922000.  Train.CreateStationStop  crash.

### DIFF
--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -12727,7 +12727,7 @@ namespace Orts.Simulation.Physics
                                 {
                                     int otherSectionIndex = thisElement.Direction == 0 ?
                                         otherPlatform.TCSectionIndex[0] :
-                                        otherPlatform.TCSectionIndex[thisPlatform.TCSectionIndex.Count - 1];
+                                        otherPlatform.TCSectionIndex[otherPlatform.TCSectionIndex.Count - 1];
                                     if (otherSectionIndex == beginSectionIndex)
                                     {
                                         if (otherPlatform.TCOffset[0, thisElement.Direction] < actualBegin)


### PR DESCRIPTION
Fix for the CreateStationStop  crash.
Using the proper count for its own list (otherPlatform.TCSectionIndex) solves this bug.
Thanks to Roeter for his support.