### PR TITLE
Add default signal function in case of SIGCFG errors

### DIFF
--- a/Source/Orts.Simulation/Simulation/Signalling/SignalHead.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/SignalHead.cs
@@ -156,6 +156,7 @@ namespace Orts.Simulation.Signalling
                 }
                 else
                 {
+                    Function = SignalFunction.UNKNOWN;
                     Trace.TraceWarning("SignalObject trItem={0}, trackNode={1} has SignalHead with undefined SignalType {2}.",
                                   mainSignal.trItem, mainSignal.trackNode, sigItem.SignalType);
                 }

--- a/Source/Orts.Simulation/Simulation/Signalling/SignalHead.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/SignalHead.cs
@@ -50,7 +50,7 @@ namespace Orts.Simulation.Signalling
         public float? ApproachControlLimitPositionM;
         public float? ApproachControlLimitSpeedMpS;
 
-        public SignalFunction Function { get; protected set; }
+        public SignalFunction Function { get; protected set; } = SignalFunction.UNKNOWN;
 
         public int ORTSNormalSubtypeIndex;     // subtype index form sigcfg file
 
@@ -156,7 +156,6 @@ namespace Orts.Simulation.Signalling
                 }
                 else
                 {
-                    Function = SignalFunction.UNKNOWN;
                     Trace.TraceWarning("SignalObject trItem={0}, trackNode={1} has SignalHead with undefined SignalType {2}.",
                                   mainSignal.trItem, mainSignal.trackNode, sigItem.SignalType);
                 }


### PR DESCRIPTION
Prevents a crash if signal type is not defined in SIGCFG.