### PR TITLE
bug 2008614 bad http link in manual

### DIFF
--- a/Source/Documentation/Manual/intro.rst
+++ b/Source/Documentation/Manual/intro.rst
@@ -86,7 +86,7 @@ called an *MSTS installation* for convenience, even if this wording is not
 completely correct. 
 
 A proof that Open Rails itself does not need an MSTS installation at all to 
-run is `this route <http://www.burrinjuck.coalstonewcastle.com.au/route/route-install/>`.
+run is `this route <http://www.burrinjuck.coalstonewcastle.com.au/route/route-install/>`_ (Burrinjuck Railway).
 
 Community
 =========


### PR DESCRIPTION
In: "3.3. Does Open Rails Require You to Have MSTS Installed?" link to www.burrinjuck.coalstonewcastle.com.au not clickable