### PR TITLE
Fixed brake controller script not being loaded in timetable mode

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/BrakeController.cs
@@ -317,10 +317,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
 
                 case "engine(ortstrainbrakecontroller":
                 case "engine(ortsenginebrakecontroller":
-                    if (Locomotive.Train as AITrain == null)
-                    {
-                        ScriptName = stf.ReadStringBlock(null);
-                    }
+                    ScriptName = stf.ReadStringBlock(null);
                     break;
             }
         }


### PR DESCRIPTION
BTW, the brake controller scripts that I have supports AI control, so it's not an issue to keep scripts active for a train in AI mode.
And I think I am probably the only that have written brake controller scripts.