### PR TITLE
Extends CabControls for user input

### DIFF
--- a/Source/RunActivity/Viewer3D/WebServices/Web/CabControls/index.css
+++ b/Source/RunActivity/Viewer3D/WebServices/Web/CabControls/index.css
@@ -6,3 +6,20 @@ tr td { text-align: right;}
 td { padding: 2px; }
 .scale { width: 100px; background-color: lightgray; }
 .gauge { margin: 0px; background-color: gold; }
+
+.row {
+    display: flex;
+}
+
+.column {
+    flex: 50%;
+}
+
+div.control {
+    text-align: left;
+    padding: 20px;
+}
+
+label {
+    padding: 0 0 20px 0;
+}

--- a/Source/RunActivity/Viewer3D/WebServices/Web/CabControls/index.html
+++ b/Source/RunActivity/Viewer3D/WebServices/Web/CabControls/index.html
@@ -20,7 +20,7 @@ along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 <html lang="en">
 <head>
 	<title>OR: Cab Controls</title>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1"><!-- adds zooming for mobiles -->
 	<link rel="shortcut icon" type="image/png" href="/or_logo.png"><!-- This icon appears in the page's tab and its bookmark. -->
 	<link rel="stylesheet" type="text/css" href="/index.css"><!-- share styles with home page -->
@@ -30,19 +30,57 @@ along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 
 <body onload="setInterval (ApiCabControls, 500)">
 	<div id="menu"><a href="/">Back to Menu</a></div>
-	<br><h2>Cab Controls, Instruments, Dials, Meters and Gauges</h2>
-	<table>
-		<thead>
-			<tr>
-				<th>Control</th>
-				<th>Min</th>
-				<th>Value</th>
-				<th>Max</th>
-				<th>Scale</th>
-			</tr>
-		</thead>
-		<tbody id="markup">
-		</tbody>
-	</table>
+	<br />
+	<div class="row">
+		<div class="column">
+			<h2>Cab Instruments, Dials, Meters and Gauges</h2>
+			<table>
+				<thead>
+					<tr>
+						<th>Control</th>
+						<th>Min</th>
+						<th>Value</th>
+						<th>Max</th>
+						<th>Scale</th>
+					</tr>
+				</thead>
+				<tbody id="markup">
+				</tbody>
+			</table>
+		</div>
+		<div class="column">
+			<h2>Basic Controls</h2>
+			<br />
+			<br />
+			<div class="control">
+				<input id="train_brake" type="range" step="any" value="0" min="0" max="100" onchange="sendValue(this.value/100, 'TRAIN_BRAKE')" />
+				<label for="train_brake">Train Brake (0 - 100)</label>
+			</div>
+			<div class="control">
+				<input id="direction" type="range" value="0" min="-1" max="1" onchange="sendValue(this.value, 'DIRECTION')" />
+				<label for="direction">Direction/Reverser (-1 - +1)</label>
+			</div>
+			<div class="control">
+				<input id="train_brake" type="range" step="10" value="0" min="0" max="100" onchange="sendValue(this.value/100, 'THROTTLE')" />
+				<label for="train_brake">Throttle/Regulator (0 - 100)</label>
+			</div>
+			<div class="control">
+				<input id="train_brake" type="range" step="1" value="0" min="0" max="1" onchange="sendValue(this.value, 'HORN')" />
+				<label for="train_brake">Horn (0 - 1)</label>
+			</div>
+			<div class="control">
+				<input id="train_brake" type="range" step="1" value="0" min="0" max="1" onchange="sendValue(this.value, 'BELL')" />
+				<label for="train_brake">Bell (0 - 1)</label>
+			</div>
+			<div class="control">
+				<input id="train_brake" type="range" step="1" value="0" min="0" max="3" onchange="sendValue(this.value, 'FRONT_HLIGHT')" />
+				<label for="train_brake">Front Headlight (0 - 3)</label>
+			</div>
+			<div class="control">
+				<input id="train_brake" type="range" step="1" value="0" min="0" max="1" onchange="sendValue(this.value, 'PANTOGRAPH')" />
+				<label for="train_brake">Pantograph (0 - 1)</label>
+			</div>
+		</div>
+	</div>
 </body>
 </html>

--- a/Source/RunActivity/Viewer3D/WebServices/Web/CabControls/index.js
+++ b/Source/RunActivity/Viewer3D/WebServices/Web/CabControls/index.js
@@ -31,13 +31,16 @@ function ApiCabControls() {
 	hr.open("GET", "/API/CABCONTROLS/", true);
 	hr.send();
 	hr.onreadystatechange = function () {
-		if (this.readyState == xmlHttpRequestCodeDone && this.status == httpCodeSuccess) {
-			var jso = JSON.parse(hr.responseText);
-			if (jso != null) // Can happen using IEv11
-			{
-				// Replaces any content (innerHTML) of the element with id=markup with the data from the jso JavaScript Object
-				markup.innerHTML = prepareData(jso);
-			}
+        if (this.readyState == xmlHttpRequestCodeDone && this.status == httpCodeSuccess) {
+            if (hr.responseText != "") {
+                console.log(hr.responseText);
+                var jso = JSON.parse(hr.responseText);
+                if (jso != null) // Can happen using IEv11
+                {
+                    // Replaces any content (innerHTML) of the element with id=markup with the data from the jso JavaScript Object
+                    markup.innerHTML = prepareData(jso);
+                }
+            }
 		}
 	}
 }
@@ -95,4 +98,22 @@ function prepareData(jso)
 		data += "</tr>";
 	}
 	return data;
+}
+
+// Sends the setting for a control.
+function sendValue(value, typeName)
+{
+    // GET to fetch data, POST to send it
+    // "/API/APISAMPLE" /API is a prefix hard-coded into the WebServer class
+    hr.open("POST", "/API/CABCONTROLS", true);    // true to send asynchronously (without waiting)
+    hr.setRequestHeader("Content-Type", "application/json");    // Default is ;charset=UTF-8
+    hr.send
+    ( JSON.stringify
+        (   [   { "TypeName": typeName
+             // , "ControlIndex": intData.value // If provided, used in rendering cab view
+                , "Value": value
+				}
+            ]
+        )
+    );
 }


### PR DESCRIPTION
The Content/Web/CabControls webpage shows the values of the cab controls.
This extension shows how users can set the cab controls as well.
It depends on the extension of /API/CABCONTROLS provided by PR 751.

See blueprint https://blueprints.launchpad.net/or/+spec/web-api-samples and forum post http://www.elvastower.com/forums/index.php?/topic/34945-web-server/page__view__findpost__p__291091 
