### PR TITLE
feat: Add latest version information to registry

### DIFF
--- a/Source/ORTS.Common/SettingsStore.cs
+++ b/Source/ORTS.Common/SettingsStore.cs
@@ -53,6 +53,7 @@ namespace ORTS.Common
             Debug.Assert(new[] {
                 typeof(bool),
                 typeof(int),
+                typeof(long),
                 typeof(DateTime),
                 typeof(TimeSpan),
                 typeof(string),
@@ -87,6 +88,13 @@ namespace ORTS.Common
         /// <param name="name">name of the setting</param>
         /// <param name="value">value of the setting</param>
         public abstract void SetUserValue(string name, int value);
+
+        /// <summary>
+        /// Set a value of a user setting
+        /// </summary>
+        /// <param name="name">name of the setting</param>
+        /// <param name="value">value of the setting</param>
+        public abstract void SetUserValue(string name, long value);
 
         /// <summary>
         /// Set a value of a user setting
@@ -229,6 +237,16 @@ namespace ORTS.Common
         public override void SetUserValue(string name, int value)
         {
             Key.SetValue(name, value, RegistryValueKind.DWord);
+        }
+
+        /// <summary>
+        /// Set a value of a user setting
+        /// </summary>
+        /// <param name="name">name of the setting</param>
+        /// <param name="value">value of the setting</param>
+        public override void SetUserValue(string name, long value)
+        {
+            Key.SetValue(name, value, RegistryValueKind.QWord);
         }
 
         /// <summary>
@@ -390,6 +408,9 @@ namespace ORTS.Common
                     case "int":
                         userValue = int.Parse(Uri.UnescapeDataString(value[1]), CultureInfo.InvariantCulture);
                         break;
+                    case "long":
+                        userValue = long.Parse(Uri.UnescapeDataString(value[1]), CultureInfo.InvariantCulture);
+                        break;
                     case "DateTime":
                         userValue = DateTime.FromBinary(long.Parse(Uri.UnescapeDataString(value[1]), CultureInfo.InvariantCulture));
                         break;
@@ -438,6 +459,16 @@ namespace ORTS.Common
         public override void SetUserValue(string name, int value)
         {
             NativeMethods.WritePrivateProfileString(Section, name, "int:" + Uri.EscapeDataString(value.ToString(CultureInfo.InvariantCulture)), FilePath);
+        }
+
+        /// <summary>
+        /// Set a value of a user setting
+        /// </summary>
+        /// <param name="name">name of the setting</param>
+        /// <param name="value">value of the setting</param>
+        public override void SetUserValue(string name, long value)
+        {
+            NativeMethods.WritePrivateProfileString(Section, name, "long:" + Uri.EscapeDataString(value.ToString(CultureInfo.InvariantCulture)), FilePath);
         }
 
         /// <summary>

--- a/Source/ORTS.Common/VersionInfo.cs
+++ b/Source/ORTS.Common/VersionInfo.cs
@@ -132,5 +132,15 @@ namespace ORTS.Common
             // parsedVersion.Build will be -1 if the version only has major and minor, but we need the build number >= 0 here
             return new Version(parsedVersion.Major, parsedVersion.Minor, Math.Max(0, parsedVersion.Build), commits);
         }
+
+        public static long GetVersionLong(Version version)
+        {
+            long number = 0;
+            if (version.Major > 0) number += (long)(version.Major & 0xFFFF) << 48;
+            if (version.Minor > 0) number += (long)(version.Minor & 0xFFFF) << 32;
+            if (version.Build > 0) number += (version.Build & 0xFFFF) << 16;
+            if (version.Revision > 0) number += (version.Revision & 0xFFFF);
+            return number;
+        }
     }
 }


### PR DESCRIPTION
Storing the latest version number in the registry has been requested by content creators, so that their installers can validate the user's version of Open Rails is compatible with the content

This will be stored per-user, next to the existing content folders storage, which installers already modify to add content

The version will be stored in a machine-readable format (so that it may be updated automatically) and human-readable text for display purposes

**Discussion:** http://www.elvastower.com/forums/index.php?/topic/35458-store-latest-version-number-in-registry/
**Trello card:** https://trello.com/c/6ybEXrey/508-store-latest-version-number-in-registry