### PR TITLE
copies website policies to repo

### DIFF
--- a/Docs/Policies.md
+++ b/Docs/Policies.md
@@ -1,0 +1,41 @@
+# Project Policies
+
+This document records the policies currently in place under which the Project Team operates.
+
+## License
+
+The [GNU Public License](http://www.gnu.org/licenses/licenses.html) allows a user to use Open Rails in any way, except that you may not distribute software containing part of Open Rails without respecting the license terms. 
+
+## Liability
+
+Open Rails is intended for entertainment purposes only and, to avoid liability, is not suitable for professional applications.
+
+## Code Submissions
+
+[Code contributions](https://github.com/openrails/openrails/blob/master/Docs/Contributing.md) to our repository must be in Microsoft's C# language. An authorised developer may not change content in the official version of Open Rails without approval from another authorised developer.
+
+## Content Compatibility
+
+Open Rails will continue to maintain compatibility with content from previous official versions of Open Rails.
+
+## File Formats
+
+New types of content will use the JavaScript Object Notation (JSON).
+Existing types of content from previous official versions of Open Rails will continue to be loaded without change. 
+
+## Keyboard Assignments
+
+New key assignments should obey the following rules where that is possible.
+
+* Reserve digit keys for camera operations.
+* Reserve Fn keys for pop-up windows.
+* Reserve the Alt modifier for debug operations.
+* Reserve modifier+space (e.g. Ctrl+space) for future expansion using sequences of keys.
+
+Existing key assignments may not be changed without community discussion and approval of the Open Rails Management Team.
+
+## Crashes and Derailments
+
+Open Rails simulates emergency events which bring a train to a standstill, such as a derailment, and provides both a visual indication and a notification of the problem.
+
+Open Rails does not show rolling stock leaving the track due to crashes or derailments. We have many members from the rail industry who have spent their working lives preventing incidents that cause injuries and loss of life and we respect that point of view. 


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/36794-ormt-sessions/page__view__findpost__p__297145

I considered having one document per policy in a /Docs/Policies folder, but easier to read when in a single document.