### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1926983 Fog distance can't be initialized to value > 20000

### DIFF
--- a/Source/RunActivity/Viewer3D/Weather.cs
+++ b/Source/RunActivity/Viewer3D/Weather.cs
@@ -640,7 +640,7 @@ namespace Orts.Viewer3D
                     {
                         fogDistanceIncreasing = true;
                         fogChangeRate = -fogChangeRate;
-                        ORTSFog = weatherControl.Weather.FogDistance;
+                        if (fogTimer > 0) ORTSFog = weatherControl.Weather.FogDistance;
                     }
                     wChangeOn = true;
                 }


### PR DESCRIPTION
See also http://www.elvastower.com/forums/index.php?/topic/35135-weather-activity-event-wont-go-over-20000m-fog/page__view__findpost__p__271705