### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1987504 Server can't throw switches for clients in multiplayer

### DIFF
--- a/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
@@ -157,6 +157,7 @@ namespace Orts.Viewer3D.Debugging
             TimetableWindow = new TimetableWindow(this);
 
             nodes = simulator.TDB.TrackDB.TrackNodes;
+            if (MultiPlayer.MPManager.IsMultiPlayer()) { MultiPlayer.MPManager.AllowedManualSwitch = false; }
 
             // initialise the timer used to handle user input
             UITimer = new Timer();
@@ -218,10 +219,6 @@ namespace Orts.Viewer3D.Debugging
             boxSetSignal.Items.Add("Proceed");
             chkAllowUserSwitch.Checked = false;
             selectedTrainList = new List<Train>();
-            if (MPManager.IsMultiPlayer())
-            { 
-                MPManager.AllowedManualSwitch = false;
-            }
 
             InitData();
             InitImage();


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/36481-behavior-of-the-switches-in-multiplayer/