### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1944725 Switching 3D cab the camera position is incorrect

### DIFF
--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -1866,8 +1866,9 @@ namespace Orts.Viewer3D
             // View is only reset on move to a different cab or "Ctl + 8".
             if (attachedCar.CabViewpoints != null)
             {
-                if (ActViewPoint != prevViewPoint)
+                if (car.CarID != prevcar || ActViewPoint != prevViewPoint)
                 {
+                    prevcar = car.CarID;
                     prevViewPoint = ActViewPoint;
                     viewPointLocation = attachedCar.CabViewpoints[ActViewPoint].Location;
                     viewPointRotationXRadians = attachedCar.CabViewpoints[ActViewPoint].RotationXRadians;


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/35522-3d-cab-position-bug/ . The bug was introduced after 1.3.1