### PR TITLE
Remove the locomotive handle from the script, because no interface function can allow access to any internal structure.

### DIFF
--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -300,10 +300,6 @@ namespace ORTS.Scripting.Api
         /// Get distance of next station if any, else max float value
         /// </summary>
         public Func<float> NextStationDistanceM;
-        /// <summary>
-        /// Get locomotive handle
-        /// </summary>
-        public Func<MSTSLocomotive> Locomotive;
 
         /// <summary>
         /// (float targetDistanceM, float targetSpeedMpS, float slope, float delayS, float decelerationMpS2)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -382,7 +382,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.GetControlMode = () => (TRAIN_CONTROL)(int)Locomotive.Train.ControlMode;
                 Script.NextStationName = () => Locomotive.Train.StationStops != null && Locomotive.Train.StationStops.Count > 0 ? Locomotive.Train.StationStops[0].PlatformItem.Name : "";
                 Script.NextStationDistanceM = () => Locomotive.Train.StationStops != null && Locomotive.Train.StationStops.Count > 0 ? Locomotive.Train.StationStops[0].DistanceToTrainM : float.MaxValue;
-                Script.Locomotive = () => Locomotive;
 
                 // TrainControlSystem functions
                 Script.SpeedCurve = (arg1, arg2, arg3, arg4, arg5) => SpeedCurve(arg1, arg2, arg3, arg4, arg5);


### PR DESCRIPTION
It was a huge mistake adding this function to the scripting interface. It must be (must have been, actually) removed ASAP.