### PR TITLE
Bug fix for Crash when switching cabs and changing screen page  https://bugs.launchpad.net/or/+bug/1955575

### DIFF
--- a/Source/RunActivity/Viewer3D/Commands.cs
+++ b/Source/RunActivity/Viewer3D/Commands.cs
@@ -93,7 +93,7 @@ namespace Orts.Viewer3D
     [Serializable()]
     public sealed class SelectScreenCommand : BooleanCommand
     {
-        public static CabRenderer Receiver { get; set; }
+        public static Viewer Receiver { get; set; }
 
         public SelectScreenCommand(CommandLog log, bool toState, string screen, int display)
             : base(log, toState)
@@ -105,7 +105,10 @@ namespace Orts.Viewer3D
         {
             if (ToState)
             {
-                Receiver.ActiveScreen[display] = screen;
+                var finalReceiver = Receiver.Camera  is ThreeDimCabCamera ?
+                    (Receiver.PlayerLocomotiveViewer as MSTSLocomotiveViewer).ThreeDimentionCabRenderer :
+                    (Receiver.PlayerLocomotiveViewer as MSTSLocomotiveViewer)._CabRenderer;
+                finalReceiver.ActiveScreen[display] = screen;
             }
         }
 

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -590,8 +590,7 @@ namespace Orts.Viewer3D
 
             ImmediateRefillCommand.Receiver = (MSTSLocomotiveViewer)PlayerLocomotiveViewer;
             RefillCommand.Receiver = (MSTSLocomotiveViewer)PlayerLocomotiveViewer;
-            SelectScreenCommand.Receiver = (!Simulator.PlayerLocomotive.HasFront3DCab && !Simulator.PlayerLocomotive.HasRear3DCab) ? 
-                ((MSTSLocomotiveViewer)PlayerLocomotiveViewer)._CabRenderer : ((MSTSLocomotiveViewer)PlayerLocomotiveViewer).ThreeDimentionCabRenderer;
+            SelectScreenCommand.Receiver = this;
             ToggleOdometerCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
             ResetOdometerCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;
             ToggleOdometerDirectionCommand.Receiver = (MSTSLocomotive)PlayerLocomotive;


### PR DESCRIPTION
 After a cab change cabrenderers are not yet alive at the moment that the command receivers are set.
Changed command receiver and having also a better selection between 2D and 3D cabrenderer as command receiver.