### PR TITLE
Allow independent drive axles for locomotives

### DIFF
--- a/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
@@ -6346,7 +6346,7 @@ namespace Orts.Simulation.AIs
                 if (car is MSTSLocomotive)
                 {
                     var loco = car as MSTSLocomotive;
-                    loco.LocomotiveAxle.Reset(Simulator.GameTime, SpeedMpS);
+                    loco.LocomotiveAxles.InitializeMoving();
                     loco.AntiSlip = false; // <CSComment> TODO Temporary patch until AntiSlip is re-implemented
                 }
                 if (car == Simulator.PlayerLocomotive) { leadLocomotiveIndex = j; }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -2805,16 +2805,8 @@ public List<CabView> CabViewList = new List<CabView>();
             // This enables steam locomotives to have different speeds for driven and non-driven wheels.
             if (EngineType == EngineTypes.Steam && SteamEngineType != MSTSSteamLocomotive.SteamEngineTypes.Geared)
             {
-                if (AbsSpeedMpS <= 0.15 && !WheelSlip)
-                {
-                    WheelSpeedSlipMpS = SpeedMpS;
-                    WheelSpeedMpS = SpeedMpS;
-                }
-                else
-                {
-                    WheelSpeedSlipMpS = LocomotiveAxles[0].AxleSpeedMpS;
-                    WheelSpeedMpS = SpeedMpS;
-                }
+                WheelSpeedSlipMpS = LocomotiveAxles[0].AxleSpeedMpS;
+                WheelSpeedMpS = SpeedMpS;
             }
             else WheelSpeedMpS = LocomotiveAxles[0].AxleSpeedMpS; 
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1740,8 +1740,8 @@ public List<CabView> CabViewList = new List<CabView>();
 
         public override void InitializeMoving()
         {
-            AdhesionFilter.Reset(0.5f);
             base.InitializeMoving();
+            AdhesionFilter.Reset(0.5f);
             AverageForceN = MaxForceN * Train.MUThrottlePercent / 100;
             float maxPowerW = MaxPowerW * Train.MUThrottlePercent * Train.MUThrottlePercent / 10000;
             if (AverageForceN * SpeedMpS > maxPowerW) AverageForceN = maxPowerW / SpeedMpS;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -448,11 +448,12 @@ public List<CabView> CabViewList = new List<CabView>();
             AC,
         }
         public TractionMotorTypes TractionMotorType = TractionMotorTypes.DC;
+        public List<ElectricMotor> TractionMotors = new List<ElectricMotor>();
 
         public ILocomotivePowerSupply LocomotivePowerSupply => PowerSupply as ILocomotivePowerSupply;
         public ScriptedTrainControlSystem TrainControlSystem;
 
-        public Axle LocomotiveAxle;
+        public Axles LocomotiveAxles;
         public IIRFilter CurrentFilter;
         public IIRFilter AdhesionFilter;
         public float SaveAdhesionFilter;
@@ -479,8 +480,8 @@ public List<CabView> CabViewList = new List<CabView>();
             MilepostUnitsMetric = Simulator.TRK.Tr_RouteFile.MilepostUnitsMetric;
             BrakeCutsPowerAtBrakeCylinderPressurePSI = 4.0f;
 
-            LocomotiveAxle = new Axle();
-            LocomotiveAxle.DriveType = AxleDriveType.ForceDriven;
+            LocomotiveAxles = new Axles(this);
+            LocomotiveAxles.Add(new Axle());
             CurrentFilter = new IIRFilter(IIRFilter.FilterTypes.Butterworth, 1, IIRFilter.HzToRad(0.5f), 0.001f);
             AdhesionFilter = new IIRFilter(IIRFilter.FilterTypes.Butterworth, 1, IIRFilter.HzToRad(1f), 0.001f);
 
@@ -1238,10 +1239,10 @@ public List<CabView> CabViewList = new List<CabView>();
         /// </summary>
         public void MoveParamsToAxle()
         {
-            if (LocomotiveAxle != null)
+            foreach (var axle in LocomotiveAxles)
             {
-                LocomotiveAxle.SlipWarningTresholdPercent = SlipWarningThresholdPercent;
-                LocomotiveAxle.AdhesionK = AdhesionK;
+                axle.SlipWarningTresholdPercent = SlipWarningThresholdPercent;
+                axle.AdhesionK = AdhesionK;
             }
         }
 
@@ -1266,7 +1267,6 @@ public List<CabView> CabViewList = new List<CabView>();
             outf.Write(VacuumExhausterIsOn);
             outf.Write(TrainBrakePipeLeakPSIorInHgpS);
             outf.Write(AverageForceN);
-            outf.Write(LocomotiveAxle.AxleSpeedMpS);
             outf.Write(CabLightOn);
             outf.Write(UsingRearCab);
             outf.Write(CalculatedCarHeaterSteamUsageLBpS);
@@ -1294,7 +1294,7 @@ public List<CabView> CabViewList = new List<CabView>();
             LocomotivePowerSupply?.Save(outf);
             TrainControlSystem.Save(outf);
 
-            LocomotiveAxle.Save(outf);
+            LocomotiveAxles.Save(outf);
             CruiseControl?.Save(outf);
         }
 
@@ -1318,7 +1318,6 @@ public List<CabView> CabViewList = new List<CabView>();
             VacuumExhausterIsOn = inf.ReadBoolean();
             TrainBrakePipeLeakPSIorInHgpS = inf.ReadSingle();
             AverageForceN = inf.ReadSingle();
-            float axleSpeedMpS = inf.ReadSingle();
             CabLightOn = inf.ReadBoolean();
             UsingRearCab = inf.ReadBoolean();
             CalculatedCarHeaterSteamUsageLBpS = inf.ReadSingle();
@@ -1349,10 +1348,9 @@ public List<CabView> CabViewList = new List<CabView>();
 
             LocomotivePowerSupply?.Restore(inf);
             TrainControlSystem.Restore(inf);
-
-            LocomotiveAxle = new Axle(inf);
+                        
             MoveParamsToAxle();
-            LocomotiveAxle.Reset(Simulator.GameTime, axleSpeedMpS);
+            LocomotiveAxles.Restore(inf);
             CruiseControl?.Restore(inf);
         }
 
@@ -1434,6 +1432,7 @@ public List<CabView> CabViewList = new List<CabView>();
             BrakemanBrakeController.Initialize();
             LocomotivePowerSupply?.Initialize();
             TrainControlSystem.Initialize();
+            LocomotiveAxles.Initialize();
             CruiseControl?.Initialize();
             foreach (MultiPositionController mpc in MultiPositionControllers)
             {
@@ -1494,7 +1493,11 @@ public List<CabView> CabViewList = new List<CabView>();
             }
             if (TractionMotorType == TractionMotorTypes.AC)
             {
-                InductionMotor motor = new InductionMotor(LocomotiveAxle, this);
+                foreach (var axle in LocomotiveAxles)
+                {
+                    InductionMotor motor = new InductionMotor(axle, this);
+                    TractionMotors.Add(motor);
+                }
             }
 
 
@@ -1746,8 +1749,8 @@ public List<CabView> CabViewList = new List<CabView>();
         public override void InitializeMoving()
         {
             base.InitializeMoving();
-            LocomotiveAxle.Reset(Simulator.GameTime, SpeedMpS);
             AdhesionFilter.Reset(0.5f);
+            LocomotiveAxles.InitializeMoving();
             AverageForceN = MaxForceN * Train.MUThrottlePercent / 100;
             float maxPowerW = MaxPowerW * Train.MUThrottlePercent * Train.MUThrottlePercent / 10000;
             if (AverageForceN * SpeedMpS > maxPowerW) AverageForceN = maxPowerW / SpeedMpS;
@@ -1991,29 +1994,6 @@ public List<CabView> CabViewList = new List<CabView>();
             {
                 mpc.Update(elapsedClockSeconds);
             }
-
-            ApplyDirectionToTractiveForce();
-
-            // Calculate the total motive force for the locomotive - ie TractiveForce (driving force) + Dynamic Braking force.
-            // Note typically only one of the above will only ever be non-zero at the one time.
-            // For flipped locomotives the force is "flipped" elsewhere, whereas dynamic brake force is "flipped" below by the direction of the speed.
-            MotiveForceN = TractiveForceN;
-
-            if (DynamicBrakePercent > 0 && DynamicBrakeForceCurves != null && AbsSpeedMpS > 0)
-            {
-                float f = DynamicBrakeForceCurves.Get(.01f * DynamicBrakePercent, AbsTractionSpeedMpS);
-                if (f > 0 && LocomotivePowerSupply.DynamicBrakeAvailable)
-                {
-                    DynamicBrakeForceN = f * (1 - PowerReduction);
-                    MotiveForceN -= (SpeedMpS > 0 ? 1 : SpeedMpS < 0 ? -1 : Direction == Direction.Reverse ? -1 : 1) * DynamicBrakeForceN;                 
-                }
-                else
-                {
-                    DynamicBrakeForceN = 0f;
-                }
-            }
-            else
-                DynamicBrakeForceN = 0; // Set dynamic brake force to zero if in Notch 0 position
                 
 
             UpdateFrictionCoefficient(elapsedClockSeconds); // Find the current coefficient of friction depending upon the weather
@@ -2438,6 +2418,57 @@ public List<CabView> CabViewList = new List<CabView>();
                     w = 0;
                 AverageForceN = w * AverageForceN + (1 - w) * TractiveForceN;
             }
+
+            ApplyDirectionToTractiveForce();
+
+            // Calculate the total tractive force for the locomotive - ie Traction + Dynamic Braking force.
+            // Note typically only one of the above will only ever be non-zero at the one time.
+            // For flipped locomotives the force is "flipped" elsewhere, whereas dynamic brake force is "flipped" below by the direction of the speed.
+
+            if (DynamicBrakePercent > 0 && DynamicBrakeForceCurves != null && AbsSpeedMpS > 0)
+            {
+                float f = DynamicBrakeForceCurves.Get(.01f * DynamicBrakePercent, AbsTractionSpeedMpS);
+                if (f > 0 && LocomotivePowerSupply.DynamicBrakeAvailable)
+                {
+                    DynamicBrakeForceN = f * (1 - PowerReduction);
+                    TractiveForceN -= (SpeedMpS > 0 ? 1 : SpeedMpS < 0 ? -1 : Direction == Direction.Reverse ? -1 : 1) * DynamicBrakeForceN;                 
+                }
+                else
+                {
+                    DynamicBrakeForceN = 0f;
+                }
+            }
+            else
+                DynamicBrakeForceN = 0; // Set dynamic brake force to zero if in Notch 0 position
+
+            foreach (var motor in TractionMotors)
+            {
+                motor.UpdateTractiveForce(elapsedClockSeconds, t);
+            }
+
+            if (Simulator.UseAdvancedAdhesion && !Simulator.Settings.SimpleControlPhysics)
+            {
+                UpdateAxleDriveForce();
+            }
+        }
+
+        protected virtual void UpdateAxleDriveForce()
+        {
+            foreach (var axle in LocomotiveAxles)
+            {
+                if (axle.DriveType == AxleDriveType.ForceDriven)
+                {
+                    axle.DriveForceN = TractiveForceN / LocomotiveAxles.Count;
+                    if (SlipControlSystem == SlipControlType.Full)
+                    {
+                        // Simple slip control
+                        // Motive force is reduced to the maximum adhesive force
+                        // In wheelslip situations, motive force is set to zero
+                        axle.DriveForceN = Math.Sign(axle.DriveForceN) * Math.Min(axle.AdhesionLimit * axle.AxleWeightN, Math.Abs(axle.DriveForceN));
+                        if (axle.IsWheelSlip) axle.DriveForceN = 0;
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -2485,7 +2516,7 @@ public List<CabView> CabViewList = new List<CabView>();
 
         public void ConfirmWheelslip(float elapsedClockSeconds)
         {
-            if (elapsedClockSeconds > 0 && Simulator.GameTime - LocomotiveAxle.ResetTime > 5)
+            if (elapsedClockSeconds > 0 && Simulator.GameTime - LocomotiveAxles.ResetTime > 5)
             {
                 if (AdvancedAdhesionModel)
                 {
@@ -2784,47 +2815,28 @@ public List<CabView> CabViewList = new List<CabView>();
                     else
                         AxleInertiaKgm2 = 2000.0f;
                 }
-                //Limit the inertia to 40000 kgm2
-                LocomotiveAxle.InertiaKgm2 = Math.Min(AxleInertiaKgm2, 40000);
-                LocomotiveAxle.DampingNs = MassKG / 1000.0f;
-                LocomotiveAxle.FrictionN = MassKG / 1000.0f;
-
-                if (LocomotiveAxle.Motor is InductionMotor motor)
+                foreach (var axle in LocomotiveAxles)
                 {
-                    motor.SlipControl = SlipControlSystem == SlipControlType.Full;
-                    motor.TargetForceN = MotiveForceN;
-                    motor.EngineMaxSpeedMpS = MaxSpeedMpS;
+                    //Limit the inertia to 40000 kgm2
+                    axle.InertiaKgm2 = Math.Min(AxleInertiaKgm2, 40000);
+                    axle.DampingNs = MassKG / 1000.0f;
+                    axle.FrictionN = MassKG / 1000.0f;
+                    axle.AxleWeightN = 9.81f * DrvWheelWeightKg/LocomotiveAxles.Count;;  //remains fixed for diesel/electric locomotives, but varies for steam locomotives
                 }
-                else
-                {
-                    if (SlipControlSystem == SlipControlType.Full)
-                    {
-                        // Simple slip control
-                        // Motive force is reduced to the maximum adhesive force
-                        // In wheelslip situations, motive force is set to zero
-                        MotiveForceN = Math.Sign(MotiveForceN) * Math.Min(LocomotiveAxle.AdhesionLimit * LocomotiveAxle.AxleWeightN, Math.Abs(MotiveForceN));
-                        if (LocomotiveAxle.IsWheelSlip) MotiveForceN = 0;
-                    }
-                }
-
-                LocomotiveAxle.AxleWeightN = 9.81f * DrvWheelWeightKg;  //remains fixed for diesel/electric locomotives, but varies for steam locomotives
             }
+            foreach (var axle in LocomotiveAxles)
+            {
+                axle.BrakeRetardForceN = BrakeRetardForceN/LocomotiveAxles.Count;
+                axle.TrainSpeedMpS = SpeedMpS;                //Set the train speed of the axle mod
+                axle.WheelRadiusM = DriverWheelRadiusM;
+            }
+            LocomotiveAxles.Update(elapsedClockSeconds);
+            MotiveForceN = LocomotiveAxles.CompensatedForceN;
 
-            //Set axle model parameters
-
-            // Inputs
-            LocomotiveAxle.BrakeRetardForceN = BrakeRetardForceN;
-            LocomotiveAxle.DriveForceN = MotiveForceN;              //Total force applied to wheels
-            LocomotiveAxle.TrainSpeedMpS = SpeedMpS;                //Set the train speed of the axle mod
-            LocomotiveAxle.WheelRadiusM = DriverWheelRadiusM;
-
-            LocomotiveAxle.Update(elapsedClockSeconds); //Main updater of the axle model
-
-            MotiveForceN = LocomotiveAxle.CompensatedAxleForceN;
             if (elapsedClockSeconds > 0)
             {
-                WheelSlip = LocomotiveAxle.IsWheelSlip;             //Get the wheelslip indicator
-                WheelSlipWarning = LocomotiveAxle.IsWheelSlipWarning && SlipControlSystem != SlipControlType.Full;
+                WheelSlip = LocomotiveAxles.IsWheelSlip;
+                WheelSlipWarning = LocomotiveAxles.IsWheelSlipWarning;
             }
             
             // This enables steam locomotives to have different speeds for driven and non-driven wheels.
@@ -2837,17 +2849,17 @@ public List<CabView> CabViewList = new List<CabView>();
                 }
                 else
                 {
-                    WheelSpeedSlipMpS = LocomotiveAxle.AxleSpeedMpS;
+                    WheelSpeedSlipMpS = LocomotiveAxles[0].AxleSpeedMpS;
                     WheelSpeedMpS = SpeedMpS;
                 }
             }
-            else WheelSpeedMpS = LocomotiveAxle.AxleSpeedMpS; 
+            else WheelSpeedMpS = LocomotiveAxles[0].AxleSpeedMpS; 
 
         }
 
         public void SimpleAdhesion()
         {
-
+            MotiveForceN = TractiveForceN;
             // Check if the following few lines are required???
             if (LocoNumDrvAxles <= 0)
             {
@@ -3293,7 +3305,10 @@ public List<CabView> CabViewList = new List<CabView>();
             {
                 SaveAdhesionFilter = AdhesionFilter.Filter(BaseFrictionCoefficientFactor + AdhesionRandom, elapsedClockSeconds);
                 AdhesionConditions = MathHelper.Clamp(AdhesionMultiplier * SaveAdhesionFilter, 0.05f, 2.5f);
-                LocomotiveAxle.AdhesionLimit = AdhesionConditions * BaseuMax;
+                foreach (var axle in LocomotiveAxles)
+                {
+                    axle.AdhesionLimit = AdhesionConditions * BaseuMax;
+                }
             }
 
            // Set adhesion conditions for other steam locomotives
@@ -3303,7 +3318,7 @@ public List<CabView> CabViewList = new List<CabView>();
             }
             else
             {
-                LocomotiveCoefficientFrictionHUD = LocomotiveAxle.AdhesionLimit; // Set display value for HUD - diesel
+                LocomotiveCoefficientFrictionHUD = LocomotiveAxles[0].AdhesionLimit; // Set display value for HUD - diesel
             }
         }
 
@@ -5008,7 +5023,12 @@ public List<CabView> CabViewList = new List<CabView>();
                 case Event.VacuumExhausterOn: { if(FastVacuumExhausterFitted) VacuumExhausterPressed = true; if (this.IsLeadLocomotive() && this == Simulator.PlayerLocomotive && Simulator.Confirmer != null) Simulator.Confirmer.Confirm(CabControl.VacuumExhauster, CabSetting.On); break; }
                 case Event.VacuumExhausterOff: { if (FastVacuumExhausterFitted) VacuumExhausterPressed = false; if (this.IsLeadLocomotive() && this == Simulator.PlayerLocomotive && Simulator.Confirmer != null) Simulator.Confirmer.Confirm(CabControl.VacuumExhauster, CabSetting.Off); break; }
 
-                case Event._ResetWheelSlip: { LocomotiveAxle.Reset(Simulator.GameTime, SpeedMpS); ThrottleController.SetValue(0.0f); break; }
+                case Event._ResetWheelSlip:
+                    {
+                        LocomotiveAxles.InitializeMoving();
+                        ThrottleController.SetValue(0.0f);
+                        break;
+                    }
                 case Event.TrainBrakePressureDecrease:
                 case Event.TrainBrakePressureIncrease:
                     {
@@ -5112,7 +5132,7 @@ public List<CabView> CabViewList = new List<CabView>();
                             direction = ((CVCGauge)cvc).Direction;
                         if (MaxCurrentA == 0)
                             MaxCurrentA = (float)cvc.MaxValue;
-                        if (LocomotiveAxle != null)
+                        if (LocomotiveAxles.Count > 0)
                         {
                             data = 0.0f;
                             if (ThrottlePercent > 0)
@@ -5122,7 +5142,7 @@ public List<CabView> CabViewList = new List<CabView>();
                                 if (FilteredMotiveForceN != 0)
                                     data = this.FilteredMotiveForceN / MaxForceN * rangeFactor;
                                 else
-                                    data = this.LocomotiveAxle.DriveForceN / MaxForceN * rangeFactor;
+                                    data = this.LocomotiveAxles[cvc.ControlId].DriveForceN / MaxForceN * rangeFactor;
                                 data = Math.Abs(data);
                             }
                             if (DynamicBrakePercent > 0 && MaxDynamicBrakeForceN > 0)
@@ -5168,7 +5188,7 @@ public List<CabView> CabViewList = new List<CabView>();
                             if (FilteredMotiveForceN != 0)
                                 data = this.FilteredMotiveForceN / MaxForceN * MaxCurrentA;
                             else
-                                data = this.LocomotiveAxle.DriveForceN / MaxForceN * MaxCurrentA;
+                                data = this.LocomotiveAxles[cvc.ControlId].DriveForceN / MaxForceN * MaxCurrentA;
                             data = Math.Abs(data);
                         }
                         if (DynamicBrakePercent > 0 && MaxDynamicBrakeForceN > 0)
@@ -5189,7 +5209,7 @@ public List<CabView> CabViewList = new List<CabView>();
                         if (FilteredMotiveForceN != 0)
                             data = this.FilteredMotiveForceN;
                         else
-                            data = this.LocomotiveAxle.DriveForceN;
+                            data = this.LocomotiveAxles[cvc.ControlId].DriveForceN;
                         if (DynamicBrakePercent > 0)
                         {
                             data = DynamicBrakeForceN;
@@ -5237,7 +5257,7 @@ public List<CabView> CabViewList = new List<CabView>();
                         if (FilteredMotiveForceN != 0)
                             data = Math.Abs(this.FilteredMotiveForceN);
                         else
-                            data = Math.Abs(this.LocomotiveAxle.DriveForceN);
+                            data = Math.Abs(this.LocomotiveAxles[cvc.ControlId].DriveForceN);
                         if (DynamicBrakePercent > 0)
                         {
                             data = -Math.Abs(DynamicBrakeForceN);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -2069,7 +2069,6 @@ namespace Orts.Simulation.RollingStocks
             UpdateBoiler(elapsedClockSeconds);
             UpdateCylinders(elapsedClockSeconds, throttle, cutoff, absSpeedMpS);
             UpdateMotion(elapsedClockSeconds, cutoff, absSpeedMpS);
-            UpdateTractiveForce(elapsedClockSeconds, 0, 0, 0);
             UpdateAuxiliaries(elapsedClockSeconds, absSpeedMpS);
             #endregion
 
@@ -2104,7 +2103,7 @@ namespace Orts.Simulation.RollingStocks
 //                    Trace.TraceInformation("NumCyl - {0} i {1}", NumCylinders, i);
                     
                     // float realCrankAngleRad = (float)(LocomotiveAxle.AxlePositionRad + i * WheelCrankAngleDiffRad[i]);
-                    float realCrankAngleRad = (float)(LocomotiveAxle.AxlePositionRad);
+                    float realCrankAngleRad = (float)(LocomotiveAxles[0].AxlePositionRad);
                     float normalisedCrankAngleRad = 0;
 
                     realCrankAngleRad = (float)(MathHelper.WrapAngle(realCrankAngleRad));
@@ -5092,7 +5091,7 @@ namespace Orts.Simulation.RollingStocks
 
                 for (int i = 0; i < NumCylinders; i++)
                 {
-                    float crankAngleRad = (float)(LocomotiveAxle.AxlePositionRad + i * WheelCrankAngleDiffRad[i]);
+                    float crankAngleRad = (float)(LocomotiveAxles[0].AxlePositionRad + i * WheelCrankAngleDiffRad[i]);
 
                     testCrankAngle = crankAngleRad;
 
@@ -5331,7 +5330,7 @@ namespace Orts.Simulation.RollingStocks
 #endif
                 }
 
-                LocomotiveAxle.AxleWeightN = totalDrvWeightN + 9.81f * DrvWheelWeightKg;
+                LocomotiveAxles[0].AxleWeightN = totalDrvWeightN + 9.81f * DrvWheelWeightKg;
                 SteamStaticWheelForce = N.ToLbf(totalDrvWeightN + 9.81f * DrvWheelWeightKg) * LocomotiveCoefficientFrictionHUD;
 /*
                 if (DisplayTangentialWheelTreadForceLbf > SteamStaticWheelForce)
@@ -5388,6 +5387,10 @@ namespace Orts.Simulation.RollingStocks
                     absStartTractiveEffortN = Math.Abs(TractiveForceN); // update to new maximum TE
                 }
             }
+
+            ApplyDirectionToTractiveForce();
+            
+            LocomotiveAxles[0].DriveForceN = TractiveForceN;
         }
 
 
@@ -5425,10 +5428,10 @@ namespace Orts.Simulation.RollingStocks
 
                 float TotalMomentInertia = TotalWheelMomentofInertia + RodMomentInertia;
 
-                LocomotiveAxle.InertiaKgm2 = TotalMomentInertia;
-                LocomotiveAxle.DampingNs = 9.81f * DrvWheelWeightKg / 200;
+                LocomotiveAxles[0].InertiaKgm2 = TotalMomentInertia;
+                LocomotiveAxles[0].DampingNs = 9.81f * DrvWheelWeightKg / 200;
                 // Calculate internal resistance - IR = 3.8 * diameter of cylinder^2 * stroke * dia of drivers (all in inches) - This should reduce wheel force
-                LocomotiveAxle.FrictionN = N.FromLbf(3.8f * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / Me.ToIn(DrvWheelDiaM));
+                LocomotiveAxles[0].FrictionN = N.FromLbf(3.8f * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderDiameterM) * Me.ToIn(CylinderStrokeM) / Me.ToIn(DrvWheelDiaM));
 
                 if (WheelSlip && AdvancedAdhesionModel)
                     {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -43,6 +43,7 @@ using Orts.Simulation.RollingStocks.SubSystems;
 using Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS;
 using Orts.Simulation.RollingStocks.SubSystems.Controllers;
 using Orts.Simulation.RollingStocks.SubSystems.PowerSupplies;
+using Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions;
 using ORTS.Common;
 using ORTS.Scripting.Api;
 using System;
@@ -148,12 +149,13 @@ namespace Orts.Simulation.RollingStocks
         public float Curtius_KnifflerC = 0.161f;             //                                      speedMpS * 3.6 + B
         public float AdhesionK = 0.7f;   //slip characteristics slope
         public float AxleInertiaKgm2;    //axle inertia
-        public float AdhesionDriveWheelRadiusM;
         public float WheelSpeedMpS;
         public float WheelSpeedSlipMpS; // speed of wheel if locomotive is slipping
         public float SlipWarningThresholdPercent = 70;
         public MSTSNotchController WeightLoadController; // Used to control freight loading in freight cars
         public float AbsWheelSpeedMpS; // Math.Abs(WheelSpeedMpS) is used frequently in the subclasses, maybe it's more efficient to compute it once
+
+        public Axles LocomotiveAxles; // Only used at locomotives for efficiency
 
         // Colours for smoke and steam effects
         public Color ExhaustTransientColor = Color.Black;
@@ -348,6 +350,7 @@ namespace Orts.Simulation.RollingStocks
         {
             Pantographs = new Pantographs(this);
             Doors = new Doors(this);
+            LocomotiveAxles = new Axles(this);
         }
 
         public void Load()
@@ -981,6 +984,7 @@ namespace Orts.Simulation.RollingStocks
             Pantographs.Initialize();
             Doors.Initialize();
             PassengerCarPowerSupply?.Initialize();
+            LocomotiveAxles.Initialize();
 
             base.Initialize();
                        
@@ -1012,6 +1016,7 @@ namespace Orts.Simulation.RollingStocks
         public override void InitializeMoving()
         {
             PassengerCarPowerSupply?.InitializeMoving();
+            LocomotiveAxles.InitializeMoving();
 
             base.InitializeMoving();
         }
@@ -1384,15 +1389,8 @@ namespace Orts.Simulation.RollingStocks
                     SlipWarningThresholdPercent = stf.ReadFloat(STFReader.UNITS.None, 70.0f); if (SlipWarningThresholdPercent <= 0) SlipWarningThresholdPercent = 70.0f;
                     stf.SkipRestOfBlock();
                     break;
-                case "wagon(ortsadhesion(wheelset(axle(ortsinertia":
-                    stf.MustMatch("(");
-                    AxleInertiaKgm2 = stf.ReadFloat(STFReader.UNITS.RotationalInertia, null);
-                    stf.SkipRestOfBlock();
-                    break;
-                case "wagon(ortsadhesion(wheelset(axle(ortsradius":
-                    stf.MustMatch("(");
-                    AdhesionDriveWheelRadiusM = stf.ReadFloat(STFReader.UNITS.Distance, null);
-                    stf.SkipRestOfBlock();
+                case "wagon(ortsadhesion(wheelset":
+                    LocomotiveAxles.Parse(lowercasetoken, stf);
                     break;
                 case "wagon(lights":
                     Lights = new LightCollection(stf);
@@ -1557,7 +1555,6 @@ namespace Orts.Simulation.RollingStocks
             Curtius_KnifflerC = copy.Curtius_KnifflerC;
             AdhesionK = copy.AdhesionK;
             AxleInertiaKgm2 = copy.AxleInertiaKgm2;
-            AdhesionDriveWheelRadiusM = copy.AdhesionDriveWheelRadiusM;
             SlipWarningThresholdPercent = copy.SlipWarningThresholdPercent;
             Lights = copy.Lights;
             ExternalSoundPassThruPercent = copy.ExternalSoundPassThruPercent;
@@ -1619,6 +1616,20 @@ namespace Orts.Simulation.RollingStocks
             {
                 PowerSupply = new ScriptedPassengerCarPowerSupply(this);
                 PassengerCarPowerSupply.Copy(copy.PassengerCarPowerSupply);
+            }
+            LocomotiveAxles.Copy(copy.LocomotiveAxles);
+            MoveParamsToAxle();
+        }
+
+        /// <summary>
+        /// We are moving parameters from locomotive to axle. 
+        /// </summary>
+        public void MoveParamsToAxle()
+        {
+            foreach (var axle in LocomotiveAxles)
+            {
+                axle.SlipWarningTresholdPercent = SlipWarningThresholdPercent;
+                axle.AdhesionK = AdhesionK;
             }
         }
 
@@ -1733,6 +1744,8 @@ namespace Orts.Simulation.RollingStocks
             outf.Write(DerailExpected);
             outf.Write(DerailElapsedTimeS);
 
+            LocomotiveAxles.Save(outf);
+
             base.Save(outf);
         }
 
@@ -1785,6 +1798,9 @@ namespace Orts.Simulation.RollingStocks
             DerailPossible = inf.ReadBoolean();
             DerailExpected = inf.ReadBoolean();
             DerailElapsedTimeS = inf.ReadSingle();
+
+            MoveParamsToAxle();
+            LocomotiveAxles.Restore(inf);
 
             base.Restore(inf);
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1015,10 +1015,9 @@ namespace Orts.Simulation.RollingStocks
 
         public override void InitializeMoving()
         {
+            base.InitializeMoving();
             PassengerCarPowerSupply?.InitializeMoving();
             LocomotiveAxles.InitializeMoving();
-
-            base.InitializeMoving();
         }
 
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
@@ -50,7 +50,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
     /// Sums individual axle values to create a total value
     /// </summary>
 
-    public class Axles : IEnumerable<Axle>, ISubSystem<Axles>
+    public class Axles : ISubSystem<Axles>
     {
         /// <summary>
         /// List of axles
@@ -249,11 +249,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                 axle.Update(elapsedClockSeconds);
             }
         }
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return AxleList.GetEnumerator();
-        }
-        IEnumerator<Axle> IEnumerable<Axle>.GetEnumerator()
+        public List<Axle>.Enumerator GetEnumerator()
         {
             return AxleList.GetEnumerator();
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
@@ -262,16 +262,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         public void Restore(BinaryReader inf)
         {
             int count = inf.ReadInt32();
-            if (AxleList.Count == 0)
+            for (int i = 0; i < count; i++)
             {
-                for (int i = 0; i < count; i++)
+                if (i >= AxleList.Count)
                 {
                     AxleList.Add(new Axle());
                     AxleList[i].Initialize();
                 }
+                AxleList[i].Restore(inf);
             }
-            foreach (var axle in AxleList)
-                axle.Restore(inf);
         }
         /// <summary>
         /// Updates each axle on the list

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
@@ -269,7 +269,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                     AxleList.Add(new Axle());
                     AxleList[i].Initialize();
                 }
-
             }
             foreach (var axle in AxleList)
                 axle.Restore(inf);
@@ -678,6 +677,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             previousSlipPercent = inf.ReadSingle();
             previousSlipSpeedMpS = inf.ReadSingle();
             AxleForceN = inf.ReadSingle();
+            AxleSpeedMpS = inf.ReadSingle();
         }
 
         /// <summary>
@@ -689,6 +689,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             outf.Write(previousSlipPercent);
             outf.Write(previousSlipSpeedMpS);
             outf.Write(AxleForceN);
+            outf.Write(AxleSpeedMpS);
         }
 
         /// <summary>

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/ElectricMotor.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/ElectricMotor.cs
@@ -15,12 +15,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 
-using ORTS.Common;
 using System;
+using System.IO;
+using ORTS.Common;
 
 namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
 {
-    public class ElectricMotor
+    public class ElectricMotor : ISubSystem<ElectricMotor>
     {
         protected float temperatureK;
         public float TemperatureK { get { return temperatureK; } }
@@ -40,8 +41,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
 
         public readonly float InertiaKgm2;
 
-        public ElectricMotor(Axle axle)
+        public readonly MSTSLocomotive Locomotive;
+
+        public ElectricMotor(Axle axle, MSTSLocomotive locomotive)
         {
+            Locomotive = locomotive;
             InertiaKgm2 = 1.0f;
             temperatureK = 273.0f;
             ThermalCoeffJ_m2sC = 50.0f;
@@ -51,6 +55,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             AxleConnected = axle;
             AxleConnected.Motor = this;
             AxleConnected.TransmissionRatio = 1;
+        }
+        public virtual void UpdateTractiveForce(float elapsedClockSeconds, float t)
+        {
+
         }
 
         public virtual float GetDevelopedTorqueNm(float motorSpeedRadpS)
@@ -62,9 +70,24 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         {
             temperatureK = tempIntegrator.Integrate(timeSpan, (temperatureK) => 1.0f/(SpecificHeatCapacityJ_kg_C * WeightKg)*((powerLossesW - CoolingPowerW) / (ThermalCoeffJ_m2sC * SurfaceM) - temperatureK));
         }
-
-        public virtual void Reset()
+        public virtual void Initialize()
         {
+        }
+
+        public virtual void InitializeMoving()
+        {
+        }
+        public virtual void Copy(ElectricMotor other)
+        {
+
+        }
+        public virtual void Save(BinaryWriter outf)
+        {
+
+        }
+        public virtual void Restore(BinaryReader inf)
+        {
+
         }
     }
 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/InductionMotor.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/InductionMotor.cs
@@ -37,16 +37,25 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         /// </summary>
         float requiredTorqueNm;
 
-        public InductionMotor(Axle axle, MSTSLocomotive locomotive) : base(axle)
+        public InductionMotor(Axle axle, MSTSLocomotive locomotive) : base(axle, locomotive)
         {
         }
-
+        public override void Initialize()
+        {
+            base.Initialize();
+        }
+        public override void UpdateTractiveForce(float elapsedClockSeconds, float t)
+        {
+            TargetForceN = Locomotive.TractiveForceN / Locomotive.LocomotiveAxles.Count;
+        }
         public override float GetDevelopedTorqueNm(float motorSpeedRadpS)
         {
             return requiredTorqueNm * MathHelper.Clamp((DriveSpeedRadpS - motorSpeedRadpS) / OptimalAsyncSpeedRadpS, -1, 1);
         }
         public override void Update(float timeSpan)
         {
+            EngineMaxSpeedMpS = Locomotive.MaxSpeedMpS;
+            SlipControl = Locomotive.SlipControlSystem == MSTSLocomotive.SlipControlType.Full;
             float linToAngFactor = AxleConnected.TransmissionRatio / AxleConnected.WheelRadiusM;
             if (SlipControl)
             {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/SeriesMotor.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/SeriesMotor.cs
@@ -129,7 +129,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             return temp;
         }
 
-        public SeriesMotor(float nomCurrentA, float nomVoltageV, float nomRevolutionsRad, Axle axle) : base(axle)
+        public SeriesMotor(float nomCurrentA, float nomVoltageV, float nomRevolutionsRad, Axle axle, MSTSLocomotive locomotive) : base(axle, locomotive)
         {
             NominalCurrentA = nomCurrentA;
             NominalVoltageV = nomVoltageV;
@@ -175,12 +175,12 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
 
             base.Update(timeSpan);
         }
-        public override void Reset()
+        public override void Initialize()
         {
             fieldCurrentA = 0.0f;
             armatureCurrentA = 0.0f;
             fieldWb = 0.0f;
-            base.Reset();
+            base.Initialize();
         }
     }
 }

--- a/Source/RunActivity/Viewer3D/InfoDisplay.cs
+++ b/Source/RunActivity/Viewer3D/InfoDisplay.cs
@@ -265,8 +265,8 @@ namespace Orts.Viewer3D
                         Logger.Data(Viewer.PlayerLocomotive.ThrottlePercent.ToString("F0"));
                         Logger.Data(Viewer.PlayerLocomotive.MotiveForceN.ToString("F0"));
                         Logger.Data(Viewer.PlayerLocomotive.BrakeForceN.ToString("F0"));
-                        Logger.Data((Viewer.PlayerLocomotive as MSTSLocomotive).LocomotiveAxle.AxleForceN.ToString("F2"));
-                        Logger.Data((Viewer.PlayerLocomotive as MSTSLocomotive).LocomotiveAxle.SlipSpeedPercent.ToString("F1"));
+                        Logger.Data((Viewer.PlayerLocomotive as MSTSLocomotive).LocomotiveAxles.CompensatedForceN.ToString("F2"));
+                        Logger.Data((Viewer.PlayerLocomotive as MSTSLocomotive).LocomotiveAxles.SlipSpeedPercent.ToString("F1"));
 
                         void logSpeed(float speedMpS)
                         {

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -199,7 +199,7 @@ namespace Orts.Viewer3D.Popups
                     ForceGraphDynamicForce.AddSample(-loco.MotiveForceN / loco.MaxForceN);
                 }
 
-                ForceGraphNumOfSubsteps.AddSample(loco.LocomotiveAxle.NumOfSubstepsPS / 50.0f);
+                ForceGraphNumOfSubsteps.AddSample(loco.LocomotiveAxles.NumOfSubstepsPS / 50.0f);
 
                 ForceGraphs.PrepareFrame(frame);
             }
@@ -1075,23 +1075,23 @@ namespace Orts.Viewer3D.Popups
 
 
                         TableAddLine(table, Viewer.Catalog.GetString("(Advanced adhesion model)"));
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Wheel slip"), "{0:F0}% ({1:F0}%/{2})", mstsLocomotive.LocomotiveAxle.SlipSpeedPercent, mstsLocomotive.LocomotiveAxle.SlipDerivationPercentpS, FormatStrings.s);
+                        TableAddLabelValue(table, Viewer.Catalog.GetString("Wheel slip"), "{0:F0}% ({1:F0}%/{2})", mstsLocomotive.LocomotiveAxles.SlipSpeedPercent, mstsLocomotive.LocomotiveAxles.SlipDerivationPercentpS, FormatStrings.s);
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Conditions"), "{0:F0}%", mstsLocomotive.AdhesionConditions * 100.0f);
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Axle drive force"), "{0} ({1})", FormatStrings.FormatForce(mstsLocomotive.LocomotiveAxle.DriveForceN, mstsLocomotive.IsMetric),
-                        FormatStrings.FormatPower(mstsLocomotive.LocomotiveAxle.DriveForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Axle brake force"), "{0}", FormatStrings.FormatForce(mstsLocomotive.LocomotiveAxle.BrakeRetardForceN, mstsLocomotive.IsMetric));
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Number of substeps"), "{0:F0}", mstsLocomotive.LocomotiveAxle.NumOfSubstepsPS);
+                        TableAddLabelValue(table, Viewer.Catalog.GetString("Axle drive force"), "{0} ({1})", FormatStrings.FormatForce(mstsLocomotive.TractiveForceN, mstsLocomotive.IsMetric),
+                        FormatStrings.FormatPower(mstsLocomotive.TractiveForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
+                        TableAddLabelValue(table, Viewer.Catalog.GetString("Axle brake force"), "{0}", FormatStrings.FormatForce(mstsLocomotive.BrakeRetardForceN, mstsLocomotive.IsMetric));
+                        TableAddLabelValue(table, Viewer.Catalog.GetString("Number of substeps"), "{0:F0}", mstsLocomotive.LocomotiveAxles.NumOfSubstepsPS);
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Axle out force"), "{0} ({1})",
-                        FormatStrings.FormatForce(mstsLocomotive.LocomotiveAxle.AxleForceN, mstsLocomotive.IsMetric),
-                        FormatStrings.FormatPower(mstsLocomotive.LocomotiveAxle.AxleForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
+                        FormatStrings.FormatForce(mstsLocomotive.LocomotiveAxles.AxleForceN, mstsLocomotive.IsMetric),
+                        FormatStrings.FormatPower(mstsLocomotive.LocomotiveAxles.AxleForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Comp Axle out force"), "{0} ({1})",
-                        FormatStrings.FormatForce(mstsLocomotive.LocomotiveAxle.CompensatedAxleForceN, mstsLocomotive.IsMetric),
-                        FormatStrings.FormatPower(mstsLocomotive.LocomotiveAxle.CompensatedAxleForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
+                        FormatStrings.FormatForce(mstsLocomotive.LocomotiveAxles.CompensatedForceN, mstsLocomotive.IsMetric),
+                        FormatStrings.FormatPower(mstsLocomotive.LocomotiveAxles.CompensatedForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Wheel Speed"), "{0} ({1})",
                         FormatStrings.FormatSpeedDisplay((HUDEngineType == TrainCar.EngineTypes.Steam && (HUDSteamEngineType == TrainCar.SteamEngineTypes.Compound || HUDSteamEngineType == TrainCar.SteamEngineTypes.Simple || HUDSteamEngineType == TrainCar.SteamEngineTypes.Unknown)) ? mstsLocomotive.WheelSpeedSlipMpS : mstsLocomotive.AbsWheelSpeedMpS, mstsLocomotive.IsMetric),
-                        FormatStrings.FormatSpeedDisplay(mstsLocomotive.LocomotiveAxle.SlipSpeedMpS, mstsLocomotive.IsMetric)
+                        FormatStrings.FormatSpeedDisplay(mstsLocomotive.LocomotiveAxles.SlipSpeedMpS, mstsLocomotive.IsMetric)
                                                     );
-                        if (HUDEngineType == TrainCar.EngineTypes.Steam && (HUDSteamEngineType == TrainCar.SteamEngineTypes.Compound || HUDSteamEngineType == TrainCar.SteamEngineTypes.Simple || HUDSteamEngineType == TrainCar.SteamEngineTypes.Unknown)) TableAddLabelValue(table, Viewer.Catalog.GetString("Wheel ang. pos."), "{0}º", (int)(mstsLocomotive.LocomotiveAxle.AxlePositionRad * 180 / Math.PI + 180));
+                        if (HUDEngineType == TrainCar.EngineTypes.Steam && (HUDSteamEngineType == TrainCar.SteamEngineTypes.Compound || HUDSteamEngineType == TrainCar.SteamEngineTypes.Simple || HUDSteamEngineType == TrainCar.SteamEngineTypes.Unknown)) TableAddLabelValue(table, Viewer.Catalog.GetString("Wheel ang. pos."), "{0}º", (int)(mstsLocomotive.LocomotiveAxles[0].AxlePositionRad * 180 / Math.PI + 180));
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Loco Adhesion"), "{0:F0}%", mstsLocomotive.LocomotiveCoefficientFrictionHUD * 100.0f);
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Wagon Adhesion"), "{0:F0}%", mstsLocomotive.WagonCoefficientFrictionHUD * 100.0f);
 

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -1072,25 +1072,34 @@ namespace Orts.Viewer3D.Popups
                 {
                     if (mstsLocomotive.AdvancedAdhesionModel)
                     {
-
-
                         TableAddLine(table, Viewer.Catalog.GetString("(Advanced adhesion model)"));
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Wheel slip"), "{0:F0}% ({1:F0}%/{2})", mstsLocomotive.LocomotiveAxles.SlipSpeedPercent, mstsLocomotive.LocomotiveAxles.SlipDerivationPercentpS, FormatStrings.s);
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Conditions"), "{0:F0}%", mstsLocomotive.AdhesionConditions * 100.0f);
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Axle drive force"), "{0} ({1})", FormatStrings.FormatForce(mstsLocomotive.TractiveForceN, mstsLocomotive.IsMetric),
-                        FormatStrings.FormatPower(mstsLocomotive.TractiveForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Axle brake force"), "{0}", FormatStrings.FormatForce(mstsLocomotive.BrakeRetardForceN, mstsLocomotive.IsMetric));
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Number of substeps"), "{0:F0}", mstsLocomotive.LocomotiveAxles.NumOfSubstepsPS);
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Axle out force"), "{0} ({1})",
-                        FormatStrings.FormatForce(mstsLocomotive.LocomotiveAxles.AxleForceN, mstsLocomotive.IsMetric),
-                        FormatStrings.FormatPower(mstsLocomotive.LocomotiveAxles.AxleForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Comp Axle out force"), "{0} ({1})",
-                        FormatStrings.FormatForce(mstsLocomotive.LocomotiveAxles.CompensatedForceN, mstsLocomotive.IsMetric),
-                        FormatStrings.FormatPower(mstsLocomotive.LocomotiveAxles.CompensatedForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
-                        TableAddLabelValue(table, Viewer.Catalog.GetString("Wheel Speed"), "{0} ({1})",
-                        FormatStrings.FormatSpeedDisplay((HUDEngineType == TrainCar.EngineTypes.Steam && (HUDSteamEngineType == TrainCar.SteamEngineTypes.Compound || HUDSteamEngineType == TrainCar.SteamEngineTypes.Simple || HUDSteamEngineType == TrainCar.SteamEngineTypes.Unknown)) ? mstsLocomotive.WheelSpeedSlipMpS : mstsLocomotive.AbsWheelSpeedMpS, mstsLocomotive.IsMetric),
-                        FormatStrings.FormatSpeedDisplay(mstsLocomotive.LocomotiveAxles.SlipSpeedMpS, mstsLocomotive.IsMetric)
-                                                    );
+                        int row0 = table.CurrentRow;
+                        TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Wheel slip"));
+                        TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Conditions"));
+                        TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Axle drive force"));
+                        TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Axle brake force"));
+                        TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Number of substeps"));
+                        TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Axle out force"));
+                        TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Comp Axle out force"));
+                        TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Wheel speed"));
+                        for (int i=0; i<mstsLocomotive.LocomotiveAxles.Count; i++)
+                        {
+                            table.CurrentRow = row0;
+                            var axle = mstsLocomotive.LocomotiveAxles[i];
+                            TableSetCell(table, table.CurrentRow++, table.CurrentValueColumn + 2*i, "{0:F0}% ({1:F0}%/{2})", axle.SlipSpeedPercent, axle.SlipDerivationPercentpS, FormatStrings.s);
+                            TableSetCell(table, table.CurrentRow++, table.CurrentValueColumn + 2*i, "{0:F0}%", mstsLocomotive.AdhesionConditions * 100.0f);
+                            TableSetCell(table, table.CurrentRow++, table.CurrentValueColumn + 2*i, "{0} ({1})", FormatStrings.FormatForce(axle.DriveForceN, mstsLocomotive.IsMetric),
+                            FormatStrings.FormatPower(axle.DriveForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
+                            TableSetCell(table, table.CurrentRow++, table.CurrentValueColumn + 2*i, "{0}", FormatStrings.FormatForce(axle.BrakeRetardForceN, mstsLocomotive.IsMetric));
+                            TableSetCell(table, table.CurrentRow++, table.CurrentValueColumn + 2*i, "{0:F0}", axle.NumOfSubstepsPS);
+                            TableSetCell(table, table.CurrentRow++, table.CurrentValueColumn + 2*i, "{0} ({1})",
+                            FormatStrings.FormatForce(axle.AxleForceN, mstsLocomotive.IsMetric),
+                            FormatStrings.FormatPower(axle.AxleForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
+                            TableSetCell(table, table.CurrentRow++, table.CurrentValueColumn + 2*i, "{0} ({1})",
+                            FormatStrings.FormatForce(axle.CompensatedAxleForceN, mstsLocomotive.IsMetric),
+                            FormatStrings.FormatPower(axle.CompensatedAxleForceN * mstsLocomotive.AbsTractionSpeedMpS, mstsLocomotive.IsMetric, false, false));
+                            TableSetCell(table, table.CurrentRow++, table.CurrentValueColumn + 2*i, "{0} ({1})", FormatStrings.FormatSpeedDisplay(axle.AxleSpeedMpS, mstsLocomotive.IsMetric), FormatStrings.FormatSpeedDisplay(axle.SlipSpeedMpS, mstsLocomotive.IsMetric));
+                        }
                         if (HUDEngineType == TrainCar.EngineTypes.Steam && (HUDSteamEngineType == TrainCar.SteamEngineTypes.Compound || HUDSteamEngineType == TrainCar.SteamEngineTypes.Simple || HUDSteamEngineType == TrainCar.SteamEngineTypes.Unknown)) TableAddLabelValue(table, Viewer.Catalog.GetString("Wheel ang. pos."), "{0}º", (int)(mstsLocomotive.LocomotiveAxles[0].AxlePositionRad * 180 / Math.PI + 180));
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Loco Adhesion"), "{0:F0}%", mstsLocomotive.LocomotiveCoefficientFrictionHUD * 100.0f);
                         TableAddLabelValue(table, Viewer.Catalog.GetString("Wagon Adhesion"), "{0:F0}%", mstsLocomotive.WagonCoefficientFrictionHUD * 100.0f);


### PR DESCRIPTION
https://blueprints.launchpad.net/or/+spec/enhance-adhesion

This is the first part of a set of PRs which will allow the existence of multiple engines, each one connected to a separate wheelset. Each Axle is independent, so it's possible to get wheelslip in one axle but not in another one.

Further changes to be done include:
- Move steam engine physics to a separate class, and allow multiple steam engines (WIP by @peternewell)
- Create a new block for the .eng file which allows the definition of multiple axles (each axle must define Wheel Radius, engines attached to it (or none if not driven) and which animations correspond to each axle).
- Link all existing engine types (diesel-mechanical, AC, steam) to different axles, and calculate tractive force for every engine separately.
- Link wheel animations to axles to get visual slip effects (partially implemented by me, but conflicts with #570 so won't be included here at the moment)