### PR TITLE
Strengthened log message when restoring from a bad save

### DIFF
--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -8114,7 +8114,7 @@ namespace Orts.Simulation.Signalling
                     }
                     else
                     {
-                        Trace.TraceInformation("Invalid reservation for train : {0} [{1}], section : {2} not restored", reservedTrain.Name, reservedDirection, sectionIndex);
+                        Trace.TraceWarning("Invalid reservation for train : {0} [{1}], section : {2} not restored. May lead to a fatal error later.", reservedTrain.Name, reservedDirection, sectionIndex);
                     }
                 }
                 else


### PR DESCRIPTION
See bug report https://bugs.launchpad.net/or/+bug/1992236 

This PR only strengthens the message and does nothing to abandon the Restore operation or to solve the root cause, which is the bad save.