### PR TITLE
added Web\CabControls\ files to RunActivity projects

### DIFF
--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -346,8 +346,10 @@ namespace Orts.Formats.Msts
         public double Width;
         public double Height;
 
-        public double MinValue;
-        public double MaxValue;
+        // Defaults which may be overridden when parsing CVF file
+        public double MinValue = 0.0;
+        public double MaxValue = 1.0;
+        
         public double OldValue;
         public string ACEFile = "";
 

--- a/Source/RunActivity/RunActivity.csproj
+++ b/Source/RunActivity/RunActivity.csproj
@@ -766,6 +766,9 @@
     <Content Include="Viewer3D\WebServices\Web\APISample\index.html" />
     <Content Include="Viewer3D\WebServices\Web\APISample\index.js" />
     <Content Include="Viewer3D\WebServices\Web\APISample\or_logo.png" />
+    <Content Include="Viewer3D\WebServices\Web\CabControls\index.css" />
+    <Content Include="Viewer3D\WebServices\Web\CabControls\index.html" />
+    <Content Include="Viewer3D\WebServices\Web\CabControls\index.js" />
     <Content Include="Viewer3D\WebServices\Web\HUD\index.css" />
     <Content Include="Viewer3D\WebServices\Web\HUD\index.html" />
     <Content Include="Viewer3D\WebServices\Web\HUD\index.js" />


### PR DESCRIPTION
Follow up to https://github.com/openrails/openrails/pull/377/files
Doesn't stop anything working, but meant that files were not listed in Visual Studio's Solution Explorer.

The need for default values for CabControl.MinValue and MaxValue were exposed when ORTS_POWERKEY and ALERTER_DISPLAY were stuck at 0 in the API/CABCONTROLS