### PR TITLE
Headlight switch makes sound when not appropriate

### DIFF
--- a/Source/Orts.Simulation/Common/Commands.cs
+++ b/Source/Orts.Simulation/Common/Commands.cs
@@ -1135,14 +1135,16 @@ namespace Orts.Common
                         {
                             Receiver.Headlight = 1;
                             Receiver.Simulator.Confirmer.Confirm(CabControl.Headlight, CabSetting.Neutral);
+                            Receiver.SignalEvent(Event.LightSwitchToggle);
                         }
                         break;
                     case 1:
                         Receiver.Headlight = 2;
                         Receiver.Simulator.Confirmer.Confirm(CabControl.Headlight, CabSetting.On);
+                        Receiver.SignalEvent(Event.LightSwitchToggle);
                         break;
                 }
-                Receiver.SignalEvent(Event.LightSwitchToggle);
+                
             }
             else
             {
@@ -1153,14 +1155,15 @@ namespace Orts.Common
                         {
                             Receiver.Headlight = 0;
                             Receiver.Simulator.Confirmer.Confirm(CabControl.Headlight, CabSetting.Off);
+                            Receiver.SignalEvent(Event.LightSwitchToggle);
                         }
                         break;
                     case 2:
                         Receiver.Headlight = 1;
                         Receiver.Simulator.Confirmer.Confirm(CabControl.Headlight, CabSetting.Neutral);
+                        Receiver.SignalEvent(Event.LightSwitchToggle);
                         break;
                 }
-                Receiver.SignalEvent(Event.LightSwitchToggle);
             }
         }
     }


### PR DESCRIPTION
If trying to switch the headlight beyond or below the last position, for certain locomotives who have this defined, a click sound is to be heard. In real live the switch would not make such a sound.

Just a small fix.