### PR TITLE
fix: Correctly merge exception and current stack traces in logger

### DIFF
--- a/Source/Orts.Simulation/Common/ErrorLogger.cs
+++ b/Source/Orts.Simulation/Common/ErrorLogger.cs
@@ -153,16 +153,12 @@ namespace Orts.Common
                 // full stack to this trace call, which goes via the catch block at the same level as the try block. We'd prefer to have the whole stack, so we need to find the
                 // join and stitch the stacks together.
                 var error = args[0] as Exception;
-                var errorStack = new StackTrace(args[0] as Exception);
-                var errorStackLast = errorStack.GetFrame(errorStack.FrameCount - 1);
-                var catchStack = new StackTrace();
-                var catchStackIndex = 0;
-                while (catchStackIndex < catchStack.FrameCount && errorStackLast != null && catchStack.GetFrame(catchStackIndex).GetMethod().Name != errorStackLast.GetMethod().Name)
-                    catchStackIndex++;
-                catchStack = new StackTrace(catchStackIndex < catchStack.FrameCount ? catchStackIndex + 1 : 0, true);
+                var errorStack = error.ToString().Replace("\r", "").Split('\n');
+                var catchStack = new StackTrace(true).ToString().Replace("\r", "").Split('\n');
+                var catchIndex = Array.IndexOf(catchStack, errorStack[errorStack.Length - 1]);
 
                 output.AppendLine(error.ToString());
-                output.AppendLine(catchStack.ToString());
+                if (catchIndex >= 0) output.AppendLine(String.Join(Environment.NewLine, catchStack, catchIndex + 1, catchStack.Length - catchIndex - 1));
             }
             else
             {

--- a/Source/RunActivity/Viewer3D/Processes/WatchdogProcess.cs
+++ b/Source/RunActivity/Viewer3D/Processes/WatchdogProcess.cs
@@ -312,6 +312,11 @@ namespace Orts.Viewer3D.Processes
 
     class ThreadWatchdogException : Exception
     {
+        public override string ToString()
+        {
+            return $"{GetType()}: {Message}{Environment.NewLine}{StackTrace}";
+        }
+
         public override string StackTrace
         {
             get


### PR DESCRIPTION
I noticed in http://www.elvastower.com/forums/index.php?/topic/36331-or-crashclose-after-loading-a-route/ that the hang details were not looking correct, so I have fixed them with this change