### PR TITLE
Add a PreUpdate variable to scripts

### DIFF
--- a/Source/Orts.Simulation/Common/Scripting/Common.cs
+++ b/Source/Orts.Simulation/Common/Scripting/Common.cs
@@ -15,10 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 
-using System;
 using Orts.Common;
 using Orts.Simulation;
 using Orts.Simulation.RollingStocks;
+using System;
 
 namespace ORTS.Scripting.Api
 {
@@ -35,6 +35,10 @@ namespace ORTS.Scripting.Api
         /// Clock value (in seconds) for the simulation. Starts with a value = 0.
         /// </summary>
         public Func<float> GameTime;
+        /// <summary>
+        /// Simulator is in pre-update mode (update during loading screen).
+        /// </summary>
+        public Func<bool> PreUpdate;
     }
     /// <summary>
     /// Base class for scripts related to train subsystems.

--- a/Source/Orts.Simulation/Simulation/AIs/AI.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AI.cs
@@ -54,7 +54,6 @@ namespace Orts.Simulation.AIs
         public List<AITrain> AutoGenTrains = new List<AITrain>(); // auto-generated trains
         public double clockTime; // clock time : local time before activity start, common time from simulator after start
         private bool localTime;  // if true : clockTime is local time
-        public bool PreUpdate; // if true : running in pre-update phase
         public List<AITrain> TrainsToRemove = new List<AITrain>();
         public List<AITrain> TrainsToAdd = new List<AITrain>();
         public List<AITrain> TrainsToRemoveFromAI = new List<AITrain>();
@@ -341,14 +340,14 @@ namespace Orts.Simulation.AIs
 
                 clockTime = firstAITime - 1.0f;
                 localTime = true;
-                PreUpdate = true;
+                Simulator.PreUpdate = true;
 
                 for (double runTime = firstAITime; runTime < Simulator.ClockTime; runTime += 5.0) // update with 5 secs interval
                 {
                     int fullsec = Convert.ToInt32(runTime);
                     if (fullsec % 3600 == 0) Trace.Write(" " + (fullsec / 3600).ToString("00") + ":00 ");
 
-                    AIUpdate((float)(runTime - clockTime), PreUpdate);
+                    AIUpdate((float)(runTime - clockTime), Simulator.PreUpdate);
                     Simulator.Signals.Update(true);
                     clockTime = runTime;
                     if (cancellation.IsCancellationRequested) return; // ping watchdog process
@@ -371,14 +370,14 @@ namespace Orts.Simulation.AIs
 
                 clockTime = firstAITime - 1.0f;
                 localTime = true;
-                PreUpdate = true;
+                Simulator.PreUpdate = true;
                 bool activeTrains = false;
                 for (double runTime = firstAITime; runTime < Simulator.ClockTime && !endPreRun; runTime += 5.0) // update with 5 secs interval
                 {
                     int fullsec = Convert.ToInt32(runTime);
                     if (fullsec % 3600 < 5) Trace.Write(" " + (fullsec / 3600).ToString("00") + ":00 ");
 
-                    endPreRun = AITTUpdate((float)(runTime - clockTime), PreUpdate, ref activeTrains);
+                    endPreRun = AITTUpdate((float)(runTime - clockTime), Simulator.PreUpdate, ref activeTrains);
 
                     if (activeTrains)
                     {
@@ -541,7 +540,7 @@ namespace Orts.Simulation.AIs
 
                     while (!playerTrainStarted)
                     {
-                        endPreRun = AITTUpdate((float)(runTime - clockTime), PreUpdate, ref dummy);
+                        endPreRun = AITTUpdate((float)(runTime - clockTime), Simulator.PreUpdate, ref dummy);
                         Simulator.Signals.Update(true);
                         clockTime = runTime;
                         runTime += deltaTime;
@@ -625,8 +624,7 @@ namespace Orts.Simulation.AIs
             }
 
             Trace.Write("\n");
-            PreUpdate = false;
-
+            Simulator.PreUpdate = false;
         }
 
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
@@ -5903,7 +5903,7 @@ namespace Orts.Simulation.AIs
                 if (nextActionInfo.RequiredSpeedMpS == 0)
                 {
                     NextStopDistanceM = thisItem.ActivateDistanceM - PresentPosition[0].DistanceTravelledM;
-                    if (AI.PreUpdate && !(nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.AUX_ACTION && NextStopDistanceM > minCheckDistanceM))
+                    if (Simulator.PreUpdate && !(nextActionInfo.NextAction == AIActionItem.AI_ACTION_TYPE.AUX_ACTION && NextStopDistanceM > minCheckDistanceM))
                     {
                         AITrainBrakePercent = 100; // because of short reaction time
                         AITrainThrottlePercent = 0;

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -1461,7 +1461,7 @@ namespace Orts.Simulation.Physics
                 MUDirection = DirectionControl.Flip(MUDirection);
                 MUReverserPercent = -MUReverserPercent;
             }
-            if (!((this is AITrain && (this as AITrain).AI.PreUpdate) || this.TrainType == TRAINTYPE.STATIC)) FormationReversed = true;
+            if (!((this is AITrain && Simulator.PreUpdate) || this.TrainType == TRAINTYPE.STATIC)) FormationReversed = true;
         }
 
         //================================================================================================//

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
@@ -343,6 +343,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
                 // AbstractScriptClass
                 Script.ClockTime = () => (float)Simulator.ClockTime;
                 Script.GameTime = () => (float)Simulator.GameTime;
+                Script.PreUpdate = () => Simulator.PreUpdate;
                 Script.DistanceM = () => Locomotive.DistanceM;
                 Script.SpeedMpS = () => Math.Abs(Locomotive.SpeedMpS);
                 Script.Confirm = Locomotive.Simulator.Confirmer.Confirm;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/CircuitBreaker.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/CircuitBreaker.cs
@@ -131,6 +131,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 // AbstractScriptClass
                 Script.ClockTime = () => (float)Simulator.ClockTime;
                 Script.GameTime = () => (float)Simulator.GameTime;
+                Script.PreUpdate = () => Simulator.PreUpdate;
                 Script.DistanceM = () => Locomotive.DistanceM;
                 Script.SpeedMpS = () => Math.Abs(Locomotive.SpeedMpS);
                 Script.Confirm = Locomotive.Simulator.Confirmer.Confirm;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/LocomotivePowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/LocomotivePowerSupply.cs
@@ -253,6 +253,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             // AbstractScriptClass
             AbstractScript.ClockTime = () => (float)Simulator.ClockTime;
             AbstractScript.GameTime = () => (float)Simulator.GameTime;
+            AbstractScript.PreUpdate = () => Simulator.PreUpdate;
             AbstractScript.DistanceM = () => Locomotive.DistanceM;
             AbstractScript.SpeedMpS = () => Math.Abs(Locomotive.SpeedMpS);
             AbstractScript.Confirm = Locomotive.Simulator.Confirmer.Confirm;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/PassengerCarPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/PassengerCarPowerSupply.cs
@@ -302,6 +302,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             // AbstractScriptClass
             Script.ClockTime = () => (float)Simulator.ClockTime;
             Script.GameTime = () => (float)Simulator.GameTime;
+            Script.PreUpdate = () => Simulator.PreUpdate;
             Script.DistanceM = () => Wagon.DistanceM;
             Script.SpeedMpS = () => Math.Abs(Wagon.SpeedMpS);
             Script.Confirm = Simulator.Confirmer.Confirm;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/TractionCutOffRelay.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/TractionCutOffRelay.cs
@@ -114,6 +114,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 // AbstractScriptClass
                 Script.ClockTime = () => (float)Simulator.ClockTime;
                 Script.GameTime = () => (float)Simulator.GameTime;
+                Script.PreUpdate = () => Simulator.PreUpdate;
                 Script.DistanceM = () => Locomotive.DistanceM;
                 Script.Confirm = Locomotive.Simulator.Confirmer.Confirm;
                 Script.Message = Locomotive.Simulator.Confirmer.Message;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -260,6 +260,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 // AbstractScriptClass
                 Script.ClockTime = () => (float)Simulator.ClockTime;
                 Script.GameTime = () => (float)Simulator.GameTime;
+                Script.PreUpdate = () => Simulator.PreUpdate;
                 Script.DistanceM = () => Locomotive.DistanceM;
                 Script.Confirm = Locomotive.Simulator.Confirmer.Confirm;
                 Script.Message = Locomotive.Simulator.Confirmer.Message;

--- a/Source/Orts.Simulation/Simulation/Signalling/CsSignalScript.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/CsSignalScript.cs
@@ -334,6 +334,7 @@ namespace Orts.Simulation.Signalling
             // Build AbstractScriptClass API functions
             ClockTime = () => (float)SignalObject.signalRef.Simulator.ClockTime;
             GameTime = () => (float)SignalObject.signalRef.Simulator.GameTime;
+            PreUpdate = () => SignalObject.signalRef.Simulator.PreUpdate;
         }
 
         // Functions to be implemented in script

--- a/Source/Orts.Simulation/Simulation/Simulator.cs
+++ b/Source/Orts.Simulation/Simulation/Simulator.cs
@@ -90,6 +90,7 @@ namespace Orts.Simulation
         public string ActivityFileName;
         public string TimetableFileName;
         public bool TimetableMode;
+        public bool PreUpdate;
         public ActivityFile Activity;
         public Activity ActivityRun;
         public TrackDatabaseFile TDB;
@@ -578,7 +579,7 @@ namespace Orts.Simulation
             if (playerTrain != null)
             {
                 var validPosition = playerTrain.PostInit();  // place player train after pre-running of AI trains
-                if (validPosition && AI != null) AI.PreUpdate = false;
+                if (validPosition && AI != null) PreUpdate = false;
                 if (playerTrain.InitialSpeed > 0 && playerTrain.MovementState != AITrain.AI_MOVEMENT_STATE.STATION_STOP)
                 {
                     playerTrain.InitializeMoving();

--- a/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
@@ -2231,7 +2231,7 @@ namespace Orts.Simulation.Timetables
             // check position
 
             float margin = 0.0f;
-            if (AI.PreUpdate)
+            if (Simulator.PreUpdate)
                 margin = 2.0f * clearingDistanceM;  // allow margin in pre-update due to low update rate
 
             int stationIndex = ValidRoute[0].GetRouteIndex(stationTCSectionIndex, PresentPosition[0].RouteListIndex);
@@ -5741,7 +5741,7 @@ namespace Orts.Simulation.Timetables
         public void DelayedStartMoving(AI_START_MOVEMENT reason)
         {
             // do not apply delayed restart while running in pre-update
-            if (AI.PreUpdate)
+            if (Simulator.PreUpdate)
             {
                 RestdelayS = 0.0f;
                 DelayedStart = false;
@@ -11820,7 +11820,7 @@ namespace Orts.Simulation.Timetables
                 }
 
                 // if not in preupdate there must be an engine
-                if (AI.Simulator.PlayerLocomotive == null && !AI.PreUpdate)
+                if (AI.Simulator.PlayerLocomotive == null && !Simulator.PreUpdate)
                 {
                     throw new InvalidDataException("Can't find player locomotive in " + attachTrain.Name);
                 }

--- a/Source/Orts.Simulation/Simulation/Timetables/TTTurntable.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTTurntable.cs
@@ -2027,7 +2027,7 @@ namespace Orts.Simulation.Timetables
 
                 // in prerun, also perform turntable update as simulation is not yet running
                 // also perform turntable update if this is not the active moving table
-                bool performUpdate = parentTrain.AI.PreUpdate;
+                bool performUpdate = parentTrain.Simulator.PreUpdate;
                 if (!performUpdate)
                 {
                     if (parentPool.Simulatorref.ActiveMovingTable == null)


### PR DESCRIPTION
Timers don't work really well during the pre-update phase because the time step is huge during this phase.
For example, in C# signal scripts, they are causing huge delays to AI trains because the signals are opening too late.
Having access to the PreUpdate variable allows for the scripts to disable timers during pre-update.