### PR TITLE
Electric locomotive hot start

### DIFF
--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -415,6 +415,7 @@ Uncheck this option for a more detailed behaviour in which the player has to swi
 
 The default setting is checked.
 
+In timetable mode, power status is not affected by these options.
 
 .. _options-forced-red:
 

--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -413,7 +413,7 @@ At game start, Electric - power connected
 When this option is checked, stationary electric locos start the simulation with power available.
 Uncheck this option for a more detailed behaviour in which the player has to switch on electrical equipment.
 
-The default setting is unchecked.
+The default setting is checked.
 
 
 .. _options-forced-red:

--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -407,6 +407,15 @@ Uncheck this option for a more detailed behaviour in which the player has to sta
 The default setting is checked.
 
 
+At game start, Electric - power connected
+-----------------------------------
+
+When this option is checked, stationary electric locos start the simulation with power available.
+Uncheck this option for a more detailed behaviour in which the player has to switch on electrical equipment.
+
+The default setting is unchecked.
+
+
 .. _options-forced-red:
 
 Forced red at station stops

--- a/Source/Menu/Options.Designer.cs
+++ b/Source/Menu/Options.Designer.cs
@@ -1374,9 +1374,6 @@
             // checkElectricPowerConnected
             // 
             this.checkElectricPowerConnected.AutoSize = true;
-            this.checkElectricPowerConnected.Checked = true;
-            this.checkElectricPowerConnected.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkElectricPowerConnected.Enabled = false;
             this.checkElectricPowerConnected.Location = new System.Drawing.Point(26, 238);
             this.checkElectricPowerConnected.Name = "checkElectricPowerConnected";
             this.checkElectricPowerConnected.Size = new System.Drawing.Size(153, 17);

--- a/Source/Menu/Options.cs
+++ b/Source/Menu/Options.cs
@@ -187,6 +187,7 @@ namespace ORTS
             checkForcedRedAtStationStops.Checked = !Settings.NoForcedRedAtStationStops;
             checkDoorsAITrains.Checked = Settings.OpenDoorsInAITrains;
             checkDieselEnginesStarted.Checked = !Settings.NoDieselEngineStart; // Inverted as "EngineStart" is better UI than "NoEngineStart"
+            checkElectricPowerConnected.Checked = Settings.ElectricHotStart;
 
             // Keyboard tab
             InitializeKeyboardSettings();
@@ -472,6 +473,7 @@ namespace ORTS
             Settings.NoForcedRedAtStationStops = !checkForcedRedAtStationStops.Checked;
             Settings.OpenDoorsInAITrains = checkDoorsAITrains.Checked;
             Settings.NoDieselEngineStart = !checkDieselEnginesStarted.Checked; // Inverted as "EngineStart" is better UI than "NoEngineStart"
+            Settings.ElectricHotStart = checkElectricPowerConnected.Checked;
 
             // Keyboard tab
             // These are edited live.

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -226,7 +226,7 @@ namespace ORTS.Settings
         public bool HotStart { get; set; }
         [Default(false)]
         public bool NoDieselEngineStart { get; set; }
-        [Default(false)]
+        [Default(true)]
         public bool ElectricHotStart { get; set; }
 
         // Data logger settings:

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -226,6 +226,8 @@ namespace ORTS.Settings
         public bool HotStart { get; set; }
         [Default(false)]
         public bool NoDieselEngineStart { get; set; }
+        [Default(false)]
+        public bool ElectricHotStart { get; set; }
 
         // Data logger settings:
         [Default("comma")]

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs
@@ -131,6 +131,8 @@ namespace Orts.Simulation.RollingStocks
                     CurrentLocomotiveSteamHeatBoilerWaterCapacityL = L.FromGUK(800.0f);
                 }
             }
+
+            if (Simulator.Settings.ElectricHotStart) SetPower(true);
         }
 
         //================================================================================================//

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/BatterySwitch.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/BatterySwitch.cs
@@ -343,7 +343,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     {
                         case ModeType.Switch:
                             CommandSwitch = false;
-                            Wagon.SignalEvent(Event.BatterySwitchCommandOn);
+                            Wagon.SignalEvent(Event.BatterySwitchCommandOff);
                             break;
                         case ModeType.PushButtons:
                             CommandButtonOff = true;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/BatterySwitch.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/BatterySwitch.cs
@@ -43,6 +43,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         public bool CommandButtonOn { get; protected set; } = false;
         public bool CommandButtonOff { get; protected set; } = false;
         public bool On { get; protected set; } = false;
+        protected bool QuickPowerOn;
+        protected bool QuickPowerOff;
 
         public BatterySwitch(MSTSWagon wagon)
         {
@@ -201,6 +203,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 case ModeType.PushButtons:
                     if (On)
                     {
+                        if (QuickPowerOn)
+                        {
+                            QuickPowerOn = false;
+                            if (CommandButtonOn)
+                            {
+                                CommandButtonOn = false;
+                                Wagon.SignalEvent(Event.BatterySwitchCommandOff);
+                            }
+                        }
                         if (CommandButtonOff)
                         {
                             if (!Timer.Started)
@@ -225,6 +236,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     }
                     else
                     {
+                        if (QuickPowerOff)
+                        {
+                            QuickPowerOff = false;
+                            if (CommandButtonOff)
+                            {
+                                CommandButtonOff = false;
+                                Wagon.SignalEvent(Event.BatterySwitchCommandOff);
+                            }
+                        }
                         if (CommandButtonOn)
                         {
                             if (!Timer.Started)
@@ -300,6 +320,37 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     {
                         CommandButtonOff = false;
                         Wagon.SignalEvent(Event.BatterySwitchCommandOff);
+                    }
+                    break;
+                case PowerSupplyEvent.QuickPowerOn:
+                    switch (Mode)
+                    {
+                        case ModeType.Switch:
+                            CommandSwitch = true;
+                            Wagon.SignalEvent(Event.BatterySwitchCommandOn);
+                            break;
+                        case ModeType.PushButtons:
+                            CommandButtonOn = true;
+                            Wagon.SignalEvent(Event.BatterySwitchCommandOn);
+                            QuickPowerOn = true;
+                            QuickPowerOff = false;
+                            break;
+
+                    }
+                    break;
+                case PowerSupplyEvent.QuickPowerOff:
+                    switch (Mode)
+                    {
+                        case ModeType.Switch:
+                            CommandSwitch = false;
+                            Wagon.SignalEvent(Event.BatterySwitchCommandOn);
+                            break;
+                        case ModeType.PushButtons:
+                            CommandButtonOff = true;
+                            Wagon.SignalEvent(Event.BatterySwitchCommandOn);
+                            QuickPowerOn = false;
+                            QuickPowerOff = true;
+                            break;
                     }
                     break;
             }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselPowerSupply.cs
@@ -320,7 +320,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             {
                 case PowerSupplyEvent.QuickPowerOn:
                     QuickPowerOn = true;
-                    SignalEventToBatterySwitch(PowerSupplyEvent.CloseBatterySwitch);
+                    SignalEventToBatterySwitch(PowerSupplyEvent.QuickPowerOn);
                     SignalEventToMasterKey(PowerSupplyEvent.TurnOnMasterKey);
                     SignalEventToDieselEngines(PowerSupplyEvent.StartEngine);
                     SignalEventToElectricTrainSupplySwitch(PowerSupplyEvent.SwitchOnElectricTrainSupply);
@@ -332,7 +332,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     SignalEventToTractionCutOffRelay(PowerSupplyEvent.OpenTractionCutOffRelay);
                     SignalEventToDieselEngines(PowerSupplyEvent.StopEngine);
                     SignalEventToMasterKey(PowerSupplyEvent.TurnOffMasterKey);
-                    SignalEventToBatterySwitch(PowerSupplyEvent.OpenBatterySwitch);
+                    SignalEventToBatterySwitch(PowerSupplyEvent.QuickPowerOff);
                     break;
 
                 case PowerSupplyEvent.TogglePlayerEngine:

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricPowerSupply.cs
@@ -271,7 +271,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             {
                 case PowerSupplyEvent.QuickPowerOn:
                     QuickPowerOn = true;
-                    SignalEventToBatterySwitch(PowerSupplyEvent.CloseBatterySwitch);
+                    SignalEventToBatterySwitch(PowerSupplyEvent.QuickPowerOn);
                     SignalEventToMasterKey(PowerSupplyEvent.TurnOnMasterKey);
                     SignalEventToPantograph(PowerSupplyEvent.RaisePantograph, 1);
                     SignalEventToOtherTrainVehiclesWithId(PowerSupplyEvent.RaisePantograph, 1);
@@ -285,7 +285,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                     SignalEventToPantographs(PowerSupplyEvent.LowerPantograph);
                     SignalEventToOtherTrainVehicles(PowerSupplyEvent.LowerPantograph);
                     SignalEventToMasterKey(PowerSupplyEvent.TurnOffMasterKey);
-                    SignalEventToBatterySwitch(PowerSupplyEvent.OpenBatterySwitch);
+                    SignalEventToBatterySwitch(PowerSupplyEvent.QuickPowerOff);
                     break;
 
                 default:


### PR DESCRIPTION
User-configurable hot start for electric locomotives:
- Battery connected
- Master key on
- Pantograph up
- Circuit breaker closed

https://trello.com/c/Rp0vQlVc/564-electric-locomotive-hot-start