### PR TITLE
Fix for https://bugs.launchpad.net/or/+bug/1960519. Crash, diesel locomotive with vacuum brakes.

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
@@ -1056,7 +1056,8 @@ namespace Orts.Simulation.RollingStocks
             {
                 var indexIni = trainBrakeStatus.IndexOf(tokenIni) + tokenIni.Length + 1;
                 var indexEnd = trainBrakeStatus.IndexOf(tokenEnd) - indexIni;
-                brakeInfoValue = trainBrakeStatus.Substring(indexIni, indexEnd).TrimEnd();
+                if (indexEnd > 0)// BP found before EOT
+                    brakeInfoValue = trainBrakeStatus.Substring(indexIni, indexEnd).TrimEnd();
             }
             return brakeInfoValue;
         }

--- a/Source/RunActivity/Viewer3D/Popups/TrainDPUWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainDPUWindow.cs
@@ -194,8 +194,10 @@ namespace Orts.Viewer3D.Popups
         protected internal override void Initialize()
         {
             base.Initialize();
-            // Reset window size
-            UpdateWindowSize();
+            if (Visible)
+            {   // Reset window size
+                UpdateWindowSize();
+            }
         }
 
         protected override ControlLayout Layout(ControlLayout layout)
@@ -537,7 +539,7 @@ namespace Orts.Viewer3D.Popups
             }
             else
             {
-                if (this.Visible)
+                if (Visible)
                 {
                     // Detect Autopilot is on to avoid flickering when slim window is displayed
                     var AutopilotOn = Owner.Viewer.PlayerLocomotive.Train.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING ? true : false;


### PR DESCRIPTION
When the Player locomotive is a diesel with vacuum brakes, a crash occurs, when <Shift+F9> is pressed.
It is related to the GetDpuStatus() function.
Fix for https://bugs.launchpad.net/or/+bug/1960519