### PR TITLE
Initialize cars before restore

### DIFF
--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -952,9 +952,8 @@ namespace Orts.Simulation.Physics
             {
                 for (int i = 0; i < count; ++i)
                 {
-                    TrainCar car = RollingStock.Load(simulator, this, inf.ReadString(), false);
+                    TrainCar car = RollingStock.Load(simulator, this, inf.ReadString());
                     car.Restore(inf);
-                    car.Initialize();
                 }
             }
             SetDPUnitIDs(true);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
@@ -91,11 +91,6 @@ namespace Orts.Simulation.RollingStocks
 
         public float LocomotiveMaxRailOutputPowerW;
 
-        public int currentGearIndexRestore = -1;
-        public int currentnextGearRestore = -1;
-        public bool gearSaved;
-        public int dieselEngineRestoreState;
-
         public float EngineRPM;
         public SmoothedData ExhaustParticles = new SmoothedData(1);
         public SmoothedData ExhaustMagnitude = new SmoothedData(1);
@@ -474,17 +469,6 @@ namespace Orts.Simulation.RollingStocks
                 {
                     CurrentLocomotiveSteamHeatBoilerWaterCapacityL = L.FromGUK(800.0f);
                 }
-            }
-
-            // TO BE LOOKED AT - fix restoration process for gearbox and gear controller
-            // It appears that the gearbox is initialised in two different places to cater for Basic and Advanced ENG file configurations(?).
-            // Hence the restore values recovered in gearbox class are being overwritten , and resume was not working correctly
-            // Hence restore gear position values are read as part of the diesel and restored at this point.
-            if (gearSaved)
-            {
-                DieselEngines[0].GearBox.nextGearIndex = currentnextGearRestore;
-                DieselEngines[0].GearBox.currentGearIndex = currentGearIndexRestore;
-                GearBoxController.SetValue((float)DieselEngines[0].GearBox.currentGearIndex);
             }
 
             if (Simulator.Settings.VerboseConfigurationMessages)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/CircuitBreaker.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/CircuitBreaker.cs
@@ -188,7 +188,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public void Save(BinaryWriter outf)
         {
-            outf.Write(ScriptName);
             outf.Write(DelayS);
             outf.Write(State.ToString());
             outf.Write(DriverClosingOrder);
@@ -199,7 +198,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public void Restore(BinaryReader inf)
         {
-            ScriptName = inf.ReadString();
             DelayS = inf.ReadSingle();
             State = (CircuitBreakerState)Enum.Parse(typeof(CircuitBreakerState), inf.ReadString());
             DriverClosingOrder = inf.ReadBoolean();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselPowerSupply.cs
@@ -110,16 +110,12 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public override void Save(BinaryWriter outf)
         {
-            outf.Write(ScriptName);
-
             base.Save(outf);
             TractionCutOffRelay.Save(outf);
         }
 
         public override void Restore(BinaryReader inf)
         {
-            ScriptName = inf.ReadString();
-
             base.Restore(inf);
             TractionCutOffRelay.Restore(inf);
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DualModePowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DualModePowerSupply.cs
@@ -112,8 +112,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public override void Save(BinaryWriter outf)
         {
-            outf.Write(ScriptName);
-
             base.Save(outf);
             CircuitBreaker.Save(outf);
             TractionCutOffRelay.Save(outf);
@@ -121,8 +119,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public override void Restore(BinaryReader inf)
         {
-            ScriptName = inf.ReadString();
-
             base.Restore(inf);
             CircuitBreaker.Restore(inf);
             TractionCutOffRelay.Restore(inf);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricPowerSupply.cs
@@ -108,16 +108,12 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public override void Save(BinaryWriter outf)
         {
-            outf.Write(ScriptName);
-
             base.Save(outf);
             CircuitBreaker.Save(outf);
         }
 
         public override void Restore(BinaryReader inf)
         {
-            ScriptName = inf.ReadString();
-
             base.Restore(inf);
             CircuitBreaker.Restore(inf);
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/Pantograph.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/Pantograph.cs
@@ -79,13 +79,14 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public void Restore(BinaryReader inf)
         {
-            List.Clear();
-
             int n = inf.ReadInt32();
             for (int i = 0; i < n; i++)
             {
-                List.Add(new Pantograph(Wagon));
-                List.Last().Restore(inf);
+                if (i >= List.Count)
+                {
+                    List.Add(new Pantograph(Wagon));
+                }
+                List[i].Restore(inf);
             }
         }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/TractionCutOffRelay.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/TractionCutOffRelay.cs
@@ -165,7 +165,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public void Save(BinaryWriter outf)
         {
-            outf.Write(ScriptName);
             outf.Write(DelayS);
             outf.Write(State.ToString());
             outf.Write(DriverClosingOrder);
@@ -176,7 +175,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
         public void Restore(BinaryReader inf)
         {
-            ScriptName = inf.ReadString();
             DelayS = inf.ReadSingle();
             State = (TractionCutOffRelayState)Enum.Parse(typeof(TractionCutOffRelayState), inf.ReadString());
             DriverClosingOrder = inf.ReadBoolean();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/GearBox.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/GearBox.cs
@@ -751,9 +751,7 @@ public Gear NextGear
         public void Restore(BinaryReader inf)
         {
             currentGearIndex = inf.ReadInt32();
-            Locomotive.currentGearIndexRestore = currentGearIndex;
             nextGearIndex = inf.ReadInt32();
-            Locomotive.currentnextGearRestore = nextGearIndex;
             gearedUp = inf.ReadBoolean();
             gearedDown = inf.ReadBoolean();
             clutchOn = inf.ReadBoolean();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -946,19 +946,14 @@ namespace Orts.Simulation.RollingStocks.SubSystems
 
         public void Save(BinaryWriter outf)
         {
-            outf.Write(ScriptName ?? "");
-            if (ScriptName != "")
+            if (!string.IsNullOrEmpty(ScriptName))
                 Script.Save(outf);
         }
 
         public void Restore(BinaryReader inf)
         {
-            ScriptName = inf.ReadString();
-            if (ScriptName != "")
-            {
-                Initialize();
+            if (!string.IsNullOrEmpty(ScriptName))
                 Script.Restore(inf);
-            }
         }
     }
 


### PR DESCRIPTION
Cars should be initialized before Restore()

https://bugs.launchpad.net/or/+bug/2024684

http://www.elvastower.com/forums/index.php?/topic/37210-engine-hp-and-load-is-zero-on-resuming-saved-activity