### PR TITLE
Fix wrong variable used in battery button

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -5208,7 +5208,7 @@ public List<CabView> CabViewList = new List<CabView>();
                     break;
 
                 case CABViewControlTypes.ORTS_BATTERY_SWITCH_COMMAND_BUTTON_OPEN:
-                    data = LocomotivePowerSupply.BatterySwitch.CommandButtonOn ? 1 : 0;
+                    data = LocomotivePowerSupply.BatterySwitch.CommandButtonOff ? 1 : 0;
                     break;
 
                 case CABViewControlTypes.ORTS_BATTERY_SWITCH_ON:


### PR DESCRIPTION
The CommandButtonOn variable was incorrectly used for both battery open and battery close buttons