### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/2014992 EOT can't be dismounted after train reversal

### DIFF
--- a/Source/Orts.Simulation/Common/Commands.cs
+++ b/Source/Orts.Simulation/Common/Commands.cs
@@ -2265,9 +2265,9 @@ namespace Orts.Common
         {
             if (Receiver?.Train != null)
             {
+                var wagonFilePath = PickedEOTType.ToLower();
                 if (ToState)
                 {
-                    var wagonFilePath = PickedEOTType.ToLower();
                     try
                     {
                         EOT eot = (EOT)RollingStock.Load(Receiver.Train.Simulator, Receiver.Train, wagonFilePath);
@@ -2284,8 +2284,14 @@ namespace Orts.Common
                 }
                 else
                 {
-                    Receiver.Train.RecalculateRearTDBTraveller();
                     var car = Receiver.Train.Cars[Receiver.Train.Cars.Count - 1];
+                    if (wagonFilePath != car.WagFilePath.ToLower())
+                    {
+                        car = Receiver.Train.Cars[0];
+                        if (Receiver.Train.LeadLocomotive != null) Receiver.Train.LeadLocomotiveIndex--;
+                    }
+                    else
+                        Receiver.Train.RecalculateRearTDBTraveller();
                     car.Train = null;
                     car.IsPartOfActiveTrain = false;  // to stop sounds
                     Receiver.Train.Cars.Remove(car);

--- a/Source/RunActivity/Viewer3D/Popups/EOTListWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/EOTListWindow.cs
@@ -103,7 +103,8 @@ namespace Orts.Viewer3D.Popups
                     Viewer.Simulator.Confirmer.Information(Viewer.Catalog.GetString("Can't attach EOT if player train not stopped"));
                     return;
                 }
-                if (PickedEOTTypeFromList.ToLower() != Viewer.PlayerLocomotive.Train.Cars[Viewer.PlayerLocomotive.Train.Cars.Count - 1].WagFilePath.ToLower())
+                if (PickedEOTTypeFromList.ToLower() != Viewer.PlayerLocomotive.Train.Cars[Viewer.PlayerLocomotive.Train.Cars.Count - 1].WagFilePath.ToLower() &&
+                    PickedEOTTypeFromList.ToLower() != Viewer.PlayerLocomotive.Train.Cars[0].WagFilePath.ToLower())
                 {
                     if (Viewer.PlayerLocomotive.Train?.EOT != null)
                     {
@@ -113,7 +114,8 @@ namespace Orts.Viewer3D.Popups
                     //Ask to mount EOT
                     new EOTMountCommand(Viewer.Log, true, PickedEOTTypeFromList);
                 }
-                else if (PickedEOTTypeFromList.ToLower() == Viewer.PlayerLocomotive.Train.Cars[Viewer.PlayerLocomotive.Train.Cars.Count - 1].WagFilePath.ToLower())
+                else if (PickedEOTTypeFromList.ToLower() == Viewer.PlayerLocomotive.Train.Cars[Viewer.PlayerLocomotive.Train.Cars.Count - 1].WagFilePath.ToLower() ||
+                    PickedEOTTypeFromList.ToLower() == Viewer.PlayerLocomotive.Train.Cars[0].WagFilePath.ToLower())
                 {
                     new EOTMountCommand(Viewer.Log, false, PickedEOTTypeFromList);
                 }


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/37001-unable-to-remove-eot-after-passing-reverse-point/page__view__findpost__p__295646