### PR TITLE
Get correct signal id if signal ahead is in same Track Circuit

### DIFF
--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -9759,6 +9759,18 @@ namespace Orts.Simulation.Signalling
             else
             {
                 thisSection = signalRef.TrackCircuitList[thisTC];
+                if (!isSignalNormal())
+                {
+                    TrackCircuitSignalList thisList = thisSection.CircuitItems.TrackCircuitSignals[direction][reqtype];
+                    foreach (var item in thisList.TrackCircuitItem)
+                    {
+                        if (item.SignalRef.TCOffset > TCOffset)
+                        {
+                            signalFound = item.SignalRef.thisRef;
+                            break;
+                        }
+                    }
+                }
                 sectionSet = enabledTrain == null ? false : thisSection.IsSet(enabledTrain, false);
 
                 if (sectionSet)


### PR DESCRIPTION
https://bugs.launchpad.net/or/+bug/1967313
When looking for not-normal signals from a not-normal signal, the search currently does not take into account signals ahead that are in the same Track Circuit.