### PR TITLE
Replaced truncated brake token table with lists

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -2334,492 +2334,277 @@ The following notch positions can be defined for the train brake at ``Engine(Eng
    single: ORTSTrainBrakesControllerOverchargeEliminationRate
    single: ORTSTrainBrakesControllerSlowApplicationRate
 
-.. table:: Brake Controller Tokens
-    :widths: 20 45 20 15
+**RELEASE and RUNNING tokens**
 
-    +-----------------+-----------------+-----------------+-----------+
-    | OR Brake Token  | Description     | Brake Systems   | Operation |
-    +-----------------+-----------------+-----------------+-----------+
-    | **RELEASE and RUNNING tokens**                                  |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | RELEASE or      | Air single pipe | Air       |
-    | Brakes |-|      | OVERCHARGE      |                 |           |
-    | Controller |-|  |                 | Air twin pipe   |           |
-    | Overcharge |-|  | Rapidly         |                 |           |
-    | Start           | releases air    | EP              |           |
-    |                 | brakes and      |                 |           |
-    |                 | charges air     |                 |           |
-    |                 | reservoirs.     |                 |           |
-    |                 |                 |                 |           |
-    |                 | Train brake     |                 |           |
-    |                 | pipe may be     |                 |           |
-    |                 | overcharged (up |                 |           |
-    |                 | to ORTS |-|     |                 |           |
-    |                 | Train |-|       |                 |           |
-    |                 | Brakes |-|      |                 |           |
-    |                 | Controller |-|  |                 |           |
-    |                 | Max |-|         |                 |           |
-    |                 | Overcharge |-|  |                 |           |
-    |                 | Pressure |-|    |                 |           |
-    |                 | and will        |                 |           |
-    |                 | gradually       |                 |           |
-    |                 | return to       |                 |           |
-    |                 | normal working  |                 |           |
-    |                 | pressure when   |                 |           |
-    |                 | the controller  |                 |           |
-    |                 | is moved to a   |                 |           |
-    |                 | release         |                 |           |
-    |                 | position (the   |                 |           |
-    |                 | rate will be    |                 |           |
-    |                 | determined by   |                 |           |
-    |                 | ORTS |-| Train  |                 |           |
-    |                 | Brakes |-|      |                 |           |
-    |                 | Controller |-|  |                 |           |
-    |                 | Overcharge |-|. |                 |           |
-    |                 | Elimination |-| |                 |           |
-    |                 | Rate            |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | RELEASE or      | Air single pipe | Air       |
-    | Brakes |-|      | QUICK RELEASE   |                 |           |
-    | Controller |-|  |                 | Air twin pipe   | EP        |
-    | Full |-| Quick  | Air brakes:     |                 |           |
-    | |-| Release |-| | Rapidly         | EP              | Vacuum    |
-    | Start           | releases air    |                 |           |
-    |                 | brakes and      | Vacuum single   |           |
-    |                 | charges air     | pipe            |           |
-    |                 | reservoirs,     |                 |           |
-    |                 | without         |                 |           |
-    |                 | overcharging    |                 |           |
-    |                 | the train pipe. |                 |           |
-    |                 |                 |                 |           |
-    |                 | EP brakes:      |                 |           |
-    |                 | Rapidly         |                 |           |
-    |                 | releases EP     |                 |           |
-    |                 | brakes.         |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes – |                 |           |
-    |                 | diesel and      |                 |           |
-    |                 | electric loco:  |                 |           |
-    |                 | Operates        |                 |           |
-    |                 | exhauster at    |                 |           |
-    |                 | fast speed.     |                 |           |
-    |                 | Rapidly         |                 |           |
-    |                 | releases vacuum |                 |           |
-    |                 | brakes and      |                 |           |
-    |                 | charges vacuum  |                 |           |
-    |                 | reservoirs.     |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes – |                 |           |
-    |                 | steam with      |                 |           |
-    |                 | combination     |                 |           |
-    |                 | ejector:        |                 |           |
-    |                 | Operates large  |                 |           |
-    |                 | ejector at full |                 |           |
-    |                 | power. Rapidly  |                 |           |
-    |                 | releases vacuum |                 |           |
-    |                 | brakes and      |                 |           |
-    |                 | charges vacuum  |                 |           |
-    |                 | reservoirs.     |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes – |                 |           |
-    |                 | steam with      |                 |           |
-    |                 | separate        |                 |           |
-    |                 | ejector:        |                 |           |
-    |                 | Connects brake  |                 |           |
-    |                 | pipe to         |                 |           |
-    |                 | ejector(s)      |                 |           |
-    |                 | and/or vacuum   |                 |           |
-    |                 | pump. Brakes    |                 |           |
-    |                 | may be released |                 |           |
-    |                 | by operating    |                 |           |
-    |                 | large or small  |                 |           |
-    |                 | ejector.        |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | RUNNING or      | Air single pipe | Air       |
-    | Brakes |-|      | RELEASE         |                 |           |
-    | Controller |-|  |                 | Air twin pipe   | EP        |
-    | Release |-|     | Air brakes:     |                 |           |
-    | Start           | Maintains       | EP              | Vacuum    |
-    |                 | working         |                 |           |
-    |                 | pressure in     | Vacuum single   |           |
-    |                 | train pipe.     | pipe            |           |
-    |                 | Slowly releases |                 |           |
-    |                 | brakes.         |                 |           |
-    |                 |                 |                 |           |
-    |                 | EP brakes:      |                 |           |
-    |                 | Releases        |                 |           |
-    |                 | brakes.         |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes – |                 |           |
-    |                 | diesel and      |                 |           |
-    |                 | electric loco:  |                 |           |
-    |                 | Connects brake  |                 |           |
-    |                 | pipe to         |                 |           |
-    |                 | exhauster.      |                 |           |
-    |                 | Maintains       |                 |           |
-    |                 | vacuum in train |                 |           |
-    |                 | pipe. Slowly    |                 |           |
-    |                 | releases        |                 |           |
-    |                 | brakes.         |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes – |                 |           |
-    |                 | steam with      |                 |           |
-    |                 | combination     |                 |           |
-    |                 | ejector:        |                 |           |
-    |                 | Operates large  |                 |           |
-    |                 | ejector at full |                 |           |
-    |                 | power. Rapidly  |                 |           |
-    |                 | releases vacuum |                 |           |
-    |                 | brakes and      |                 |           |
-    |                 | charges vacuum  |                 |           |
-    |                 | reservoirs.     |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes – |                 |           |
-    |                 | steam with      |                 |           |
-    |                 | separate        |                 |           |
-    |                 | ejector:        |                 |           |
-    |                 | Connects brake  |                 |           |
-    |                 | pipe to         |                 |           |
-    |                 | ejector(s)      |                 |           |
-    |                 | and/or vacuum   |                 |           |
-    |                 | pump. Brakes    |                 |           |
-    |                 | may be released |                 |           |
-    |                 | by operating    |                 |           |
-    |                 | large or small  |                 |           |
-    |                 | ejector.        |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | **LAP, HOLDING and NEUTRAL tokens**                             |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | LAP or RUNNING  | Air single pipe | Air       |
-    | Brakes |-|      |                 |                 |           |
-    | Controller |-|  | Air brakes:     | Air twin pipe   | EP        |
-    | Running |-|     | Train pipe      |                 |           |
-    | Start           | pressure is     | EP              | Vacuum    |
-    |                 | held at any     |                 |           |
-    |                 | pressure with   | Vacuum single   |           |
-    |                 | compensation    | pipe            |           |
-    |                 | for leakage.    |                 |           |
-    |                 |                 |                 |           |
-    |                 | EP brakes:      |                 |           |
-    |                 | Brake           |                 |           |
-    |                 | application is  |                 |           |
-    |                 | held at any     |                 |           |
-    |                 | value.          |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes – |                 |           |
-    |                 | diesel and      |                 |           |
-    |                 | electric loco:  |                 |           |
-    |                 | Train pipe      |                 |           |
-    |                 | vacuum is held  |                 |           |
-    |                 | at any value    |                 |           |
-    |                 | with            |                 |           |
-    |                 | compensation    |                 |           |
-    |                 | for leakage.    |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes – |                 |           |
-    |                 | steam with      |                 |           |
-    |                 | combination     |                 |           |
-    |                 | ejector:        |                 |           |
-    |                 | Connects brake  |                 |           |
-    |                 | pipe to small   |                 |           |
-    |                 | ejector and/or  |                 |           |
-    |                 | vacuum pump.    |                 |           |
-    |                 | Maintains       |                 |           |
-    |                 | vacuum. Brakes  |                 |           |
-    |                 | may be released |                 |           |
-    |                 | by operating    |                 |           |
-    |                 | small ejector.  |                 |           |
-    |                 |                 |                 |           |
-    |                 | (Vacuum brakes  |                 |           |
-    |                 | – steam with    |                 |           |
-    |                 | separate        |                 |           |
-    |                 | ejector:        |                 |           |
-    |                 | Connects brake  |                 |           |
-    |                 | pipe only to    |                 |           |
-    |                 | small ejector   |                 |           |
-    |                 | and/or vacuum   |                 |           |
-    |                 | pump.)          |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | LAP             | Air single pipe | Air       |
-    | Brakes |-|      |                 |                 |           |
-    | Controller |-|  | Air brakes:     | Air twin pipe   | EP        |
-    | Self |-| Lap    | Train pipe      |                 |           |
-    | |-| Start       | pressure is     | EP              | Vacuum    |
-    |                 | held at any     |                 |           |
-    |                 | pressure with   | Vacuum single   |           |
-    |                 | compensation    | pipe            |           |
-    |                 | for leakage.    |                 |           |
-    |                 |                 |                 |           |
-    |                 | EP brakes:      |                 |           |
-    |                 | Brake           |                 |           |
-    |                 | application is  |                 |           |
-    |                 | held at any     |                 |           |
-    |                 | value.          |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes:  |                 |           |
-    |                 | Train pipe      |                 |           |
-    |                 | vacuum is held  |                 |           |
-    |                 | with            |                 |           |
-    |                 | compensation    |                 |           |
-    |                 | for leakage.    |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | LAP – all brake | Air single pipe | Air       |
-    | Brakes |-|      | types held      |                 |           |
-    | Controller |-|  | without change  | Air twin pipe   | EP        |
-    | Hold |-| Start  | – legacy MSTS   |                 |           |
-    |                 | token           | EP              | Vacuum    |
-    |                 |                 |                 |           |
-    |                 |                 | Vacuum single   |           |
-    |                 |                 | pipe            |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train\ |-|\     | HOLD EP – EP    | EP              | EP        |
-    | Brakes\ |-|\    | brake setting   |                 |           |
-    | Controller\     | is held without |                 |           |
-    | |-|\ EP\ Hold   | influence on    |                 |           |
-    | |-|  Start      | train air pipe. |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | LAP or NEUTRAL  | Air single pipe | Air       |
-    | Brakes |-|      |                 |                 |           |
-    | Controller |-|  | Air brakes:     | Air twin pipe   | EP        |
-    | Hold |-| Lapped | Train pipe      |                 |           |
-    | |-| Start       | pressure is     | EP              | Vacuum    |
-    |                 | held without    |                 |           |
-    |                 | compensation    | Vacuum single   |           |
-    |                 | for leakage.    | pipe            |           |
-    |                 |                 |                 |           |
-    |                 | EP brakes:      |                 |           |
-    |                 | Brake           |                 |           |
-    |                 | application is  |                 |           |
-    |                 | held at any     |                 |           |
-    |                 | value.          |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes:  |                 |           |
-    |                 | Train pipe      |                 |           |
-    |                 | vacuum is held  |                 |           |
-    |                 | without         |                 |           |
-    |                 | compensation    |                 |           |
-    |                 | for leakage.    |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | LAP or NEUTRAL  | Air single pipe | Air       |
-    | Brakes |-|      |                 |                 |           |
-    | Controller |-|  | Air brakes:     | Air twin pipe   | EP        |
-    | Neutral |-|     | Train pipe      |                 |           |
-    | Handle |-| Off  | pressure is     | EP              | Vacuum    |
-    | |-| Start       | held without    |                 |           |
-    |                 | compensation    | Vacuum single   |           |
-    |                 | for leakage.    | pipe            |           |
-    |                 |                 |                 |           |
-    |                 | EP brakes:      |                 |           |
-    |                 | Brake           |                 |           |
-    |                 | application is  |                 |           |
-    |                 | held at any     |                 |           |
-    |                 | value.          |                 |           |
-    |                 |                 |                 |           |
-    |                 | Vacuum brakes:  |                 |           |
-    |                 | Train pipe      |                 |           |
-    |                 | vacuum is held  |                 |           |
-    |                 | without         |                 |           |
-    |                 | compensation    |                 |           |
-    |                 | for leakage.    |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | **SELF LAPPING APPLY tokens**                                   |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | INITIAL / FIRST | Air single pipe | Air       |
-    | Brakes |-|      | SERVICE         |                 |           |
-    | Controller |-|  |                 | Air twin pipe   | Vacuum    |
-    | Minimal |-|     | Notch. Train    |                 |           |
-    | Reduction |-|   | pipe pressure   | Vacuum single   |           |
-    | Start           | or vacuum is    | pipe            |           |
-    |                 | held at Minimum |                 |           |
-    |                 | Reduction       |                 |           |
-    |                 | value.          |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | INITIAL / FIRST | Air single pipe | Air       |
-    | Brakes |-|      | SERVICE << >>   |                 |           |
-    | Controller |-|  | FULL SERVICE    | Air twin pipe   |           |
-    | Graduated |-|   |                 |                 |           |
-    | Self |-| Lap    | Graduated       |                 |           |
-    | |-| Limited |-| | service         |                 |           |
-    | Start           | application and |                 |           |
-    |                 | release of air  |                 |           |
-    |                 | brakes only.    |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | INITIAL / FIRST | Air single pipe | Air       |
-    | Brakes |-|      | SERVICE >>>>    |                 |           |
-    | Controller |-|  | FULL SERVICE    | Air twin pipe   |           |
-    | Graduated |-|   |                 |                 |           |
-    | Self |-| Lap    | Graduated       |                 |           |
-    | |-| Limited |-| | service         |                 |           |
-    | Holding |-|     | application of  |                 |           |
-    | Start           | air brakes      |                 |           |
-    |                 | only. (Release  |                 |           |
-    |                 | is not          |                 |           |
-    |                 | graduable.)     |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | INITIAL / FIRST | Air single pipe | Air       |
-    | Brakes |-|      | SERVICE << >>   |                 |           |
-    | Controller |-|  | FULL SERVICE    | Air twin pipe   | EP        |
-    | EPApply |-|     |                 |                 |           |
-    | Start           | Graduated       | EP              |           |
-    |                 | service         |                 |           |
-    |                 | application and |                 |           |
-    |                 | release of air  |                 |           |
-    |                 | brakes and EP   |                 |           |
-    |                 | brakes.         |                 |           |
-    |                 |                 |                 |           |
-    |                 | Can be used for |                 |           |
-    |                 | notched         |                 |           |
-    |                 | controllers.    |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | INITIAL / FIRST | Air single pipe | Air       |
-    | Brakes |-|      | SERVICE >>>>    |                 |           |
-    | Controller |-|  | FULL SERVICE    | Air twin pipe   | EP        |
-    | Continuous |-|  |                 |                 |           |
-    | Service |-|     | Graduated       | EP              |           |
-    | Start           | service         |                 |           |
-    |                 | application of  |                 |           |
-    |                 | air brakes and  |                 |           |
-    |                 | EP brakes.      |                 |           |
-    |                 | (Release is not |                 |           |
-    |                 | graduable.)     |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | INITIAL / FIRST | EP              | EP        |
-    | Brakes |-|      | SERVICE << >>   |                 |           |
-    | Controller |-|  | FULL SERVICE    |                 |           |
-    | EPOnly |-|      |                 |                 |           |
-    | Start           | Graduated       |                 |           |
-    |                 | service         |                 |           |
-    |                 | application and |                 |           |
-    |                 | release of EP   |                 |           |
-    |                 | brakes only     |                 |           |
-    |                 | without         |                 |           |
-    |                 | reduction in    |                 |           |
-    |                 | air train pipe  |                 |           |
-    |                 | pressure.       |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | RUNNING << >>   | Vacuum single   | Vacuum    |
-    | Brakes |-|      | FULL SERVICE /  | pipe            |           |
-    | Controller |-|  | EMERGENCY       |                 |           |
-    | Vacuum |-|      |                 |                 |           |
-    | Continuous |-|  | Graduated       |                 |           |
-    | Service |-|     | application and |                 |           |
-    | Start           | release of      |                 |           |
-    |                 | vacuum brakes.  |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Dummy           | Train pipe      | Air single pipe | Air       |
-    |                 | pressure of     |                 |           |
-    |                 | vacuum can be   | Air twin pipe   | Vacuum    |
-    |                 | held at any     |                 |           |
-    |                 | value.          | Vacuum single   |           |
-    |                 |                 | pipe            |           |
-    |                 | Can be used for |                 |           |
-    |                 | notched         |                 |           |
-    |                 | controllers.    |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | **NON SELF LAPPING APPLY tokens**                               |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | FIRST SERVICE   | Air single pipe | Air       |
-    | Brakes |-|      | or SLOW APPLY   |                 |           |
-    | Controller |-|  |                 | Air twin pipe   | EP        |
-    | Slow |-|        | Notch. Train    |                 |           |
-    | Service |-|     | brakes are      | EP              |           |
-    | Start           | applied at a    |                 |           |
-    |                 | slow rate from  |                 |           |
-    |                 | minimal         |                 |           |
-    |                 | application     |                 |           |
-    |                 | until full      |                 |           |
-    |                 | service         |                 |           |
-    |                 | application.    |                 |           |
-    |                 | The rate is     |                 |           |
-    |                 | determined by   |                 |           |
-    |                 | ORTS |-| Train  |                 |           |
-    |                 | |-| Brakes |-|  |                 |           |
-    |                 | Controller |-|  |                 |           |
-    |                 | Slow |-|        |                 |           |
-    |                 | Application |-| |                 |           |
-    |                 | Rate in the     |                 |           |
-    |                 | .eng file.      |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | APPLY           | Air single pipe | Air       |
-    | Brakes |-|      |                 |                 |           |
-    | Controller |-|  | Notch. Train    | Air twin pipe   | EP        |
-    | Full |-|        | brakes are      |                 |           |
-    | Service |-|     | applied at the  | EP              |           |
-    | Start           | normal service  |                 |           |
-    |                 | rate from       |                 |           |
-    |                 | minimal         |                 |           |
-    |                 | application     |                 |           |
-    |                 | until full      |                 |           |
-    |                 | service         |                 |           |
-    |                 | application.    |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | EP APPLY        | EP              | EP        |
-    | Brakes |-|      |                 |                 |           |
-    | Controller |-|  | Notch. EP       |                 |           |
-    | EP |-| Full |-| | brakes are      |                 |           |
-    | Service |-|     | applied at the  |                 |           |
-    | Start           | normal service  |                 |           |
-    |                 | rate without    |                 |           |
-    |                 | reduction in    |                 |           |
-    |                 | air train pipe  |                 |           |
-    |                 | pressure.       |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | APPLY           | Air single pipe | Air       |
-    | Brakes |-|      |                 |                 |           |
-    | Controller |-|  | Notch. Train    | Air twin pipe   | EP        |
-    | Apply |-| Start | brakes are      |                 |           |
-    |                 | applied at the  | EP              | Vacuum    |
-    |                 | normal service  |                 |           |
-    |                 | rate from       | Vacuum single   |           |
-    |                 | minimal         | pipe            |           |
-    |                 | application     |                 |           |
-    |                 | until emergency |                 |           |
-    |                 | application.    |                 |           |
-    |                 |                 |                 |           |
-    |                 | (Vacuum brakes  |                 |           |
-    |                 | – steam: MSTS   |                 |           |
-    |                 | legacy          |                 |           |
-    |                 | controller is   |                 |           |
-    |                 | now replaced by |                 |           |
-    |                 | Train |-|       |                 |           |
-    |                 | Brakes |-|      |                 |           |
-    |                 | Controller |-|  |                 |           |
-    |                 | Vaccuum |-|     |                 |           |
-    |                 | Apply |-|       |                 |           |
-    |                 | Continuous |-|  |                 |           |
-    |                 | Service |-|     |                 |           |
-    |                 | Start)          |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | APPLY           | Vacuum single   | Vacuum    |
-    | Brakes |-|      |                 | pipe            |           |
-    | Controller |-|  | Range. The rate |                 |           |
-    | Vacuum |-|      | of the brake    |                 |           |
-    | Apply |-|       | application is  |                 |           |
-    | Continuous |-|  | determined by   |                 |           |
-    | ServiceStart    | the position of |                 |           |
-    |                 | the valve.      |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | EMERGENCY       | Air single pipe | Air       |
-    | Brakes |-|      |                 |                 |           |
-    | Controller |-|  | Notch. Makes a  | Air twin pipe   | EP        |
-    | Emergency |-|   | full emergency  |                 |           |
-    | Start           | application of  | EP              | Vacuum    |
-    |                 | brakes at the   |                 |           |
-    |                 | fastest         | Vacuum single   |           |
-    |                 | possible rate.  | pipe            |           |
-    +-----------------+-----------------+-----------------+-----------+
-    | **OTHER train brake controller tokens**                         |
-    +-----------------+-----------------+-----------------+-----------+
-    | Train |-|       | Cancels effect  | Air single pipe | Air       |
-    | Brakes |-|      | of penalty      |                 |           |
-    | Controller |-|  | brake           | Air twin pipe   | EP        |
-    | Suppression |-| | application by  |                 |           |
-    | Start           | TCS and         | EP              |           |
-    |                 | restores        |                 |           |
-    |                 | control of      |                 |           |
-    |                 | brakes to       |                 |           |
-    |                 | driver.         |                 |           |
-    +-----------------+-----------------+-----------------+-----------+
+Brake Token:   ``TrainBrakesControllerOverchargeStart``
+
+- Operation:     Air
+- Brake Systems: Air single pipe, Air twin pipe, EP
+- Description:   RELEASE or OVERCHARGE
+ 
+                 Rapidly releases air brakes and charges air reservoirs
+
+                 Train brake pipe may be overcharged (up to ORTSTrainBrakesControllerMaxOverchargePressure) and will gradually
+                 return to normal working pressure when the controller is moved to a release position.
+                 (The rate will be determined by ORTSTrainBrakesControllerOverchargeEliminationRate.)
+
+Brake Token:   ``TrainBrakesControllerFullQuickReleaseStart``
+
+- Operation:     Air, EP, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, EP, Vacuum single pipe
+- Description:   RELEASE or QUICK RELEASE
+  
+                - Air brakes: Rapidly releases air brakes and charges air reservoirs, without overcharging the train pipe.
+                - EP brakes: Rapidly releases EP brakes.
+                - Vacuum brakes:
+                   
+                  - diesel and electric loco:                     
+
+                    - Operates exhauster at fast speed. Rapidly releases vacuum brakes and charges vacuum reservoirs.
+                       
+                  - steam with combination ejector: 
+                     
+                    - Operates large ejector at full power. Rapidly releases vacuum brakes and charges vacuum reservoirs.
+                       
+                  - steam with separate ejector:
+                     
+                    - Connects brake pipe to ejector(s) and/or vacuum pump. Brakes may be released by operating large or small ejector.  
+
+Brake Token:   ``TrainBrakesControllerReleaseStart``
+
+- Operation:     Air, EP, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, EP, Vacuum single pipe
+- Description:   RUNNING or RELEASE
+   
+                - Air brakes: Maintains working pressure in train pipe. Slowly releases brakes.
+                - EP brakes: Releases brakes.
+                - Vacuum brakes:
+
+                  - diesel and electric locos:
+
+                    - Connects brake pipe to exhauster. Maintains vacuum in train pipe. Slowly releases brakes.
+
+                  - steam with combination ejector:
+
+                    - Operates large ejector at full power. Rapidly releases vacuum brakes and charges vacuum reservoirs. 
+
+                  - steam with separate ejector:
+
+                    - Connects brake pipe to ejector(s) and/or vacuum pump. Brakes may be released by operating large or small ejector.  
+
+**LAP, HOLDING and NEUTRAL tokens**
+
+Brake Token:   ``TrainBrakesControllerRunningStart``
+
+- Operation:     Air, EP, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, EP, Vacuum single pipe
+- Description:   LAP or RUNNING
+
+                - Air brakes: Train pipe pressure is held at any pressure with compensation for leakage.
+                - EP brakes: Brake application is held at any value.
+                - Vacuum brakes:
+
+                  - diesel and electric locos:
+
+                    - Train pipe vacuum is held at any value with compensation for leakage.
+
+                  - steam with combination ejector:
+
+                    - Connects brake pipe to small ejector and/or vacuum pump. Maintains vacuum. Brakes may be released by operating small ejector.
+
+                  - steam with separate ejector:
+
+                    - Connects brake pipe only to small ejector and/or vacuum pump.  
+
+
+Brake Token:   ``TrainBrakesControllerSelfLapStart``
+
+- Operation:     Air, EP, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, EP, Vacuum single pipe
+- Description:   LAP
+
+                - Air brakes: Train pipe pressure is held at any pressure with compensation for leakage.
+                - EP brakes: Brake application is held at any value.
+                - Vacuum brakes: Train pipe vacuum is held at any value with compensation for leakage.  
+
+
+Brake Token:   ``TrainBrakesControllerHoldStart`` (legacy MSTS token)
+
+- Operation:     Air, EP, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, EP, Vacuum single pipe
+- Description:   LAP
+
+                - All brake types held without change.  
+
+
+Brake Token:   ``TrainBrakesControllerEPHoldStart``
+
+- Operation:     EP
+- Brake Systems: EP
+- Description:   HOLD EP
+
+                - EP brakes: Setting is held without influence on train air pipe.  
+
+
+Brake Token:   ``TrainBrakesControllerHoldLappedStart``
+
+- Operation:     Air, EP, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, EP, Vacuum single pipe
+- Description:   LAP or NEUTRAL
+
+                - Air brakes: Train pipe pressure is held without compensation for leakage.
+                - EP brakes: Brake application is held at any value.
+                - Vacuum brakes: Train pipe vacuum is held without compensation for leakage.  
+
+
+Brake Token:   ``TrainBrakesControllerNeutralHandleOffStart``
+
+- Operation:     Air, EP, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, EP, Vacuum single pipe
+- Description:   LAP or NEUTRAL
+
+                - Air brakes: Train pipe pressure is held without compensation for leakage.
+                - EP brakes: Brake application is held at any value.
+                - Vacuum brakes: Train pipe vacuum is held without compensation for leakage.  
+
+
+**SELF LAPPING APPLY tokens**
+
+Brake Token:   ``TrainBrakesControllerMinimalReductionStart``
+
+- Operation:     Air, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, Vacuum single pipe
+- Description:   INITIAL / FIRST SERVICE
+
+                - Notch: Train pipe pressure or vacuum is held at Minimum Reduction value.  
+
+
+Brake Token:   ``TrainBrakesControllerGraduatedSelfLapLimitedHoldingStart``
+
+- Operation:     Air
+- Brake Systems: Air single pipe, Air twin pipe
+- Description:   INITIAL / FIRST SERVICE << >> FULL SERVICE
+
+                 Graduated service application of air brakes only. (Release is not graduable.)  
+
+
+Brake Token:   ``TrainBrakesControllerEPApplyStart``
+
+- Operation:     Air, EP
+- Brake Systems: Air single pipe, Air twin pipe, EP
+- Description:   INITIAL / FIRST SERVICE << >> FULL SERVICE
+
+                 Graduated service application and release of air brakes and EP brakes.
+                 Can be used for notched controllers.  
+
+
+Brake Token:   ``TrainBrakesControllerContinuousServiceStart``
+
+- Operation:     Air, EP
+- Brake Systems: Air single pipe, Air twin pipe, EP
+- Description:   INITIAL / FIRST SERVICE >>>> FULL SERVICE
+
+                 Graduated service application of air brakes and EP brakes. (Release is not graduable.)  
+
+
+Brake Token:   ``TrainBrakesControllerEPOnlyStart``
+
+- Operation:     EP
+- Brake Systems: EP
+- Description:   INITIAL / FIRST SERVICE << >> FULL SERVICE
+
+                 Graduated service application and release of EP brakes only without reduction in air train pressure.  
+
+
+Brake Token:   ``TrainBrakesControllerVacuumContinuousServiceStart``
+
+- Operation:     Vacuum
+- Brake Systems: Vacuum single pipe
+- Description:   RUNNING << >> FULL SERVICE / EMERGENCY
+
+                 Graduated application and release of vacuum brakes.  
+
+
+Brake Token:   ``Dummy``
+
+- Operation:     Air, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, Vacuum single pipe
+- Description:   RUNNING << >> FULL SERVICE / EMERGENCY
+
+                 Train pipe pressure or vacuum can be held at any value.
+
+                 Can be used for notched controllers.  
+
+
+**NON SELF LAPPING APPLY tokens**
+
+Brake Token:   ``TrainBrakesControllerSlowServiceStart``
+
+- Operation:     Air, EP
+- Brake Systems: Air single pipe, Air twin pipe, EP
+- Description:   FIRST SERVICE or SLOW APPLY
+
+                 Notch: Train brakes are applied at a slow rate from minimal application until full service application.
+                 The rate is determined by ``ORTSTrainBrakesControllerSlowApplicationRate`` in the .eng file.  
+
+                
+Brake Token:   ``TrainBrakesControllerFullServiceStart``
+
+- Operation:     Air, EP
+- Brake Systems: Air single pipe, Air twin pipe, EP
+- Description:   APPLY
+
+                 Notch: Train brakes are applied at the normal service rate from minimal application until full service application.  
+
+
+Brake Token:   ``TrainBrakesControllerEPFullServiceStart``
+
+- Operation:     EP
+- Brake Systems: EP
+- Description:   EP APPLY
+
+                 Notch: EP brakes are applied at the normal service rate without reduction in air train pipe pressure.  
+
+
+                
+Brake Token:   ``TrainBrakesControllerApplyStart``
+
+- Operation:     Air, EP, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, EP, Vacuum single pipe
+- Description:   APPLY
+
+                 Notch: Train brakes are applied at the normal service rate from minimal application until emergency application.  
+
+                 Vacuum brakes - steam. MSTS legacy controller is now replaced by next token
+                 ``TrainBrakesControllerVacuumApplyContoinousServiceStart``  
+
+
+Brake Token:   ``TrainBrakesControllerVacuumApplyContoinousServiceStart``
+
+- Operation:     Vacuum
+- Brake Systems: Vacuum single pipe
+- Description:   APPLY
+
+                 Range: The rate of the brake application is determined by the position of the valve.  
+
+                
+Brake Token:   ``TrainBrakesControllerEmeregencyStart``
+
+- Operation:     Air, EP, Vacuum
+- Brake Systems: Air single pipe, Air twin pipe, EP, Vacuum single pipe
+- Description:   EMERGENCY
+
+                 Notch: Make a full emergency application of brakes at the fastest possible rate.  
+
+
+**OTHER train brake controller tokens**
+
+Brake Token:   ``TrainBrakesControllerSupressionStart``
+
+- Operation:     Air, EP
+- Brake Systems: Air single pipe, Air twin pipe, EP
+- Description:   Cancels effect of penalty brake application by TCS and restores control of brakes to driver.  
+
 
 .. _physics-hud-brake:
 


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/34208-missing-from-the-manual/page__view__findpost__p__288675

Couldn't get a table to flow across multiple pages reliably, so replaced it with multiple lists.