### PR TITLE
Add additional default brakeshoe CoF

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -2753,7 +2753,7 @@ Brake Shoe Force - This is the current change being implemented. The following c
 
 ``ORTSBrakeShoeType`` - this defines a number of different brake shoe types and curves. To provide a more realistic representation of the braking force the default CoF curves are 2D, ie 
 they are impacted by both the speed and Brake Shoe Force.  Typically ``ORTSBrakeShoeType`` will have one of the following keywords included - 
-``Cast_Iron`` - older cast iron brake shoes, 2D as above, ``Cast_Iron_P10`` - newer cast iron brake shoes with increased phosphorous, 2D as above, ``Hi_Friction_Composite`` 
+``Cast_Iron_P6`` - older cast iron brake shoes, 2D as above, ``Cast_Iron_P10`` - newer cast iron brake shoes with increased phosphorous, 2D as above, ``Hi_Friction_Composite`` 
 - high friction composite shoe, 2D as above, ``Disc_Pads`` - brakes with disc pads, 2D as above, ``User_Defined`` - is a user defined curve 
 using the ORTSBrakeShoeFriction parameter, 1D (ie, speed only, see above section for the parameter format).
 

--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -2753,7 +2753,8 @@ Brake Shoe Force - This is the current change being implemented. The following c
 
 ``ORTSBrakeShoeType`` - this defines a number of different brake shoe types and curves. To provide a more realistic representation of the braking force the default CoF curves are 2D, ie 
 they are impacted by both the speed and Brake Shoe Force.  Typically ``ORTSBrakeShoeType`` will have one of the following keywords included - 
-``Cast_Iron`` - cast iron brake shoe, 2D as above, ``Hi_Friction_Composite`` - high friction composite shoe, 2D as above, ``User_Defined`` - is a user defined curve 
+``Cast_Iron`` - older cast iron brake shoes, 2D as above, ``Cast_Iron_P10`` - newer cast iron brake shoes with increased phosphorous, 2D as above, ``Hi_Friction_Composite`` 
+- high friction composite shoe, 2D as above, ``Disc_Pads`` - brakes with disc pads, 2D as above, ``User_Defined`` - is a user defined curve 
 using the ORTSBrakeShoeFriction parameter, 1D (ie, speed only, see above section for the parameter format).
 
 ``ORTSNumberCarBrakeShoes`` - to facilitate the operation of the default 2D curves above it is necessary to configure the number of brake shoes for each car.

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -632,7 +632,7 @@ namespace Orts.Simulation.RollingStocks
                     NumberCarBrakeShoes = (LocoNumDrvAxles * 4) + (WagonNumAxles * 4); // Assume 4 brake shoes per axle on all wheels
                 } 
 
-                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.Cast_Iron || BrakeShoeType == BrakeShoeTypes.High_Friction_Composite))
+                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType != BrakeShoeTypes.User_Defined || BrakeShoeType != BrakeShoeTypes.Unknown))
                 {
                     Trace.TraceInformation("Number of Locomotive Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
                 }
@@ -641,7 +641,7 @@ namespace Orts.Simulation.RollingStocks
             {
                 NumberCarBrakeShoes = WagonNumAxles * 4; // Assume 4 brake shoes per axle
 
-                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType == BrakeShoeTypes.Cast_Iron || BrakeShoeType == BrakeShoeTypes.High_Friction_Composite))
+                if (Simulator.Settings.VerboseConfigurationMessages && (BrakeShoeType != BrakeShoeTypes.User_Defined || BrakeShoeType != BrakeShoeTypes.Unknown))
                 {
                     Trace.TraceInformation("Number of Wagon Brakeshoes set to default value of {0}", NumberCarBrakeShoes);
                 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -684,7 +684,7 @@ namespace Orts.Simulation.RollingStocks
         public enum BrakeShoeTypes
         {
             Unknown,
-            Cast_Iron,
+            Cast_Iron_P6,
             Cast_Iron_P10,
             Disc_Pads,
             High_Friction_Composite,
@@ -3243,53 +3243,21 @@ namespace Orts.Simulation.RollingStocks
                 // Karwatzki developed a formula for brakeshoe friction that used 5 constant values k1, ..... , k5.
                 // Wende present a number of different brake shoes k values, two sets of which line up with the UIC values above.
 
-                float NewtonsTokNewtons = 0.001f;
-                float brakeShoeForcekN = (NewtonsTokNewtons * BrakeShoeForceN) / NumberCarBrakeShoes;
-                float k1 = 0;
-                float k2 = 0;
-                float k3 = 0;
-                float k4 = 0;
-                float k5 = 0;
-
-                if (BrakeShoeType == BrakeShoeTypes.Cast_Iron)
+                if (BrakeShoeType == BrakeShoeTypes.Cast_Iron_P6)
                 {
-                    k1 = 0.024f;
-                    k2 = 62.5f;
-                    k3 = 12.5f;
-                    k4 = 100f;
-                    k5 = 20f;
-
-                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                    frictionfraction = KarwatzkiBrakeShoeFriction(0.024f, 62.5f, 12.5f, 100, 20);
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.Cast_Iron_P10)
                 {
-                    k1 = 0.05f;
-                    k2 = 62.5f;
-                    k3 = 31.25f;
-                    k4 = 100f;
-                    k5 = 20f;
-
-                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                    frictionfraction = KarwatzkiBrakeShoeFriction(0.05f, 62.5f, 31.25f, 100, 20);
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.High_Friction_Composite)
                 {
-                    k1 = 0.055f;
-                    k2 = 200f;
-                    k3 = 50f;
-                    k4 = 150f;
-                    k5 = 75f;
-
-                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                    frictionfraction = KarwatzkiBrakeShoeFriction(0.055f, 200, 50, 150, 75);
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.Disc_Pads)
                 {
-                    k1 = 0.385f;
-                    k2 = -24.5f;
-                    k3 = -27.2f;
-                    k4 = 39.5f;
-                    k5 = 33f;
-
-                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                    frictionfraction = KarwatzkiBrakeShoeFriction(0.385f, -24.5f, -27.2f, 39.5f, 33);
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.User_Defined)
                 {
@@ -3351,53 +3319,21 @@ namespace Orts.Simulation.RollingStocks
                 // Karwatzki developed a formula for brakeshoe friction that used 5 constant values k1, ..... , k5.
                 // Wende present a number of different brake shoes k values, two sets of which line up with the UIC values above.
 
-                float NewtonsTokNewtons = 0.001f;
-                float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN / NumberCarBrakeShoes;
-                float k1 = 0;
-                float k2 = 0;
-                float k3 = 0;
-                float k4 = 0;
-                float k5 = 0;
-
-                if (BrakeShoeType == BrakeShoeTypes.Cast_Iron)
+                if (BrakeShoeType == BrakeShoeTypes.Cast_Iron_P6)
                 {
-                    k1 = 0.024f;
-                    k2 = 62.5f;
-                    k3 = 12.5f;
-                    k4 = 100f;
-                    k5 = 20f;
-
-                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                    frictionfraction = KarwatzkiBrakeShoeFriction (0.024f, 62.5f, 12.5f, 100, 20);
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.Cast_Iron_P10)
                 {
-                    k1 = 0.05f;
-                    k2 = 62.5f;
-                    k3 = 31.25f;
-                    k4 = 100f;
-                    k5 = 20f;
-
-                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                    frictionfraction = KarwatzkiBrakeShoeFriction(0.05f, 62.5f, 31.25f, 100, 20);
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.High_Friction_Composite)
                 {
-                    k1 = 0.055f;
-                    k2 = 200f;
-                    k3 = 50f;
-                    k4 = 150f;
-                    k5 = 75f;
-
-                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                    frictionfraction = KarwatzkiBrakeShoeFriction(0.055f, 200, 50f, 150, 75);
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.Disc_Pads)
                 {
-                    k1 = 0.385f;
-                    k2 = -24.5f;
-                    k3 = -27.2f;
-                    k4 = 39.5f;
-                    k5 = 33f;
-
-                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                    frictionfraction = KarwatzkiBrakeShoeFriction(0.385f, -24.5f, -27.2f, 39.5f, 33);
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.User_Defined)
                 {
@@ -3422,6 +3358,16 @@ namespace Orts.Simulation.RollingStocks
                 frictionfraction = 1.0f;  // Default value set to leave existing brakeforce constant regardless of changing speed
                 return frictionfraction;
             }
+        }
+
+        public float KarwatzkiBrakeShoeFriction ( float k1, float k2, float k3, float k4, float k5 )
+        {
+                var friction = 0.0f;
+                float NewtonsTokNewtons = 0.001f;
+                float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN / NumberCarBrakeShoes;
+                friction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+
+                return friction;
         }
 
         public virtual void InitializeCarHeatingVariables()

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -685,6 +685,8 @@ namespace Orts.Simulation.RollingStocks
         {
             Unknown,
             Cast_Iron,
+            Cast_Iron_P10,
+            Disc_Pads,
             High_Friction_Composite,
             User_Defined,
         }
@@ -3236,17 +3238,58 @@ namespace Orts.Simulation.RollingStocks
                 // Formula 9 and 10 from the paper "Study of the influence of the brake shoe temperature and wheel tread on braking effectiveness" by P Ivanov1, A Khudonogov1,
                 // E Dulskiy1, N Manuilov1, A Khamnaeva1, A Korsun1, S Treskin is used for the Cast Iron and Hi Friction Composite brake shoe friction curves.
                 // https://iopscience.iop.org/article/10.1088/1742-6596/1614/1/012086/pdf
+                //
+                // These formulas are based upon the work of Karwatzki, which is described further in "Fahrdynamik des Schienenverkehrs" by Dietrich Wende 2003.
+                // Karwatzki developed a formula for brakeshoe friction that used 5 constant values k1, ..... , k5.
+                // Wende present a number of different brake shoes k values, two sets of which line up with the UIC values above.
 
                 float NewtonsTokNewtons = 0.001f;
                 float brakeShoeForcekN = (NewtonsTokNewtons * BrakeShoeForceN) / NumberCarBrakeShoes;
+                float k1 = 0;
+                float k2 = 0;
+                float k3 = 0;
+                float k4 = 0;
+                float k5 = 0;
 
                 if (BrakeShoeType == BrakeShoeTypes.Cast_Iron)
                 {
-                    frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 100.0f) / (5.0f * MpS.ToKpH(AbsSpeedMpS) + 100.0f));
+                    k1 = 0.024f;
+                    k2 = 62.5f;
+                    k3 = 12.5f;
+                    k4 = 100f;
+                    k5 = 20f;
+
+                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                }
+                else if (BrakeShoeType == BrakeShoeTypes.Cast_Iron_P10)
+                {
+                    k1 = 0.05f;
+                    k2 = 62.5f;
+                    k3 = 31.25f;
+                    k4 = 100f;
+                    k5 = 20f;
+
+                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.High_Friction_Composite)
                 {
-                    frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 150.0f) / (2.0f * MpS.ToKpH(AbsSpeedMpS) + 150.0f));
+                    k1 = 0.055f;
+                    k2 = 200f;
+                    k3 = 50f;
+                    k4 = 150f;
+                    k5 = 75f;
+
+                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                }
+                else if (BrakeShoeType == BrakeShoeTypes.Disc_Pads)
+                {
+                    k1 = 0.385f;
+                    k2 = -24.5f;
+                    k3 = -27.2f;
+                    k4 = 39.5f;
+                    k5 = 33f;
+
+                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.User_Defined)
                 {
@@ -3303,17 +3346,58 @@ namespace Orts.Simulation.RollingStocks
                 // Formula 9 and 10 from the paper "Study of the influence of the brake shoe temperature and wheel tread on braking effectiveness" by P Ivanov1, A Khudonogov1,
                 // E Dulskiy1, N Manuilov1, A Khamnaeva1, A Korsun1, S Treskin is used for the Cast Iron and Hi Friction Composite brake shoe friction curves.
                 // https://iopscience.iop.org/article/10.1088/1742-6596/1614/1/012086/pdf
+                //
+                // These formulas are based upon the work of Karwatzki, which is described further in "Fahrdynamik des Schienenverkehrs" by Dietrich Wende 2003.
+                // Karwatzki developed a formula for brakeshoe friction that used 5 constant values k1, ..... , k5.
+                // Wende present a number of different brake shoes k values, two sets of which line up with the UIC values above.
 
                 float NewtonsTokNewtons = 0.001f;
                 float brakeShoeForcekN = NewtonsTokNewtons * BrakeShoeForceN / NumberCarBrakeShoes;
+                float k1 = 0;
+                float k2 = 0;
+                float k3 = 0;
+                float k4 = 0;
+                float k5 = 0;
 
                 if (BrakeShoeType == BrakeShoeTypes.Cast_Iron)
                 {
-                    frictionfraction = 0.6f * ((1.6f * brakeShoeForcekN + 100.0f) / (8.0f * brakeShoeForcekN + 100.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 100.0f) / (5.0f * MpS.ToKpH(AbsSpeedMpS) + 100.0f));
+                    k1 = 0.024f;
+                    k2 = 62.5f;
+                    k3 = 12.5f;
+                    k4 = 100f;
+                    k5 = 20f;
+
+                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                }
+                else if (BrakeShoeType == BrakeShoeTypes.Cast_Iron_P10)
+                {
+                    k1 = 0.05f;
+                    k2 = 62.5f;
+                    k3 = 31.25f;
+                    k4 = 100f;
+                    k5 = 20f;
+
+                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.High_Friction_Composite)
                 {
-                    frictionfraction = 0.44f * ((0.1f * brakeShoeForcekN + 20.0f) / (0.4f * brakeShoeForcekN + 20.0f)) * ((MpS.ToKpH(AbsSpeedMpS) + 150.0f) / (2.0f * MpS.ToKpH(AbsSpeedMpS) + 150.0f));
+                    k1 = 0.055f;
+                    k2 = 200f;
+                    k3 = 50f;
+                    k4 = 150f;
+                    k5 = 75f;
+
+                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
+                }
+                else if (BrakeShoeType == BrakeShoeTypes.Disc_Pads)
+                {
+                    k1 = 0.385f;
+                    k2 = -24.5f;
+                    k3 = -27.2f;
+                    k4 = 39.5f;
+                    k5 = 33f;
+
+                    frictionfraction = k1 * ((brakeShoeForcekN + k2) / (brakeShoeForcekN + k3)) * ((MpS.ToKpH(AbsSpeedMpS) + k4) / (MpS.ToKpH(AbsSpeedMpS) + k5));
                 }
                 else if (BrakeShoeType == BrakeShoeTypes.User_Defined)
                 {


### PR DESCRIPTION
Following some research some additional CoF curves have been found for brake shoe operation.

These have been added to increase the variety available to users.

These changes are an enhancement as part of - https://blueprints.launchpad.net/or/+spec/braking-enhancement