### PR TITLE
Avoid error on inserting train without start time

### DIFF
--- a/Source/Orts.Simulation/Simulation/AIs/AI.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AI.cs
@@ -1408,6 +1408,12 @@ namespace Orts.Simulation.AIs
 
         public void InsertTrain(AITrain thisTrain)
         {
+            if (thisTrain.StartTime == null)
+            {
+                Trace.TraceInformation("Train : " + thisTrain.Name + " : missing start time, train not included");
+                return;
+            }
+            
             if (this.Count == 0)
             {
                 this.AddFirst(thisTrain);


### PR DESCRIPTION
Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)