### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/1997482. Explore in Activity Mode, is not restored.

### DIFF
--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -682,7 +682,7 @@ namespace ORTS
                 SelectedRoute != null ? SelectedRoute.Path : "",
                 // Activity mode items / Explore mode items
                 radioButtonModeActivity.Checked ?
-                    SelectedActivity != null && SelectedActivity.FilePath != null ? SelectedActivity.FilePath : "" :
+                    SelectedActivity != null && SelectedActivity.FilePath != null ? SelectedActivity.FilePath : SelectedActivity != null? SelectedActivity.Name : "" :
                     SelectedTimetableSet != null ? SelectedTimetableSet.fileName : "",
                 radioButtonModeActivity.Checked ?
                     SelectedActivity is ExploreActivity && comboBoxLocomotive.SelectedItem != null && (comboBoxLocomotive.SelectedItem as Locomotive).FilePath != null ? (comboBoxLocomotive.SelectedItem as Locomotive).FilePath : "" :
@@ -1349,9 +1349,10 @@ namespace ORTS
             if (comboBox.Items.Count == 0)
                 return;
 
+            var index = (int)UserSettings.Menu_SelectionIndex.Activity;
             for (var i = 0; i < comboBox.Items.Count; i++)
             {
-                if (comboBox.Items[i] is T && predicate((T)comboBox.Items[i]))
+                if (comboBox.Items[i] is T && predicate((T)comboBox.Items[i]) || (Settings.Menu_Selection.Length > i && comboBox.Items[i].ToString() == Settings.Menu_Selection[index] ))
                 {
                     comboBox.SelectedIndex = i;
                     return;


### PR DESCRIPTION
When the selected activity is "Explore in Activity Mode", this setting is not restored and "Explore Route" is displayed.
More info: https://bugs.launchpad.net/or/+bug/1997482