### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1930630. The web TrainDriving window is not available.

### DIFF
--- a/Source/RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs
@@ -509,7 +509,7 @@ namespace Orts.Viewer3D.WebServices
 
             if (locomotiveStatus != null)
             {
-                foreach (string data in locomotiveStatus.Split('\n').Where((string d) => d.Length > 1))
+                foreach (string data in locomotiveStatus.Split('\n').Where((string d) => !string.IsNullOrWhiteSpace(d)))
                 {
                     string[] parts = data.Split(new string[] { " = " }, 2, StringSplitOptions.None);
                     string keyPart = parts[0];

--- a/Source/RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs
@@ -509,7 +509,7 @@ namespace Orts.Viewer3D.WebServices
 
             if (locomotiveStatus != null)
             {
-                foreach (string data in locomotiveStatus.Split('\n').Where((string d) => d.Length > 0))
+                foreach (string data in locomotiveStatus.Split('\n').Where((string d) => d.Length > 1))
                 {
                     string[] parts = data.Split(new string[] { " = " }, 2, StringSplitOptions.None);
                     string keyPart = parts[0];


### PR DESCRIPTION
The web Train Driving window is not available, since the locomotiveStatus contains consecutive escape sequences, e.g. “\n\r”.
