### PR TITLE
Add support for dual-screen ETCS DMI

### DIFF
--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -720,7 +720,14 @@ instead::
 			Type ( ORTS_ETCS SCREEN_DISPLAY )
 			Position ( 280 272 320 240 )
 			Units ( KM_PER_HOUR )
+			Parameters (
+				Mode FullSize
+			)
 		)
+		
+The following DMI size variants are available: FullSize (displays the whole DMI), SpeedArea
+(displays only the left part with information about distance and speed) and PlanningArea
+(displays only the planning area and navigation buttons).
 
 The information displayed in the DMI is controlled via the TCS script. For more details,
 see :ref:`C# engine scripting - Train Control System <features-scripting-tcs>`.

--- a/Source/RunActivity/Viewer3D/RollingStock/SubSystems/ETCS/TextMessages.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/SubSystems/ETCS/TextMessages.cs
@@ -47,18 +47,16 @@ namespace Orts.Viewer3D.RollingStock.SubSystems.ETCS
 
         readonly int MaxTextLines;
 
-        readonly int RowHeight = 20;
+        const int RowHeight = 20;
 
         readonly TextPrimitive[] DisplayedTexts;
         readonly TextPrimitive[] DisplayedTimes;
 
         List<TextMessage> MessageList;
         TextMessage? AcknowledgingMessage;
-        public MessageArea(DriverMachineInterface dmi) : base(Viewer.Catalog.GetString("Acknowledge"), true, dmi, false)
+        public MessageArea(DriverMachineInterface dmi) : base(Viewer.Catalog.GetString("Acknowledge"), true, null, 234, (dmi.IsSoftLayout ? 4 : 5)*RowHeight, dmi, false)
         {
             MaxTextLines = dmi.IsSoftLayout ? 4 : 5;
-            Height = MaxTextLines * RowHeight;
-            Width = 234;
 
             DisplayedTexts = new TextPrimitive[MaxTextLines];
             DisplayedTimes = new TextPrimitive[MaxTextLines];


### PR DESCRIPTION
https://blueprints.launchpad.net/or/+spec/etcs-dual-screens

Allow displaying of only half of the ETCS DMI, as it is being implemented this way in a lot of new trains (http://www.elvastower.com/forums/uploads/monthly_11_2021/post-9658-0-81402000-1636153074_thumb.jpg)

There is some interest in having this feature in OR, see http://www.elvastower.com/forums/index.php?/topic/34577-planning-area-of-the-etcs-dmi/page__view__findpost__p__271577