### PR TITLE
fix: Fix squashed logo on menu

### DIFF
--- a/Source/Menu/MainForm.Designer.cs
+++ b/Source/Menu/MainForm.Designer.cs
@@ -369,7 +369,7 @@ namespace ORTS
             this.pictureBoxLogo.Location = new System.Drawing.Point(12, 472);
             this.pictureBoxLogo.Name = "pictureBoxLogo";
             this.pictureBoxLogo.Size = new System.Drawing.Size(64, 64);
-            this.pictureBoxLogo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBoxLogo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.pictureBoxLogo.TabIndex = 5;
             this.pictureBoxLogo.TabStop = false;
             // 


### PR DESCRIPTION
This is a very tiny fix for an issue which has bugged me for ages... the logo on the menu is squashed:

![image](https://user-images.githubusercontent.com/1017843/130475664-878ca31b-fb0a-4562-8dad-de8d1f925249.png)

After this change it looks much better:

![image](https://user-images.githubusercontent.com/1017843/130475841-01970d2a-ef33-4f94-bc85-a1778a91eec3.png)
