### PR TITLE
Sky Color Fix (Addresses Trello Roadmap Card #367 for More accurate sunrise and sunset)

### DIFF
--- a/Source/RunActivity/Content/ParticleEmitterShader.fx
+++ b/Source/RunActivity/Content/ParticleEmitterShader.fx
@@ -141,7 +141,7 @@ void _PSApplyDay2Night(inout float3 Color)
 	// The following constants define the beginning and the end conditions of the day-night transition
 	const float startNightTrans = 0.1; // The "NightTrans" values refer to the Y postion of LightVector
 	const float finishNightTrans = -0.1;
-	const float minDarknessCoeff = 0.15;
+	const float minDarknessCoeff = 0.03;
 	
 	// Internal variables
 	// The following two are used to interpoate between day and night lighting (y = mx + b)

--- a/Source/RunActivity/Content/SkyShader.fx
+++ b/Source/RunActivity/Content/SkyShader.fx
@@ -177,7 +177,15 @@ float4 PSSky(VERTEX_OUTPUT In) : COLOR
 	skyColor *= SkyColor.y;
 	
 	// Stars (power function keeps stars hidden until after sunset)
-	skyColor = lerp(starColor, skyColor, pow(SkyColor.y,0.125));
+	// if-statement handles astronomical/final stage of twilight
+	if (LightVector.y < -0.2)
+		{
+		skyColor = lerp(starColor, skyColor, LightVector.y*6.6+2.22);
+		}
+		else 
+		{
+		skyColor = lerp(starColor, skyColor, pow(abs(SkyColor.y),0.125));
+		}
 	
 	// Fogging
 	skyColor.rgb = lerp(skyColor.rgb, FogColor.rgb, saturate((1 - In.Normal.y) * Fog.x));

--- a/Source/RunActivity/Content/SkyShader.fx
+++ b/Source/RunActivity/Content/SkyShader.fx
@@ -147,6 +147,7 @@ VERTEX_OUTPUT VSMoon(VERTEX_INPUT In)
 
 // This function adjusts brightness, saturation and contrast
 // By Romain Dura aka Romz
+// Colors edit by DR_Aeronautics
 float3 ContrastSaturationBrightness(float3 color, float brt, float sat, float con)
 {
 	// Increase or decrease theese values to adjust r, g and b color channels separately
@@ -173,10 +174,10 @@ float4 PSSky(VERTEX_OUTPUT In) : COLOR
 	float4 starColor = tex2D(StarMapSampler, TexCoord);
 	
 	// Adjust sky color brightness for time of day
-	skyColor *= SkyColor.x;
+	skyColor *= SkyColor.y;
 	
-	// Stars
-	skyColor = lerp(starColor, skyColor, SkyColor.y);
+	// Stars (power function keeps stars hidden until after sunset)
+	skyColor = lerp(starColor, skyColor, pow(SkyColor.y,0.125));
 	
 	// Fogging
 	skyColor.rgb = lerp(skyColor.rgb, FogColor.rgb, saturate((1 - In.Normal.y) * Fog.x));
@@ -189,11 +190,35 @@ float4 PSSky(VERTEX_OUTPUT In) : COLOR
 	// Coefficients selected by the author to achieve the desired appearance - fot limits the effect
 	skyColor += angleRcp * Fog.y;
 	
-	// increase orange at sunset - fog limits the effect
+	// increase orange at sunset and yellow at sunrise - fog limits the effect
 	if (LightVector.x < 0)
 	{
-		skyColor.r += SkyColor.z * angleRcp * Fog.z;
-		skyColor.g += skyColor.r * Fog.w;
+		// These if-statements prevent the yellow-flash effect
+		if (LightVector.y > 0.13)
+		{
+			skyColor.rg += SkyColor.z*2 * angleRcp * Fog.z;
+			skyColor.r += SkyColor.z*2 * angleRcp * Fog.z;
+		}
+	
+		else
+		{
+			skyColor.rg += angleRcp * 0.075 * SkyColor.y;
+			skyColor.r += angleRcp * 0.075 * SkyColor.y;
+		}
+	}
+	else
+	{
+		if (LightVector.y > 0.15)
+		{
+			skyColor.rg += SkyColor.z*3 * angleRcp * Fog.z;
+			skyColor.r += SkyColor.z * angleRcp * Fog.z;
+		}
+	
+		else
+		{
+			skyColor.rg += angleRcp * 0.075 * SkyColor.y;
+			skyColor.r += pow(angleRcp * 0.075 * SkyColor.y,2);
+		}
 	}
 	
 	// Keep alpha opague


### PR DESCRIPTION
**I updated SkyShader.fx to make the sunset and sunrise more realistic.**
**Link to Road Map Card**: https://trello.com/c/cQi6FPz5/367-more-accurate-sunrise-and-sunset
**Link to forum**: http://www.elvastower.com/forums/index.php?/topic/36123-discussion-code-fixing-the-openrails-sky/
Please forgive me if I'm uploading the code/doing pull requests wrong- this GitHub stuff is new to me.
The old pull request wasn't correct so it was closed and this one replaces it.
Old pull request: https://github.com/openrails/openrails/pull/628

**Improvements**
1.	Blue Sky remains until dusk (and darkens slowly)
2.	Stars no longer visible when the sun is above the horizon
3.	Sky color is now citrus, as opposed to full yellow or full red
4.	No rapid sky color changes (removed the yellow flash effect)
5.	Sunrise coloring now supported (it's a little more yellow than sunset)
Fixes were tested in 4 seasons on PRRV2 (Pennsylvania, USA), VBSR5 (Norway), and Blue Mountains (Australia)

**Videos of the results**:
Timelapse real vs old code vs new code: https://www.youtube.com/watch?v=6NHYx8R1vWo
Realtime test on PRRV2 Route: https://www.youtube.com/watch?v=OvW9w8UGZaI&t=259s

Attached is a memo on more information about the changes, including why I made them
[OpenRails.Sky.Recoding.Memo.pdf](https://github.com/openrails/openrails/files/8366374/OpenRails.Sky.Recoding.Memo.pdf)
: