### PR TITLE
Fixed the wrong states of battery switch, master key and ETS switch after restoring from a save

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/BatterySwitch.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/BatterySwitch.cs
@@ -38,10 +38,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         // Variables
         readonly MSTSWagon Wagon;
         protected Timer Timer;
-        public bool CommandSwitch { get; protected set; } = true;
+        public bool CommandSwitch { get; protected set; } = false;
         public bool CommandButtonOn { get; protected set; } = false;
         public bool CommandButtonOff { get; protected set; } = false;
-        public bool On { get; protected set; } = true;
+        public bool On { get; protected set; } = false;
 
         public BatterySwitch(MSTSWagon wagon)
         {
@@ -91,17 +91,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public virtual void Initialize()
         {
-            switch (Mode)
-            {
-                case ModeType.Switch:
-                    CommandSwitch = false;
-                    On = false;
-                    break;
-
-                case ModeType.PushButtons:
-                    On = false;
-                    break;
-            }
         }
 
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricTrainSupplySwitch.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricTrainSupplySwitch.cs
@@ -35,8 +35,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         // Variables
         readonly MSTSLocomotive Locomotive;
-        public bool CommandSwitch { get; protected set; } = true;
-        public bool On { get; protected set; } = true;
+        public bool CommandSwitch { get; protected set; } = false;
+        public bool On { get; protected set; } = false;
 
         public ElectricTrainSupplySwitch(MSTSLocomotive locomotive)
         {
@@ -77,18 +77,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public virtual void Initialize()
         {
-            switch (Mode)
-            {
-                case ModeType.Unfitted:
-                    CommandSwitch = false;
-                    On = false;
-                    break;
-
-                case ModeType.Switch:
-                    CommandSwitch = false;
-                    On = false;
-                    break;
-            }
         }
 
         /// <summary>
@@ -126,6 +114,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         {
             switch (Mode)
             {
+                case ModeType.Unfitted:
+                    On = false;
+                    break;
+
                 case ModeType.Automatic:
                     if (On)
                     {
@@ -150,8 +142,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     {
                         if (!CommandSwitch || !Locomotive.LocomotivePowerSupply.AuxiliaryPowerSupplyOn)
                         {
-                                On = false;
-                                Locomotive.SignalEvent(Event.ElectricTrainSupplyOff);
+                            On = false;
+                            Locomotive.SignalEvent(Event.ElectricTrainSupplyOff);
                         }
                     }
                     else

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/MasterKey.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/MasterKey.cs
@@ -41,8 +41,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         // Variables
         readonly MSTSLocomotive Locomotive;
         protected Timer Timer;
-        public bool CommandSwitch { get; protected set; } = true;
-        public bool On { get; protected set; } = true;
+        public bool CommandSwitch { get; protected set; } = false;
+        public bool On { get; protected set; } = false;
         public bool OtherCabInUse {
             get
             {
@@ -105,11 +105,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public virtual void Initialize()
         {
-            if (Mode == ModeType.Manual)
-            {
-                CommandSwitch = false;
-                On = false;
-            }
         }
 
         /// <summary>
@@ -117,8 +112,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         /// </summary>
         public virtual void InitializeMoving()
         {
-            CommandSwitch = true;
-            On = true;
+            if (Locomotive.IsLeadLocomotive())
+            {
+                CommandSwitch = true;
+                On = true;
+            }
         }
 
         public virtual void Save(BinaryWriter outf)


### PR DESCRIPTION
https://bugs.launchpad.net/or/+bug/1940094
http://www.elvastower.com/forums/index.php?/topic/35377-restoring-the-master-key-variables-does-not-work-correctly/