### PR TITLE
Add check to prevent crashes when signal scripts use a bad draw state

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -659,7 +659,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
 
                 var functionHead = trainSignal.SignalObject.SignalHeads.Find(head => head.ORTSsigFunctionIndex == fn_type);
                 signalTypeName = functionHead.SignalTypeName;
-                if (functionHead.draw_state >= 0)
+                if (functionHead.signalType.DrawStates.Any(d => d.Value.Index == functionHead.draw_state))
                 {
                     drawStateName = functionHead.signalType.DrawStates.First(d => d.Value.Index == functionHead.draw_state).Value.Name;
                 }


### PR DESCRIPTION
Bug fix in case draw state index does not correspond to a valid draw state