### PR TITLE
Add Alternate Syntax for Confusing Tokens

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -974,6 +974,7 @@ public List<CabView> CabViewList = new List<CabView>();
                 case "engine(awsmonitor":
                 case "engine(overspeedmonitor": VigilanceMonitor = true; TrainControlSystem.Parse(lowercasetoken, stf); break;
                 case "engine(enginecontrollers(combined_control": ParseCombData(lowercasetoken, stf); break;
+                case "engine(ortsairbrakemainresvolume":
                 case "engine(airbrakesmainresvolume": MainResVolumeM3 = Me3.FromFt3(stf.ReadFloatBlock(STFReader.UNITS.VolumeDefaultFT3, null)); break;
                 case "engine(airbrakesmainmaxairpressure": MainResPressurePSI = MaxMainResPressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, null); break;
                 case "engine(airbrakemaxmainrespipepressure": MaximumMainReservoirPipePressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, null); break;
@@ -1007,10 +1008,15 @@ public List<CabView> CabViewList = new List<CabView>();
                 case "engine(ortstractioncharacteristics": TractiveForceCurves = new InterpolatorDiesel2D(stf, true); break;
                 case "engine(ortsdynamicbrakeforcecurves": DynamicBrakeForceCurves = new InterpolatorDiesel2D(stf, false); break;
                 case "engine(ortscontinuousforcetimefactor": ContinuousForceTimeFactor = stf.ReadFloatBlock(STFReader.UNITS.None, null); break;
+                case "engine(ortssanderspeedeffectupto":
                 case "engine(orts(ortssanderspeedeffectupto": SanderSpeedEffectUpToMpS = stf.ReadFloatBlock(STFReader.UNITS.Speed, null); break;
+                case "engine(ortsemergencycausespowerdown":
                 case "engine(orts(ortsemergencycausespowerdown": EmergencyCausesPowerDown = stf.ReadBoolBlock(false); break;
+                case "engine(ortsemergencycausesthrottledown":
                 case "engine(orts(ortsemergencycausesthrottledown": EmergencyCausesThrottleDown = stf.ReadBoolBlock(false); break;
+                case "engine(ortsemergencyengageshorn":
                 case "engine(orts(ortsemergencyengageshorn": EmergencyEngagesHorn = stf.ReadBoolBlock(false); break;
+                case "engine(ortswheelslipcausesthrottledown":
                 case "engine(orts(ortswheelslipcausesthrottledown": WheelslipCausesThrottleDown = stf.ReadBoolBlock(false); break;
                 case "engine(dynamicbrakesminusablespeed": DynamicBrakeSpeed1MpS = stf.ReadFloatBlock(STFReader.UNITS.SpeedDefaultMPH, null); break;
                 case "engine(dynamicbrakesfadingspeed": DynamicBrakeSpeed2MpS = stf.ReadFloatBlock(STFReader.UNITS.SpeedDefaultMPH, null); break;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1444,6 +1444,7 @@ namespace Orts.Simulation.RollingStocks
                     stf.ReadFloat(STFReader.UNITS.None, null);
                     stf.SkipRestOfBlock();
                     break;
+                case "wagon(ortscurtius_kniffler":
                 case "wagon(ortsadhesion(ortscurtius_kniffler":
                     //e.g. Wagon ( ORTSAdhesion ( ORTSCurtius_Kniffler ( 7.5 44 0.161 0.7 ) ) )
                     stf.MustMatch("(");
@@ -1453,11 +1454,13 @@ namespace Orts.Simulation.RollingStocks
                     AdhesionK = stf.ReadFloat(STFReader.UNITS.None, 0.7f); if (AdhesionK <= 0) AdhesionK = 0.7f;
                     stf.SkipRestOfBlock();
                     break;
+                case "wagon(ortsslipwarningthreshold":
                 case "wagon(ortsadhesion(ortsslipwarningthreshold":
                     stf.MustMatch("(");
                     SlipWarningThresholdPercent = stf.ReadFloat(STFReader.UNITS.None, 70.0f); if (SlipWarningThresholdPercent <= 0) SlipWarningThresholdPercent = 70.0f;
                     stf.SkipRestOfBlock();
                     break;
+                case "wagon(wheelset":
                 case "wagon(ortsadhesion(wheelset":
                     LocomotiveAxles.Parse(lowercasetoken, stf);
                     break;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1460,7 +1460,6 @@ namespace Orts.Simulation.RollingStocks
                     SlipWarningThresholdPercent = stf.ReadFloat(STFReader.UNITS.None, 70.0f); if (SlipWarningThresholdPercent <= 0) SlipWarningThresholdPercent = 70.0f;
                     stf.SkipRestOfBlock();
                     break;
-                case "wagon(wheelset":
                 case "wagon(ortsadhesion(wheelset":
                     LocomotiveAxles.Parse(lowercasetoken, stf);
                     break;


### PR DESCRIPTION
Some tokens have syntax that doesn't conform to user expectations, resulting in some users, even payware developers, to either use syntax that doesn't work or to just avoid some features as the inconsistent syntax is too confusing to use. This PR adds alternate syntax to allow the confused tokens to be implemented in ways users expect and understand.

Specifically:
- Adding **`ORTSAirBrakeMainResVolume`** as an alternate token for `AirBrakesMainResVolume`. Some community members, and even payware developer TrainSimulations, were misled into thinking this token existed when it did not, resulting in locomotives with smaller (default-sized) main reservoirs than intended. As this 'ORTS...' syntax has been used so much, it makes more sense to add it officially than to attempt to change the minds of those who have used it for years.
- Allowing tokens which normally need to be in an `orts ( )` block to also be parsed if placed outside of an orts ( ) block. A very small number of tokens needed to be in an `engine(orts(` section, which is ultimately redundant as the token names already have 'orts' in them, and is also confusing because it is inconsistent with the multitude of tokens which do not require an orts ( ) block. Users have shown confusion with the whole orts ( ) block thing, and some have gotten the impression that the orts ( ) block isn't necessary (even though it is), so allowing this alternate should vibe better with people.
- Similar story for tokens that would require an `ortsadhesion ( )` block. While this is more sensible than the orts ( ) block, there's 2 `ORTSAdhesion( ORTS... (` tokens, which is still redundant, adding unneeded complexity and room for user error.

Parsing of the original syntax still remains to retain support for users who were able to decipher the correct formatting. Similarly, I'm not intending on changing the documentation for these tokens as the changes here are only intended to be a fallback to account for user error and their use does not need to be encouraged.

Discussion on this issue came up [here](http://www.elvastower.com/forums/index.php?/topic/37183-max-sander-speed-bug/page__st__10__p__297852#entry297852) on ElvasTower, in response to the tweaks to sander behavior included in PR #840, and the subsequent confusion that `ORTSSanderSpeedEffectUpTo` wouldn't work unless inside an `engine(orts(` section.

Feature request: https://www.elvastower.com/forums/index.php?/topic/37183-max-sander-speed-bug/page__view__findpost__p__297852