### PR TITLE
Fix for https://bugs.launchpad.net/or/+bug/2024295  Freight weight only added for first wagon

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/FreightAnimations.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/FreightAnimations.cs
@@ -290,8 +290,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             ContinuousFreightAnimationsPresent = copyFACollection.ContinuousFreightAnimationsPresent;
             StaticFreightAnimationsPresent = copyFACollection.StaticFreightAnimationsPresent;
             DiscreteFreightAnimationsPresent = copyFACollection.DiscreteFreightAnimationsPresent;
-
-//            Load(Wagon, LoadDataList);
+            StaticFreightWeight = copyFACollection.StaticFreightWeight;
         }
 
         public void Load(string loadFilePath, LoadPosition loadPosition, LoadState loadState)


### PR DESCRIPTION
See http://www.elvastower.com/forums/index.php?/topic/37200-loading-not-calculated-correctly-for-train/