### PR TITLE
Fix to add .Mark() for Coupler and AirHose shapes

### DIFF
--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSWagonViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSWagonViewer.cs
@@ -1401,6 +1401,14 @@ namespace Orts.Viewer3D.RollingStock
             FreightShape?.Mark();
             InteriorShape?.Mark();
             FreightAnimations?.Mark();
+            FrontCouplerShape?.Mark();
+            FrontCouplerOpenShape?.Mark();
+            RearCouplerShape?.Mark();
+            RearCouplerOpenShape?.Mark();
+            FrontAirHoseShape?.Mark();
+            FrontAirHoseDisconnectedShape?.Mark();
+            RearAirHoseShape?.Mark();
+            RearAirHoseDisconnectedShape?.Mark();
         }
     }
 }


### PR DESCRIPTION
Coupler shapes disppeared with 9 Feb commit "Merge pull request https://github.com/openrails/openrails/pull/545 from Sharpe49/fix-vram-usage".

This fix aims to restore them.

Tested using stock from activity https://www.coalstonewcastle.com.au/downloads/physics/au_ctn_test_model_norfolk_southern_v1a.exe