### PR TITLE
Announce train driving window

### DIFF
--- a/Source/Documentation/Manual/news.rst
+++ b/Source/Documentation/Manual/news.rst
@@ -14,7 +14,7 @@ Headlines
 
 - Monogame graphics replace XNA with `support for ReShade <https://reshade.me/>`_ and more memory
 - Web server providing train data for web pages on other devices
-- Train Driving display on other devices
+- Train Driving display in-game and on other devices
 - More realistic vacuum braking
 - Trainspotting camera including train-following car
 

--- a/Website/openrails.org/discover/version-1-4/index.php
+++ b/Website/openrails.org/discover/version-1-4/index.php
@@ -1,0 +1,81 @@
+<?php include "../../shared/head_notrack.php" ?>
+    <link rel="stylesheet" href="../../shared/iframe/iframe.css" type="text/css" />
+  </head>
+
+  <body>
+    <div class="container"><!-- Centres content and sets fixed width to suit device -->
+<?php include "../../shared/banners/choose_banner.php" ?>
+<?php include "../../shared/banners/show_banner.php" ?>
+<?php include "../../shared/menu.php" ?>
+      <div class="row">
+        <div class="col-md-12">
+          <h1>Discover > Version 1.4</h1>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-1"></div>
+        <div class="col-md-10">
+          <h2>New in Open Rails 1.4 (since 1.3)</h2>
+          <p>
+            A summary of the new and improved features can be found below. 
+          </p><p>
+            <a href="https://launchpad.net/or/+milestone/1.4">Important bugs</a> have been fixed in this release.
+            Please keep <a href="http://openrails.org/contribute/reporting-bugs/">reporting bugs and suggesting new features</a> 
+            so Open Rails can continue to improve.
+          </p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-1"></div>
+        <div class="col-md-5">
+          <h3>Headlines</h3>
+          <ul>
+            <li>Monogame graphics replace XNA with support for <a href="https://reshade.me/">ReShade</a> and more memory</li>
+            <li>Web server providing train data for web pages on other devices</li>
+            <li>Train Driving display in-game and on other devices</li>
+            <li>More realistic vacuum braking</li>
+            <li>Trainspotting camera including train-following car</li>
+          </ul>
+          <h3>What's been added</h3>
+          <ul>
+            <li>Analogue clocks suitable for 2d cabs and for buildings</li>
+            <li>Smooth transitions for signal lamps that blink</li>
+            <li>Letterboxing for 2D cabs</li>
+            <li>Tilted digital displays in 2D cabs</li>
+            <li>Manual braking for individual wagons</li>
+            <li>Large ejector for charging vacuum brakes</li>
+            <li>Eames vacuum brake</li>
+            <li>Overcharge braking position</li>
+            <li>Russian and Brazilian Portuguese languages</li>
+            <li>Advanced call-on for signalling</li>
+            <li>USA horn blow sequence for AI trains</li>
+            <li>Turntables in timetable mode</li>
+            <li>Map window for timetabled trains</li>
+            <li>Timetable briefings</li>
+            <li>Manual index</li>
+          </ul>
+        </div>
+        <div class="col-md-1"></div>
+        <div class="col-md-5">
+        <h3>What's been improved</h3>
+          <ul>
+            <li>Vacuum brakes, EP braking and air braking</li>
+            <li>Visual effects for steam ejectors</li>
+            <li>Improved water troughs</li>
+            <li>Scripted train control system (TCS)</li>
+            <li>Sound events for gear positions, injectors, fireman etc.</li>
+            <li>Traction braking display</li>
+          </ul>
+          <h3>Detailed changelog</h3>
+          <p>
+            A <a href="https://launchpad.net/or/+milestone/1.4">full list of changes</a> is available.
+          </p>
+          <h3><a href="../version-1-3-1/">Changes in previous version</a></h3>
+          <p>&nbsp;</p>
+        </div>
+      </div>
+	</div>
+<?php include "../../shared/tail.php" ?>
+<?php include "../../shared/banners/preload_next_banner.php" ?>
+  </body>
+</html>

--- a/Website/openrails.org/discover/version-1-4/title.php
+++ b/Website/openrails.org/discover/version-1-4/title.php
@@ -1,0 +1,1 @@
+<?php echo "<title>Open Rails - Discover - Version 1.4</title>"; ?>


### PR DESCRIPTION
Small change to extend the new features item to include in-game Train Dr

"cjakeman wants to merge 3 commits into openrails:master from cjakeman:announce-train-driving-windowiving window in the manual and on the website page." NO. I started from release/1.4, not master. and I want to merge into release/1.4 I don't have the option to change from master :-(