### PR TITLE
deletes RunActivityLAA.* post-build

### DIFF
--- a/Source/RunActivity/RunActivity.csproj
+++ b/Source/RunActivity/RunActivity.csproj
@@ -858,6 +858,8 @@
     <PostBuildEvent>CD ..\
 IF EXIST "Program\Content\Web" RMDIR "Program\Content\Web" /S /Q
 IF NOT EXIST "Program\Content\Web" MKDIR "Program\Content\Web"
-XCOPY "Source\RunActivity\Viewer3D\WebServices\Web" "Program\Content\Web" /S /Y</PostBuildEvent>
+XCOPY "Source\RunActivity\Viewer3D\WebServices\Web" "Program\Content\Web" /S /Y
+DEL "Program\RunActivityLAA.*"
+</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Small extension to the RunActivity project file to prevent old version of RunActivityLAA.exe being used accidentally.

See https://blueprints.launchpad.net/or/+spec/delete-runactivitylaa