### PR TITLE
test: Fix tests when StfReader tests run before JsonReader tests

### DIFF
--- a/Source/Tests/AssertWarnings.cs
+++ b/Source/Tests/AssertWarnings.cs
@@ -25,6 +25,7 @@ using Xunit;
 
 namespace Tests
 {
+    // TODO: This class needs to be removed and replaced with a `JsonReaderTests`-style warning counter, instead of modifying global state (`Trace.Listeners`)
     /// <summary>
     /// This class can be used to test for Trace.TraceWarning() calls.
     /// Instead of having the warnings go to the output window of xunit, they are captured by this class.

--- a/Source/Tests/Orts.Parsers.OR/JsonReaderTests.cs
+++ b/Source/Tests/Orts.Parsers.OR/JsonReaderTests.cs
@@ -24,10 +24,12 @@ using Xunit;
 
 namespace Tests.Orts.Parsers.OR
 {
+    // TODO: This class is a temporary fix until `AssertWarnings` is removed
     public class JsonReaderTestsSetup
     {
         public JsonReaderTestsSetup()
         {
+            Trace.Listeners.Clear();
             Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
             Trace.AutoFlush = true;
         }


### PR DESCRIPTION
Because the `StfReader` tests modify global state (`Trace.Listeners`), we need to counter with more global state modifications in `JsonReader` tests

Ultimately, though, the `AssertWarnings` class needs to go