### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1949292 AI train disappears after coupling and reversing

### DIFF
--- a/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
@@ -4114,6 +4114,8 @@ namespace Orts.Simulation.AIs
 
             int directionNow = ValidRoute[0][PresentPosition[0].RouteListIndex].Direction;
             int positionNow = ValidRoute[0][PresentPosition[0].RouteListIndex].TCSectionIndex;
+            int directionNowBack = PresentPosition[1].TCDirection;
+            int positionNowBack = PresentPosition[1].TCSectionIndex;
 
             bool[] nextPart = UpdateRouteActions(0, checkLoop);
 
@@ -4132,7 +4134,7 @@ namespace Orts.Simulation.AIs
                          Number.ToString() + " continued, part : " + TCRoute.activeSubpath.ToString() + "\n");
                 }
 
-                if (positionNow == PresentPosition[0].TCSectionIndex && directionNow != PresentPosition[0].TCDirection)
+                if (positionNowBack == PresentPosition[0].TCSectionIndex && directionNowBack != PresentPosition[0].TCDirection)
                 {
                     ReverseFormation(false);
                     // active subpath must be incremented in parallel in incorporated train if present


### PR DESCRIPTION
The fix follows the same lines used for the player train