### PR TITLE
Generic items: optional internal 3DCab animation linked to them

### DIFF
--- a/Source/Documentation/Manual/cabs.rst
+++ b/Source/Documentation/Manual/cabs.rst
@@ -564,6 +564,14 @@ It may be modified with following parameter in the .sd file::
 Examples of use are fan control, open/close of aerodynamic coverages of couplers 
 in high speed trains, menu pages switching.
 
+Animations within the 3D cab .s file are also available, as follows::
+
+        ORTS_ITEM1CONTINUOUS
+        ORTS_ITEM2CONTINUOUS
+        ORTS_ITEM1TWOSTATE
+        ORTS_ITEM2TWOSTATE
+
+in analogy to the four animations for the locomotive .s file.
 
 High-resolution Cab Backgrounds and Controls
 --------------------------------------------

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -265,7 +265,11 @@ namespace Orts.Formats.Msts
         EXTERNALWIPERS,
         LEFTDOOR,
         RIGHTDOOR,
-        MIRRORS
+        MIRRORS,
+        ORTS_ITEM1CONTINUOUS,
+        ORTS_ITEM2CONTINUOUS,
+        ORTS_ITEM1TWOSTATE,
+        ORTS_ITEM2TWOSTATE,
     }
 
     public enum CABViewControlStyles

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2857,6 +2857,10 @@ namespace Orts.Viewer3D.RollingStock
                             case CABViewControlTypes.MIRRORS:
                             case CABViewControlTypes.LEFTDOOR:
                             case CABViewControlTypes.RIGHTDOOR:
+                            case CABViewControlTypes.ORTS_ITEM1CONTINUOUS:
+                            case CABViewControlTypes.ORTS_ITEM2CONTINUOUS:
+                            case CABViewControlTypes.ORTS_ITEM1TWOSTATE:
+                            case CABViewControlTypes.ORTS_ITEM2TWOSTATE:
                                 break;
                             default:
                                 //cvf file has no external wipers, left door, right door and mirrors key word
@@ -2961,6 +2965,18 @@ namespace Orts.Viewer3D.RollingStock
                             break;
                         case CABViewControlTypes.MIRRORS:
                             p.Value.UpdateState(Locomotive.MirrorOpen, elapsedTime);
+                            break;
+                        case CABViewControlTypes.ORTS_ITEM1CONTINUOUS:
+                            p.Value.UpdateLoop(Locomotive.GenericItem1, elapsedTime);
+                            break;
+                        case CABViewControlTypes.ORTS_ITEM2CONTINUOUS:
+                            p.Value.UpdateLoop(Locomotive.GenericItem2, elapsedTime);
+                            break;
+                        case CABViewControlTypes.ORTS_ITEM1TWOSTATE:
+                            p.Value.UpdateState(Locomotive.GenericItem1, elapsedTime);
+                            break;
+                        case CABViewControlTypes.ORTS_ITEM2TWOSTATE:
+                            p.Value.UpdateState(Locomotive.GenericItem2, elapsedTime);
                             break;
                         default:
                             break;


### PR DESCRIPTION
This  is an extension of https://blueprints.launchpad.net/or/+spec/cabview-controls-for-generic-items .
See http://www.elvastower.com/forums/index.php?/topic/35572-cabview-controls-for-generic-items/page__view__findpost__p__279164