### PR TITLE
fix: Swap defaults for instancing and glass back

### DIFF
--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -183,7 +183,7 @@ namespace ORTS.Settings
         public bool DynamicShadows { get; set; }
         [Default(false)]
         public bool ShadowAllShapes { get; set; }
-        [Default(false)]
+        [Default(true)]
         public bool ModelInstancing { get; set; }
         [Default(true)]
         public bool Wire { get; set; }
@@ -273,7 +273,7 @@ namespace ORTS.Settings
         public bool FullScreen { get; set; }
         [Default("1024x768")]
         public string WindowSize { get; set; }
-        [Default(true)]
+        [Default(false)]
         public bool WindowGlass { get; set; }
         [Default(false)]
         public bool SuppressConfirmations { get; set; }


### PR DESCRIPTION
It looks like the default values of these two settings got accidentally swapped in #632 so this swaps them back