### PR TITLE
Drops XNA references from .appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,14 +5,11 @@ cache:
   - C:\ProgramData\chocolatey\bin -> .appveyor.yml
   - C:\ProgramData\chocolatey\lib -> .appveyor.yml
   - C:\lazarus -> .appveyor.yml
-  - C:\Program Files (x86)\Common Files\Microsoft Shared\XNA -> .appveyor.yml
-  - C:\Windows\assembly\GAC_32\Microsoft.Xna.Framework -> .appveyor.yml
-  - C:\Windows\assembly\GAC_32\Microsoft.Xna.Framework.Game -> .appveyor.yml
 install:
 - ps: >-
     $ErrorActionPreference = "Stop"
 
-    choco install --yes --no-progress lazarus 7zip.portable xunit xna31
+    choco install --yes --no-progress lazarus 7zip.portable xunit
 
     if ($LASTEXITCODE -ne 0) { throw "Chocolatey failed to install all required packages - use the 're-build' option to try again" }
 


### PR DESCRIPTION
The Appveyor build is failing when building the Unstable version.
The Chocolatey installer is having trouble downloading and installing XNA.
As this is no longer needed, I have removed it from the script so it more closely matches the release/1.4 script.