### PR TITLE
Release locomotive brake when player train enters game with speed > 0

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1653,6 +1653,7 @@ public List<CabView> CabViewList = new List<CabView>();
                 TrainControlSystem.InitializeMoving();
                 TrainBrakeController.InitializeMoving();
                 BrakeSystem.LocoInitializeMoving();
+                EngineBrakeController?.SetPercent(0);
             }
         }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1653,7 +1653,7 @@ public List<CabView> CabViewList = new List<CabView>();
                 TrainControlSystem.InitializeMoving();
                 TrainBrakeController.InitializeMoving();
                 BrakeSystem.LocoInitializeMoving();
-                EngineBrakeController?.SetPercent(0);
+                EngineBrakeController?.InitializeMoving();
             }
         }
 


### PR DESCRIPTION
At the moment the locomotive brake is set at the value defined in the .eng file, which may have a % higher than 0. This is acceptable only if the train has speed zero at game start.