### PR TITLE
Fix : Passenger car power supply should not be available for locomotives

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1347,11 +1347,15 @@ namespace Orts.Simulation.RollingStocks
                 case "wagon(ortspowersupplyheatingpower":
                 case "wagon(ortspowersupplyairconditioningpower":
                 case "wagon(ortspowersupplyairconditioningyield":
-                    if (PassengerCarPowerSupply == null)
+                    if (this is MSTSLocomotive)
+                    {
+                        Trace.TraceWarning($"Defining the {lowercasetoken} parameter is forbidden for locomotives (in {stf.FileName}:line {stf.LineNumber})");
+                    }
+                    else if (PassengerCarPowerSupply == null)
                     {
                         PowerSupply = new ScriptedPassengerCarPowerSupply(this);
                     }
-                    PassengerCarPowerSupply.Parse(lowercasetoken, stf);
+                    PassengerCarPowerSupply?.Parse(lowercasetoken, stf);
                     break;
 
                 case "wagon(intakepoint": IntakePointList.Add(new IntakePoint(stf)); break;


### PR DESCRIPTION
https://bugs.launchpad.net/or/+bug/1938611