### PR TITLE
ci: Automatically create merge-to-master PR on release branch push

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches:
+      - "release/*"
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR
+        uses: funivan/github-autopr@0.2.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
**For the upcoming stable release**

This is the best I could manage for automatically merging `release/*` pushes into `master`, as GitHub branch restrictions cannot be bypassed - we cannot allow the action to push directly to `master` without also allowing everyone else

For each push, this will create a new PR which someone with write access needs to approve and merge manually:

![image](https://user-images.githubusercontent.com/1017843/123526956-522c2380-d6d3-11eb-9622-f4b9704273e2.png)

