### PR TITLE
Don't unload sound sources of the player train when camera near it 

### DIFF
--- a/Source/RunActivity/Viewer3D/Sound.cs
+++ b/Source/RunActivity/Viewer3D/Sound.cs
@@ -494,7 +494,8 @@ namespace Orts.Viewer3D
     {
         /// <summary>
         /// Squared cutoff distance. No sound is audible above that, except for the actual player train,
-        /// where cutoff occurs at a distance wich is higher than the train length
+        /// where cutoff occurs at a distance wich is higher than the train length plus offset to 
+        /// approximately take into account distance from camera to car
         /// </summary>
         private int CutOffDistanceM2
         {
@@ -502,7 +503,8 @@ namespace Orts.Viewer3D
             {
                 const int staticDistanceM2 = 4000000;
                 var isPlayer = Car?.Train?.IsActualPlayerTrain ?? false;
-                return (int)Math.Max(staticDistanceM2, isPlayer ? Car.Train.Length * Car.Train.Length : 0);
+                var correctedLength = isPlayer ? Car.Train.Length + 50 : 0; 
+                return (int)Math.Max(staticDistanceM2, correctedLength * correctedLength);
             }
         }
         /// <summary>

--- a/Source/RunActivity/Viewer3D/Sound.cs
+++ b/Source/RunActivity/Viewer3D/Sound.cs
@@ -493,7 +493,8 @@ namespace Orts.Viewer3D
     public class SoundSource : SoundSourceBase
     {
         /// <summary>
-        /// Squeared cutoff distance. No sound is audible above that
+        /// Squared cutoff distance. No sound is audible above that, except for the actual player train,
+        /// where cutoff occurs at a distance wich is higher than the train length
         /// </summary>
         private const int CUTOFFDISTANCE = 4000000;
         /// <summary>
@@ -1009,13 +1010,15 @@ namespace Orts.Viewer3D
                 float.IsNaN(WorldLocation.Location.Y) ||
                 float.IsNaN(WorldLocation.Location.Z))
             {
-                DistanceSquared = CUTOFFDISTANCE + 1;
+                DistanceSquared = (Car != null && Car.Train != null && Car.Train.IsActualPlayerTrain ?
+                Math.Max(CUTOFFDISTANCE, Car.Train.Length * Car.Train.Length) : CUTOFFDISTANCE) + 1;
                 return true;
             }
 
             DistanceSquared = WorldLocation.GetDistanceSquared(WorldLocation, Viewer.Camera.CameraWorldLocation);
 
-            return DistanceSquared > CUTOFFDISTANCE;
+            return DistanceSquared > (Car != null && Car.Train != null && Car.Train.IsActualPlayerTrain ? 
+                Math.Max (CUTOFFDISTANCE, Car.Train.Length * Car.Train.Length) +2500f : CUTOFFDISTANCE);
         }
 
         /// <summary>
@@ -1034,7 +1037,8 @@ namespace Orts.Viewer3D
                 {
                     // (ActivationConditions.Distance == 0) means distance checking disabled
                     if ((ActivationConditions.Distance == 0 || DistanceSquared < ActivationConditions.Distance * ActivationConditions.Distance) &&
-                        DistanceSquared < CUTOFFDISTANCE)
+                        DistanceSquared < (Car != null && Car.Train != null && Car.Train.IsActualPlayerTrain ?
+                        Math.Max(CUTOFFDISTANCE, Car.Train.Length * Car.Train.Length) +2500f : CUTOFFDISTANCE))
                         return true;
                 }
                 else
@@ -1059,7 +1063,8 @@ namespace Orts.Viewer3D
             if (WorldLocation != WorldLocation.None)
             {
                 if (DeactivationConditions.Distance != 0 && DistanceSquared > DeactivationConditions.Distance * DeactivationConditions.Distance ||
-                    DistanceSquared > CUTOFFDISTANCE)
+                    DistanceSquared > (Car != null && Car.Train != null && Car.Train.IsActualPlayerTrain ?
+                    Math.Max(CUTOFFDISTANCE, Car.Train.Length * Car.Train.Length) + 2500f : CUTOFFDISTANCE))
                     return true;
             }
 


### PR DESCRIPTION
Feature request: https://www.elvastower.com/forums/index.php?/topic/35244-problem-in-locomotive-sound/

Avoids that sounds restart when switching camera from head to tail of long player trains.