### PR TITLE
Fix GetDrawState when using upper characters

### DIFF
--- a/Source/Orts.Simulation/Simulation/Signalling/CsSignalScript.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/CsSignalScript.cs
@@ -118,12 +118,14 @@ namespace Orts.Simulation.Signalling
         /// <param name="signalAspect">Aspect for which the default draw state must be found</param>
         /// <returns></returns>
         public int DefaultDrawState(Aspect signalAspect) => SignalHead.def_draw_state((MstsSignalAspect)signalAspect);
+
         /// <summary>
         /// Index of the draw state with the specified name
         /// </summary>
         /// <param name="name">Name of the draw state as defined in sigcfg</param>
         /// <returns>The index of the draw state, -1 if no one exist with that name</returns>
-        public int GetDrawState(string name) => SignalHead.signalType.DrawStates.TryGetValue(name, out SignalDrawState drawState) ? drawState.Index : -1;
+        public int GetDrawState(string name) => SignalHead.signalType.DrawStates.TryGetValue(name.ToLower(), out SignalDrawState drawState) ? drawState.Index : -1;
+
         /// <summary>
         /// Signal identity of this signal
         /// </summary>


### PR DESCRIPTION
Already validated in release 1.5 branch but pull request in master branch was not created automatically
See pull request #710 