### PR TITLE
Add support for the building the manual with a Visual Studio Code development container

### DIFF
--- a/Source/Documentation/Manual/.devcontainer/Dockerfile
+++ b/Source/Documentation/Manual/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM sphinxdoc/sphinx-latexpdf
+RUN pip install --no-cache-dir sphinx-rtd-theme

--- a/Source/Documentation/Manual/.devcontainer/devcontainer.json
+++ b/Source/Documentation/Manual/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/docs,type=bind",
+    "workspaceFolder": "/docs",
+    "remoteUser": "vscode",
+    "features": {
+        "common": {
+            "username": "automatic",
+            "uid": "automatic",
+            "gid": "automatic",
+            "installZsh": true,
+            "installOhMyZsh": true,
+            "upgradePackages": true,
+            "nonFreePackages": false
+        }
+    },
+    "extensions": [
+        "TatsuyaNakamori.resttext"
+    ]
+}

--- a/Source/Documentation/Manual/.vscode/tasks.json
+++ b/Source/Documentation/Manual/.vscode/tasks.json
@@ -1,0 +1,32 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "shell",
+			"command": "make",
+			"args": ["html"],
+			"label": "Build: html",
+			"problemMatcher": [],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"type": "shell",
+			"command": "make",
+			"args": ["latexpdf"],
+			"label": "Build: latex",
+			"problemMatcher": [],
+			"group": "build"
+		},
+		{
+			"type": "shell",
+			"command": "make",
+			"args": ["clean"],
+			"label": "Build: Make Clean",
+			"problemMatcher": [],
+			"group": "build"
+		}
+	]
+}


### PR DESCRIPTION
Visual Studio Code's [development containers](https://code.visualstudio.com/docs/remote/containers) feature allows us to construct a reproducible, well-defined Linux toolstack to work with our code on our Windows machines. It's the perfect technology to apply to our manual; rather than installing and maintaining the full Python/Sphinx/LaTeX stack, you can let VS Code and Docker do all the work for you!

To use the feature:

1. Install the [Remote Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for VS Code and [Docker Desktop](https://www.docker.com/products/docker-desktop) for Windows 10/11. Start Docker Desktop.
2. In VS Code, press F1 and search for the "Open Folder in Container" command. Browse to the Source\Documentation\Manual folder. After opening the workspace, VS Code will pull the Docker image straight from Sphinx and spin it up.
3. Press Ctrl+Shift+B to build the HTML version of the manual. And that's it! The files will output to the _build directory, just as if you'd used Sphinx for Windows. (Under Terminal > Run Task, I've also included commands to build the PDF manual and to clean the output directory.)

This will hopefully make it much easier for other developers and interested power users to contribute to our manual.

Caveat: You're normally able to use VS Code's Git integration in a development container, but it doesn't work for our use case. That's because the manual is located in a subdirectory, and VS Code doesn't yet detect development container workspaces within subdirectories (https://github.com/microsoft/vscode-remote-release/issues/2413), so you can't open the openrails root folder and get full Git integration. One possible workaround would be to spin off the manual to separate repository, as we are doing for the website.