### PR TITLE
delay option for masterkey does not delay switch off

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/MasterKey.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/MasterKey.cs
@@ -63,7 +63,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             Locomotive = locomotive;
 
             Timer = new Timer(Locomotive);
-            Timer.Setup(DelayS);
         }
 
         public virtual void Parse(string lowercasetoken, STFReader stf)
@@ -105,6 +104,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public virtual void Initialize()
         {
+            Timer.Setup(DelayS);
         }
 
         /// <summary>


### PR DESCRIPTION
in MasterKey.cs timer is setup before the delay variable has been set.

Time setup now done after the delay variable has been parsed