### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/2013969 Crash after uncoupling player loco of a train with EOT

### DIFF
--- a/Source/Orts.Simulation/MultiPlayer/Message.cs
+++ b/Source/Orts.Simulation/MultiPlayer/Message.cs
@@ -1634,11 +1634,11 @@ namespace Orts.MultiPlayer
 
                 train.MUDirection = (Direction)mDirection;
                 train.RearTDBTraveller = traveller;
+                train.ReinitializeEOT();
                 train.CalculatePositionOfCars();
                 train.travelled = Travelled;
                 train.CheckFreight();
                 train.SetDPUnitIDs();
-                train.ReinitializeEOT();
             }
             // New train
             else

--- a/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
@@ -4419,6 +4419,8 @@ namespace Orts.Simulation.AIs
                 Cars.Clear();
                 attachTrain.Length += Length;
 
+                attachTrain.ReinitializeEOT();
+
                 // recalculate position of formed train
                 if (attachTrainFront)  // coupled to front, so rear position is still valid
                 {
@@ -4447,7 +4449,6 @@ namespace Orts.Simulation.AIs
                 // set various items
                 attachTrain.CheckFreight();
                 attachTrain.SetDPUnitIDs();
-                attachTrain.ReinitializeEOT();
                 attachTrain.activityClearingDistanceM = attachTrain.Cars.Count < standardTrainMinCarNo ? shortClearingDistanceM : standardClearingDistanceM;
                 attachCar.SignalEvent(Event.Couple);
 
@@ -4533,6 +4534,8 @@ namespace Orts.Simulation.AIs
             Length += attachTrain.Length;
             attachTrain.Cars.Clear();
 
+            ReinitializeEOT();
+
             // recalculate position of formed train
             if (thisTrainFront)  // coupled to front, so rear position is still valid
             {
@@ -4581,7 +4584,6 @@ namespace Orts.Simulation.AIs
             UpdateOccupancies();
             AddTrackSections();
             ResetActions(true);
-            ReinitializeEOT();
             physicsUpdate(0);
 
         }
@@ -4749,6 +4751,8 @@ namespace Orts.Simulation.AIs
             UncoupledFrom = attachTrain;
             attachTrain.UncoupledFrom = this;
 
+            ReinitializeEOT();
+            attachTrain.ReinitializeEOT();
 
             // recalculate position of coupling train
             if (thisTrainFront)  // coupled to front, so rear position is still valid
@@ -4809,11 +4813,9 @@ namespace Orts.Simulation.AIs
             // set various items
             CheckFreight();
             SetDPUnitIDs();
-            ReinitializeEOT();
             activityClearingDistanceM = Cars.Count < standardTrainMinCarNo ? shortClearingDistanceM : standardClearingDistanceM;
             attachTrain.CheckFreight();
             attachTrain.SetDPUnitIDs();
-            attachTrain.ReinitializeEOT();
             attachTrain.activityClearingDistanceM = attachTrain.Cars.Count < standardTrainMinCarNo ? shortClearingDistanceM : standardClearingDistanceM;
             // anticipate reversal point and remove active action
             TCRoute.ReversalInfo[TCRoute.activeSubpath].ReverseReversalOffset = Math.Max(PresentPosition[0].TCOffset - 10f, 0.3f);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -2983,7 +2983,7 @@ namespace Orts.Simulation.RollingStocks
 
             // Don't add vibrations to train cars less than 2.5 meter in length; they're unsuitable for these calculations.
             // Don't let vibrate car before EOT to avoid EOT not moving together with that car
-            if (CarLengthM < 2.5f || Train.EOT != null && Train.Cars[Train.Cars.Count - 2] == this) return;
+            if (CarLengthM < 2.5f || Train.EOT != null && Train.Cars.Count > 1 && Train.Cars[Train.Cars.Count - 2] == this) return;
             if (Simulator.Settings.CarVibratingLevel != 0)
             {
 

--- a/Source/Orts.Simulation/Simulation/Simulator.cs
+++ b/Source/Orts.Simulation/Simulation/Simulator.cs
@@ -1749,6 +1749,10 @@ namespace Orts.Simulation
 
             }
 
+            // update EOT state
+            train.ReinitializeEOT();
+            train2.ReinitializeEOT();
+
             // and fix up the travellers
             if (train.IsActualPlayerTrain && j >= i || !keepFront)
             {
@@ -1846,10 +1850,8 @@ namespace Orts.Simulation
 
             train.CheckFreight();
             train.SetDPUnitIDs();
-            train.ReinitializeEOT();
             train2.CheckFreight();
             train2.SetDPUnitIDs();
-            train2.ReinitializeEOT();
 
             train.Update(0);   // stop the wheels from moving etc
             train2.Update(0);  // stop the wheels from moving etc

--- a/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
@@ -11705,6 +11705,8 @@ namespace Orts.Simulation.Timetables
             attachTrain.Length += Length;
             float distanceTravelledCorrection = 0;
 
+            attachTrain.ReinitializeEOT();
+
             // recalculate position of formed train
             if (attachTrainFront)  // coupled to front, so rear position is still valid
             {
@@ -11769,7 +11771,6 @@ namespace Orts.Simulation.Timetables
             // set various items
             attachTrain.CheckFreight();
             attachTrain.SetDPUnitIDs();
-            attachTrain.ReinitializeEOT();
             attachCar.SignalEvent(Event.Couple);
             attachTrain.ProcessSpeedSettings();
 
@@ -12105,6 +12106,9 @@ namespace Orts.Simulation.Timetables
 
             }
 
+            ReinitializeEOT();
+            newTrain.ReinitializeEOT();
+
             // and fix up the travellers
             if (DetachPosition)
             {
@@ -12153,10 +12157,8 @@ namespace Orts.Simulation.Timetables
             // check freight for both trains
             CheckFreight();
             SetDPUnitIDs();
-            ReinitializeEOT();
             newTrain.CheckFreight();
             newTrain.SetDPUnitIDs();
-            newTrain.ReinitializeEOT();
 
             // check speed values for both trains
             ProcessSpeedSettings();


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/37001-unable-to-remove-eot-after-passing-reverse-point/page__view__findpost__p__295646