### PR TITLE
chore: Add GitHub automatic release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - appveyor
+      - dependabot
+      - github-actions
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Documentation and Localization
+      labels:
+        - documentation
+        - locales
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Unfortunately, I don't believe we can test this, but the idea is to make GitHub's automatic release notes generator better: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

For the purpose of evaluating this after merge, and generally how we write PR titles, before the next release I have added the generated output from GitHub to the top of https://james-ross.co.uk/projects/or/triage - this updates daily