### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1961304. HUD - DPI extended page, misaligned.

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
@@ -919,9 +919,9 @@ namespace Orts.Simulation.RollingStocks
 
             var status = new StringBuilder();
             status.AppendFormat("{0}({1})\t", CarID, DPUnitID);
+            status.AppendFormat("{0}\t", throttle);
             status.AppendFormat("{0} {1}\t", GetStringAttribute.GetPrettyName(Direction), Flipped ? Simulator.Catalog.GetString("(flipped)") : "");
             status.AppendFormat("{0}\t", IsLeadLocomotive() || RemoteControlGroup < 0 ? "———" : RemoteControlGroup == 0 ? Simulator.Catalog.GetString("Sync") : Simulator.Catalog.GetString("Async"));
-            status.AppendFormat("{0}\t", throttle);
             status.AppendFormat("{0}\t", FormatStrings.FormatFuelVolume(DieselLevelL, IsMetric, IsUK));
             status.AppendFormat("{0}{1}", FormatStrings.FormatForce(MotiveForceN, IsMetric), CouplerOverloaded ? "???" : "");
             status.Append(DieselEngines.GetDPStatus());
@@ -1098,9 +1098,8 @@ namespace Orts.Simulation.RollingStocks
         private static string[] DpuLabels;
         private static string[] DPULabels;
 
-        private static void SetDebugLabels(int numberOfEngines)
+        private static void SetDebugLabels()
         {
-            MaxNumberOfEngines = numberOfEngines;
             var labels = new StringBuilder();
             labels.AppendFormat("{0}\t", Simulator.Catalog.GetString("ID"));
             labels.AppendFormat("{0}\t", Simulator.Catalog.GetString("Throttle"));
@@ -1108,7 +1107,7 @@ namespace Orts.Simulation.RollingStocks
             labels.AppendFormat("{0}\t", Simulator.Catalog.GetString("Remote"));
             labels.AppendFormat("{0}\t", Simulator.Catalog.GetString("Fuel"));
             labels.AppendFormat("{0}\t", Simulator.Catalog.GetString("Tractive Effort"));
-            labels.Append(DieselEngines.SetDebugLabels(numberOfEngines));
+            labels.Append(DieselEngines.SetDebugLabels());
             DebugLabels = labels.ToString().Split('\t');
         }
 
@@ -1135,10 +1134,11 @@ namespace Orts.Simulation.RollingStocks
             }
         }
 
-        public static string GetDebugTableBase(int locomotivesInTrain, int maxNumberOfEngines)
+        public static string GetDebugTableBase(int locomotivesInTrain)
         {
-            if (MaxNumberOfEngines != maxNumberOfEngines || DebugLabels == null)
-                SetDebugLabels(maxNumberOfEngines);
+            if (DebugLabels == null)
+                SetDebugLabels();
+
             string table = "";
             for (var i = 0; i < DebugLabels.Length; i++)
             {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
@@ -377,11 +377,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             return new DieselEnum(DEList.ToArray());
         }
 
-        public static string SetDebugLabels(int numberOfEngines)
+        public static string SetDebugLabels()
         {
             var labels = new StringBuilder();
             var tabs = "\t";
-            for (var i = 1; i < numberOfEngines; i++) tabs += "\t";
             labels.AppendFormat("{0}{1}", Simulator.Catalog.GetString("Status"), tabs);
             labels.AppendFormat("{0}{1}", Simulator.Catalog.GetParticularString("HUD", "Power"), tabs);
             labels.AppendFormat("{0}{1}", Simulator.Catalog.GetString("Load"), tabs);

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -718,19 +718,17 @@ namespace Orts.Viewer3D.Popups
             var train = locomotive.Train;
 
             int numberOfDieselLocomotives = 0;
-            int maxNumberOfEngines = 0;
             for (var i = 0; i<train.Cars.Count; i++)
             {
                 if (train.Cars[i] is MSTSDieselLocomotive)
                 {
                     numberOfDieselLocomotives++;
-                    maxNumberOfEngines = Math.Max(maxNumberOfEngines, (train.Cars[i] as MSTSDieselLocomotive).DieselEngines.Count);
                 }
             }
             if (numberOfDieselLocomotives > 0)
             {
                 var row = table.CurrentRow;
-                TableAddLines(table, MSTSDieselLocomotive.GetDebugTableBase(numberOfDieselLocomotives, maxNumberOfEngines));
+                TableAddLines(table, MSTSDieselLocomotive.GetDebugTableBase(numberOfDieselLocomotives));
                 var k = 0;
                 var dpUnitId = 0;
                 for (var i = 0; i<train.Cars.Count; i++)


### PR DESCRIPTION
The HUD’s "Distributed Power Information" extended page, shows misaligned labels, when the locomotive is a diesel, such as the "Deltic", that uses two diesel engines.
Also, the Throttle data is misplaced.
Fix for https://bugs.launchpad.net/or/+bug/1961304.
