### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1939064. Web-HUD label is not displayed.

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -1238,6 +1238,7 @@ namespace Orts.Viewer3D.Popups
 
         void TextPageWeather(TableData table)
         {
+            TableSetLabelValueColumns(table, 0, 2);
             TextPageHeading(table, Viewer.Catalog.GetString("WEATHER INFORMATION"));
 
             TableAddLabelValue(table, Viewer.Catalog.GetString("Visibility"), Viewer.Catalog.GetStringFmt("{0:N0} m", Viewer.Simulator.Weather.FogDistance));
@@ -1250,6 +1251,7 @@ namespace Orts.Viewer3D.Popups
 
         void TextPageDebugInfo(TableData table)
         {
+            TableSetLabelValueColumns(table, 0, 2);
             TextPageHeading(table, Viewer.Catalog.GetString("DEBUG INFORMATION"));
 
             var allocatedBytesPerSecond = AllocatedBytesPerSecCounter == null ? 0 : AllocatedBytesPerSecCounter.NextValue();

--- a/Source/RunActivity/Viewer3D/WebServices/Web/HUD/index.html
+++ b/Source/RunActivity/Viewer3D/WebServices/Web/HUD/index.html
@@ -33,6 +33,7 @@ along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
     <li><a id="common">Common</a></li>
     <li><a id="consist">Consist</a></li>
     <li><a id="locomotive">Locomotive</a></li>
+    <li><a id="power supply">Power Supply</a></li>
     <li><a id="brake">Brake</a></li>
     <li><a id="force">Force</a></li>
     <li><a id="dispatcher">Dispatcher</a></li>
@@ -56,24 +57,24 @@ document.getElementById("consist").onclick = function (){
 document.getElementById("locomotive").onclick = function (){
 	pageNo = 2;
 }
-document.getElementById("brake").onclick = function (){
+document.getElementById("power supply").onclick = function (){
 	pageNo = 3;
 }
-document.getElementById("force").onclick = function (){
+document.getElementById("brake").onclick = function (){
 	pageNo = 4;
 }
-document.getElementById("dispatcher").onclick = function (){
+document.getElementById("force").onclick = function (){
 	pageNo = 5;
 }
-document.getElementById("weather").onclick = function (){
+document.getElementById("dispatcher").onclick = function (){
 	pageNo = 6;
 }
-document.getElementById("debug").onclick = function (){
+document.getElementById("weather").onclick = function (){
 	pageNo = 7;
+}
+document.getElementById("debug").onclick = function (){
+	pageNo = 8;
 }
 </script>
 </body>
 </html>
-
-
-


### PR DESCRIPTION
On the Web-HUD page, once the Weather or Debug tabs is selected, the name for each item displayed is missing.
Also, the tab for the power supply information is missing.
Bug fix for https://bugs.launchpad.net/or/+bug/1939064.