### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1950578 Dyn Brake setup state not disappearing in cab

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -502,7 +502,7 @@ namespace Orts.Simulation.RollingStocks
             }
         }
 
-        public float LocalDynamicBrakePercent;
+        public float LocalDynamicBrakePercent = -1;
         public float DynamicBrakePercent
         {
             get
@@ -526,6 +526,8 @@ namespace Orts.Simulation.RollingStocks
                 if (AcceptMUSignals && Train != null)
                     Train.MUDynamicBrakePercent = value;
                 else
+                    LocalDynamicBrakePercent = value;
+                if (Train != null && this == Train.LeadLocomotive)
                     LocalDynamicBrakePercent = value;
             }
         }

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -1937,7 +1937,10 @@ namespace Orts.Viewer3D.RollingStock
                     if (Locomotive.DynamicBrakeController != null)
                     {
                         if (dynBrakePercent == -1)
+                        {
+                            index = 0;
                             break;
+                        }
                         if (!Locomotive.HasSmoothStruc)
                         {
                             index = Locomotive.DynamicBrakeController != null ? Locomotive.DynamicBrakeController.CurrentNotch : 0;


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/35649-dynamic-brakes-cab-display/ and http://www.elvastower.com/forums/index.php?/topic/34471-in-cab-dynamic-brakes-display-error/ .