### PR TITLE
perf: Improved performance counter initialisation

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -1,4 +1,4 @@
-﻿// COPYRIGHT 2011, 2012, 2013 by the Open Rails project.
+// COPYRIGHT 2011, 2012, 2013 by the Open Rails project.
 //
 // This file is part of Open Rails.
 //
@@ -112,14 +112,15 @@ namespace Orts.Viewer3D.Popups
             ProcessMemoryCounters = new PROCESS_MEMORY_COUNTERS() { Size = 40 };
             ProcessVirtualAddressLimit = GetVirtualAddressLimit();
 
+            var processId = Process.GetCurrentProcess().Id;
             try
             {
                 var counterDotNetClrMemory = new PerformanceCounterCategory(".NET CLR Memory");
-                foreach (var process in counterDotNetClrMemory.GetInstanceNames())
+                foreach (InstanceData instance in counterDotNetClrMemory.ReadCategory()["Process ID"].Values)
                 {
-                    var processId = new PerformanceCounter(".NET CLR Memory", "Process ID", process);
-                    if (processId.NextValue() == Process.GetCurrentProcess().Id)
+                    if (instance.RawValue == processId)
                     {
+                        var process = instance.InstanceName;
                         CLRMemoryAllocatedBytesPerSecCounter = new PerformanceCounter(".NET CLR Memory", "Allocated Bytes/sec", process);
                         Trace.TraceInformation($"Found Microsoft .NET Framework performance counter {process}");
                         break;
@@ -135,11 +136,11 @@ namespace Orts.Viewer3D.Popups
             try
             {
                 var counterProcess = new PerformanceCounterCategory("Process");
-                foreach (var process in counterProcess.GetInstanceNames())
+                foreach (InstanceData instance in counterProcess.ReadCategory()["ID Process"].Values)
                 {
-                    var processId = new PerformanceCounter("Process", "ID Process", process);
-                    if (processId.NextValue() == Process.GetCurrentProcess().Id)
+                    if (instance.RawValue == processId)
                     {
+                        var process = instance.InstanceName;
                         CPUMemoryPrivateCounter = new PerformanceCounter("Process", "Private Bytes", process);
                         CPUMemoryWorkingSetCounter = new PerformanceCounter("Process", "Working Set", process);
                         CPUMemoryWorkingSetPrivateCounter = new PerformanceCounter("Process", "Working Set - Private", process);


### PR DESCRIPTION
This improves the performance of the performance counter initialisation by loading all the data at once (`ReadCategory()`) instead of repeatedly reading a single item (`new PerformanceCounter()` + `NextValue()`)

It does not change the behaviour

In testing, this improves the time taken for the three try blocks for performance counter initialisation:

* 0.81 seconds before
* 0.58 seconds after (28% improvement)