### PR TITLE
Updated links to Deco Games

### DIFF
--- a/Website/openrails.org/download/content/index.php
+++ b/Website/openrails.org/download/content/index.php
@@ -57,7 +57,7 @@ players to Open Rails.
 <p>
 The Spanish websites <a href="http://viajerosaltren.es">Viajeros al Tren</a> and <a href="http://www.spaintrainzrutas.com/">Spain Trainz Rutas</a> are some of the first to offer Open Rails-specific products.
 </p><p>
-<a href="http://www.dekosoft.com">Dekosoft Trains</a> offer GP30 locos with 3D cabs exclusively for Open Rails.
+<a href="https://dekogames.com/wordpress/csx-mainline-power/">Deko Games</a> offer SD60M and SD40-2 locos with 3D cabs exclusively for Open Rails.
 </p><p>
 Some Australian routes (New South Wales) have been packaged by Peter Newell to work just with Open Rails:
 </p>

--- a/Website/openrails.org/trade/index.php
+++ b/Website/openrails.org/trade/index.php
@@ -38,7 +38,7 @@ These vendors sell or create products suitable for Open Rails:
   <li><a href="https://pikku.msts.cz">Pikku Locomotive Works</a> - Czechoslovakia</li>
   <li><a href="http://broadgaugeproduction.irts.in/">Broad Gauge Productions</a> - India</li>  
   <li><a href="http://www.3dtrains.com" target="_blank">3DTrains</a> - USA</li>
-  <li><a href="http://dekosoft.com/trains">Dekosoft Trains</a> - USA</li>
+  <li><a href="https://dekogames.com/trains/">Deko Games</a> - USA</li>
   <li><a href="http://www.gabriele90.com/">Gabriele 90</a> - Italy</li>
 </ul>
 <p>&nbsp;</p>


### PR DESCRIPTION
Decosoft has changed its name to Deco Games and its domain too.