### PR TITLE
Correct Brake Shoe Force Calculation

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -2739,6 +2739,34 @@ These changes introduce an extra challenge to train braking, but provide a more 
 
 For example, in a lot of normal Westinghouse brake systems, a minimum pressure reduction was applied by moving the brake controller to the LAP position. Typically Westinghouse recommended values of between 7 and 10 psi.
 
+Brake Shoe Force
+----------------
+
+As indicated above the ``MaxBrakeForce`` parameter in the WAG file is the actual force applied to the wheel after reduction by the friction coefficient, often railway companies will provide an Net Braking Ratio (NBR) value to 
+specify the amount of force to be applied to the brake shoe. This force is then reduced by the brake shoe CoF to determine the actual force applied to the wheel.
+
+To facilitate the direct usage of the NBR value in the WAG file, the following parameters can be used. NB: When using these parameters the ``MaxBrakeForce`` parameter is not required.
+
+Brake Shoe Force - This is the current change being implemented. The following changes and parameter are included.
+
+``ORTSMaxBrakeShoeForce`` - the force applied to the brake shoe is the main braking force.
+
+``ORTSBrakeShoeType`` - this defines a number of different brake shoe types and curves. To provide a more realistic representation of the braking force the default CoF curves are 2D, ie 
+they are impacted by both the speed and Brake Shoe Force.  Typically ``ORTSBrakeShoeType`` will have one of the following keywords included - 
+``CastIron`` - cast iron brake shoe, 2D as above, ``HiFrictionCompost`` - high friction composite shoe, 2D as above, ``UserDefined`` - is a user defined curve 
+using the ORTSBrakeShoeFriction parameter, 1D (ie, speed only, see above section for the parameter format).
+
+``ORTSNumberCarBrakeShoes`` - to facilitate the operation of the default 2D curves above it is necessary to configure the number of brake shoes for each car.
+
+Whilst OR will attempt to set some defaults if parameters are left out, the most realistic operation will be achieved by using all the relevant parameters.
+
+The following two legacy arrangements can be used as an alternative to the above method,
+
+-  Legacy #1 - legacy arrangements using MaxBrakeForce on its own will remain unchanged. This in effect is an old MSTS file.
+
+- Legacy #2 - where MaxBrakeForce and ORTSBrakeShoeFriction have been set, legacy operation will remain unchanged.
+
+
 Train Brake Pipe Losses
 -----------------------
 

--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -2753,7 +2753,7 @@ Brake Shoe Force - This is the current change being implemented. The following c
 
 ``ORTSBrakeShoeType`` - this defines a number of different brake shoe types and curves. To provide a more realistic representation of the braking force the default CoF curves are 2D, ie 
 they are impacted by both the speed and Brake Shoe Force.  Typically ``ORTSBrakeShoeType`` will have one of the following keywords included - 
-``CastIron`` - cast iron brake shoe, 2D as above, ``HiFrictionCompost`` - high friction composite shoe, 2D as above, ``UserDefined`` - is a user defined curve 
+``Cast_Iron`` - cast iron brake shoe, 2D as above, ``Hi_Friction_Composite`` - high friction composite shoe, 2D as above, ``User_Defined`` - is a user defined curve 
 using the ORTSBrakeShoeFriction parameter, 1D (ie, speed only, see above section for the parameter format).
 
 ``ORTSNumberCarBrakeShoes`` - to facilitate the operation of the default 2D curves above it is necessary to configure the number of brake shoes for each car.

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -5460,7 +5460,7 @@ namespace Orts.Simulation.Physics
                 if (car is MSTSLocomotive) locoBehind = false;
                 if (car.SpeedMpS > 0)
                 {
-                    car.SpeedMpS += car.TotalForceN / car.MassKG * elapsedTime;
+                    car.SpeedMpS += (car.TotalForceN / car.MassKG) * elapsedTime;
                     if (car.SpeedMpS < 0)
                         car.SpeedMpS = 0;
                     // If car is manual braked, air_piped car or vacuum_piped, and preceeding car is at stop, then set speed to zero.  
@@ -5473,7 +5473,7 @@ namespace Orts.Simulation.Physics
                 }
                 else if (car.SpeedMpS < 0)
                 {
-                    car.SpeedMpS += car.TotalForceN / car.MassKG * elapsedTime;
+                    car.SpeedMpS += (car.TotalForceN / car.MassKG) * elapsedTime;
                     if (car.SpeedMpS > 0)
                         car.SpeedMpS = 0;
                     // If car is manual braked, air_piped car or vacuum_piped, and preceeding car is at stop, then set speed to zero.  

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1834,7 +1834,7 @@ public List<CabView> CabViewList = new List<CabView>();
                 {
                     if (DynamicBrakeBlendingForceMatch)
                     {
-                        float diff = target * MaxBrakeForceN - DynamicBrakeForceN;
+                        float diff = target * FrictionBrakeBlendingMaxForceN - DynamicBrakeForceN;
                         float threshold = 100;
                         if (diff > threshold && DynamicBrakeIntervention < 1)
                             DynamicBrakeIntervention = Math.Min(DynamicBrakeIntervention + elapsedClockSeconds, 1);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1492,6 +1492,7 @@ public List<CabView> CabViewList = new List<CabView>();
                     Trace.TraceInformation("Number of Locomotive Drive Axles set to default value of {0}", LocoNumDrvAxles);
                 }
             }
+
             if (TractionMotorType == TractionMotorTypes.AC)
             {
                 InductionMotor motor = new InductionMotor(LocomotiveAxle, this);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1492,7 +1492,6 @@ public List<CabView> CabViewList = new List<CabView>();
                     Trace.TraceInformation("Number of Locomotive Drive Axles set to default value of {0}", LocoNumDrvAxles);
                 }
             }
-
             if (TractionMotorType == TractionMotorTypes.AC)
             {
                 InductionMotor motor = new InductionMotor(LocomotiveAxle, this);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -6307,10 +6307,6 @@ namespace Orts.Simulation.RollingStocks
 
         public override string GetDebugStatus()
         {
-            // calculate values for display, so that display value doesn't go negative
-            var superheatTempDisplayC = C.FromF(CurrentSuperheatTempF);
-            superheatTempDisplayC = MathHelper.Clamp(superheatTempDisplayC, 0.0f, C.FromF(MaxSuperheatRefTempF));
-
             var status = new StringBuilder(base.GetDebugStatus());
 
             status.AppendFormat("\n\n\t\t === {0} === \t\t\n", Simulator.Catalog.GetString("Key Inputs"));
@@ -6382,8 +6378,7 @@ namespace Orts.Simulation.RollingStocks
                 Simulator.Catalog.GetString("MaxSupH"),
                 FormatStrings.FormatTemperature(C.FromF(MaxSuperheatRefTempF), IsMetric, false),
                 Simulator.Catalog.GetString("CurSupH"),
-                FormatStrings.FormatTemperature(superheatTempDisplayC, IsMetric, false)
-                );
+                FormatStrings.FormatTemperature(C.FromF(CurrentSuperheatTempF), IsMetric, false));
 
             status.AppendFormat("\n\t\t === {0} === \t\t{1}/{2}\n",
                 Simulator.Catalog.GetString("Steam Usage"),

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -6307,6 +6307,10 @@ namespace Orts.Simulation.RollingStocks
 
         public override string GetDebugStatus()
         {
+            // calculate values for display, so that display value doesn't go negative
+            var superheatTempDisplayC = C.FromF(CurrentSuperheatTempF);
+            superheatTempDisplayC = MathHelper.Clamp(superheatTempDisplayC, 0.0f, C.FromF(MaxSuperheatRefTempF));
+
             var status = new StringBuilder(base.GetDebugStatus());
 
             status.AppendFormat("\n\n\t\t === {0} === \t\t\n", Simulator.Catalog.GetString("Key Inputs"));
@@ -6378,7 +6382,8 @@ namespace Orts.Simulation.RollingStocks
                 Simulator.Catalog.GetString("MaxSupH"),
                 FormatStrings.FormatTemperature(C.FromF(MaxSuperheatRefTempF), IsMetric, false),
                 Simulator.Catalog.GetString("CurSupH"),
-                FormatStrings.FormatTemperature(C.FromF(CurrentSuperheatTempF), IsMetric, false));
+                FormatStrings.FormatTemperature(superheatTempDisplayC, IsMetric, false)
+                );
 
             status.AppendFormat("\n\t\t === {0} === \t\t{1}/{2}\n",
                 Simulator.Catalog.GetString("Steam Usage"),

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -6369,6 +6369,10 @@ namespace Orts.Simulation.RollingStocks
                 FormatStrings.FormatEnergy(W.FromBTUpS(BoilerHeatBTU), IsMetric)
                 );
 
+            // calculate values for display, so that display value doesn't go negative
+            var superheatTempDisplayC = C.FromF(CurrentSuperheatTempF);
+            superheatTempDisplayC = MathHelper.Clamp(superheatTempDisplayC, 0.0f, C.FromF(MaxSuperheatRefTempF));
+
             status.AppendFormat("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}\t{8}\n",
                 Simulator.Catalog.GetString("Temp:"),
                 Simulator.Catalog.GetString("Flue"),
@@ -6378,7 +6382,8 @@ namespace Orts.Simulation.RollingStocks
                 Simulator.Catalog.GetString("MaxSupH"),
                 FormatStrings.FormatTemperature(C.FromF(MaxSuperheatRefTempF), IsMetric, false),
                 Simulator.Catalog.GetString("CurSupH"),
-                FormatStrings.FormatTemperature(C.FromF(CurrentSuperheatTempF), IsMetric, false));
+                FormatStrings.FormatTemperature(superheatTempDisplayC, IsMetric, false)
+                );
 
             status.AppendFormat("\n\t\t === {0} === \t\t{1}/{2}\n",
                 Simulator.Catalog.GetString("Steam Usage"),
@@ -6819,8 +6824,8 @@ namespace Orts.Simulation.RollingStocks
                     );
             }
 
-            if (Simulator.UseAdvancedAdhesion && !Simulator.Settings.SimpleControlPhysics && SteamEngineType != SteamEngineTypes.Geared) 
-                // Only display slip monitor if advanced adhesion is set and simplecontrols/physics not set
+            if (Simulator.UseAdvancedAdhesion && !Simulator.Settings.SimpleControlPhysics && SteamEngineType != SteamEngineTypes.Geared)
+            // Only display slip monitor if advanced adhesion is set and simplecontrols/physics not set
             {
                 status.AppendFormat("\n\t\t === {0} === \n", Simulator.Catalog.GetString("Slip Monitor"));
                 status.AppendFormat("{0}\t{1}\t{2:N0}\t{3}\t{4}\t{5}\t{6}\t{7}\t{8:N2}\t{9}\t{10}\t{11:N2}\t{12}\t{13}\t{14:N1}\n",

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -626,7 +626,7 @@ namespace Orts.Simulation.RollingStocks
                     NumberCarBrakeShoes = (LocoNumDrvAxles * 4) + (WagonNumAxles * 4); // Assume 4 brake shoes per axle on all wheels
                 } 
 
-                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))
+                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.Cast_Iron || BrakeShoeType == BrakeShoeTypes.Hi_Friction_Compost))
                 {
                     Trace.TraceInformation("Number of Locomotive Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
                 }
@@ -635,7 +635,7 @@ namespace Orts.Simulation.RollingStocks
             {
                 NumberCarBrakeShoes = WagonNumAxles * 4; // Assume 4 brake shoes per axle
 
-                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))
+                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.Cast_Iron || BrakeShoeType == BrakeShoeTypes.Hi_Friction_Compost))
                 {
                     Trace.TraceInformation("Number of Wagon Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
                 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -981,7 +981,6 @@ namespace Orts.Simulation.RollingStocks
                 Trace.TraceInformation("Empty Values = Brake {0} Handbrake {1} DavisA {2} DavisB {3} DavisC {4} CoGY {5}", LoadEmptyMaxBrakeForceN, LoadEmptyMaxHandbrakeForceN, LoadEmptyORTSDavis_A, LoadEmptyORTSDavis_B, LoadEmptyORTSDavis_C, LoadEmptyCentreOfGravityM_Y);
                 Trace.TraceInformation("Full Values = Brake {0} Handbrake {1} DavisA {2} DavisB {3} DavisC {4} CoGY {5}", LoadFullMaxBrakeForceN, LoadFullMaxHandbrakeForceN, LoadFullORTSDavis_A, LoadFullORTSDavis_B, LoadFullORTSDavis_C, LoadFullCentreOfGravityM_Y);
 #endif
-
             }
 
             // Determine whether or not to use the Davis friction model. Must come after freight animations are initialized.

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -597,15 +597,10 @@ namespace Orts.Simulation.RollingStocks
             MassKG = InitialMassKG;
 
             MaxHandbrakeForceN = InitialMaxHandbrakeForceN;
+
             if (MaxBrakeShoeForceN != 0 && BrakeShoeType != BrakeShoeTypes.Unknown)
             {
-                MaxBrakeForceN = MaxBrakeShoeForceN;
-
-                if (Simulator.Settings.VerboseConfigurationMessages)
-                {
-                    Trace.TraceInformation("BrakeShoeType set to {0}, with a MaxBrakeShoeForce of {1}", BrakeShoeType, FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
-                }
-                
+                MaxBrakeForceN = MaxBrakeShoeForceN;            
             }
             else
             {
@@ -613,7 +608,7 @@ namespace Orts.Simulation.RollingStocks
 
                 if (Simulator.Settings.VerboseConfigurationMessages)
                 {
-                    Trace.TraceInformation("BrakeShoeType set to {0}, with a MaxBrakeForce of {1}", BrakeShoeType, FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
+                    Trace.TraceInformation("Unknown BrakeShoeType set to OR default (Cast Iron) with a MaxBrakeForce of {0}", FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
                 }
             }
 
@@ -621,10 +616,20 @@ namespace Orts.Simulation.RollingStocks
             if (NumberCarBrakeShoes == 0 && WagonType == WagonTypes.Engine)
             {
                 NumberCarBrakeShoes = LocoNumDrvAxles * 4.0f; // Assume 4 brake shoes per axle
+
+                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))
+                {
+                    Trace.TraceInformation("Number of Locomotive Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
+                }
             }
             else if (NumberCarBrakeShoes == 0)
             {
                 NumberCarBrakeShoes = WagonNumAxles * 4.0f; // Assume 4 brake shoes per axle
+
+                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))
+                {
+                    Trace.TraceInformation("Number of Wagon Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
+                }
             }
 
             CentreOfGravityM = InitialCentreOfGravityM;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1147,6 +1147,19 @@ namespace Orts.Simulation.RollingStocks
                 case "wagon(maxhandbrakeforce": InitialMaxHandbrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(maxbrakeforce": InitialMaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(ortsmaxbrakeshoeforce": MaxBrakeShoeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
+                case "wagon(ortsbrakeshoetype":
+                    stf.MustMatch("(");
+                    var brakeShoeType = stf.ReadString();
+                    try
+                    {
+                        BrakeShoeType = (BrakeShoeTypes)Enum.Parse(typeof(BrakeShoeTypes), brakeShoeType);
+                    }
+                    catch
+                    {
+                        STFException.TraceWarning(stf, "Assumed unknown brake shoe type " + brakeShoeType);
+                    }
+                    break;
+
                 case "wagon(ortswheelbrakeslideprotection":
                   // stf.MustMatch("(");
                     var brakeslideprotection = stf.ReadFloatBlock(STFReader.UNITS.None, null);
@@ -1480,6 +1493,7 @@ namespace Orts.Simulation.RollingStocks
             HasPassengerCapacity = copy.HasPassengerCapacity;
             WagonType = copy.WagonType;
             WagonSpecialType = copy.WagonSpecialType;
+            BrakeShoeType = copy.BrakeShoeType;
             FreightShapeFileName = copy.FreightShapeFileName;
             FreightAnimMaxLevelM = copy.FreightAnimMaxLevelM;
             FreightAnimMinLevelM = copy.FreightAnimMinLevelM;
@@ -3969,46 +3983,6 @@ namespace Orts.Simulation.RollingStocks
             if (FreightAnimations.LoadedOne != null) fraction = FreightAnimations.LoadedOne.LoadPerCent / 100;
             return fraction;
         }
-
-        /// <summary>
-        /// Returns the Brake shoe coefficient.
-        /// </summary>
-
-        public override float GetUserBrakeShoeFrictionFactor()
-        {
-            var frictionfraction = 0.0f;
-            if ( BrakeShoeFrictionFactor == null)
-            {
-                frictionfraction = 0.0f;
-            }
-            else
-            {
-                frictionfraction = BrakeShoeFrictionFactor[MpS.ToKpH(AbsSpeedMpS)];
-            }
-            
-            return frictionfraction;
-        }
-
-        /// <summary>
-        /// Returns the Brake shoe coefficient at zero speed.
-        /// </summary>
-
-        public override float GetZeroUserBrakeShoeFrictionFactor()
-        {
-            var frictionfraction = 0.0f;
-            if (BrakeShoeFrictionFactor == null)
-            {
-                frictionfraction = 0.0f;
-            }
-            else
-            {
-                frictionfraction = BrakeShoeFrictionFactor[0.0f];
-            }
-
-            return frictionfraction;
-        }       
-      
-        
         
         /// <summary>
         /// Starts a continuous increase in controlled value.

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -626,7 +626,7 @@ namespace Orts.Simulation.RollingStocks
                     NumberCarBrakeShoes = (LocoNumDrvAxles * 4) + (WagonNumAxles * 4); // Assume 4 brake shoes per axle on all wheels
                 } 
 
-                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.Cast_Iron || BrakeShoeType == BrakeShoeTypes.Hi_Friction_Compost))
+                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.Cast_Iron || BrakeShoeType == BrakeShoeTypes.High_Friction_Composite))
                 {
                     Trace.TraceInformation("Number of Locomotive Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
                 }
@@ -635,7 +635,7 @@ namespace Orts.Simulation.RollingStocks
             {
                 NumberCarBrakeShoes = WagonNumAxles * 4; // Assume 4 brake shoes per axle
 
-                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.Cast_Iron || BrakeShoeType == BrakeShoeTypes.Hi_Friction_Compost))
+                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.Cast_Iron || BrakeShoeType == BrakeShoeTypes.High_Friction_Composite))
                 {
                     Trace.TraceInformation("Number of Wagon Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
                 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -676,7 +676,11 @@ namespace Orts.Simulation.RollingStocks
                     LoadEmptyWagonFrontalAreaM2 = WagonFrontalAreaM2;
                 }
 
-                if (FreightAnimations.EmptyMaxBrakeForceN > 0)
+                if (FreightAnimations.EmptyMaxBrakeShoeForceN > 0)
+                {
+                    LoadEmptyMaxBrakeForceN = FreightAnimations.EmptyMaxBrakeShoeForceN;
+                }
+                else if (FreightAnimations.EmptyMaxBrakeForceN > 0)
                 {
                     LoadEmptyMaxBrakeForceN = FreightAnimations.EmptyMaxBrakeForceN;
                 }
@@ -752,8 +756,11 @@ namespace Orts.Simulation.RollingStocks
                         LoadFullWagonFrontalAreaM2 = WagonFrontalAreaM2;
                     }
 
-
-                    if (FreightAnimations.FullPhysicsStaticOne.FullStaticMaxBrakeForceN > 0)
+                    if (FreightAnimations.FullPhysicsStaticOne.FullStaticMaxBrakeShoeForceN > 0)
+                    {
+                        LoadFullMaxBrakeForceN = FreightAnimations.FullPhysicsStaticOne.FullStaticMaxBrakeShoeForceN;
+                    }
+                    else if (FreightAnimations.FullPhysicsStaticOne.FullStaticMaxBrakeForceN > 0)
                     {
                         LoadFullMaxBrakeForceN = FreightAnimations.FullPhysicsStaticOne.FullStaticMaxBrakeForceN;
                     }
@@ -839,8 +846,11 @@ namespace Orts.Simulation.RollingStocks
                         LoadFullWagonFrontalAreaM2 = WagonFrontalAreaM2;
                     }
 
-
-                    if (FreightAnimations.FullPhysicsContinuousOne.FullMaxBrakeForceN > 0)
+                    if (FreightAnimations.FullPhysicsContinuousOne.FullMaxBrakeShoeForceN > 0)
+                    {
+                        LoadFullMaxBrakeForceN = FreightAnimations.FullPhysicsContinuousOne.FullMaxBrakeShoeForceN;
+                    }
+                    else if (FreightAnimations.FullPhysicsContinuousOne.FullMaxBrakeForceN > 0)
                     {
                         LoadFullMaxBrakeForceN = FreightAnimations.FullPhysicsContinuousOne.FullMaxBrakeForceN;
                     }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -597,7 +597,14 @@ namespace Orts.Simulation.RollingStocks
             // Initialise key wagon parameters
             MassKG = InitialMassKG;
             MaxHandbrakeForceN = InitialMaxHandbrakeForceN;
-            MaxBrakeForceN = InitialMaxBrakeForceN;
+            if (MaxBrakeShoeForceN != 0)
+            {
+                MaxBrakeForceN = MaxBrakeShoeForceN;
+            }
+            else
+            {
+                MaxBrakeForceN = InitialMaxBrakeForceN;
+            }
             CentreOfGravityM = InitialCentreOfGravityM;
 
             if (FreightAnimations != null)
@@ -1129,6 +1136,7 @@ namespace Orts.Simulation.RollingStocks
                 case "wagon(ortsbrakeshoefriction": BrakeShoeFrictionFactor = new Interpolator(stf); break;
                 case "wagon(maxhandbrakeforce": InitialMaxHandbrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(maxbrakeforce": InitialMaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
+                case "wagon(maxbrakeshoebrakeforce": MaxBrakeShoeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(ortswheelbrakeslideprotection":
                   // stf.MustMatch("(");
                     var brakeslideprotection = stf.ReadFloatBlock(STFReader.UNITS.None, null);
@@ -1504,6 +1512,7 @@ namespace Orts.Simulation.RollingStocks
             InitialMaxBrakeForceN = copy.InitialMaxBrakeForceN;
             InitialMaxHandbrakeForceN = copy.InitialMaxHandbrakeForceN;
             MaxBrakeForceN = copy.MaxBrakeForceN;
+            MaxBrakeShoeForceN = copy.MaxBrakeShoeForceN;
             MaxHandbrakeForceN = copy.MaxHandbrakeForceN;
             WindowDeratingFactor = copy.WindowDeratingFactor;
             DesiredCompartmentTempSetpointC = copy.DesiredCompartmentTempSetpointC;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1168,7 +1168,7 @@ namespace Orts.Simulation.RollingStocks
                 case "wagon(maxhandbrakeforce": InitialMaxHandbrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(maxbrakeforce": InitialMaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(ortsmaxbrakeshoeforce": MaxBrakeShoeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
-                case "engine(ortsnumberwagonbrakeshoes": NumberCarBrakeShoes = stf.ReadIntBlock(null); break;
+                case "engine(ortsnumbercarbrakeshoes": NumberCarBrakeShoes = stf.ReadIntBlock(null); break;
                 case "wagon(ortsbrakeshoetype":
                     stf.MustMatch("(");
                     var brakeShoeType = stf.ReadString();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -85,8 +85,7 @@ namespace Orts.Simulation.RollingStocks
 
         public bool GenericItem1;
         public bool GenericItem2;
-
-        Interpolator BrakeShoeFrictionFactor;  // Factor of friction for wagon brake shoes
+                
         const float WaterLBpUKG = 10.0f;    // lbs of water in 1 gal (uk)
         float TempMassDiffRatio;
 
@@ -596,8 +595,9 @@ namespace Orts.Simulation.RollingStocks
 
             // Initialise key wagon parameters
             MassKG = InitialMassKG;
+
             MaxHandbrakeForceN = InitialMaxHandbrakeForceN;
-            if (MaxBrakeShoeForceN != 0)
+            if (MaxBrakeShoeForceN != 0 && BrakeShoeFrictionFactor != null)
             {
                 MaxBrakeForceN = MaxBrakeShoeForceN;
             }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -597,13 +597,24 @@ namespace Orts.Simulation.RollingStocks
             MassKG = InitialMassKG;
 
             MaxHandbrakeForceN = InitialMaxHandbrakeForceN;
-            if (MaxBrakeShoeForceN != 0 && BrakeShoeFrictionFactor != null)
+            if (MaxBrakeShoeForceN != 0 && BrakeShoeType != BrakeShoeTypes.Unknown)
             {
                 MaxBrakeForceN = MaxBrakeShoeForceN;
+
+                if (Simulator.Settings.VerboseConfigurationMessages)
+                {
+                    Trace.TraceInformation("BrakeShoeType set to {0}, with a MaxBrakeShoeForce of {1}", BrakeShoeType, FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
+                }
+                
             }
             else
             {
                 MaxBrakeForceN = InitialMaxBrakeForceN;
+
+                if (Simulator.Settings.VerboseConfigurationMessages)
+                {
+                    Trace.TraceInformation("BrakeShoeType set to {0}, with a MaxBrakeForce of {1}", BrakeShoeType, FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
+                }
             }
             CentreOfGravityM = InitialCentreOfGravityM;
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1136,7 +1136,7 @@ namespace Orts.Simulation.RollingStocks
                 case "wagon(ortsbrakeshoefriction": BrakeShoeFrictionFactor = new Interpolator(stf); break;
                 case "wagon(maxhandbrakeforce": InitialMaxHandbrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(maxbrakeforce": InitialMaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
-                case "wagon(maxbrakeshoebrakeforce": MaxBrakeShoeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
+                case "wagon(ortsmaxbrakeshoeforce": MaxBrakeShoeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(ortswheelbrakeslideprotection":
                   // stf.MustMatch("(");
                     var brakeslideprotection = stf.ReadFloatBlock(STFReader.UNITS.None, null);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -597,15 +597,10 @@ namespace Orts.Simulation.RollingStocks
             MassKG = InitialMassKG;
 
             MaxHandbrakeForceN = InitialMaxHandbrakeForceN;
+
             if (MaxBrakeShoeForceN != 0 && BrakeShoeType != BrakeShoeTypes.Unknown)
             {
-                MaxBrakeForceN = MaxBrakeShoeForceN;
-
-                if (Simulator.Settings.VerboseConfigurationMessages)
-                {
-                    Trace.TraceInformation("BrakeShoeType set to {0}, with a MaxBrakeShoeForce of {1}", BrakeShoeType, FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
-                }
-                
+                MaxBrakeForceN = MaxBrakeShoeForceN;             
             }
             else
             {
@@ -613,7 +608,7 @@ namespace Orts.Simulation.RollingStocks
 
                 if (Simulator.Settings.VerboseConfigurationMessages)
                 {
-                    Trace.TraceInformation("BrakeShoeType set to {0}, with a MaxBrakeForce of {1}", BrakeShoeType, FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
+                    Trace.TraceInformation("Unknown BrakeShoeType set to OR default (Cast Iron) with a MaxBrakeForce of {0}", FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
                 }
             }
 
@@ -621,10 +616,20 @@ namespace Orts.Simulation.RollingStocks
             if (NumberCarBrakeShoes == 0 && WagonType == WagonTypes.Engine)
             {
                 NumberCarBrakeShoes = LocoNumDrvAxles * 4.0f; // Assume 4 brake shoes per axle
+
+                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))
+                {
+                    Trace.TraceInformation("Number of Locomotive Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
+                }
             }
-            else if (NumberCarBrakeShoes == 0)
+            else if (NumberCarBrakeShoes == 0 )
             {
                 NumberCarBrakeShoes = WagonNumAxles * 4.0f; // Assume 4 brake shoes per axle
+
+                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))
+                {
+                    Trace.TraceInformation("Number of Wagon Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
+                }
             }
 
             CentreOfGravityM = InitialCentreOfGravityM;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -617,13 +617,13 @@ namespace Orts.Simulation.RollingStocks
             {
                 var LocoTest = Simulator.PlayerLocomotive as MSTSLocomotive;
 
-                if (LocoTest != null && !LocoTest.DriveWheelOnlyBrakes)
+                if (LocoTest != null && LocoTest.DriveWheelOnlyBrakes)
                 {
-                    NumberCarBrakeShoes = LocoNumDrvAxles * 4 + WagonNumAxles * 4; // Assume 4 brake shoes per axle on all wheels
+                    NumberCarBrakeShoes = LocoNumDrvAxles * 4; // Assume 4 brake shoes per axle on drive wheels only                    
                 }
                 else
                 {
-                    NumberCarBrakeShoes = LocoNumDrvAxles * 4; // Assume 4 brake shoes per axle on drive wheels only
+                    NumberCarBrakeShoes = (LocoNumDrvAxles * 4) + (WagonNumAxles * 4); // Assume 4 brake shoes per axle on all wheels
                 } 
 
                 if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -597,10 +597,15 @@ namespace Orts.Simulation.RollingStocks
             MassKG = InitialMassKG;
 
             MaxHandbrakeForceN = InitialMaxHandbrakeForceN;
-
             if (MaxBrakeShoeForceN != 0 && BrakeShoeType != BrakeShoeTypes.Unknown)
             {
-                MaxBrakeForceN = MaxBrakeShoeForceN;             
+                MaxBrakeForceN = MaxBrakeShoeForceN;
+
+                if (Simulator.Settings.VerboseConfigurationMessages)
+                {
+                    Trace.TraceInformation("BrakeShoeType set to {0}, with a MaxBrakeShoeForce of {1}", BrakeShoeType, FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
+                }
+                
             }
             else
             {
@@ -608,7 +613,7 @@ namespace Orts.Simulation.RollingStocks
 
                 if (Simulator.Settings.VerboseConfigurationMessages)
                 {
-                    Trace.TraceInformation("Unknown BrakeShoeType set to OR default (Cast Iron) with a MaxBrakeForce of {0}", FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
+                    Trace.TraceInformation("BrakeShoeType set to {0}, with a MaxBrakeForce of {1}", BrakeShoeType, FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
                 }
             }
 
@@ -616,20 +621,10 @@ namespace Orts.Simulation.RollingStocks
             if (NumberCarBrakeShoes == 0 && WagonType == WagonTypes.Engine)
             {
                 NumberCarBrakeShoes = LocoNumDrvAxles * 4.0f; // Assume 4 brake shoes per axle
-
-                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))
-                {
-                    Trace.TraceInformation("Number of Locomotive Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
-                }
             }
-            else if (NumberCarBrakeShoes == 0 )
+            else if (NumberCarBrakeShoes == 0)
             {
                 NumberCarBrakeShoes = WagonNumAxles * 4.0f; // Assume 4 brake shoes per axle
-
-                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))
-                {
-                    Trace.TraceInformation("Number of Wagon Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
-                }
             }
 
             CentreOfGravityM = InitialCentreOfGravityM;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -598,6 +598,8 @@ namespace Orts.Simulation.RollingStocks
 
             MaxHandbrakeForceN = InitialMaxHandbrakeForceN;
 
+            FrictionBrakeBlendingMaxForceN = InitialMaxBrakeForceN; // set the value of braking when blended with dynamic brakes
+
             if (MaxBrakeShoeForceN != 0 && BrakeShoeType != BrakeShoeTypes.Unknown)
             {
                 MaxBrakeForceN = MaxBrakeShoeForceN;            

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -616,6 +616,17 @@ namespace Orts.Simulation.RollingStocks
                     Trace.TraceInformation("BrakeShoeType set to {0}, with a MaxBrakeForce of {1}", BrakeShoeType, FormatStrings.FormatForce(MaxBrakeForceN, IsMetric));
                 }
             }
+
+            // Initialise number of brake shoes per wagon
+            if (NumberCarBrakeShoes == 0 && WagonType == WagonTypes.Engine)
+            {
+                NumberCarBrakeShoes = LocoNumDrvAxles * 4.0f; // Assume 4 brake shoes per axle
+            }
+            else if (NumberCarBrakeShoes == 0)
+            {
+                NumberCarBrakeShoes = WagonNumAxles * 4.0f; // Assume 4 brake shoes per axle
+            }
+
             CentreOfGravityM = InitialCentreOfGravityM;
 
             if (FreightAnimations != null)
@@ -1157,6 +1168,7 @@ namespace Orts.Simulation.RollingStocks
                 case "wagon(maxhandbrakeforce": InitialMaxHandbrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(maxbrakeforce": InitialMaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(ortsmaxbrakeshoeforce": MaxBrakeShoeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
+                case "engine(ortsnumberwagonbrakeshoes": NumberCarBrakeShoes = stf.ReadIntBlock(null); break;
                 case "wagon(ortsbrakeshoetype":
                     stf.MustMatch("(");
                     var brakeShoeType = stf.ReadString();
@@ -1547,6 +1559,7 @@ namespace Orts.Simulation.RollingStocks
             InitialMaxHandbrakeForceN = copy.InitialMaxHandbrakeForceN;
             MaxBrakeForceN = copy.MaxBrakeForceN;
             MaxBrakeShoeForceN = copy.MaxBrakeShoeForceN;
+            NumberCarBrakeShoes = copy.NumberCarBrakeShoes;
             MaxHandbrakeForceN = copy.MaxHandbrakeForceN;
             WindowDeratingFactor = copy.WindowDeratingFactor;
             DesiredCompartmentTempSetpointC = copy.DesiredCompartmentTempSetpointC;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -615,7 +615,16 @@ namespace Orts.Simulation.RollingStocks
             // Initialise number of brake shoes per wagon
             if (NumberCarBrakeShoes == 0 && WagonType == WagonTypes.Engine)
             {
-                NumberCarBrakeShoes = LocoNumDrvAxles * 4.0f; // Assume 4 brake shoes per axle
+                var LocoTest = Simulator.PlayerLocomotive as MSTSLocomotive;
+
+                if (LocoTest != null && !LocoTest.DriveWheelOnlyBrakes)
+                {
+                    NumberCarBrakeShoes = LocoNumDrvAxles * 4 + WagonNumAxles * 4; // Assume 4 brake shoes per axle on all wheels
+                }
+                else
+                {
+                    NumberCarBrakeShoes = LocoNumDrvAxles * 4; // Assume 4 brake shoes per axle on drive wheels only
+                } 
 
                 if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))
                 {
@@ -624,7 +633,7 @@ namespace Orts.Simulation.RollingStocks
             }
             else if (NumberCarBrakeShoes == 0)
             {
-                NumberCarBrakeShoes = WagonNumAxles * 4.0f; // Assume 4 brake shoes per axle
+                NumberCarBrakeShoes = WagonNumAxles * 4; // Assume 4 brake shoes per axle
 
                 if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.CastIron || BrakeShoeType == BrakeShoeTypes.HiFrictionCompost))
                 {
@@ -1173,7 +1182,7 @@ namespace Orts.Simulation.RollingStocks
                 case "wagon(maxhandbrakeforce": InitialMaxHandbrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(maxbrakeforce": InitialMaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
                 case "wagon(ortsmaxbrakeshoeforce": MaxBrakeShoeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); break;
-                case "engine(ortsnumbercarbrakeshoes": NumberCarBrakeShoes = stf.ReadIntBlock(null); break;
+                case "wagon(ortsnumbercarbrakeshoes": NumberCarBrakeShoes = stf.ReadIntBlock(null); break;
                 case "wagon(ortsbrakeshoetype":
                     stf.MustMatch("(");
                     var brakeShoeType = stf.ReadString();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -721,6 +721,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             else Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
 
             float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
+            Car.HuDBrakeShoeFriction = Car.GetBrakeShoeFrictionCoefficientHuD();
 
             Car.BrakeRetardForceN = Car.BrakeShoeForceN * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding to excessive brake force

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -711,23 +711,25 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             {
                 Car.Train.HUDWagonBrakeCylinderPSI = CylPressurePSI;
             }
-
-            float f;
+            
             if (!Car.BrakesStuck)
             {
-                f = Car.MaxBrakeForceN * Math.Min(CylPressurePSI / MaxCylPressurePSI, 1);
-                if (f < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
-                    f = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
+                Car.BrakeShoeForceN = Car.MaxBrakeForceN * Math.Min(CylPressurePSI / MaxCylPressurePSI, 1);
+                if (Car.BrakeShoeForceN < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
+                    Car.BrakeShoeForceN = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
             }
-            else f = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2); 
-            Car.BrakeRetardForceN = f * Car.BrakeShoeRetardCoefficientFrictionAdjFactor; // calculates value of force applied to wheel, independent of wheel skid
+            else Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
+
+            float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
+
+            Car.BrakeRetardForceN = Car.BrakeShoeForceN * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding to excessive brake force
             {
-                Car.BrakeForceN = f * Car.SkidFriction;   // if excessive brakeforce, wheel skids, and loses adhesion
+                Car.BrakeForceN = Car.BrakeShoeForceN * Car.SkidFriction;   // if excessive brakeforce, wheel skids, and loses adhesion
             }
             else
             {
-                Car.BrakeForceN = f * Car.BrakeShoeCoefficientFrictionAdjFactor; // In advanced adhesion model brake shoe coefficient varies with speed, in simple model constant force applied as per value in WAG file, will vary with wheel skid.
+                Car.BrakeForceN = Car.BrakeShoeForceN * brakeShoeFriction; // In advanced adhesion model brake shoe coefficient varies with speed, in simple model constant force applied as per value in WAG file, will vary with wheel skid.
             }
 
             // sound trigger checking runs every half second, to avoid the problems caused by the jumping BrakeLine1PressurePSI value, and also saves cpu time :)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -587,15 +587,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                                 }
                             }
                         }
-                        if (loco.DynamicBrakePercent > 0 && Car.MaxBrakeForceN > 0)
+                        if (loco.DynamicBrakePercent > 0 && Car.FrictionBrakeBlendingMaxForceN > 0)
                         {
                             if (loco.DynamicBrakePartialBailOff)
                             {
-                                var requiredBrakeForceN = Math.Min(AutoCylPressurePSI / MaxCylPressurePSI, 1) * Car.MaxBrakeForceN;
-                                var localBrakeForceN = loco.DynamicBrakeForceN + Math.Min(CylPressurePSI / MaxCylPressurePSI, 1) * Car.MaxBrakeForceN;
-                                if (localBrakeForceN > requiredBrakeForceN - 0.15f * Car.MaxBrakeForceN)
+                                var requiredBrakeForceN = Math.Min(AutoCylPressurePSI / MaxCylPressurePSI, 1) * Car.FrictionBrakeBlendingMaxForceN;
+                                var localBrakeForceN = loco.DynamicBrakeForceN + Math.Min(CylPressurePSI / MaxCylPressurePSI, 1) * Car.FrictionBrakeBlendingMaxForceN;
+                                if (localBrakeForceN > requiredBrakeForceN - 0.15f * Car.FrictionBrakeBlendingMaxForceN)
                                 {
-                                    demandedPressurePSI = Math.Min(Math.Max((requiredBrakeForceN - loco.DynamicBrakeForceN)/Car.MaxBrakeForceN*MaxCylPressurePSI, 0), MaxCylPressurePSI);
+                                    demandedPressurePSI = Math.Min(Math.Max((requiredBrakeForceN - loco.DynamicBrakeForceN)/Car.FrictionBrakeBlendingMaxForceN * MaxCylPressurePSI, 0), MaxCylPressurePSI);
                                     if (demandedPressurePSI > CylPressurePSI && demandedPressurePSI < CylPressurePSI + 4) // Allow some margin for unnecessary air brake application
                                     {
                                         demandedPressurePSI = CylPressurePSI;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/ManualBraking.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/ManualBraking.cs
@@ -210,9 +210,14 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             {
                 Car.BrakeShoeForceN = Car.MaxBrakeForceN * Math.Min(BrakeForceFraction, 1);
                 if (Car.BrakeShoeForceN < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
+                {
                     Car.BrakeShoeForceN = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
+                }
             }
-            else Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
+            else
+            {
+                Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
+            }
 
             float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
             Car.HuDBrakeShoeFriction = Car.GetBrakeShoeFrictionCoefficientHuD();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/ManualBraking.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/ManualBraking.cs
@@ -215,6 +215,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             else Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
 
             float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
+            Car.HuDBrakeShoeFriction = Car.GetBrakeShoeFrictionCoefficientHuD();
 
             Car.BrakeRetardForceN = Car.BrakeShoeForceN * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding to excessive brake force

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/ManualBraking.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/ManualBraking.cs
@@ -206,22 +206,24 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 }
             }
 
-                float f;
             if (!Car.BrakesStuck)
             {
-                f = Car.MaxBrakeForceN * Math.Min(BrakeForceFraction, 1);
-                if (f < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
-                    f = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
+                Car.BrakeShoeForceN = Car.MaxBrakeForceN * Math.Min(BrakeForceFraction, 1);
+                if (Car.BrakeShoeForceN < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
+                    Car.BrakeShoeForceN = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
             }
-            else f = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
-            Car.BrakeRetardForceN = f * Car.BrakeShoeRetardCoefficientFrictionAdjFactor; // calculates value of force applied to wheel, independent of wheel skid
+            else Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
+
+            float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
+
+            Car.BrakeRetardForceN = Car.BrakeShoeForceN * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding to excessive brake force
             {
-                Car.BrakeForceN = f * Car.SkidFriction;   // if excessive brakeforce, wheel skids, and loses adhesion
+                Car.BrakeForceN = Car.BrakeShoeForceN * Car.SkidFriction;   // if excessive brakeforce, wheel skids, and loses adhesion
             }
             else
             {
-                Car.BrakeForceN = f * Car.BrakeShoeCoefficientFrictionAdjFactor; // In advanced adhesion model brake shoe coefficient varies with speed, in simple model constant force applied as per value in WAG file, will vary with wheel skid.
+                Car.BrakeForceN = Car.BrakeShoeForceN * brakeShoeFriction; // In advanced adhesion model brake shoe coefficient varies with speed, in simple model constant force applied as per value in WAG file, will vary with wheel skid.
             }
 
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/SingleTransferPipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/SingleTransferPipe.cs
@@ -160,6 +160,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             BleedOffValveOpen = false;
 
             float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
+            Car.HuDBrakeShoeFriction = Car.GetBrakeShoeFrictionCoefficientHuD();
 
             Car.BrakeRetardForceN = ( Car.MaxHandbrakeForceN * HandbrakePercent / 100) * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding to excessive brake force

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/SingleTransferPipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/SingleTransferPipe.cs
@@ -158,14 +158,17 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         public override void Update(float elapsedClockSeconds)
         {
             BleedOffValveOpen = false;
-            Car.BrakeRetardForceN = ( Car.MaxHandbrakeForceN * HandbrakePercent / 100) * Car.BrakeShoeRetardCoefficientFrictionAdjFactor; // calculates value of force applied to wheel, independent of wheel skid
+
+            float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
+
+            Car.BrakeRetardForceN = ( Car.MaxHandbrakeForceN * HandbrakePercent / 100) * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding to excessive brake force
             {
                 Car.BrakeForceN = (Car.MaxHandbrakeForceN * HandbrakePercent / 100) * Car.SkidFriction;   // if excessive brakeforce, wheel skids, and loses adhesion
             }
             else
             {
-                Car.BrakeForceN = (Car.MaxHandbrakeForceN * HandbrakePercent / 100) * Car.BrakeShoeCoefficientFrictionAdjFactor; // In advanced adhesion model brake shoe coefficient varies with speed, in simple model constant force applied as per value in WAG file, will vary with wheel skid.
+                Car.BrakeForceN = (Car.MaxHandbrakeForceN * HandbrakePercent / 100) * brakeShoeFriction; // In advanced adhesion model brake shoe coefficient varies with speed, in simple model constant force applied as per value in WAG file, will vary with wheel skid.
             }
         
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/StraightVacuumSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/StraightVacuumSinglePipe.cs
@@ -138,7 +138,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         Car.BrakeShoeForceN = Car.MaxBrakeForceN * brakecylinderfraction;
 
                         if (Car.BrakeShoeForceN < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
+                        {
                             Car.BrakeShoeForceN = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
+                        }
                     }
                     else
                     {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/StraightVacuumSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/StraightVacuumSinglePipe.cs
@@ -128,30 +128,33 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     }
 
                     // Adjust braking force as brake cylinder pressure varies.
-                    float f;
+
                     if (!Car.BrakesStuck)
                     {
 
                         float brakecylinderfraction = ((OneAtmospherePSI - CylPressurePSIA) / MaxForcePressurePSI);
                         brakecylinderfraction = MathHelper.Clamp(brakecylinderfraction, 0, 1);
 
-                        f = Car.MaxBrakeForceN * brakecylinderfraction;
+                        Car.BrakeShoeForceN = Car.MaxBrakeForceN * brakecylinderfraction;
 
-                        if (f < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
-                            f = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
+                        if (Car.BrakeShoeForceN < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
+                            Car.BrakeShoeForceN = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
                     }
                     else
                     {
-                        f = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
+                        Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
                     }
-                    Car.BrakeRetardForceN = f * Car.BrakeShoeRetardCoefficientFrictionAdjFactor; // calculates value of force applied to wheel, independent of wheel skid
+
+                    float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
+
+                    Car.BrakeRetardForceN = Car.BrakeShoeForceN * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
                     if (Car.BrakeSkid) // Test to see if wheels are skiding due to excessive brake force
                     {
-                        Car.BrakeForceN = f * Car.SkidFriction;   // if excessive brakeforce, wheel skids, and loses adhesion
+                        Car.BrakeForceN = Car.BrakeShoeForceN * Car.SkidFriction;   // if excessive brakeforce, wheel skids, and loses adhesion
                     }
                     else
                     {
-                        Car.BrakeForceN = f * Car.BrakeShoeCoefficientFrictionAdjFactor; // In advanced adhesion model brake shoe coefficient varies with speed, in simple odel constant force applied as per value in WAG file, will vary with wheel skid.
+                        Car.BrakeForceN = Car.BrakeShoeForceN * brakeShoeFriction; // In advanced adhesion model brake shoe coefficient varies with speed, in simple odel constant force applied as per value in WAG file, will vary with wheel skid.
                     }
 
                     // If wagons are not attached to the locomotive, then set wagon BC pressure to same as locomotive in the Train brake line

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/StraightVacuumSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/StraightVacuumSinglePipe.cs
@@ -146,6 +146,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     }
 
                     float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
+                    Car.HuDBrakeShoeFriction = Car.GetBrakeShoeFrictionCoefficientHuD();
 
                     Car.BrakeRetardForceN = Car.BrakeShoeForceN * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
                     if (Car.BrakeSkid) // Test to see if wheels are skiding due to excessive brake force

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
@@ -562,32 +562,34 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             }
 
                 float vrp = VacResPressureAdjPSIA();
-                float f;
+                
             if (!Car.BrakesStuck)
             {
                 // depending upon whether steam brake fitted or not, calculate brake force to be applied
                 if (LocomotiveSteamBrakeFitted && (Car.WagonType == MSTSWagon.WagonTypes.Engine || Car.WagonType == MSTSWagon.WagonTypes.Tender))
                 {
                     var leadLocomotiveMaxBoilerPressurePSI = lead == null ? 200.0f : (lead.MaxBoilerPressurePSI);
-                    f = Car.MaxBrakeForceN * Math.Min(SteamBrakeCylinderPressurePSI / leadLocomotiveMaxBoilerPressurePSI, 1);
+                    Car.BrakeShoeForceN = Car.MaxBrakeForceN * Math.Min(SteamBrakeCylinderPressurePSI / leadLocomotiveMaxBoilerPressurePSI, 1);
                 }
                 else
                 {
-                    f = CylPressurePSIA <= vrp ? 0 : Car.MaxBrakeForceN * Math.Min((CylPressurePSIA - vrp) / MaxForcePressurePSI, 1);
+                    Car.BrakeShoeForceN = CylPressurePSIA <= vrp ? 0 : Car.MaxBrakeForceN * Math.Min((CylPressurePSIA - vrp) / MaxForcePressurePSI, 1);
                 }
-                if (f < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
-                    f = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
+                if (Car.BrakeShoeForceN < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
+                    Car.BrakeShoeForceN = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
             }
-            else f = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
+            else Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
 
-                Car.BrakeRetardForceN = f * Car.BrakeShoeRetardCoefficientFrictionAdjFactor; // calculates value of force applied to wheel, independent of wheel skid
+            float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
+
+            Car.BrakeRetardForceN = Car.BrakeShoeForceN * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding due to excessive brake force
             {
-                Car.BrakeForceN = f * Car.SkidFriction;   // if excessive brakeforce, wheel skids, and loses adhesion
+                Car.BrakeForceN = Car.BrakeShoeForceN * Car.SkidFriction;   // if excessive brakeforce, wheel skids, and loses adhesion
             }
             else
             {
-                Car.BrakeForceN = f * Car.BrakeShoeCoefficientFrictionAdjFactor; // In advanced adhesion model brake shoe coefficient varies with speed, in simple model constant force applied as per value in WAG file, will vary with wheel skid.
+                Car.BrakeForceN = Car.BrakeShoeForceN * brakeShoeFriction; // In advanced adhesion model brake shoe coefficient varies with speed, in simple model constant force applied as per value in WAG file, will vary with wheel skid.
             }
            
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
@@ -581,7 +581,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     Car.BrakeShoeForceN = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
                 }
             }
-            else Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
+            else
+            {
+                Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
+            }
 
             float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
             Car.HuDBrakeShoeFriction = Car.GetBrakeShoeFrictionCoefficientHuD();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
@@ -562,7 +562,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             }
 
                 float vrp = VacResPressureAdjPSIA();
-                
+
             if (!Car.BrakesStuck)
             {
                 // depending upon whether steam brake fitted or not, calculate brake force to be applied
@@ -575,8 +575,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 {
                     Car.BrakeShoeForceN = CylPressurePSIA <= vrp ? 0 : Car.MaxBrakeForceN * Math.Min((CylPressurePSIA - vrp) / MaxForcePressurePSI, 1);
                 }
+
                 if (Car.BrakeShoeForceN < Car.MaxHandbrakeForceN * HandbrakePercent / 100)
+                {
                     Car.BrakeShoeForceN = Car.MaxHandbrakeForceN * HandbrakePercent / 100;
+                }
             }
             else Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
@@ -581,6 +581,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             else Car.BrakeShoeForceN = Math.Max(Car.MaxBrakeForceN, Car.MaxHandbrakeForceN / 2);
 
             float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
+            Car.HuDBrakeShoeFriction = Car.GetBrakeShoeFrictionCoefficientHuD();
 
             Car.BrakeRetardForceN = Car.BrakeShoeForceN * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding due to excessive brake force

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/FreightAnimations.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/FreightAnimations.cs
@@ -67,6 +67,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
         public float EmptyORTSWagonFrontalAreaM2 = -9999;
         public float EmptyORTSDavisDragConstant = -9999;
         public float EmptyMaxBrakeForceN = -9999;
+        public float EmptyMaxBrakeShoeForceN = -9999;
         public float EmptyMaxHandbrakeForceN = -9999;
         public float EmptyCentreOfGravityM_Y = -9999; // get centre of gravity after adjusted for freight animation
         public bool ContinuousFreightAnimationsPresent = false; // Flag to indicate that a continuous freight animation is present
@@ -104,6 +105,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 new STFReader.TokenProcessor("emptyortswagonfrontalarea", ()=>{ EmptyORTSWagonFrontalAreaM2 = stf.ReadFloatBlock(STFReader.UNITS.AreaDefaultFT2, -1); }),
                 new STFReader.TokenProcessor("emptyortsdavisdragconstant", ()=>{ EmptyORTSDavisDragConstant = stf.ReadFloatBlock(STFReader.UNITS.Any, -1); }),
                 new STFReader.TokenProcessor("emptymaxbrakeforce", ()=>{ EmptyMaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, -1); }),
+                new STFReader.TokenProcessor("emptymaxbrakeshoeforce", ()=>{ EmptyMaxBrakeShoeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, -1); }),
                 new STFReader.TokenProcessor("emptymaxhandbrakeforce", ()=>{ EmptyMaxHandbrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, -1); }),
                 new STFReader.TokenProcessor("emptycentreofgravity_y", ()=>{ EmptyCentreOfGravityM_Y = stf.ReadFloatBlock(STFReader.UNITS.Distance, -1); }),
                 new STFReader.TokenProcessor("freightanimcontinuous", ()=>
@@ -285,6 +287,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             EmptyORTSWagonFrontalAreaM2 = copyFACollection.EmptyORTSWagonFrontalAreaM2;
             EmptyORTSDavisDragConstant = copyFACollection.EmptyORTSDavisDragConstant;
             EmptyMaxBrakeForceN = copyFACollection.EmptyMaxBrakeForceN;
+            EmptyMaxBrakeShoeForceN = copyFACollection.EmptyMaxBrakeShoeForceN;
             EmptyMaxHandbrakeForceN = copyFACollection.EmptyMaxHandbrakeForceN;
             EmptyCentreOfGravityM_Y = copyFACollection.EmptyCentreOfGravityM_Y;
             ContinuousFreightAnimationsPresent = copyFACollection.ContinuousFreightAnimationsPresent;
@@ -982,6 +985,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
         public float FullORTSWagonFrontalAreaM2 = -9999;
         public float FullORTSDavisDragConstant = -9999;
         public float FullMaxBrakeForceN = -9999;
+        public float FullMaxBrakeShoeForceN = -9999;
         public float FullMaxHandbrakeForceN = -9999;
         public float FullCentreOfGravityM_Y = -9999; // get centre of gravity after adjusted for freight animation
 
@@ -1008,6 +1012,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 new STFReader.TokenProcessor("fullortswagonfrontalarea", ()=>{ FullORTSWagonFrontalAreaM2 = stf.ReadFloatBlock(STFReader.UNITS.AreaDefaultFT2, -1); }),
                 new STFReader.TokenProcessor("fullortsdavisdragconstant", ()=>{ FullORTSDavisDragConstant = stf.ReadFloatBlock(STFReader.UNITS.Any, -1); }),
                 new STFReader.TokenProcessor("fullmaxbrakeforce", ()=>{ FullMaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, -1); }),
+                new STFReader.TokenProcessor("fullmaxbrakeshoeforce", ()=>{ FullMaxBrakeShoeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, -1); }),
                 new STFReader.TokenProcessor("fullmaxhandbrakeforce", ()=>{ FullMaxHandbrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, -1); }),
                 new STFReader.TokenProcessor("fullcentreofgravity_y", ()=>{ FullCentreOfGravityM_Y = stf.ReadFloatBlock(STFReader.UNITS.Distance, -1); })
             });
@@ -1036,6 +1041,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             FullORTSWagonFrontalAreaM2 = freightAnimContin.FullORTSWagonFrontalAreaM2;
             FullORTSDavisDragConstant = freightAnimContin.FullORTSDavisDragConstant;
             FullMaxBrakeForceN = freightAnimContin.FullMaxBrakeForceN;
+            FullMaxBrakeShoeForceN = freightAnimContin.FullMaxBrakeShoeForceN;
             FullMaxHandbrakeForceN = freightAnimContin.FullMaxHandbrakeForceN;
             FullCentreOfGravityM_Y = freightAnimContin.FullCentreOfGravityM_Y;          
         }
@@ -1070,6 +1076,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
         public float FullStaticORTSWagonFrontalAreaM2 = -9999;
         public float FullStaticORTSDavisDragConstant = -9999;
         public float FullStaticMaxBrakeForceN = -9999;
+        public float FullStaticMaxBrakeShoeForceN = -9999;
         public float FullStaticMaxHandbrakeForceN = -9999;
         public float FullStaticCentreOfGravityM_Y = -9999; // get centre of gravity after adjusted for freight animation
 
@@ -1125,6 +1132,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             new STFReader.TokenProcessor("fullortswagonfrontalarea", ()=>{ FullStaticORTSWagonFrontalAreaM2 = stf.ReadFloatBlock(STFReader.UNITS.AreaDefaultFT2, -1); }),
             new STFReader.TokenProcessor("fullortsdavisdragconstant", ()=>{ FullStaticORTSDavisDragConstant = stf.ReadFloatBlock(STFReader.UNITS.Any, -1); }),
             new STFReader.TokenProcessor("fullmaxbrakeforce", ()=>{ FullStaticMaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, -1); }),
+            new STFReader.TokenProcessor("fullmaxbrakeshoeforce", ()=>{ FullStaticMaxBrakeShoeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, -1); }),
             new STFReader.TokenProcessor("fullmaxhandbrakeforce", ()=>{ FullStaticMaxHandbrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, -1); }),
             new STFReader.TokenProcessor("fullcentreofgravity_y", ()=>{ FullStaticCentreOfGravityM_Y = stf.ReadFloatBlock(STFReader.UNITS.Distance, -1); })
             });
@@ -1150,6 +1158,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             FullStaticORTSWagonFrontalAreaM2 = freightAnimStatic.FullStaticORTSWagonFrontalAreaM2;
             FullStaticORTSDavisDragConstant = freightAnimStatic.FullStaticORTSDavisDragConstant;
             FullStaticMaxBrakeForceN = freightAnimStatic.FullStaticMaxBrakeForceN;
+            FullStaticMaxBrakeShoeForceN = freightAnimStatic.FullStaticMaxBrakeShoeForceN;
             FullStaticMaxHandbrakeForceN = freightAnimStatic.FullStaticMaxHandbrakeForceN;
             FullStaticCentreOfGravityM_Y = freightAnimStatic.FullStaticCentreOfGravityM_Y;
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -210,8 +210,9 @@ namespace Orts.Simulation.RollingStocks
 
         public float MaxHandbrakeForceN;
         public float MaxBrakeForceN = 89e3f;
+        public float MaxBrakeShoeForceN;
         public float InitialMaxHandbrakeForceN;  // Initial force when agon initialised
-        public float InitialMaxBrakeForceN = 89e3f;   // Initial force when agon initialised
+        public float InitialMaxBrakeForceN = 89e3f;   // Initial force when wagon initialised
 
         // Coupler Animation
         public AnimatedCoupler FrontCoupler = new AnimatedCoupler();
@@ -959,12 +960,21 @@ namespace Orts.Simulation.RollingStocks
                 float UserFriction = GetUserBrakeShoeFrictionFactor();
                 float ZeroUserFriction = GetZeroUserBrakeShoeFrictionFactor();
                 float AdhesionMultiplier = Simulator.Settings.AdhesionFactor / 100.0f; // User set adjustment factor - convert to a factor where 100% = no change to adhesion
+                BrakeShoeCoefficientFrictionAdjFactor = 1.0f;
+                BrakeShoeRetardCoefficientFrictionAdjFactor = 1.0f;
+                BrakeShoeCoefficientFriction = 1.0f;
 
                 // This section calculates an adjustment factor for the brake force dependent upon the "base" (zero speed) friction value. 
                 //For a user defined case the base value is the zero speed value from the curve entered by the user.
                 // For a "default" case where no user data has been added to the WAG file, the base friction value has been assumed to be 0.2, thus maximum value of 20% applied.
 
-                if (UserFriction != 0)  // User defined friction has been applied in WAG file - Assume MaxBrakeForce is correctly set in the WAG, so no adjustment required 
+                if (UserFriction != 0 && MaxBrakeShoeForceN != 0) // Assume user has set up brakeshoe force and brakeshoe CoF
+                {
+                    BrakeShoeCoefficientFrictionAdjFactor = UserFriction * AdhesionMultiplier;
+                    BrakeShoeRetardCoefficientFrictionAdjFactor = BrakeShoeCoefficientFrictionAdjFactor;
+                    BrakeShoeCoefficientFriction = UserFriction * AdhesionMultiplier; // For display purposes on HUD
+                }
+                else if (UserFriction != 0)  // User defined friction has been applied in WAG file - Assume MaxBrakeForce is correctly set in the WAG, so no adjustment required 
                 {
                     BrakeShoeCoefficientFrictionAdjFactor = UserFriction / ZeroUserFriction * AdhesionMultiplier; // Factor calculated by normalising zero speed value on friction curve applied in WAG file
                     BrakeShoeRetardCoefficientFrictionAdjFactor = UserFriction / ZeroUserFriction * AdhesionMultiplier;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -684,7 +684,7 @@ namespace Orts.Simulation.RollingStocks
         {
             Unknown,
             Cast_Iron,
-            Hi_Friction_Compost,
+            High_Friction_Composite,
             User_Defined,
         }
         public BrakeShoeTypes BrakeShoeType;
@@ -3243,7 +3243,7 @@ namespace Orts.Simulation.RollingStocks
                 {
                     frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 100.0f) / (5.0f * MpS.ToKpH(AbsSpeedMpS) + 100.0f));
                 }
-                else if (BrakeShoeType == BrakeShoeTypes.Hi_Friction_Compost)
+                else if (BrakeShoeType == BrakeShoeTypes.High_Friction_Composite)
                 {
                     frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 150.0f) / (2.0f * MpS.ToKpH(AbsSpeedMpS) + 150.0f));
                 }
@@ -3310,7 +3310,7 @@ namespace Orts.Simulation.RollingStocks
                 {
                     frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 100.0f) / (5.0f * MpS.ToKpH(AbsSpeedMpS) + 100.0f));
                 }
-                else if (BrakeShoeType == BrakeShoeTypes.Hi_Friction_Compost)
+                else if (BrakeShoeType == BrakeShoeTypes.High_Friction_Composite)
                 {
                     frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 150.0f) / (2.0f * MpS.ToKpH(AbsSpeedMpS) + 150.0f));
                 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -213,6 +213,7 @@ namespace Orts.Simulation.RollingStocks
         public float MaxHandbrakeForceN;
         public float MaxBrakeForceN = 89e3f;
         public float MaxBrakeShoeForceN; // This is the force applied to the brake shoe, hence it will be decreased by CoF to give force applied to the wheel
+        public float NumberCarBrakeShoes;
         public float InitialMaxHandbrakeForceN;  // Initial force when agon initialised
         public float InitialMaxBrakeForceN = 89e3f;   // Initial force when wagon initialised, this is the force on the wheel, ie after the brake shoe.
 
@@ -3236,7 +3237,7 @@ namespace Orts.Simulation.RollingStocks
                 // https://iopscience.iop.org/article/10.1088/1742-6596/1614/1/012086/pdf
 
                 float NewtonsTokNewtons = 0.001f;
-                float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN;
+                float brakeShoeForcekN = (NewtonsTokNewtons * BrakeShoeForceN) / NumberCarBrakeShoes;
 
                 if (BrakeShoeType == BrakeShoeTypes.CastIron)
                 {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -210,9 +210,9 @@ namespace Orts.Simulation.RollingStocks
 
         public float MaxHandbrakeForceN;
         public float MaxBrakeForceN = 89e3f;
-        public float MaxBrakeShoeForceN;
+        public float MaxBrakeShoeForceN; // This is the force applied to the brake shoe, hence it will be decreased by CoF to give force applied to the wheel
         public float InitialMaxHandbrakeForceN;  // Initial force when agon initialised
-        public float InitialMaxBrakeForceN = 89e3f;   // Initial force when wagon initialised
+        public float InitialMaxBrakeForceN = 89e3f;   // Initial force when wagon initialised, this is the force on the wheel, ie after the brake shoe.
 
         // Coupler Animation
         public AnimatedCoupler FrontCoupler = new AnimatedCoupler();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -683,9 +683,9 @@ namespace Orts.Simulation.RollingStocks
         public enum BrakeShoeTypes
         {
             Unknown,
-            CastIron,
-            HiFrictionCompost,
-            UserDefined,
+            Cast_Iron,
+            Hi_Friction_Compost,
+            User_Defined,
         }
         public BrakeShoeTypes BrakeShoeType;
 
@@ -3239,15 +3239,15 @@ namespace Orts.Simulation.RollingStocks
                 float NewtonsTokNewtons = 0.001f;
                 float brakeShoeForcekN = (NewtonsTokNewtons * BrakeShoeForceN) / NumberCarBrakeShoes;
 
-                if (BrakeShoeType == BrakeShoeTypes.CastIron)
+                if (BrakeShoeType == BrakeShoeTypes.Cast_Iron)
                 {
                     frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 100.0f) / (5.0f * MpS.ToKpH(AbsSpeedMpS) + 100.0f));
                 }
-                else if (BrakeShoeType == BrakeShoeTypes.HiFrictionCompost)
+                else if (BrakeShoeType == BrakeShoeTypes.Hi_Friction_Compost)
                 {
                     frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 150.0f) / (2.0f * MpS.ToKpH(AbsSpeedMpS) + 150.0f));
                 }
-                else if (BrakeShoeType == BrakeShoeTypes.UserDefined)
+                else if (BrakeShoeType == BrakeShoeTypes.User_Defined)
                 {
                     frictionfraction = BrakeShoeFrictionFactor[MpS.ToKpH(AbsSpeedMpS)];
                 }
@@ -3306,15 +3306,15 @@ namespace Orts.Simulation.RollingStocks
                 float NewtonsTokNewtons = 0.001f;
                 float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN / NumberCarBrakeShoes;
 
-                if (BrakeShoeType == BrakeShoeTypes.CastIron)
+                if (BrakeShoeType == BrakeShoeTypes.Cast_Iron)
                 {
                     frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 100.0f) / (5.0f * MpS.ToKpH(AbsSpeedMpS) + 100.0f));
                 }
-                else if (BrakeShoeType == BrakeShoeTypes.HiFrictionCompost)
+                else if (BrakeShoeType == BrakeShoeTypes.Hi_Friction_Compost)
                 {
                     frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 150.0f) / (2.0f * MpS.ToKpH(AbsSpeedMpS) + 150.0f));
                 }
-                else if (BrakeShoeType == BrakeShoeTypes.UserDefined)
+                else if (BrakeShoeType == BrakeShoeTypes.User_Defined)
                 {
                     frictionfraction = BrakeShoeFrictionFactor[MpS.ToKpH(AbsSpeedMpS)];
                 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -3296,7 +3296,7 @@ namespace Orts.Simulation.RollingStocks
                 // https://iopscience.iop.org/article/10.1088/1742-6596/1614/1/012086/pdf
 
                 float NewtonsTokNewtons = 0.001f;
-                float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN;
+                float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN / NumberCarBrakeShoes;
 
                 if (BrakeShoeType == BrakeShoeTypes.CastIron)
                 {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -3220,15 +3220,12 @@ namespace Orts.Simulation.RollingStocks
             return 0f;
         }
 
-
         /// <summary>
         /// Returns the coefficient of friction (CoF) for the brake shoe. For legacy operation, it will be a "representation" of the CoF that will adjust 
         /// the brake retard force with speed.
         /// </summary>
-
         public virtual float GetBrakeShoeFrictionFactor()
-        {
-            
+        {            
             var frictionfraction = 0.0f;
             float AdhesionMultiplier = Simulator.Settings.AdhesionFactor / 100.0f; // User set adjustment factor - convert to a factor where 100% = no change to adhesion
 
@@ -3257,7 +3254,6 @@ namespace Orts.Simulation.RollingStocks
                 {
                     if (BrakeShoeFrictionFactor != null)  // User defined friction has been applied in WAG file, but brake shoe has not be described, hence a legacy condition - Assume MaxBrakeForce is correctly set in the WAG, so no adjustment required 
                     {
-
                         float userFriction = BrakeShoeFrictionFactor[MpS.ToKpH(AbsSpeedMpS)];
                         float zeroUserFriction = BrakeShoeFrictionFactor[MpS.ToKpH(0)];
 
@@ -3275,14 +3271,12 @@ namespace Orts.Simulation.RollingStocks
                 }
 
                 return frictionfraction;
-
             }
             else
             {
                 frictionfraction = (7.6f / (MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f); // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula; // For simple friction use "default" curve
                 return frictionfraction;
             }
-
         }
 
         /// <summary>
@@ -3328,7 +3322,6 @@ namespace Orts.Simulation.RollingStocks
                 }
 
                 return frictionfraction;
-
             }
             else
             {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -213,7 +213,7 @@ namespace Orts.Simulation.RollingStocks
         public float MaxHandbrakeForceN;
         public float MaxBrakeForceN = 89e3f;
         public float MaxBrakeShoeForceN; // This is the force applied to the brake shoe, hence it will be decreased by CoF to give force applied to the wheel
-        public float NumberCarBrakeShoes;
+        public int NumberCarBrakeShoes;
         public float InitialMaxHandbrakeForceN;  // Initial force when agon initialised
         public float InitialMaxBrakeForceN = 89e3f;   // Initial force when wagon initialised, this is the force on the wheel, ie after the brake shoe.
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -275,6 +275,7 @@ namespace Orts.Simulation.RollingStocks
         float BrakeWheelTreadForceN; // The retarding force apparent on the tread of the wheel
         float WagonBrakeAdhesiveForceN; // The adhesive force existing on the wheels of the wagon
         public float SkidFriction = 0.08f; // Friction if wheel starts skidding - based upon wheel dynamic friction of approx 0.08
+        public float HuDBrakeShoeFriction;
 
         public float AuxTenderWaterMassKG;    // Water mass in auxiliary tender
         public string AuxWagonType;           // Store wagon type for use with auxilary tender calculations
@@ -3242,11 +3243,11 @@ namespace Orts.Simulation.RollingStocks
 
                 if (BrakeShoeType == BrakeShoeTypes.CastIron)
                 {
-                    frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((AbsSpeedMpS + 100.0f) / (5.0f * AbsSpeedMpS + 100.0f));
+                    frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 100.0f) / (5.0f * MpS.ToKpH(AbsSpeedMpS) + 100.0f));
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.HiFrictionCompost)
                 {
-                    frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((AbsSpeedMpS + 150.0f) / (2.0f * AbsSpeedMpS + 150.0f));
+                    frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 150.0f) / (2.0f * MpS.ToKpH(AbsSpeedMpS) + 150.0f));
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.UserDefined)
                 {
@@ -3304,11 +3305,11 @@ namespace Orts.Simulation.RollingStocks
 
                 if (BrakeShoeType == BrakeShoeTypes.CastIron)
                 {
-                    frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((AbsSpeedMpS + 100.0f) / (5.0f * AbsSpeedMpS + 100.0f));
+                    frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 100.0f) / (5.0f * MpS.ToKpH(AbsSpeedMpS) + 100.0f));
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.HiFrictionCompost)
                 {
-                    frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((AbsSpeedMpS + 150.0f) / (2.0f * AbsSpeedMpS + 150.0f));
+                    frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 150.0f) / (2.0f * MpS.ToKpH(AbsSpeedMpS) + 150.0f));
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.UserDefined)
                 {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -139,6 +139,8 @@ namespace Orts.Simulation.RollingStocks
            0.0f, 31.0f
         };
 
+        public Interpolator BrakeShoeFrictionFactor;  // Factor of friction for wagon brake shoes
+
         public static Interpolator SteamHeatBoilerWaterUsageGalukpH()
         {
             return new Interpolator(SteamUsageLbpH, WaterUsageGalukpH);
@@ -968,7 +970,7 @@ namespace Orts.Simulation.RollingStocks
                 //For a user defined case the base value is the zero speed value from the curve entered by the user.
                 // For a "default" case where no user data has been added to the WAG file, the base friction value has been assumed to be 0.2, thus maximum value of 20% applied.
 
-                if (UserFriction != 0 && MaxBrakeShoeForceN != 0) // Assume user has set up brakeshoe force and brakeshoe CoF
+                if (BrakeShoeFrictionFactor != null && MaxBrakeShoeForceN != 0) // Assume user has set up brakeshoe force and brakeshoe CoF
                 {
                     BrakeShoeCoefficientFrictionAdjFactor = UserFriction * AdhesionMultiplier;
                     BrakeShoeRetardCoefficientFrictionAdjFactor = BrakeShoeCoefficientFrictionAdjFactor;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -3296,7 +3296,7 @@ namespace Orts.Simulation.RollingStocks
                 // https://iopscience.iop.org/article/10.1088/1742-6596/1614/1/012086/pdf
 
                 float NewtonsTokNewtons = 0.001f;
-                float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN / NumberCarBrakeShoes;
+                float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN;
 
                 if (BrakeShoeType == BrakeShoeTypes.CastIron)
                 {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -3281,7 +3281,9 @@ namespace Orts.Simulation.RollingStocks
             }
             else
             {
-                frictionfraction = (7.6f / (MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f); // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula; // For simple friction use "default" curve
+                // set default values if simple adhesion model, or if diesel or electric locomotive is used, which doesn't check for brake skid.
+
+                frictionfraction = 1.0f;  // Default value set to leave existing brakeforce constant regardless of changing speed
                 return frictionfraction;
             }
         }
@@ -3332,7 +3334,7 @@ namespace Orts.Simulation.RollingStocks
             }
             else
             {
-                frictionfraction = 7.6f / ((MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f); // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula; // For simple friction use "default" curve
+                frictionfraction = 1.0f;  // Default value set to leave existing brakeforce constant regardless of changing speed
                 return frictionfraction;
             }
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -578,9 +578,10 @@ namespace Orts.Simulation.RollingStocks
 
         public float TunnelForceN;  // Resistive force due to tunnel, in Newtons
         public float FrictionForceN; // in Newtons ( kg.m/s^2 ) unsigned, includes effects of curvature
-        public float BrakeForceN;    // brake force applied to slow train (Newtons) - will be impacted by wheel/rail friction
+        public float BrakeForceN;    // current braking force applied to slow train (Newtons) - will be impacted by wheel/rail friction
         public float BrakeRetardForceN;    // brake force applied to wheel by brakeshoe (Newtons) independent of friction wheel/rail friction
         public float BrakeShoeForceN;
+        public float FrictionBrakeBlendingMaxForceN; // This is the maximum force for the friction barke when it is blended with the dynamic brake
 
         // Sum of all the forces acting on a Traincar in the direction of driving.
         // MotiveForceN and GravityForceN act to accelerate the train. The others act to brake the train.

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -271,10 +271,7 @@ namespace Orts.Simulation.RollingStocks
         public bool BrakeSkid = false;
         public bool BrakeSkidWarning = false;
         public bool HUDBrakeSkid = false;
-        public float BrakeShoeCoefficientFriction = 1.0f; // Brake Shoe coefficient - for simple adhesion model set to 1
-        public float BrakeShoeCoefficientFrictionAdjFactor = 1.0f; // Factor to adjust Brake force by - based upon changing friction coefficient with speed, will change when wheel goes into skid
-        public float BrakeShoeRetardCoefficientFrictionAdjFactor = 1.0f; // Factor of adjust Retard Brake force by - independent of skid
-        float DefaultBrakeShoeCoefficientFriction;  // A default value of brake shoe friction is no user settings are present.
+
         float BrakeWheelTreadForceN; // The retarding force apparent on the tread of the wheel
         float WagonBrakeAdhesiveForceN; // The adhesive force existing on the wheels of the wagon
         public float SkidFriction = 0.08f; // Friction if wheel starts skidding - based upon wheel dynamic friction of approx 0.08
@@ -581,6 +578,7 @@ namespace Orts.Simulation.RollingStocks
         public float FrictionForceN; // in Newtons ( kg.m/s^2 ) unsigned, includes effects of curvature
         public float BrakeForceN;    // brake force applied to slow train (Newtons) - will be impacted by wheel/rail friction
         public float BrakeRetardForceN;    // brake force applied to wheel by brakeshoe (Newtons) independent of friction wheel/rail friction
+        public float BrakeShoeForceN;
 
         // Sum of all the forces acting on a Traincar in the direction of driving.
         // MotiveForceN and GravityForceN act to accelerate the train. The others act to brake the train.
@@ -680,7 +678,16 @@ namespace Orts.Simulation.RollingStocks
         }
         public WagonSpecialTypes WagonSpecialType;
 
-    protected float CurveResistanceZeroSpeedFactor = 0.5f; // Based upon research (Russian experiments - 1960) the older formula might be about 2x actual value
+        public enum BrakeShoeTypes
+        {
+            Unknown,
+            CastIron,
+            HiFrictionCompost,
+            UserDefined,
+        }
+        public BrakeShoeTypes BrakeShoeType;
+
+        protected float CurveResistanceZeroSpeedFactor = 0.5f; // Based upon research (Russian experiments - 1960) the older formula might be about 2x actual value
         protected float RigidWheelBaseM;   // Vehicle rigid wheelbase, read from MSTS Wagon file
         protected float TrainCrossSectionAreaM2; // Cross sectional area of the train
         protected float DoubleTunnelCrossSectAreaM2;
@@ -958,44 +965,6 @@ namespace Orts.Simulation.RollingStocks
             if (Simulator.UseAdvancedAdhesion && !Simulator.Settings.SimpleControlPhysics && IsPlayerTrain)
             {
 
-                // Get user defined brake shoe coefficient if defined in WAG file
-                float UserFriction = GetUserBrakeShoeFrictionFactor();
-                float ZeroUserFriction = GetZeroUserBrakeShoeFrictionFactor();
-                float AdhesionMultiplier = Simulator.Settings.AdhesionFactor / 100.0f; // User set adjustment factor - convert to a factor where 100% = no change to adhesion
-                BrakeShoeCoefficientFrictionAdjFactor = 1.0f;
-                BrakeShoeRetardCoefficientFrictionAdjFactor = 1.0f;
-                BrakeShoeCoefficientFriction = 1.0f;
-
-                // This section calculates an adjustment factor for the brake force dependent upon the "base" (zero speed) friction value. 
-                //For a user defined case the base value is the zero speed value from the curve entered by the user.
-                // For a "default" case where no user data has been added to the WAG file, the base friction value has been assumed to be 0.2, thus maximum value of 20% applied.
-
-                if (BrakeShoeFrictionFactor != null && MaxBrakeShoeForceN != 0) // Assume user has set up brakeshoe force and brakeshoe CoF
-                {
-                    BrakeShoeCoefficientFrictionAdjFactor = UserFriction * AdhesionMultiplier;
-                    BrakeShoeRetardCoefficientFrictionAdjFactor = BrakeShoeCoefficientFrictionAdjFactor;
-                    BrakeShoeCoefficientFriction = UserFriction * AdhesionMultiplier; // For display purposes on HUD
-                }
-                else if (UserFriction != 0)  // User defined friction has been applied in WAG file - Assume MaxBrakeForce is correctly set in the WAG, so no adjustment required 
-                {
-                    BrakeShoeCoefficientFrictionAdjFactor = UserFriction / ZeroUserFriction * AdhesionMultiplier; // Factor calculated by normalising zero speed value on friction curve applied in WAG file
-                    BrakeShoeRetardCoefficientFrictionAdjFactor = UserFriction / ZeroUserFriction * AdhesionMultiplier;
-                    BrakeShoeCoefficientFriction = UserFriction * AdhesionMultiplier; // For display purposes on HUD
-                }
-                else
-                // User defined friction NOT applied in WAG file - Assume MaxBrakeForce is incorrectly set in the WAG, so adjustment is required 
-                {
-                    DefaultBrakeShoeCoefficientFriction = (7.6f / (MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f) * AdhesionMultiplier; // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula
-                    BrakeShoeCoefficientFrictionAdjFactor = DefaultBrakeShoeCoefficientFriction / 0.2f * AdhesionMultiplier;  // Assuming that current MaxBrakeForce has been set with an existing Friction Coff of 0.2f, an adjustment factor needs to be developed to reduce the MAxBrakeForce by a relative amount
-                    BrakeShoeRetardCoefficientFrictionAdjFactor = DefaultBrakeShoeCoefficientFriction / 0.2f * AdhesionMultiplier;
-                    BrakeShoeCoefficientFriction = DefaultBrakeShoeCoefficientFriction * AdhesionMultiplier;  // For display purposes on HUD
-                }
-
-                // Clamp adjustment factor to a value of 1.0 - i.e. the brakeforce can never exceed the Brake Force value defined in the WAG file
-                BrakeShoeCoefficientFrictionAdjFactor = MathHelper.Clamp(BrakeShoeCoefficientFrictionAdjFactor, 0.01f, 1.0f);
-                BrakeShoeRetardCoefficientFrictionAdjFactor = MathHelper.Clamp(BrakeShoeRetardCoefficientFrictionAdjFactor, 0.01f, 1.0f);
-
-
                 // ************  Check if diesel or electric - assumed already be cover by advanced adhesion model *********
 
                 if (this is MSTSDieselLocomotive || this is MSTSElectricLocomotive)
@@ -1048,9 +1017,7 @@ namespace Orts.Simulation.RollingStocks
                         WheelBrakeSlideProtectionTimerS = wheelBrakeSlideTimerResetValueS;
                         WheelBrakeSlideProtectionDumpValveLockout = false;
 
-                    }
-                    
-
+                    }       
 
                     // Calculate adhesive force based upon whether in skid or not
                     if (BrakeSkid)
@@ -1090,16 +1057,11 @@ namespace Orts.Simulation.RollingStocks
                 else
                 {
                     BrakeSkid = false; 	// wagon wheel is not slipping
-                    BrakeShoeRetardCoefficientFrictionAdjFactor = 1.0f;
                 }
             }
             else  // set default values if simple adhesion model, or if diesel or electric locomotive is used, which doesn't check for brake skid.
             {
                 BrakeSkid = false; 	// wagon wheel is not slipping
-                BrakeShoeCoefficientFrictionAdjFactor = 1.0f;  // Default value set to leave existing brakeforce constant regardless of changing speed
-                BrakeShoeRetardCoefficientFrictionAdjFactor = 1.0f;
-                BrakeShoeCoefficientFriction = 1.0f;  // Default value for display purposes
-
             }
 
 #if DEBUG_BRAKE_SLIDE
@@ -3257,14 +3219,121 @@ namespace Orts.Simulation.RollingStocks
             return 0f;
         }
 
-        public virtual float GetUserBrakeShoeFrictionFactor()
+
+        /// <summary>
+        /// Returns the coefficient of friction (CoF) for the brake shoe. For legacy operation, it will be a "representation" of the CoF that will adjust 
+        /// the brake retard force with speed.
+        /// </summary>
+
+        public virtual float GetBrakeShoeFrictionFactor()
         {
-            return 0f;
+            
+            var frictionfraction = 0.0f;
+            float AdhesionMultiplier = Simulator.Settings.AdhesionFactor / 100.0f; // User set adjustment factor - convert to a factor where 100% = no change to adhesion
+
+            if (Simulator.UseAdvancedAdhesion && !Simulator.Settings.SimpleControlPhysics && IsPlayerTrain)
+            {
+                // Formula 9 and 10 from the paper "Study of the influence of the brake shoe temperature and wheel tread on braking effectiveness" by P Ivanov1, A Khudonogov1,
+                // E Dulskiy1, N Manuilov1, A Khamnaeva1, A Korsun1, S Treskin is used for the Cast Iron and Hi Friction Composite brake shoe friction curves.
+                // https://iopscience.iop.org/article/10.1088/1742-6596/1614/1/012086/pdf
+
+                float NewtonsTokNewtons = 0.001f;
+                float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN;
+
+                if (BrakeShoeType == BrakeShoeTypes.CastIron)
+                {
+                    frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((AbsSpeedMpS + 100.0f) / (5.0f * AbsSpeedMpS + 100.0f));
+                }
+                else if (BrakeShoeType == BrakeShoeTypes.HiFrictionCompost)
+                {
+                    frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((AbsSpeedMpS + 150.0f) / (2.0f * AbsSpeedMpS + 150.0f));
+                }
+                else if (BrakeShoeType == BrakeShoeTypes.UserDefined)
+                {
+                    frictionfraction = BrakeShoeFrictionFactor[MpS.ToKpH(AbsSpeedMpS)];
+                }
+                else // default curve - assume that this is legacy stock
+                {
+                    if (BrakeShoeFrictionFactor != null)  // User defined friction has been applied in WAG file, but brake shoe has not be described, hence a legacy condition - Assume MaxBrakeForce is correctly set in the WAG, so no adjustment required 
+                    {
+
+                        float userFriction = BrakeShoeFrictionFactor[MpS.ToKpH(AbsSpeedMpS)];
+                        float zeroUserFriction = BrakeShoeFrictionFactor[MpS.ToKpH(0)];
+
+                        frictionfraction = userFriction / zeroUserFriction * AdhesionMultiplier; // Factor calculated by normalising zero speed value on friction curve applied in WAG file
+                    }
+                    else
+                    {
+                        // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula
+                        float defaultBrakeShoeCoefficientFriction = (7.6f / (MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f) * AdhesionMultiplier;
+
+                        // Assuming that current MaxBrakeForce has been set with an existing Friction CoF of 0.2f, an adjustment factor needs to be developed to reduce
+                        // the MAxBrakeForce by a relative amount. Note force will be higher then ENG file value at low speed and reduce to actual value at higher speeds.
+                        frictionfraction = defaultBrakeShoeCoefficientFriction / 0.2f * AdhesionMultiplier;  // Assuming that current MaxBrakeForce has been set with an existing Friction CoF of 0.2f, an adjustment factor needs to be developed to reduce the MAxBrakeForce by a relative amount
+                    }
+                }
+
+                return frictionfraction;
+
+            }
+            else
+            {
+                frictionfraction = (7.6f / (MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f); // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula; // For simple friction use "default" curve
+                return frictionfraction;
+            }
+
         }
 
-        public virtual float GetZeroUserBrakeShoeFrictionFactor()
+        /// <summary>
+        /// Returns the coefficient of friction (CoF) of the brake shoe for display on the HuD.
+        /// For legacy operation, it will be different to the "representation" of the CoF calculated above, and be the actual CoF.
+        /// </summary>
+        public virtual float GetBrakeShoeFrictionCoefficientHuD()
         {
-            return 0f;
+            var frictionfraction = 0.0f;
+            float AdhesionMultiplier = Simulator.Settings.AdhesionFactor / 100.0f; // User set adjustment factor - convert to a factor where 100% = no change to adhesion
+
+            if (Simulator.UseAdvancedAdhesion && !Simulator.Settings.SimpleControlPhysics && IsPlayerTrain)
+            {
+                // Formula 9 and 10 from the paper "Study of the influence of the brake shoe temperature and wheel tread on braking effectiveness" by P Ivanov1, A Khudonogov1,
+                // E Dulskiy1, N Manuilov1, A Khamnaeva1, A Korsun1, S Treskin is used for the Cast Iron and Hi Friction Composite brake shoe friction curves.
+                // https://iopscience.iop.org/article/10.1088/1742-6596/1614/1/012086/pdf
+
+                float NewtonsTokNewtons = 0.001f;
+                float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN;
+
+                if (BrakeShoeType == BrakeShoeTypes.CastIron)
+                {
+                    frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((AbsSpeedMpS + 100.0f) / (5.0f * AbsSpeedMpS + 100.0f));
+                }
+                else if (BrakeShoeType == BrakeShoeTypes.HiFrictionCompost)
+                {
+                    frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((AbsSpeedMpS + 150.0f) / (2.0f * AbsSpeedMpS + 150.0f));
+                }
+                else if (BrakeShoeType == BrakeShoeTypes.UserDefined)
+                {
+                    frictionfraction = BrakeShoeFrictionFactor[MpS.ToKpH(AbsSpeedMpS)];
+                }
+                else // default curve - assume that this is legacy stock
+                {
+                    if (BrakeShoeFrictionFactor != null)  // User defined friction has been applied in WAG file, but brake shoe has not be described, hence a legacy condition - Assume MaxBrakeForce is correctly set in the WAG, so no adjustment required 
+                    {
+                        frictionfraction = BrakeShoeFrictionFactor[MpS.ToKpH(AbsSpeedMpS)];
+                    }
+                    else
+                    {
+                        frictionfraction = (7.6f / (MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f) * AdhesionMultiplier; // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula
+                    }
+                }
+
+                return frictionfraction;
+
+            }
+            else
+            {
+                frictionfraction = (7.6f / (MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f); // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula; // For simple friction use "default" curve
+                return frictionfraction;
+            }
         }
 
         public virtual void InitializeCarHeatingVariables()

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -3318,7 +3318,7 @@ namespace Orts.Simulation.RollingStocks
                     }
                     else
                     {
-                        frictionfraction = (7.6f / (MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f) * AdhesionMultiplier; // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula
+                        frictionfraction = 7.6f / ((MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f) * AdhesionMultiplier; // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula
                     }
                 }
 
@@ -3326,7 +3326,7 @@ namespace Orts.Simulation.RollingStocks
             }
             else
             {
-                frictionfraction = (7.6f / (MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f); // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula; // For simple friction use "default" curve
+                frictionfraction = 7.6f / ((MpS.ToKpH(AbsSpeedMpS) + 17.5f) + 0.07f); // Base Curtius - Kniffler equation - u = 0.50, all other values are scaled off this formula; // For simple friction use "default" curve
                 return frictionfraction;
             }
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -3259,6 +3259,9 @@ namespace Orts.Simulation.RollingStocks
                         float zeroUserFriction = BrakeShoeFrictionFactor[MpS.ToKpH(0)];
 
                         frictionfraction = userFriction / zeroUserFriction * AdhesionMultiplier; // Factor calculated by normalising zero speed value on friction curve applied in WAG file
+
+                        // Clamp adjustment factor to a value of 1.0 - i.e. the brakeforce can never exceed the Brake Force value defined in the WAG file
+                        frictionfraction = MathHelper.Clamp(frictionfraction, 0.01f, 1.0f);
                     }
                     else
                     {
@@ -3268,6 +3271,9 @@ namespace Orts.Simulation.RollingStocks
                         // Assuming that current MaxBrakeForce has been set with an existing Friction CoF of 0.2f, an adjustment factor needs to be developed to reduce
                         // the MAxBrakeForce by a relative amount. Note force will be higher then ENG file value at low speed and reduce to actual value at higher speeds.
                         frictionfraction = defaultBrakeShoeCoefficientFriction / 0.2f * AdhesionMultiplier;  // Assuming that current MaxBrakeForce has been set with an existing Friction CoF of 0.2f, an adjustment factor needs to be developed to reduce the MAxBrakeForce by a relative amount
+
+                        // Clamp adjustment factor to a value of 1.0 - i.e. the brakeforce can never exceed the Brake Force value defined in the WAG file
+                        frictionfraction = MathHelper.Clamp(frictionfraction, 0.01f, 1.0f);
                     }
                 }
 

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -1160,7 +1160,7 @@ namespace Orts.Viewer3D.Popups
                 TableSetCell(table, 12, "{0}", FormatStrings.FormatLargeMass(car.MassKG, car.IsMetric, car.IsUK));
                 TableSetCell(table, 13, "{0:F2}%", -car.CurrentElevationPercent);
                 TableSetCell(table, 14, "{0}", FormatStrings.FormatDistance(car.CurrentCurveRadius, car.IsMetric));
-                TableSetCell(table, 15, "{0:F0}%", car.BrakeShoeCoefficientFriction * 100.0f);
+                TableSetCell(table, 15, "{0:F0}%", car.GetBrakeShoeFrictionCoefficientHuD() * 100.0f);
                 TableSetCell(table, 16, car.HUDBrakeSkid ? Viewer.Catalog.GetString("Yes") : Viewer.Catalog.GetString("No"));
                 TableSetCell(table, 17, "{0} {1}", FormatStrings.FormatTemperature(car.WheelBearingTemperatureDegC, car.IsMetric, false), car.DisplayWheelBearingTemperatureStatus);
                 TableSetCell(table, 18, car.Flipped ? Viewer.Catalog.GetString("Flipped") : "");

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -1160,7 +1160,7 @@ namespace Orts.Viewer3D.Popups
                 TableSetCell(table, 12, "{0}", FormatStrings.FormatLargeMass(car.MassKG, car.IsMetric, car.IsUK));
                 TableSetCell(table, 13, "{0:F2}%", -car.CurrentElevationPercent);
                 TableSetCell(table, 14, "{0}", FormatStrings.FormatDistance(car.CurrentCurveRadius, car.IsMetric));
-                TableSetCell(table, 15, "{0:F0}%", car.GetBrakeShoeFrictionCoefficientHuD() * 100.0f);
+                TableSetCell(table, 15, "{0:F0}%", car.HuDBrakeShoeFriction * 100.0f);
                 TableSetCell(table, 16, car.HUDBrakeSkid ? Viewer.Catalog.GetString("Yes") : Viewer.Catalog.GetString("No"));
                 TableSetCell(table, 17, "{0} {1}", FormatStrings.FormatTemperature(car.WheelBearingTemperatureDegC, car.IsMetric, false), car.DisplayWheelBearingTemperatureStatus);
                 TableSetCell(table, 18, car.Flipped ? Viewer.Catalog.GetString("Flipped") : "");


### PR DESCRIPTION
Adjust Brake Force to use Brake Shoe Force - 

Fixes an error in calculating the brake force applied to the wagon.

Bug report: https://www.elvastower.com/forums/index.php?/topic/34527-wishes-for-improvement-of-braking-systems/page__view__findpost__p__297184