### PR TITLE
fix: Use properly FPS-independent smoothing function

### DIFF
--- a/Source/ORTS.Common/SmoothedData.cs
+++ b/Source/ORTS.Common/SmoothedData.cs
@@ -1,4 +1,4 @@
-﻿// COPYRIGHT 2010, 2011 by the Open Rails project.
+// COPYRIGHT 2010, 2011 by the Open Rails project.
 // 
 // This file is part of Open Rails.
 // 
@@ -24,16 +24,19 @@ namespace ORTS.Common
 {
     public class SmoothedData
     {
-        public readonly float SmoothPeriodS = 3;
+        const float DefaultSmoothPeriodS = 3;
+
+        public readonly float SmoothPeriodS;
+
         protected float value = float.NaN;
         protected float smoothedValue = float.NaN;
 
         public SmoothedData()
+            : this(DefaultSmoothPeriodS)
         {
         }
 
         public SmoothedData(float smoothPeriodS)
-            : this()
         {
             SmoothPeriodS = smoothPeriodS;
         }

--- a/Source/ORTS.Common/SmoothedData.cs
+++ b/Source/ORTS.Common/SmoothedData.cs
@@ -59,6 +59,7 @@ namespace ORTS.Common
 
         protected void SmoothValue(ref float smoothedValue, float periodS, float newValue)
         {
+            // This formula and the calculation of `rate` are FPS-independent; see https://www.gamedeveloper.com/programming/improved-lerp-smoothing- for more details
             var ratio = (float)Math.Exp(-rate * periodS);
             if (float.IsNaN(smoothedValue) || float.IsInfinity(smoothedValue) || ratio < 0.5)
                 smoothedValue = newValue;

--- a/Source/ORTS.Common/SmoothedData.cs
+++ b/Source/ORTS.Common/SmoothedData.cs
@@ -1,4 +1,4 @@
-// COPYRIGHT 2010, 2011 by the Open Rails project.
+﻿// COPYRIGHT 2010, 2011 by the Open Rails project.
 // 
 // This file is part of Open Rails.
 // 
@@ -28,6 +28,7 @@ namespace ORTS.Common
 
         public readonly float SmoothPeriodS;
 
+        protected float rate = 0;
         protected float value = float.NaN;
         protected float smoothedValue = float.NaN;
 
@@ -39,6 +40,8 @@ namespace ORTS.Common
         public SmoothedData(float smoothPeriodS)
         {
             SmoothPeriodS = smoothPeriodS;
+            // Convert the input assuming 60 FPS (arbitary)
+            rate = (float)(-60 * Math.Log(1 - 1 / (60 * SmoothPeriodS)));
         }
 
         public void Update(float periodS, float newValue)
@@ -56,13 +59,11 @@ namespace ORTS.Common
 
         protected void SmoothValue(ref float smoothedValue, float periodS, float newValue)
         {
-            var rate = SmoothPeriodS / periodS;
-            if (float.IsNaN(smoothedValue) || float.IsInfinity(smoothedValue))
-                smoothedValue = newValue;
-            else if (rate < 1)
+            var ratio = (float)Math.Exp(-rate * periodS);
+            if (float.IsNaN(smoothedValue) || float.IsInfinity(smoothedValue) || ratio < 0.5)
                 smoothedValue = newValue;
             else
-                smoothedValue = (smoothedValue * (rate - 1) + newValue) / rate;
+                smoothedValue = smoothedValue * ratio + newValue * (1 - ratio);
         }
 
         public void ForceSmoothValue(float forcedValue)

--- a/Source/Tests/Orts.Common/SmoothedData.cs
+++ b/Source/Tests/Orts.Common/SmoothedData.cs
@@ -1,0 +1,47 @@
+// COPYRIGHT 2022 by the Open Rails project.
+// 
+// This file is part of Open Rails.
+// 
+// Open Rails is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Open Rails is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Linq;
+using Xunit;
+
+namespace Tests.Orts.Common
+{
+    public static class SmoothedData
+    {
+        [Theory]
+        // FPS-like tests
+        [InlineData(5, 3, 0.318)]
+        [InlineData(10, 3, 0.337)]
+        [InlineData(30, 3, 0.350)]
+        [InlineData(60, 3, 0.353)]
+        [InlineData(120, 3, 0.355)]
+        // Physics-like tests
+        [InlineData(60, 1, 0.000)] // Exhaust particles
+        [InlineData(60, 2, 0.066)] // Smoke colour
+        [InlineData(60, 45, 8.007)] // Field rate
+        [InlineData(60, 150, 9.355)] // Burn rate
+        [InlineData(60, 240, 9.592)] // Boiler heat
+        public static void SmoothedFPS(int fps, float smoothPeriodS, float expected)
+        {
+            var period = (float)(1d / fps);
+            var smoothed = new ORTS.Common.SmoothedData(smoothPeriodS);
+            smoothed.Update(0, 10);
+            foreach (var i in Enumerable.Range(0, 10 * fps)) smoothed.Update(period, 0);
+            Assert.Equal(expected, smoothed.SmoothedValue, 3);
+        }
+    }
+}

--- a/Source/Tests/Orts.Common/SmoothedData.cs
+++ b/Source/Tests/Orts.Common/SmoothedData.cs
@@ -24,11 +24,11 @@ namespace Tests.Orts.Common
     {
         [Theory]
         // FPS-like tests
-        [InlineData(5, 3, 0.318)]
-        [InlineData(10, 3, 0.337)]
-        [InlineData(30, 3, 0.350)]
+        [InlineData(5, 3, 0.353)]
+        [InlineData(10, 3, 0.353)]
+        [InlineData(30, 3, 0.353)]
         [InlineData(60, 3, 0.353)]
-        [InlineData(120, 3, 0.355)]
+        [InlineData(120, 3, 0.353)]
         // Physics-like tests
         [InlineData(60, 1, 0.000)] // Exhaust particles
         [InlineData(60, 2, 0.066)] // Smoke colour

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="DynamicPrecisionEqualityComparer.cs" />
     <Compile Include="Orts.Parsers.Msts\StfReader.cs" />
     <Compile Include="Orts.Common\Conversions.cs" />
+    <Compile Include="Orts.Common\SmoothedData.cs" />
     <Compile Include="Orts.Parsers.OR\TimetableReaderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestFile.cs" />


### PR DESCRIPTION
Roadmap: https://trello.com/c/rA9gu11Q/526-refactor-traincar-to-simplify-inheritance

I discovered this reading the code and https://www.gamedeveloper.com/programming/improved-lerp-smoothing-

First, I added some tests which confirmed that `SmoothedData` produces slightly different answers depending on the FPS: https://github.com/openrails/openrails/commit/79cea887918f53139fb012ddf6a038b3482829fd

Second, I updated the code and tests to use the improved formular from the article: https://github.com/openrails/openrails/commit/39fb000a3e2fa5abc464cba8f35dedf2412051c9