### PR TITLE
Replaces email service with FormSpark

### DIFF
--- a/Website/openrails.org/contact/form.php
+++ b/Website/openrails.org/contact/form.php
@@ -22,31 +22,41 @@
         </p>
       </div>
 			<div class="col-md-6">
-        <!-- send this to another host as uktrainsim doesn't support mail() -->
-        <form role="form" action="http://ccgi.jakeman.plus.com/or/forward_message.php" method="get">
+        <!-- send this to another host as GitHub doesn't support mail. -->
+        <form role="form" 
+          action="https://submit-form.com/BjWG1lX2"
+          data-botpoison-public-key="pk_016a2dd5-01de-4764-8a29-c4c0107438f0">
           <div class="form-group">
-            <label for="emailAddress">Email address</label>
-            <input type="email" class="form-control" id="emailAddress" name="from" placeholder="Enter your email address. (We do not share this.)" autofocus required>
+            <label for="email">Email</label>
+            <input class="form-control" type="email" id="email" name="email" placeholder="Enter your email address. (We do not share this.)" autofocus required />
           </div>
           <div class="form-group">
             <label for="emailSubject">Subject</label>
-            <input type="text" class="form-control" id="emailSubject" name="subject" placeholder="Enter your subject">
+            <input class="form-control" type="text" id="name" name="name" placeholder="Enter your subject" required />
           </div>
-    			<input type="hidden" name="send_to_name"   value="or_website">
-		    	<input type="hidden" name="send_to_domain" value="jakeman.plus.com">
-			    <input type="hidden" name="success_url"    value="http://openrails.org/contact/success.php"> 
-		    	<?php $ip = $_SERVER['REMOTE_ADDR']; echo "<input type='hidden' name='ip' value='$ip'>" ?>
-		    	<?php $referer = $_SERVER['HTTP_REFERER']; echo "<input type='hidden' name='referer' value='$referer'>" ?>
           <div class="form-group">
-            <label for="emailMessage">Message</label>
-            <textarea class="form-control" rows="10" id="emailMessage" name="body" placeholder="Please follow the guidance to the left about getting help." required title="Please follow the guidance to the left about getting help."></textarea>
+            <label for="message">Message</label>
+            <textarea 
+              class="form-control"
+              rows="10"
+              id="message"
+              name="message"
+              placeholder="Please follow the guidance to the left about getting help."
+              required 
+              title="Please follow the guidance to the left about getting help."
+            ></textarea>
           </div>
-          <button type="submit" class="btn btn-default">Send</button>
+          <input
+            type="hidden"
+            name="_redirect"
+            value="http://www.openrails.org/contact/success.php"
+          />
+          <button type="submit">Send</button>
         </form>
-
 			</div>
 		</div>
 <?php include "../shared/tail.php" ?>
 <?php include "../shared/banners/preload_next_banner.php" ?>
+    <script src="https://unpkg.com/@botpoison/browser" async></script>
   </body>
 </html>


### PR DESCRIPTION
Also BotPoison spam catcher and FreshDesk ticketing services.

The current mechanism uses the PHP mail() which will not be available in the new website.
Also the emails are all forwarded to my personal email which is not ideal. The FreshDesk ticketing service will provide a record which can be shared and handed on (when the time comes).

Note that the website Contact Form is not intended for support questions, but for contacting the Open Rails Management Team. However website visitors insist on using it for support questions - that's life!