### PR TITLE
Increase upper limit for World Object Density

### DIFF
--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -351,13 +351,13 @@ values correspond roughly to a zoom out effect. The default is 45 degrees.
 World object density
 --------------------
 
-This value can be set from 0 to 199 and the default value is 99.
-When 99 is selected, all content defined in the route files and intended for the player to see is visible. 
+This value can be set from 0 to 99 and the default value is 49.
+When 49 is selected, all content defined in the route files and intended for the player to see is visible. 
 Lower values will hide some categories of objects which tends to increase frame rates.
 
 In legacy routes, all the content was assigned to categories 0-10.
-In more modern routes, content may be assigned to categories between 0 and 99.
-Content builders are advised to reserve values 100 to 199 for objects used in building the route.
+In more modern routes, content may be assigned to categories between 0 and 49.
+Content builders are advised to reserve values 50 to 99 for objects used in building the route.
 
 Window size
 -----------

--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -351,9 +351,15 @@ values correspond roughly to a zoom out effect. The default is 45 degrees.
 World object density
 --------------------
 
-This value can be set from 0 to 10; when 10 is selected, all objects
+The default value is 10.
+This value can be set from 0 to 100; when 100 is selected, all objects
 defined in the route files are displayed. Lower values do not display some
-categories of objects.
+categories of objects and this tends to increase frame rates.
+
+In legacy routes, all the content was assigned to categories 0-10.
+In more modern routes, content may be assigned to categories above 10. 
+Please consult the documentation of the route for a recommended maximum which reveals all the content.
+Note that values above that maximum may reveal objects used in building the route.
 
 Window size
 -----------

--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -351,15 +351,13 @@ values correspond roughly to a zoom out effect. The default is 45 degrees.
 World object density
 --------------------
 
-The default value is 10.
-This value can be set from 0 to 100; when 100 is selected, all objects
-defined in the route files are displayed. Lower values do not display some
-categories of objects and this tends to increase frame rates.
+This value can be set from 0 to 199 and the default value is 99.
+When 99 is selected, all content defined in the route files and intended for the player to see is visible. 
+Lower values will hide some categories of objects which tends to increase frame rates.
 
 In legacy routes, all the content was assigned to categories 0-10.
-In more modern routes, content may be assigned to categories above 10. 
-Please consult the documentation of the route for a recommended maximum which reveals all the content.
-Note that values above that maximum may reveal objects used in building the route.
+In more modern routes, content may be assigned to categories between 0 and 99.
+Content builders are advised to reserve values 100 to 199 for objects used in building the route.
 
 Window size
 -----------

--- a/Source/Menu/Options.Designer.cs
+++ b/Source/Menu/Options.Designer.cs
@@ -1195,7 +1195,7 @@
             // 
             this.numericWorldObjectDensity.Location = new System.Drawing.Point(6, 299);
             this.numericWorldObjectDensity.Maximum = new decimal(new int[] {
-            199,
+            99,
             0,
             0,
             0});

--- a/Source/Menu/Options.Designer.cs
+++ b/Source/Menu/Options.Designer.cs
@@ -1194,6 +1194,11 @@
             // numericWorldObjectDensity
             // 
             this.numericWorldObjectDensity.Location = new System.Drawing.Point(6, 299);
+            this.numericWorldObjectDensity.Maximum = new decimal(new int[] {
+            199,
+            0,
+            0,
+            0});
             this.numericWorldObjectDensity.Name = "numericWorldObjectDensity";
             this.numericWorldObjectDensity.Size = new System.Drawing.Size(54, 20);
             this.numericWorldObjectDensity.TabIndex = 16;

--- a/Source/Menu/Options.Designer.cs
+++ b/Source/Menu/Options.Designer.cs
@@ -1194,11 +1194,6 @@
             // numericWorldObjectDensity
             // 
             this.numericWorldObjectDensity.Location = new System.Drawing.Point(6, 299);
-            this.numericWorldObjectDensity.Maximum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
             this.numericWorldObjectDensity.Name = "numericWorldObjectDensity";
             this.numericWorldObjectDensity.Size = new System.Drawing.Size(54, 20);
             this.numericWorldObjectDensity.TabIndex = 16;

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -220,7 +220,7 @@ namespace ORTS.Settings
         public int DistantMountainsViewingDistance { get; set; }
         [Default(45)] // MSTS uses 60 FOV horizontally, on 4:3 displays this is 45 FOV vertically (what OR uses).
         public int ViewingFOV { get; set; }
-        [Default(10)]
+        [Default(99)]
         public int WorldObjectDensity { get; set; }
         [Default("1024x768")]
         public string WindowSize { get; set; }

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -220,7 +220,7 @@ namespace ORTS.Settings
         public int DistantMountainsViewingDistance { get; set; }
         [Default(45)] // MSTS uses 60 FOV horizontally, on 4:3 displays this is 45 FOV vertically (what OR uses).
         public int ViewingFOV { get; set; }
-        [Default(99)]
+        [Default(49)]
         public int WorldObjectDensity { get; set; }
         [Default("1024x768")]
         public string WindowSize { get; set; }


### PR DESCRIPTION
https://blueprints.launchpad.net/or/+spec/object-density-upper-limit

Increases the limit from 10 to 199 and the default to 99 to suit modern content builders.

![image](https://user-images.githubusercontent.com/2474328/130639238-ec006253-be6d-471e-b163-50d1df07e5fa.png)

