### PR TITLE
fix: Put all cache files into the designated area away from user files

### DIFF
--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -20,6 +20,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
 using System.Windows.Forms;
 using ORTS.Common;
 
@@ -477,6 +479,20 @@ namespace ORTS.Settings
                 return (property.GetCustomAttributes(typeof(DefaultAttribute), false)[0] as DefaultAttribute).Value;
 
             throw new InvalidDataException(String.Format("UserSetting {0} has no default value.", property.Name));
+        }
+
+        public string GetCacheFilePath(string type, string key)
+        {
+            var hasher = new MD5CryptoServiceProvider();
+            hasher.ComputeHash(Encoding.Default.GetBytes(key));
+            var hash = String.Join("", hasher.Hash.Select(h => h.ToString("x2")));
+
+            var directory = Path.Combine(UserSettings.UserDataFolder, "Cache", type);
+
+            if (!Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            return Path.Combine(directory, hash + ".or-cache");
         }
 
         PropertyInfo GetProperty(string name)

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -492,7 +492,7 @@ namespace ORTS.Settings
             if (!Directory.Exists(directory))
                 Directory.CreateDirectory(directory);
 
-            return Path.Combine(directory, hash + ".or-cache");
+            return Path.Combine(directory, hash + ".cache-or");
         }
 
         PropertyInfo GetProperty(string name)


### PR DESCRIPTION
Blueprint: https://trello.com/c/qdZ0yzjy/285-virtual-filesystem

This change is necessary for the VFS, since that should not have to deal with writing changes, and this specialised feature (binary paths, opt-in timetable feature) contradicts that

Binary paths should behave as they did before, but stored in a new location

Loading information is also moved to be consistent