### PR TITLE
TCS Extensions

### DIFF
--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -188,6 +188,14 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<bool> IsRearCab;
         /// <summary>
+        /// True if left doors are open
+        /// </summary>
+        public Func<bool> AreLeftDoorsOpen;
+        /// <summary>
+        /// True if right doors are open
+        /// </summary>
+        public Func<bool> AreRightDoorsOpen;
+        /// <summary>
         /// True if train brake controller is in emergency position, otherwise false.
         /// </summary>
         public Func<bool> IsBrakeEmergency;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -343,6 +343,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.CurrentTrainMUDirection = () => Locomotive.Train.MUDirection; // Direction of train
                 Script.IsFlipped = () => Locomotive.Flipped;
                 Script.IsRearCab = () => Locomotive.UsingRearCab;
+                Script.AreLeftDoorsOpen = () => Locomotive.DoorLeftOpen;
+                Script.AreRightDoorsOpen = () => Locomotive.DoorRightOpen;
                 Script.IsBrakeEmergency = () => Locomotive.TrainBrakeController.EmergencyBraking;
                 Script.IsBrakeFullService = () => Locomotive.TrainBrakeController.TCSFullServiceBraking;
                 Script.PowerAuthorization = () => PowerAuthorization;


### PR DESCRIPTION
Add TCS function to get door state. It can be useful to cut-off traction if doors are open.