### PR TITLE
Manual call-on is reset when passing an advanced signal - https://bugs.launchpad.net/or/+bug/1955907

### DIFF
--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -227,7 +227,6 @@ namespace Orts.Simulation.Physics
         public int IndexNextSignal = -1;                 // Index in SignalObjectItems for next signal
         public int IndexNextSpeedlimit = -1;             // Index in SignalObjectItems for next speedpost
         public SignalObject[] NextSignalObject = new SignalObject[2];  // direct reference to next signal
-        public SignalObject AllowedCallOnSignal;         // Signal for which train has call on allowed by dispatcher
 
         // Local max speed independently from signal and speedpost speed;
         // depends from various parameters like route max speed, overall or section efficiency of service,
@@ -2893,8 +2892,6 @@ namespace Orts.Simulation.Physics
                 // system will take back control of the signal
                 if (signalObject.holdState == SignalObject.HoldState.ManualPass ||
                     signalObject.holdState == SignalObject.HoldState.ManualApproach) signalObject.holdState = SignalObject.HoldState.None;
-
-                AllowedCallOnSignal = null;
             }
             UpdateSectionStateManual();                                                           // update track occupation          //
             UpdateManualMode(SignalObjIndex);                                                     // update route clearance           //
@@ -2922,8 +2919,6 @@ namespace Orts.Simulation.Physics
                 // system will take back control of the signal
                 if (signalObject.holdState == SignalObject.HoldState.ManualPass ||
                     signalObject.holdState == SignalObject.HoldState.ManualApproach) signalObject.holdState = SignalObject.HoldState.None;
-
-                AllowedCallOnSignal = null;
             }
             UpdateSectionStateExplorer();                                                         // update track occupation          //
             UpdateExplorerMode(SignalObjIndex);                                                   // update route clearance           //
@@ -7457,8 +7452,6 @@ namespace Orts.Simulation.Physics
                     signalObject.holdState = SignalObject.HoldState.None;
                 }
 
-                AllowedCallOnSignal = null;
-
                 signalObject.resetSignalEnabled();
             }
         }
@@ -7610,9 +7603,6 @@ namespace Orts.Simulation.Physics
 
         public virtual bool TestCallOn(SignalObject thisSignal, bool allowOnNonePlatform, TCSubpathRoute thisRoute, string dumpfile)
         {
-            if (AllowedCallOnSignal == thisSignal)
-                return true;
-
             bool intoPlatform = false;
 
             foreach (Train.TCRouteElement routeElement in thisSignal.signalRoute)
@@ -7956,8 +7946,6 @@ namespace Orts.Simulation.Physics
                 //the following is added by JTang, passing a hold signal, will take back control by the system
                 if (thisSignal.holdState == SignalObject.HoldState.ManualPass ||
                     thisSignal.holdState == SignalObject.HoldState.ManualApproach) thisSignal.holdState = SignalObject.HoldState.None;
-
-                AllowedCallOnSignal = null;
 
                 thisSignal.resetSignalEnabled();
             }

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -8417,6 +8417,7 @@ namespace Orts.Simulation.Signalling
         private InternalBlockstate internalBlockState = InternalBlockstate.Open;    // internal blockstate
         public Permission hasPermission = Permission.Denied;  // Permission to pass red signal
         public HoldState holdState = HoldState.None;
+        public bool CallOnManuallyAllowed;
 
         public List<int> sigfound = new List<int>();  // active next signal - used for signals with NORMAL heads only
         public int reqNormalSignal = -1;              // ref of normal signal requesting route clearing (only used for signals without NORMAL heads)
@@ -10110,8 +10111,8 @@ namespace Orts.Simulation.Signalling
         public void resetSignalEnabled()
         {
             // reset train information
-
             enabledTrain = null;
+            CallOnManuallyAllowed = false;
             trainRouteDirectionIndex = 0;
             signalRoute.Clear();
             fullRoute = hasFixedRoute;
@@ -12196,7 +12197,7 @@ namespace Orts.Simulation.Signalling
 
             if (enabledTrain.Train != null && signalRoute != null)
             {
-                bool callOnValid = enabledTrain.Train.TestCallOn(this, allowOnNonePlatform, signalRoute, dumpfile);
+                bool callOnValid = CallOnManuallyAllowed || enabledTrain.Train.TestCallOn(this, allowOnNonePlatform, signalRoute, dumpfile);
                 return (callOnValid);
             }
 
@@ -12720,12 +12721,12 @@ namespace Orts.Simulation.Signalling
             {
                 if (state && CallOnEnabled)
                 {
-                    enabledTrain.Train.AllowedCallOnSignal = this;
                     clearHoldSignalDispatcher();
+                    CallOnManuallyAllowed = true;
                 }
-                else if (enabledTrain.Train.AllowedCallOnSignal == this)
+                else
                 {
-                    enabledTrain.Train.AllowedCallOnSignal = null;
+                    CallOnManuallyAllowed = false;
                 }
             }
         }

--- a/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
@@ -1547,13 +1547,8 @@ namespace Orts.Viewer3D.Debugging
 			  boxSetSignal.Items.RemoveAt(4);
 
 		  if (signalPickedItem.Signal.enabledTrain != null && signalPickedItem.Signal.CallOnEnabled)
-		  {
-			  if (signalPickedItem.Signal.enabledTrain.Train.AllowedCallOnSignal != signalPickedItem.Signal)
-			  boxSetSignal.Items.Add("Enable call on");
-			  /*else
-				  boxSetSignal.Items.Add("Disable call on");*/
-			  // To disable Call On signal must be manually set to stop, to avoid signal state change
-			  // in the interval between this list is shown and the option is selected by dispatcher
+          {
+                if (!signalPickedItem.Signal.CallOnManuallyAllowed) boxSetSignal.Items.Add("Allow call on");
 		  }
 
 		  boxSetSignal.Location = new System.Drawing.Point(LastCursorPosition.X + 2, y);


### PR DESCRIPTION
When the train is allowed to "call on" from the dispatcher window, but the signal is not the first one for the train, the CallOn is reset. Therefore, it won't work with TrainHasCallOn_Advanced and TrainHasCallOn_Restricted_Advanced sigscr functions.