### PR TITLE
Added new parameter for battery switch

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -4291,12 +4291,16 @@ In real life, the battery switch may not
 close instantly, so you can add a delay with the optional parameter
 ``ORTSBattery( Delay ( ) )`` (by default in seconds).
 
+It is possible for the battery switch to be switched on at the start of the simulation.
+To activate this behaviour, you can add the optional parameter ``ORTSBattery( DefaultOn ( 1 ) )``
+
 Example::
 
     Engine (
       ORTSBattery (
         Mode ( PushButtons )
         Delay ( 2s )
+        DefaultOn ( 1 )
       )
     )
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSControlTrailerCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSControlTrailerCar.cs
@@ -88,6 +88,7 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(ortstractioncutoffrelayclosingdelay":
                 case "engine(ortsbattery(mode":
                 case "engine(ortsbattery(delay":
+                case "engine(ortsbattery(defaulton":
                 case "engine(ortsmasterkey(mode":
                 case "engine(ortsmasterkey(delayoff":
                 case "engine(ortsmasterkey(headlightcontrol":

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
@@ -156,6 +156,7 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(ortstractioncutoffrelayclosingdelay":
                 case "engine(ortsbattery(mode":
                 case "engine(ortsbattery(delay":
+                case "engine(ortsbattery(defaulton":
                 case "engine(ortsmasterkey(mode":
                 case "engine(ortsmasterkey(delayoff":
                 case "engine(ortsmasterkey(headlightcontrol":

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs
@@ -74,6 +74,7 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(ortscircuitbreakerclosingdelay":
                 case "engine(ortsbattery(mode":
                 case "engine(ortsbattery(delay":
+                case "engine(ortsbattery(defaulton":
                 case "engine(ortsmasterkey(mode":
                 case "engine(ortsmasterkey(delayoff":
                 case "engine(ortsmasterkey(headlightcontrol":

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -868,6 +868,7 @@ namespace Orts.Simulation.RollingStocks
 
                 case "engine(ortsbattery(mode":
                 case "engine(ortsbattery(delay":
+                case "engine(ortsbattery(defaulton":
                 case "engine(ortsmasterkey(mode":
                 case "engine(ortsmasterkey(delayoff":
                 case "engine(ortsmasterkey(headlightcontrol":

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1380,6 +1380,7 @@ namespace Orts.Simulation.RollingStocks
                 case "wagon(ortspowerondelay":
                 case "wagon(ortsbattery(mode":
                 case "wagon(ortsbattery(delay":
+                case "wagon(ortsbattery(defaulton":
                 case "wagon(ortspowersupplycontinuouspower":
                 case "wagon(ortspowersupplyheatingpower":
                 case "wagon(ortspowersupplyairconditioningpower":

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/BatterySwitch.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/BatterySwitch.cs
@@ -34,6 +34,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         }
         public ModeType Mode { get; protected set; } = ModeType.AlwaysOn;
         public float DelayS { get; protected set; } = 0f;
+        public bool DefaultOn { get; protected set; } = false;
 
         // Variables
         readonly MSTSWagon Wagon;
@@ -79,6 +80,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 case "wagon(ortsbattery(delay":
                     DelayS = stf.ReadFloatBlock(STFReader.UNITS.Time, 0f);
                     break;
+
+                case "engine(ortsbattery(defaulton":
+                case "wagon(ortsbattery(defaulton":
+                    DefaultOn = stf.ReadBoolBlock(false);
+                    break;
             }
         }
 
@@ -86,11 +92,22 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         {
             Mode = other.Mode;
             DelayS = other.DelayS;
+            DefaultOn = other.DefaultOn;
         }
 
         public virtual void Initialize()
         {
             Timer.Setup(DelayS);
+
+            if (DefaultOn)
+            {
+                On = true;
+
+                if (Mode == ModeType.Switch)
+                {
+                    CommandSwitch = true;
+                }
+            }
         }
 
         /// <summary>
@@ -98,8 +115,12 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         /// </summary>
         public virtual void InitializeMoving()
         {
-            CommandSwitch = true;
             On = true;
+
+            if (Mode == ModeType.Switch)
+            {
+                CommandSwitch = true;
+            }
         }
 
         public virtual void Save(BinaryWriter outf)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/LocomotivePowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/LocomotivePowerSupply.cs
@@ -112,6 +112,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
                 case "engine(ortsbattery(mode":
                 case "engine(ortsbattery(delay":
+                case "engine(ortsbattery(defaulton":
                     BatterySwitch.Parse(lowercasetoken, stf);
                     break;
                 case "engine(ortsmasterkey(mode":

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/PassengerCarPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/PassengerCarPowerSupply.cs
@@ -88,6 +88,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
                 case "wagon(ortsbattery(mode":
                 case "wagon(ortsbattery(delay":
+                case "wagon(ortsbattery(defaulton":
                     BatterySwitch.Parse(lowercasetoken, stf);
                     break;
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/SteamPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/SteamPowerSupply.cs
@@ -73,6 +73,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             {
                 case "engine(ortsbattery(mode":
                 case "engine(ortsbattery(delay":
+                case "engine(ortsbattery(defaulton":
                     BatterySwitch.Parse(lowercasetoken, stf);
                     break;
                 case "engine(ortsmasterkey(mode":


### PR DESCRIPTION
In order to have the battery on at the start of the simulation when the train has service retention.

Feature request: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)