### PR TITLE
Correct spelling error in manual, and missing setting of parameter

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -2006,7 +2006,7 @@ can be left out are those parameters associated with power, motive force, diesel
 as the compressor and main air reservoir, and some of the diesel effects (as it has no diesel engine).
 
 Some of the cab monitoring gauges provide visibility of what is happening on the powered car. To do this OR searches for 
-the "closest" powered car near the Control car and uses its infromation.
+the "closest" powered car near the Control car and uses its information.
 
 
 Engines -- Multiple Units in Same Consist or AI Engines

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1643,7 +1643,8 @@ namespace Orts.Simulation.RollingStocks
                     MaxMainResPressurePSI = ControlActiveLocomotive.MaxMainResPressurePSI;
                     MainResPressurePSI = MaxMainResPressurePSI;
                     ControlActiveLocomotive.MainResPressurePSI = MainResPressurePSI;
-                    controlTrailerBrakeSystemSet = true;
+                    controlTrailerBrakeSystemSet = true; // Ensure this loop is only processes the first time update routine run
+                    MaximumMainReservoirPipePressurePSI = ControlActiveLocomotive.MaximumMainReservoirPipePressurePSI;
                     CompressorRestartPressurePSI = ControlActiveLocomotive.CompressorRestartPressurePSI;
                     MainResChargingRatePSIpS = ControlActiveLocomotive.MainResChargingRatePSIpS;
                     BrakePipeChargingRatePSIorInHgpS = ControlActiveLocomotive.BrakePipeChargingRatePSIorInHgpS;


### PR DESCRIPTION
Part of this blueprint -

https://blueprints.launchpad.net/or/+spec/unpowered-control-car