### PR TITLE
fix: Allow 100% cloud-free skys by making 0% overcast = 0% clouds

### DIFF
--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -384,7 +384,7 @@ namespace Orts.Viewer3D
             set
             {
                 if (value < 0.2f)
-                    overcast.SetValue(new Vector4(4 * value + 0.2f, 0.0f, 0.0f, 0.0f));
+                    overcast.SetValue(new Vector4(5 * value, 0.0f, 0.0f, 0.0f));
                 else
                     // Coefficients selected by author to achieve the desired appearance
                     overcast.SetValue(new Vector4(MathHelper.Clamp(2 * value - 0.4f, 0, 1), 1.25f - 1.125f * value, 1.15f - 0.75f * value, 1f));


### PR DESCRIPTION
Quick fix for being unable to do 100% cloud-free skys in http://www.elvastower.com/forums/index.php?/topic/34984-build-a-better-skydome-terragen-2/page__view__findpost__p__292401

Further work on the whole environmental effects will replace this in the future