### PR TITLE
Added support for activity location events to the TrackViewer

### DIFF
--- a/Source/Contrib/TrackViewer/Drawing/DrawColors.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawColors.cs
@@ -46,6 +46,7 @@ namespace ORTS.TrackViewer.Drawing
         public static ColorScheme colorsRoadsHotlight = new ColorScheme(HighlightType.Hotlight);
         public static ColorScheme colorsPathMain = new ColorScheme();
         public static ColorScheme colorsPathSiding = new ColorScheme();
+        public static ColorScheme colorsEvent = new ColorScheme();
 
         static ColorsGroupTrack trackGroupFlat = new ColorsGroupTrack();
         static ColorsGroupTrack roadTrackGroupFlat = new ColorsGroupTrack();
@@ -212,6 +213,11 @@ namespace ORTS.TrackViewer.Drawing
                 TrackViewer.catalog.GetString("Select speedpost color"));
             itemColors.Speedpost = itemColor;
 
+            itemColor = new ColorWithHighlights(Color.DarkGray, 40);
+            itemColor.MakeIntoUserPreference(preferenceChanger, "event",
+                TrackViewer.catalog.GetString("Select event color"));
+            itemColors.Event = itemColor;
+
             itemColor = new ColorWithHighlights(Color.Blue, 40);
             itemColors.CandidateNode = itemColor;
 
@@ -321,6 +327,7 @@ namespace ORTS.TrackViewer.Drawing
         public ColorWithHighlights RoadCrossing { get; set; }
         public ColorWithHighlights Speedpost { get; set; }
         public ColorWithHighlights Siding { get; set; }
+        public ColorWithHighlights Event { get; set; }
 
         public ColorWithHighlights Text { get; set; }
         public ColorWithHighlights ClearWindowInset { get; set; }
@@ -362,6 +369,7 @@ namespace ORTS.TrackViewer.Drawing
         public Color RoadCrossing { get { return TrackItemColors.RoadCrossing.Colors[highlightType]; } }
         public Color Speedpost { get { return TrackItemColors.Speedpost.Colors[highlightType]; } }
         public Color Siding { get { return TrackItemColors.Siding.Colors[highlightType]; } }
+        public Color Event { get { return TrackItemColors.Event.Colors[highlightType]; } }
 
         public Color ActiveNode { get { return TrackItemColors.ActiveNode.Colors[highlightType]; } }
         public Color CandidateNode { get { return TrackItemColors.CandidateNode.Colors[highlightType]; } }

--- a/Source/Contrib/TrackViewer/Drawing/DrawTrackDB.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawTrackDB.cs
@@ -45,6 +45,10 @@ namespace ORTS.TrackViewer.Drawing
         public RoadTrackDB RoadTrackDB { get; set; }
         /// <summary>The signal config file containing, for instance, the information to distinguish normal and non-normal signals</summary>
         public SignalConfigurationFile SigcfgFile { get; set; }
+        /// <summary>
+        /// <summary>Activity names</summary>
+        /// </summary>
+        public List<string> ActivityNames = new List<string> { };
 
         private string storedRoutePath;
         private Dictionary<uint, string> signalFileNames;
@@ -87,7 +91,7 @@ namespace ORTS.TrackViewer.Drawing
             }
             catch
             {
-            } 
+            }
 
             string ORfilepath = System.IO.Path.Combine(routePath, "OpenRails");
             if (File.Exists(ORfilepath + @"\sigcfg.dat"))
@@ -101,6 +105,72 @@ namespace ORTS.TrackViewer.Drawing
             else
             {
                 //sigcfgFile = null; // default initialization
+            }
+
+            // read the activity location events and store them in the TrackDB.TrItemTable
+
+            ActivityNames.Clear();
+            var directory = System.IO.Path.Combine(routePath, "ACTIVITIES");
+            if (System.IO.Directory.Exists(directory))
+            {
+                // counting
+                int cnt = 0;
+
+                foreach (var file in Directory.GetFiles(directory, "*.act"))
+                {
+                    try
+                    {
+                        var activityFile = new ActivityFile(file);
+                        Events events = activityFile.Tr_Activity.Tr_Activity_File.Events;
+                        if (events != null)
+                        {
+                            for (int i = 0; i < events.EventList.Count; i++)
+                            {
+                                if (events.EventList[i].GetType() == typeof(EventCategoryLocation))
+                                {
+                                    cnt++;
+                                }
+                            }
+                        }
+                    }
+                    catch { }
+                }
+
+                // adding
+                uint index = 0;
+                foreach (var file in Directory.GetFiles(directory, "*.act"))
+                {
+                    try
+                    {
+                        var activityFile = new ActivityFile(file);
+                        Events events = activityFile.Tr_Activity.Tr_Activity_File.Events;
+                        bool found = false;
+                        if (events != null)
+                        {
+                            for (int i = 0; i < events.EventList.Count; i++)
+                            {
+                                if (events.EventList[i].GetType() == typeof(EventCategoryLocation))
+                                {
+                                    EventCategoryLocation eventCategoryLocation = (EventCategoryLocation)events.EventList[i];
+                                    EventItem eventItem = new EventItem(
+                                        activityFile.Tr_Activity.Tr_Activity_Header.Name + ":" + eventCategoryLocation.Name,
+                                        eventCategoryLocation.Outcomes.DisplayMessage,
+                                        eventCategoryLocation.TileX, eventCategoryLocation.TileZ,
+                                        eventCategoryLocation.X, 0, eventCategoryLocation.Z,
+                                        index);
+                                    TrackDB.TrItemTable[index] = eventItem;
+                                    index++;
+                                    found = true;
+                                }
+                            }
+                        }
+                        if (found) {
+                            ActivityNames.Add(activityFile.Tr_Activity.Tr_Activity_Header.Name);
+                        }
+                    }
+                    catch { }
+                }
+
             }
         }
 
@@ -173,6 +243,32 @@ namespace ORTS.TrackViewer.Drawing
             {
                 return signalFileName;
             }
+        }
+    }
+
+    /// <summary>
+    /// represents an Activity Location EventItem
+    /// </summary>
+    /// defined in this trackviewer file because I want to keep changes localized to the TrackViewer
+    
+    public class EventItem : TrItem
+    {
+        /// <summary>
+        /// Default constructor, no file parsing used
+        /// </summary>
+        public EventItem(string itemName, string briefing, int tileX, int tileZ, float x, float y, float z, uint trItemId)
+        {
+            // ItemType is trEMPTY on purpose
+            // so that Orts.Formats.Msts.TrItem.trItemType does not need a change
+            ItemType = trItemType.trEMPTY;
+            ItemName = itemName;
+            TileX = tileX;
+            TileZ = tileZ;
+            X = x;
+            Y = y;
+            Z = z;
+            TrItemId = trItemId;
+            SData2 = briefing;
         }
     }
 

--- a/Source/Contrib/TrackViewer/Drawing/DrawableTrackItem.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawableTrackItem.cs
@@ -70,6 +70,7 @@ namespace ORTS.TrackViewer.Drawing
             if (originalTrItem is RoadLevelCrItem){ return new DrawableRoadLevelCrItem(originalTrItem); }
             if (originalTrItem is CarSpawnerItem) { return new DrawableCarSpawnerItem(originalTrItem); }
             if (originalTrItem is CrossoverItem)  { return new DrawableCrossoverItem(originalTrItem); }
+            if (originalTrItem is EventItem)      { return new DrawableEvent(originalTrItem); }
             return new DrawableEmptyItem(originalTrItem);
         }
 
@@ -602,6 +603,53 @@ namespace ORTS.TrackViewer.Drawing
                 return true;
             }
             return false;
+        }
+    }
+    #endregion
+
+    #region DrawableEvent
+    /// <summary>
+    /// Represents a drawable event
+    /// </summary>
+    class DrawableEvent : DrawableTrackItem
+    {
+        private string ItemName;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="originalTrItem">The original track item that we are representing for drawing</param>
+        public DrawableEvent(TrItem originalTrItem)
+            : base(originalTrItem)
+        {
+            Description = "event";
+            ItemName = originalTrItem.ItemName;
+        }
+
+        /// <summary>
+        /// Draw an event
+        /// </summary>
+        /// <param name="drawArea">The area to draw upon</param>
+        /// <param name="colors">The colorscheme to use</param>
+        /// <param name="drawAlways">Do we need to draw anyway, independent of settings?</param>
+        internal override bool Draw(DrawArea drawArea, ColorScheme colors, bool drawAlways)
+        {
+            bool returnValue = false;
+            if (String.IsNullOrEmpty(Properties.Settings.Default.CurrentActivityName) ||
+                (ItemName.StartsWith(Properties.Settings.Default.CurrentActivityName + ":")))
+            {
+                if (Properties.Settings.Default.showEvents || drawAlways)
+                {
+                    drawArea.DrawTexture(WorldLocation, "disc", 6f, 0, colors.Event);
+                    returnValue = true;
+                }
+                if (Properties.Settings.Default.showEventNames || drawAlways)
+                {
+                    drawArea.DrawExpandingString(this.WorldLocation, ItemName);
+                    returnValue = true;
+                }
+            }
+            return returnValue;
         }
     }
     #endregion

--- a/Source/Contrib/TrackViewer/Editing/Charts/DrawPathChart.cs
+++ b/Source/Contrib/TrackViewer/Editing/Charts/DrawPathChart.cs
@@ -161,7 +161,6 @@ namespace ORTS.TrackViewer.Editing.Charts
             }
             pathData.Update(trainpath);
             chartWindow.Draw();
-            chartWindow.SetTitle(pathEditor.CurrentTrainPath.PathName);
         }
         
         /// <summary>

--- a/Source/Contrib/TrackViewer/Editing/Charts/PathChartWindow.xaml.cs
+++ b/Source/Contrib/TrackViewer/Editing/Charts/PathChartWindow.xaml.cs
@@ -91,15 +91,6 @@ namespace ORTS.TrackViewer.Editing.Charts
             }
 
         }
-
-        /// <summary>
-        /// Set the title of the window
-        /// </summary>
-        /// <param name="newTitle"></param>
-        public void SetTitle(string newTitle)
-        {
-            this.Title = newTitle;
-        }
         #endregion
 
         #region Window events

--- a/Source/Contrib/TrackViewer/Properties/Settings.Designer.cs
+++ b/Source/Contrib/TrackViewer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ORTS.TrackViewer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -58,7 +58,22 @@ namespace ORTS.TrackViewer.Properties {
                 this["defaultRoute"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CurrentActivityName
+        {
+            get
+            {
+                return ((string)(this["CurrentActivityName"]));
+            }
+            set
+            {
+                this["CurrentActivityName"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -505,6 +520,30 @@ namespace ORTS.TrackViewer.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool showEvents {
+            get {
+                return ((bool)(this["showEvents"]));
+            }
+            set {
+                this["showEvents"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool showEventNames {
+            get {
+                return ((bool)(this["showEventNames"]));
+            }
+            set {
+                this["showEventNames"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool showLabels {
             get {
                 return ((bool)(this["showLabels"]));
@@ -643,6 +682,18 @@ namespace ORTS.TrackViewer.Properties {
             }
             set {
                 this["statusShowNames"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool statusShowEventNames {
+            get {
+                return ((bool)(this["statusShowEventNames"]));
+            }
+            set {
+                this["statusShowEventNames"] = value;
             }
         }
         

--- a/Source/Contrib/TrackViewer/Properties/Settings.settings
+++ b/Source/Contrib/TrackViewer/Properties/Settings.settings
@@ -122,6 +122,12 @@
     <Setting Name="showSoundRegions" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="showEvents" Type="System.Boolean" Scope="User">
+        <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="showEventNames" Type="System.Boolean" Scope="User">
+        <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="showLabels" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
@@ -156,6 +162,9 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="statusShowNames" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="statusShowEventNames" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="statusShowTerrain" Type="System.Boolean" Scope="User">

--- a/Source/Contrib/TrackViewer/TrackViewer.cs
+++ b/Source/Contrib/TrackViewer/TrackViewer.cs
@@ -220,6 +220,8 @@ namespace ORTS.TrackViewer
 
             drawPathChart = new DrawPathChart();
 
+            Properties.Settings.Default.CurrentActivityName = ""; 
+
             base.Initialize();
         }
 
@@ -519,6 +521,8 @@ namespace ORTS.TrackViewer
             base.Update(gameTime);
 
             HandleCommandLineArgs();
+
+            SetTitle();
         }
 
         /// <summary>
@@ -933,6 +937,7 @@ namespace ORTS.TrackViewer
             menuControl.PopulatePlatforms();
             menuControl.PopulateStations();
             menuControl.PopulateSidings();
+            menuControl.PopulateActivitiesMenu();
         }
 
         /// <summary>
@@ -942,7 +947,15 @@ namespace ORTS.TrackViewer
         {
             Assembly assembly = Assembly.GetExecutingAssembly();
             AssemblyTitleAttribute assemblyTitle = assembly.GetCustomAttributes(typeof(AssemblyTitleAttribute), false)[0] as AssemblyTitleAttribute;
-            Window.Title = assemblyTitle.Title + ": " + RouteData.RouteName;
+            Window.Title = assemblyTitle.Title;
+            if ((RouteData != null) && (RouteData.RouteName != null))
+            {
+                Window.Title += ": " + RouteData.RouteName;
+            }
+            if (!String.IsNullOrEmpty(Properties.Settings.Default.CurrentActivityName))
+            { 
+                Window.Title += "  Activity: " + Properties.Settings.Default.CurrentActivityName;
+            }
         }
 
         #endregion

--- a/Source/Contrib/TrackViewer/UserInterface/MenuControl.xaml
+++ b/Source/Contrib/TrackViewer/UserInterface/MenuControl.xaml
@@ -9,6 +9,7 @@
                 <Separator/>
                 <MenuItem Header="Select install folder" Name="menuInstallFolder" Click="MenuInstallFolder_Click"/>
                 <MenuItem Header="Select route" Name="menuSelectRoute"/>
+                <MenuItem Header="Select activity" Name="menuSelectActivity"/>
                 <Separator/>
                 <MenuItem Header="Search by index">
                     <MenuItem Header="Search trackNode" Name="menuSearchTrackNode" IsCheckable="False" Click="MenuSearchTrackNode_Click"/>
@@ -86,6 +87,8 @@
                     <MenuItem Header="Show hazards" Name="menuShowHazards" IsCheckable="True" Click="UpdateMenuSettings"/>
                     <MenuItem Header="Show fuel/pickups" Name="menuShowPickups" IsCheckable="True" Click="UpdateMenuSettings"/>
                     <MenuItem Header="Show sound regions" Name="menuShowSoundRegions" IsCheckable="True" Click="UpdateMenuSettings"/>
+                    <MenuItem Header="Show events" Name="menuShowEvents" IsCheckable="True" Click="UpdateMenuSettings"/>
+                    <MenuItem Header="Show event names" Name="menuShowEventNames" IsCheckable="True" Click="UpdateMenuSettings"/>
                 </MenuItem>
                 <MenuItem Header="Posts">
                     <MenuItem Header="Show speed limits (F5)" Name="menuShowSpeedLimits" IsCheckable="True" Click="UpdateMenuSettings"/>
@@ -109,6 +112,8 @@
                 <MenuItem Header="Show signal info" Name="menuStatusShowSignal" IsCheckable="True" IsChecked="False"
                           Click="UpdateMenuSettings"/>
                 <MenuItem Header="Show platform/station names" Name="menuStatusShowNames" IsCheckable="True" IsChecked="False"
+                          Click="UpdateMenuSettings"/>
+                <MenuItem Header="Show event names" Name="menuStatusShowEventNames" IsCheckable="True" IsChecked="False"
                           Click="UpdateMenuSettings"/>
             </MenuItem>
             <MenuItem Header="_Preferences" Name="menuPreferences">

--- a/Source/Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs
+++ b/Source/Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs
@@ -116,6 +116,8 @@ namespace ORTS.TrackViewer.UserInterface
             menuShowAllSignals.IsChecked = Properties.Settings.Default.showAllSignals;
             menuShowPickups.IsChecked = Properties.Settings.Default.showPickups;
             menuShowSoundRegions.IsChecked = Properties.Settings.Default.showSoundRegions;
+            menuShowEvents.IsChecked = Properties.Settings.Default.showEvents;
+            menuShowEventNames.IsChecked = Properties.Settings.Default.showEventNames;
 
             menuShowPATfile.IsChecked = Properties.Settings.Default.showPATfile;
             menuShowTrainpath.IsChecked = Properties.Settings.Default.showTrainpath;
@@ -132,6 +134,7 @@ namespace ORTS.TrackViewer.UserInterface
             menuStatusShowTerrain.IsChecked = Properties.Settings.Default.statusShowTerrain;
             menuStatusShowSignal.IsChecked = Properties.Settings.Default.statusShowSignal;
             menuStatusShowNames.IsChecked = Properties.Settings.Default.statusShowNames;
+            menuStatusShowEventNames.IsChecked = Properties.Settings.Default.statusShowEventNames;
 
 
             menuDrawRoads.IsChecked = Properties.Settings.Default.drawRoads;
@@ -215,6 +218,8 @@ namespace ORTS.TrackViewer.UserInterface
             Properties.Settings.Default.showAllSignals = menuShowAllSignals.IsChecked;
             Properties.Settings.Default.showHazards = menuShowHazards.IsChecked;
             Properties.Settings.Default.showSoundRegions = menuShowSoundRegions.IsChecked;
+            Properties.Settings.Default.showEvents = menuShowEvents.IsChecked;
+            Properties.Settings.Default.showEventNames = menuShowEventNames.IsChecked;
             Properties.Settings.Default.showPickups = menuShowPickups.IsChecked;
 
             Properties.Settings.Default.showPATfile = menuShowPATfile.IsChecked;
@@ -229,6 +234,7 @@ namespace ORTS.TrackViewer.UserInterface
             Properties.Settings.Default.statusShowTerrain = menuStatusShowTerrain.IsChecked && (menuShowTerrain.IsChecked || menuShowDMTerrain.IsChecked);
             Properties.Settings.Default.statusShowSignal = menuStatusShowSignal.IsChecked && menuShowSignals.IsChecked;
             Properties.Settings.Default.statusShowNames = menuStatusShowNames.IsChecked;
+            Properties.Settings.Default.statusShowEventNames = menuStatusShowEventNames.IsChecked;
 
             Properties.Settings.Default.drawRoads = menuDrawRoads.IsChecked;
             Properties.Settings.Default.showCarSpawners = menuShowCarSpawners.IsChecked;
@@ -288,6 +294,8 @@ namespace ORTS.TrackViewer.UserInterface
             menuShowHazards.IsChecked = isChecked;
             menuShowSignals.IsChecked = isChecked;
             menuShowAllSignals.IsChecked = isChecked;
+            menuShowEvents.IsChecked = isChecked;
+            menuShowEventNames.IsChecked = isChecked;
             menuShowPickups.IsChecked = isChecked;
             menuShowSoundRegions.IsChecked = isChecked;
 
@@ -336,6 +344,7 @@ namespace ORTS.TrackViewer.UserInterface
             {
                 CloseOtherPathsWindow();
                 PopulateRoutes();
+                PopulateActivitiesEmpty();
             }
         }
 
@@ -374,7 +383,59 @@ namespace ORTS.TrackViewer.UserInterface
                     CloseOtherPathsWindow();
                     trackViewer.SetRoute(route);
                     UpdateMenuSettings();
+                    Properties.Settings.Default.CurrentActivityName = "";
                     return;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Empty the activities menu after folder change and before route choice
+        /// </summary>
+        public void PopulateActivitiesEmpty()
+        {
+            menuSelectActivity.Items.Clear();
+            menuSelectActivity.UpdateLayout();
+            Properties.Settings.Default.CurrentActivityName = "";
+        }
+
+        /// <summary>
+        /// Update the menu to show the available activitiy names wich contain location events
+        /// </summary>
+        public void PopulateActivitiesMenu()
+        {
+            menuSelectActivity.Items.Clear();
+            if (trackViewer.RouteData != null)
+            {
+                if (trackViewer.RouteData.ActivityNames != null)
+                {
+                    foreach (string activityName in trackViewer.RouteData.ActivityNames)
+                    {
+                        MenuItem menuItem = new MenuItem
+                        {
+                            Header = activityName,
+                            IsCheckable = false,
+                            IsChecked = false
+                        };
+                        menuItem.Click += new RoutedEventHandler(MenuSelectActivity_Click);
+                        menuSelectActivity.Items.Add(menuItem);
+                    }
+                }
+            }
+            menuSelectActivity.UpdateLayout();
+        }
+
+        /// <summary>
+        /// The user has selected an activity, figure out which one and store it.
+        /// </summary>
+        private void MenuSelectActivity_Click(object sender, RoutedEventArgs e)
+        {
+            MenuItem selectedActvityItem = sender as MenuItem;
+            foreach (string activityName in trackViewer.RouteData.ActivityNames)
+            {
+                if (activityName == (string)selectedActvityItem.Header)
+                {
+                    Properties.Settings.Default.CurrentActivityName = activityName;
                 }
             }
         }
@@ -387,6 +448,7 @@ namespace ORTS.TrackViewer.UserInterface
             CloseOtherPathsWindow();
             trackViewer.ReloadRoute();
             UpdateMenuSettings();
+            Properties.Settings.Default.CurrentActivityName = "";
         }
 
         /// <summary>
@@ -599,6 +661,8 @@ namespace ORTS.TrackViewer.UserInterface
             shortcuts.Append(TrackViewer.catalog.GetString("ctrl-Y\t\tRedo in path editor\n"));
             shortcuts.Append("\n");
             shortcuts.Append(TrackViewer.catalog.GetString("alt-?\t\tVarious keys to open submenus\n"));
+            shortcuts.Append("\n");
+            shortcuts.Append(TrackViewer.catalog.GetString("mouse-right click\tOn event shows event message\n"));
             MessageBox.Show(shortcuts.ToString(), TrackViewer.catalog.GetString("Keyboard shortcuts"));
         }
 

--- a/Source/Contrib/TrackViewer/UserInterface/StatusBarControl.xaml.cs
+++ b/Source/Contrib/TrackViewer/UserInterface/StatusBarControl.xaml.cs
@@ -33,6 +33,7 @@ using Orts.Formats.Msts;
 using ORTS.Common;
 using ORTS.TrackViewer.Properties;
 using ORTS.TrackViewer.Editing;
+using ORTS.TrackViewer.Drawing;
 
 
 namespace ORTS.TrackViewer.UserInterface
@@ -165,6 +166,8 @@ namespace ORTS.TrackViewer.UserInterface
                     "{0,3:F3} ", closestPoint.Z);
                 AddSignalStatus(trackViewer, closestPoint.Description, closestPoint.Index);
                 AddNamesStatus(trackViewer, closestPoint.Description, closestPoint.Index);
+                AddEventNamesStatus(trackViewer, closestPoint.Description, closestPoint.Index);
+                CheckEventRightMouseClick(trackViewer, closestPoint.Description, closestPoint.Index);
             }
         }
 
@@ -348,6 +351,51 @@ namespace ORTS.TrackViewer.UserInterface
             if (platform == null) return;
             statusAdditional.Text += string.Format(System.Globalization.CultureInfo.CurrentCulture,
                 "{0} ({1})", platform.Station, platform.ItemName);
+        }
+
+        /// <summary>
+        /// Add event information to status line
+        /// </summary>
+        /// <param name="trackViewer">The trackviewer we need to find the trackDB</param>
+        /// <param name="description">The description of the item we might want to show, needed to make sure it is a proper item</param>
+        /// <param name="index">The index of the item to show</param>
+        /// 
+        private void AddEventNamesStatus(TrackViewer trackViewer, string description, uint index)
+        {
+            if (!String.Equals(description, "event")) return;
+
+            TrItem item = trackViewer.RouteData.TrackDB.TrItemTable[index];
+            EventItem eventItem = item as EventItem;
+            if (eventItem == null) return;
+
+            if (!Properties.Settings.Default.statusShowEventNames) return;
+
+            statusAdditional.Text += string.Format(System.Globalization.CultureInfo.CurrentCulture,
+                "{0}", eventItem.ItemName);
+        }
+
+        /// <summary>
+        /// When right mouse click on event a messagebox with event name and description pops up
+        /// </summary>
+        /// <param name="trackViewer">The trackviewer we need to find the trackDB</param>
+        /// <param name="description">The description of the item we might want to show, needed to make sure it is a proper item</param>
+        /// <param name="index">The index of the item to show</param>
+        /// 
+        private void CheckEventRightMouseClick(TrackViewer trackViewer, string description, uint index)
+        {
+            if (!String.Equals(description, "event")) return;
+
+            TrItem item = trackViewer.RouteData.TrackDB.TrItemTable[index];
+            EventItem eventItem = item as EventItem;
+            if (eventItem == null) return;
+
+            if (!(trackViewer.PathEditor != null && trackViewer.PathEditor.EditingIsActive))
+            {
+                if (TVUserInput.IsMouseRightButtonPressed())
+                {
+                    MessageBox.Show(eventItem.SData2, eventItem.ItemName);
+                }
+            }
         }
 
         #region IDisposable


### PR DESCRIPTION
For the Contributed Track Viewer I've added support for Activity Location Events: the events that fire on a certain track location. Nothing fancy, just view, no editing. I wanted a better overview of these events on the tracks of a route.

Both events and event names selectable via menu "Track items". Event names in status bar selectable in menu "Statusbar".  Right mouse click on highlighted event gives pop message with the contents. Initially all the activities are shown after loading the route. If that's too much one of the activities can be selected via menu "File".
