### PR TITLE
Select track sound volume percent retained in .eng and .wag files

### DIFF
--- a/Source/Documentation/Manual/sound.rst
+++ b/Source/Documentation/Manual/sound.rst
@@ -604,3 +604,22 @@ section of any .eng or .wag file (or in their "include" file as explained
 
 where the number in parenthesis may be anyone from 0 (nothing heard internally) 
 to 100 (external sound reproduced at original volume).  
+
+
+.. _sound-internal-track:   
+
+Manage % of internal track sound heard internally for a specific trainset
+=========================================================================
+
+The percentage of internal track sound heard internally for a specific 
+trainset may be defined for any trainset inserting in the Wagon 
+section of any .eng or .wag file (or in their "include" file as explained 
+:ref:`here <physics-inclusions>`) following line::
+
+  ORTSTrackSoundPassedThroughPercent ( 40 ) 
+
+where the number in parenthesis may be anyone from 0 (nothing heard ) 
+to 100 (internal track sound reproduced at volume as defined in .sms file).  
+
+If the parameter is not present, the internal track sound is 
+reproduced at the volume as defined in .sms file.

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -107,6 +107,7 @@ namespace Orts.Simulation.RollingStocks
         public string InteriorSoundFileName;
         public string Cab3DSoundFileName;
         public float ExternalSoundPassThruPercent = -1;
+        public float TrackSoundPassThruPercent = -1;
         public float WheelRadiusM = Me.FromIn(18.0f);  // Provide some defaults in case it's missing from the wag - Wagon wheels could vary in size from approx 10" to 25".
         protected float StaticFrictionFactorN;    // factor to multiply friction by to determine static or starting friction - will vary depending upon whether roller or friction bearing
         float FrictionLowSpeedN; // Davis low speed value 0 - 5 mph
@@ -1433,6 +1434,7 @@ namespace Orts.Simulation.RollingStocks
                     FreightAnimations = new FreightAnimations(stf, this);
                     break;
                 case "wagon(ortsexternalsoundpassedthroughpercent": ExternalSoundPassThruPercent = stf.ReadFloatBlock(STFReader.UNITS.None, -1); break;
+                case "wagon(ortstracksoundpassedthroughpercent": TrackSoundPassThruPercent = stf.ReadFloatBlock(STFReader.UNITS.None, -1); break;
                 case "wagon(ortsalternatepassengerviewpoints": // accepted only if there is already a passenger viewpoint
                     if (HasInsideView)
                     {
@@ -1559,6 +1561,7 @@ namespace Orts.Simulation.RollingStocks
             SlipWarningThresholdPercent = copy.SlipWarningThresholdPercent;
             Lights = copy.Lights;
             ExternalSoundPassThruPercent = copy.ExternalSoundPassThruPercent;
+            TrackSoundPassThruPercent = copy.TrackSoundPassThruPercent;
             foreach (PassengerViewPoint passengerViewPoint in copy.PassengerViewpoints)
                 PassengerViewpoints.Add(passengerViewPoint);
             foreach (ViewPoint headOutViewPoint in copy.HeadOutViewpoints)

--- a/Source/RunActivity/Viewer3D/Sound.cs
+++ b/Source/RunActivity/Viewer3D/Sound.cs
@@ -149,7 +149,10 @@ namespace Orts.Viewer3D
                 return;
             }
             if (isInside)
+            {
                 _inSources.Add(new SoundSource(Viewer, Car, fullPath));
+                _inSources.Last().IsInternalTrackSound = true;
+            }
             else
                 _outSources.Add(new SoundSource(Viewer, Car, fullPath));
         }
@@ -674,6 +677,7 @@ namespace Orts.Viewer3D
         private Orts.Formats.Msts.Deactivation DeactivationConditions;
         public bool IsEnvSound;
         public bool IsExternal = true;
+        public bool IsInternalTrackSound = false;
         public bool Ignore3D;
         /// <summary>
         /// MSTS treats Stereo() tagged mono wav files specially. This is a flag
@@ -1421,6 +1425,12 @@ namespace Orts.Viewer3D
                 if (SoundSource.Viewer.Camera.AttachedCar == null || ((MSTSWagon)SoundSource.Viewer.Camera.AttachedCar).ExternalSoundPassThruPercent == -1)
                     volume *= Program.Viewer.Settings.ExternalSoundPassThruPercent * 0.01f;
                 else volume *= ((MSTSWagon)SoundSource.Viewer.Camera.AttachedCar).ExternalSoundPassThruPercent * 0.01f;
+            }
+
+            if (SoundSource.IsInternalTrackSound && SoundSource.Viewer.Camera.Style != Camera.Styles.External)
+            {
+                if (((MSTSWagon)SoundSource.Viewer.Camera.AttachedCar)?.TrackSoundPassThruPercent != -1)
+                    volume *= ((MSTSWagon)SoundSource.Viewer.Camera.AttachedCar).TrackSoundPassThruPercent * 0.01f;
             }
 
             ALSoundSource.Volume = volume;


### PR DESCRIPTION
 https://blueprints.launchpad.net/or/+spec/select-tracksound-volume
http://www.elvastower.com/forums/index.php?/topic/37055-external-sound-attenuation-in-internal-views/page__view__findpost__p__296364