### PR TITLE
build: Fix the file metadata after the .NET SDK project switch

### DIFF
--- a/Source/ContentChecker/ContentChecker.csproj
+++ b/Source/ContentChecker/ContentChecker.csproj
@@ -5,9 +5,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails content checker</Description>
+    <AssemblyTitle>Open Rails Content Checker</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Contrib/ActivityEditor/ActivityEditor/ActivityEditor.csproj
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/ActivityEditor.csproj
@@ -7,9 +7,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails activity editor (contributed)</Description>
+    <AssemblyTitle>Open Rails Activity Editor (Contributed)</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails (disabled)</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <DefineConstants>TRACE;WINDOWS;ACTIVITY_EDITOR</DefineConstants>
   </PropertyGroup>

--- a/Source/Contrib/ActivityEditor/LibAE/LibAE.csproj
+++ b/Source/Contrib/ActivityEditor/LibAE/LibAE.csproj
@@ -4,9 +4,11 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Contrib.LibAE</AssemblyName>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails activity editor library (contributed)</Description>
+    <AssemblyTitle>Open Rails LibAE Library (Contributed)</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <DefineConstants>TRACE;WINDOWS;ACTIVITY_EDITOR;JSON_OR_XML</DefineConstants>
   </PropertyGroup>

--- a/Source/Contrib/ContentManager/ContentManager.csproj
+++ b/Source/Contrib/ContentManager/ContentManager.csproj
@@ -8,9 +8,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails content manager (contributed)</Description>
+    <AssemblyTitle>Open Rails Content Manager (Contributed)</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Contrib/DataCollector/DataCollector.csproj
+++ b/Source/Contrib/DataCollector/DataCollector.csproj
@@ -6,9 +6,11 @@
     <AssemblyName>Contrib.DataCollector</AssemblyName>
     <ApplicationIcon>..\..\ORTS.ico</ApplicationIcon>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails data collector (contributed)</Description>
+    <AssemblyTitle>Open Rails Data Collector (Contributed)</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Contrib/DataConverter/DataConverter.csproj
+++ b/Source/Contrib/DataConverter/DataConverter.csproj
@@ -6,9 +6,11 @@
     <AssemblyName>Contrib.DataConverter</AssemblyName>
     <ApplicationIcon>..\..\ORTS.ico</ApplicationIcon>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails data converter (contributed)</Description>
+    <AssemblyTitle>Open Rails Data Converter (Contributed)</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Contrib/DataValidator/DataValidator.csproj
+++ b/Source/Contrib/DataValidator/DataValidator.csproj
@@ -4,9 +4,11 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>Contrib.DataValidator</AssemblyName>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails data validator (contributed)</Description>
+    <AssemblyTitle>Open Rails Data Validator (Contributed)</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Contrib/SimulatorTester/SimulatorTester.csproj
+++ b/Source/Contrib/SimulatorTester/SimulatorTester.csproj
@@ -9,9 +9,11 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <OutputPath>..\..\..\Program\</OutputPath>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails save file tester</Description>
+    <AssemblyTitle>Open Rails Simulator Tester (Contributed)</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Contrib/TimetableEditor/timetableedit.lpi
+++ b/Source/Contrib/TimetableEditor/timetableedit.lpi
@@ -17,7 +17,7 @@
     </i18n>
     <VersionInfo>
       <UseVersionInfo Value="True"/>
-      <StringTable Comments="Open Rails Transport Simulator" CompanyName="Open Rails" FileDescription="Open Rails Timetable Editor (Contributed)" LegalCopyright="Copyright © 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018" ProductName="Open Rails"/>
+      <StringTable Comments="Open Rails Transport Simulator" CompanyName="Open Rails" FileDescription="Open Rails Timetable Editor (Contributed)" LegalCopyright="Copyright © 2009 - 2022" ProductName="Open Rails"/>
     </VersionInfo>
     <BuildModes Count="1">
       <Item1 Name="Default" Default="True"/>

--- a/Source/Contrib/TrackViewer/TrackViewer.csproj
+++ b/Source/Contrib/TrackViewer/TrackViewer.csproj
@@ -9,9 +9,11 @@
     <UseWPF>true</UseWPF>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails track viewer (contributed)</Description>
+    <AssemblyTitle>Open Rails Track Viewer (Contributed)</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
   </PropertyGroup>

--- a/Source/Launcher/Launcher.csproj
+++ b/Source/Launcher/Launcher.csproj
@@ -8,9 +8,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails launcher</Description>
+    <AssemblyTitle>Open Rails</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">

--- a/Source/Menu/Menu.csproj
+++ b/Source/Menu/Menu.csproj
@@ -7,9 +7,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails menu</Description>
+    <AssemblyTitle>Open Rails Menu</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">

--- a/Source/ORTS.Common/ORTS.Common.csproj
+++ b/Source/ORTS.Common/ORTS.Common.csproj
@@ -5,9 +5,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails common library</Description>
+    <AssemblyTitle>Open Rails Common Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">

--- a/Source/ORTS.Content/ORTS.Content.csproj
+++ b/Source/ORTS.Content/ORTS.Content.csproj
@@ -3,9 +3,11 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails content library</Description>
+    <AssemblyTitle>Open Rails Content Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">

--- a/Source/ORTS.IO/ORTS.IO.csproj
+++ b/Source/ORTS.IO/ORTS.IO.csproj
@@ -3,9 +3,11 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails IO library</Description>
+    <AssemblyTitle>Open Rails IO Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">

--- a/Source/ORTS.Menu/ORTS.Menu.csproj
+++ b/Source/ORTS.Menu/ORTS.Menu.csproj
@@ -3,9 +3,11 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails menu library</Description>
+    <AssemblyTitle>Open Rails Menu Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">

--- a/Source/ORTS.Settings/ORTS.Settings.csproj
+++ b/Source/ORTS.Settings/ORTS.Settings.csproj
@@ -6,9 +6,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails settings library</Description>
+    <AssemblyTitle>Open Rails Settings Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">

--- a/Source/ORTS.Updater/ORTS.Updater.csproj
+++ b/Source/ORTS.Updater/ORTS.Updater.csproj
@@ -6,9 +6,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails updater library</Description>
+    <AssemblyTitle>Open Rails Updater Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">

--- a/Source/Orts.Formats.Msts/Orts.Formats.Msts.csproj
+++ b/Source/Orts.Formats.Msts/Orts.Formats.Msts.csproj
@@ -3,9 +3,11 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails MSTS formats library</Description>
+    <AssemblyTitle>Open Rails MSTS Formats Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">

--- a/Source/Orts.Formats.OR/Orts.Formats.OR.csproj
+++ b/Source/Orts.Formats.OR/Orts.Formats.OR.csproj
@@ -3,9 +3,11 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails OR formats library</Description>
+    <AssemblyTitle>Open Rails OR Formats Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <DefineConstants>TRACE;ACTIVITY_EDITOR</DefineConstants>
   </PropertyGroup>

--- a/Source/Orts.Parsers.Msts/Orts.Parsers.Msts.csproj
+++ b/Source/Orts.Parsers.Msts/Orts.Parsers.Msts.csproj
@@ -3,9 +3,11 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails MSTS parsers library</Description>
+    <AssemblyTitle>Open Rails MSTS Parsers Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Source/Orts.Parsers.OR/Orts.Parsers.OR.csproj
+++ b/Source/Orts.Parsers.OR/Orts.Parsers.OR.csproj
@@ -3,9 +3,11 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails OR parsers library</Description>
+    <AssemblyTitle>Open Rails OR Parsers Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">

--- a/Source/Orts.Simulation/Orts.Simulation.csproj
+++ b/Source/Orts.Simulation/Orts.Simulation.csproj
@@ -3,9 +3,11 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails simulation library</Description>
+    <AssemblyTitle>Open Rails Simulation Library</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <DefineConstants>TRACE;ACTIVITY_EDITOR</DefineConstants>
   </PropertyGroup>

--- a/Source/RunActivity/RunActivity.csproj
+++ b/Source/RunActivity/RunActivity.csproj
@@ -7,9 +7,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails activity runner</Description>
+    <AssemblyTitle>Open Rails Activity Runner</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <DefineConstants>TRACE;WINDOWS;NEW_ACTION;WITH_NEW_SAVE;ACTIVITY_EDITOR</DefineConstants>
   </PropertyGroup>

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -3,9 +3,11 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails tests</Description>
+    <AssemblyTitle>Open Rails Tests</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">

--- a/Source/Updater/Updater.csproj
+++ b/Source/Updater/Updater.csproj
@@ -6,9 +6,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>
-    <Copyright>© Open Rails project</Copyright>
-    <Authors>Open Rails project</Authors>
-    <Description>Open Rails updater</Description>
+    <AssemblyTitle>Open Rails Updater</AssemblyTitle>
+    <Description>Open Rails Transport Simulator</Description>
+    <Company>Open Rails</Company>
+    <Product>Open Rails</Product>
+    <Copyright>Copyright © 2009 - 2022</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">


### PR DESCRIPTION
Looks like the project metadata fields in #569 did not match what was previously in the `AssemblyInfo.cs` files, so this PR puts it all back exactly as it was, except for:

- Copyright is updated to 2022 from 2019
- Contributed Timetable Editor copyright format changed to match the other files

Most of this is purely aesthetic, however, certain fields are used by the updater and menu:

- [Updater matches the file description and product name fields to find the main executable](https://github.com/openrails/openrails/blob/14559529ca8750365e021206c31ed04f06b4fce7/Source/ORTS.Updater/UpdateManager.cs#L76)
- [Menu checks for matching product names to show the correct tools](https://github.com/openrails/openrails/blob/14559529ca8750365e021206c31ed04f06b4fce7/Source/Menu/MainForm.cs#L195)