### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1943837 3D cabs: digitals aren't clamped against Max and MinValue

### DIFF
--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2618,6 +2618,7 @@ namespace Orts.Viewer3D.RollingStock
                 var digital = Control as CVCDigital;
                 string displayedText = "";
                 Num = Locomotive.GetDataOf(Control);
+                if (digital.MinValue < digital.MaxValue) Num = MathHelper.Clamp(Num, (float)digital.MinValue, (float)digital.MaxValue);
                 if (Math.Abs(Num) < digital.AccuracySwitch)
                     Format = Format2;
                 else


### PR DESCRIPTION
https://bugs.launchpad.net/or/+bug/1943837