### PR TITLE
fix: Store DirectX feature level as the enum internally for performance

### DIFF
--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -123,6 +123,7 @@ namespace ORTS.Settings
 
         public enum DirectXFeature
         {
+            Level /* Default value which gets replaced with what is supported */,
             Level9_1,
             Level9_3,
             Level10_0,
@@ -364,8 +365,13 @@ namespace ORTS.Settings
         [Default("")]
         public string ScreenshotPath { get; set; }
         [Default("")]
-        public string DirectXFeatureLevel { get; set; }
-        public bool IsDirectXFeatureLevelIncluded(DirectXFeature level) => (int)level <= (int)Enum.Parse(typeof(DirectXFeature), "Level" + this.DirectXFeatureLevel);
+        public string DirectXFeatureLevel
+        {
+            get => DirectXFeatureEnum.ToString().Replace("Level", "");
+            set => DirectXFeatureEnum = (DirectXFeature)Enum.Parse(typeof(DirectXFeature), "Level" + value);
+        }
+        DirectXFeature DirectXFeatureEnum;
+        public bool IsDirectXFeatureLevelIncluded(DirectXFeature level) => level <= DirectXFeatureEnum;
         [Default(true)]
         public bool ShadowMapBlur { get; set; }
         [Default(4)]


### PR DESCRIPTION
This has impact on performance because the Enum.Parse function allocates a lot of memory each time it is called, so instead of calling that repeatedly it is now only called when the feature level is set.

This results in a drop of 21% in TOTAL allocations in a simple profiling run (load activity and exit after 1000 frames are rendered), and a drop of 57% (!) in allocations post-loading.