### PR TITLE
fix: Log first error during Viewer mark-sweep clean-up

### DIFF
--- a/Source/RunActivity/Viewer3D/World.cs
+++ b/Source/RunActivity/Viewer3D/World.cs
@@ -17,6 +17,8 @@
 
 // This file is the responsibility of the 3D & Environment Team. 
 
+using System;
+using System.Diagnostics;
 using Microsoft.Xna.Framework;
 using Orts.Common;
 using ORTS.Common;
@@ -48,6 +50,7 @@ namespace Orts.Viewer3D
         int VisibleTileX;
         int VisibleTileZ;
         bool PerformanceTune;
+        bool MarkSweepError;
 
         [CallOnThread("Render")]
         public World(Viewer viewer, double gameTime)
@@ -100,25 +103,33 @@ namespace Orts.Viewer3D
             {
                 TileX = VisibleTileX;
                 TileZ = VisibleTileZ;
-                Viewer.ShapeManager.Mark();
-                Viewer.MaterialManager.Mark();
-                Viewer.TextureManager.Mark();
-                Viewer.SignalTypeDataManager.Mark();
-                if (Viewer.Settings.UseMSTSEnv)
-                    MSTSSky.Mark();
-                else
-                    Sky.Mark();
-                Precipitation.Mark();
-                Terrain.Mark();
-                Scenery.Mark();
-                Trains.Mark();
-                RoadCars.Mark();
-                Containers.Mark();
-                Viewer.Mark();
-                Viewer.ShapeManager.Sweep();
-                Viewer.MaterialManager.Sweep();
-                Viewer.TextureManager.Sweep();
-                Viewer.SignalTypeDataManager.Sweep();
+                try
+                {
+                    Viewer.ShapeManager.Mark();
+                    Viewer.MaterialManager.Mark();
+                    Viewer.TextureManager.Mark();
+                    Viewer.SignalTypeDataManager.Mark();
+                    if (Viewer.Settings.UseMSTSEnv)
+                        MSTSSky.Mark();
+                    else
+                        Sky.Mark();
+                    Precipitation.Mark();
+                    Terrain.Mark();
+                    Scenery.Mark();
+                    Trains.Mark();
+                    RoadCars.Mark();
+                    Containers.Mark();
+                    Viewer.Mark();
+                    Viewer.ShapeManager.Sweep();
+                    Viewer.MaterialManager.Sweep();
+                    Viewer.TextureManager.Sweep();
+                    Viewer.SignalTypeDataManager.Sweep();
+                }
+                catch (Exception error)
+                {
+                    if (!MarkSweepError) Trace.WriteLine(error);
+                    MarkSweepError = true;
+                }
             }
         }
 


### PR DESCRIPTION
Bug report: https://www.elvastower.com/forums/index.php?/topic/36334-open-rails-15-is-coming-soon/page__view__findpost__p__287973

This will log a warning for the first exception during the Viewer's mark-sweep clean-up routine but will continue

Subsequent errors (whether the same or different) in this code will be silently ignored

Further investigation is needed into why this crash even occurs