### PR TITLE
SamplerStates can only be set after the ShaderPasses.Current.Apply().

### DIFF
--- a/Source/RunActivity/Viewer3D/Forest.cs
+++ b/Source/RunActivity/Viewer3D/Forest.cs
@@ -426,7 +426,6 @@ namespace Orts.Viewer3D
 
             // Enable alpha blending for everything: this allows distance scenery to appear smoothly.
             graphicsDevice.BlendState = BlendState.NonPremultiplied;
-            graphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
         }
 
         public override void Render(GraphicsDevice graphicsDevice, IEnumerable<RenderItem> renderItems, ref Matrix XNAViewMatrix, ref Matrix XNAProjectionMatrix)
@@ -443,6 +442,10 @@ namespace Orts.Viewer3D
                     shader.SetMatrix(item.XNAMatrix, ref viewproj);
                     shader.ZBias = item.RenderPrimitive.ZBias;
                     ShaderPasses.Current.Apply();
+
+                    // SamplerStates can only be set after the ShaderPasses.Current.Apply().
+                    graphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
+
                     item.RenderPrimitive.Draw(graphicsDevice);
                 }
             }

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -786,7 +786,6 @@ namespace Orts.Viewer3D
         public override void SetState(GraphicsDevice graphicsDevice, Material previousMaterial)
         {
             graphicsDevice.RasterizerState = RasterizerState.CullCounterClockwise;
-            graphicsDevice.SamplerStates[0] = SamplerState.LinearWrap;
 
             var shader = Viewer.MaterialManager.SceneryShader;
             var level9_3 = Viewer.Settings.IsDirectXFeatureLevelIncluded(ORTS.Settings.UserSettings.DirectXFeature.Level9_3);
@@ -886,8 +885,6 @@ namespace Orts.Viewer3D
                     throw new InvalidDataException("Options has unexpected SceneryMaterialOptions.SpecularMask value.");
             }
 
-            graphicsDevice.SamplerStates[0] = GetShadowTextureAddressMode();
-
             if (NightTexture != null && NightTexture != SharedMaterialManager.MissingTexture && (((Options & SceneryMaterialOptions.UndergroundTexture) != 0 &&
                 (Viewer.MaterialManager.sunDirection.Y < -0.085f || Viewer.Camera.IsUnderground)) || Viewer.MaterialManager.sunDirection.Y < 0.0f - ((float)KeyLengthRemainder()) / 5000f))
             {
@@ -914,6 +911,10 @@ namespace Orts.Viewer3D
                     shader.SetMatrix(item.XNAMatrix, ref viewProj);
                     shader.ZBias = item.RenderPrimitive.ZBias;
                     ShaderPasses.Current.Apply();
+
+                    // SamplerStates can only be set after the ShaderPasses.Current.Apply().
+                    graphicsDevice.SamplerStates[0] = GetShadowTextureAddressMode();
+
                     item.RenderPrimitive.Draw(graphicsDevice);
                 }
             }
@@ -1056,8 +1057,9 @@ namespace Orts.Viewer3D
                 {
                     var wvp = item.XNAMatrix * viewproj;
                     shader.SetData(ref wvp, item.Material.GetShadowTexture());
-                    graphicsDevice.SamplerStates[0] = item.Material.GetShadowTextureAddressMode();
                     ShaderPasses.Current.Apply();
+                    // SamplerStates can only be set after the ShaderPasses.Current.Apply().
+                    graphicsDevice.SamplerStates[0] = item.Material.GetShadowTextureAddressMode();
                     item.RenderPrimitive.Draw(graphicsDevice);
                 }
             }

--- a/Source/RunActivity/Viewer3D/Terrain.cs
+++ b/Source/RunActivity/Viewer3D/Terrain.cs
@@ -524,7 +524,6 @@ namespace Orts.Viewer3D
             shader.OverlayTexture = PatchTextureOverlay;
             shader.OverlayScale = OverlayScale;
 
-            graphicsDevice.SamplerStates[0] = SamplerState.LinearWrap;
             graphicsDevice.BlendState = BlendState.NonPremultiplied;
         }
 
@@ -541,6 +540,8 @@ namespace Orts.Viewer3D
                     shader.SetMatrix(item.XNAMatrix, ref viewproj);
                     shader.ZBias = item.RenderPrimitive.ZBias;
                     ShaderPasses.Current.Apply();
+                    // SamplerStates can only be set after the ShaderPasses.Current.Apply().
+                    graphicsDevice.SamplerStates[0] = SamplerState.LinearWrap;
                     item.RenderPrimitive.Draw(graphicsDevice);
                 }
             }

--- a/Source/RunActivity/Viewer3D/Transfers.cs
+++ b/Source/RunActivity/Viewer3D/Transfers.cs
@@ -171,7 +171,6 @@ namespace Orts.Viewer3D
             shader.ImageTexture = Texture;
             shader.ReferenceAlpha = 10;
 
-            graphicsDevice.SamplerStates[0] = TransferSamplerState;
             graphicsDevice.BlendState = BlendState.NonPremultiplied;
             graphicsDevice.DepthStencilState = DepthStencilState.DepthRead;
         }
@@ -190,6 +189,8 @@ namespace Orts.Viewer3D
                     shader.SetMatrix(item.XNAMatrix, ref viewproj);
                     shader.ZBias = item.RenderPrimitive.ZBias;
                     ShaderPasses.Current.Apply();
+                    // SamplerStates can only be set after the ShaderPasses.Current.Apply().
+                    graphicsDevice.SamplerStates[0] = TransferSamplerState;
                     item.RenderPrimitive.Draw(graphicsDevice);
                 }
             }

--- a/Source/RunActivity/Viewer3D/Water.cs
+++ b/Source/RunActivity/Viewer3D/Water.cs
@@ -179,7 +179,6 @@ namespace Orts.Viewer3D
             shader.ImageTexture = WaterTexture;
             shader.ReferenceAlpha = 10;
 
-            graphicsDevice.SamplerStates[0] = SamplerState.LinearWrap;
             graphicsDevice.BlendState = BlendState.NonPremultiplied;
         }
 
@@ -196,6 +195,8 @@ namespace Orts.Viewer3D
                     shader.SetMatrix(item.XNAMatrix, ref viewproj);
                     shader.ZBias = item.RenderPrimitive.ZBias;
                     ShaderPasses.Current.Apply();
+                    // SamplerStates can only be set after the ShaderPasses.Current.Apply().
+                    graphicsDevice.SamplerStates[0] = SamplerState.LinearWrap;
                     item.RenderPrimitive.Draw(graphicsDevice);
                 }
             }


### PR DESCRIPTION
When dealing with the graphics subsystem I bumped into this bug, that probably has been in the code for a long time. This bug falls into the category "less than 10 additions and deletions each" (not counting the comments).

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)