### PR TITLE
Adding Air Flow Meters

### DIFF
--- a/Source/Documentation/Manual/appendices.rst
+++ b/Source/Documentation/Manual/appendices.rst
@@ -61,6 +61,7 @@ Mass Flow                                           g/h
 Volumetric Flow         m^3/s           air flow    m^3/s
                                         meters
 \                                                   ft^3/min
+\                                                   L/min
 \                                                   L/s
 Speed                   m/s             other       m/s         m/s             meter per second
 \                                                   km/h

--- a/Source/Documentation/Manual/appendices.rst
+++ b/Source/Documentation/Manual/appendices.rst
@@ -58,6 +58,10 @@ Voltage                 volt                        V
 Mass Flow                                           g/h
 \                                                   kg/h
 \                       lb/h                        lb/h        lb/h
+Volumetric Flow         m^3/s           air flow    m^3/s
+                                        meters
+\                                                   ft^3/min
+\                                                   L/s
 Speed                   m/s             other       m/s         m/s             meter per second
 \                                                   km/h
 \                                                   kph         kph             kilometer per hour

--- a/Source/Documentation/Manual/cabs.rst
+++ b/Source/Documentation/Manual/cabs.rst
@@ -679,6 +679,37 @@ An example of implementation of the above controls in a .cvf file follows::
 		)
 
 
+Air Flow Meter
+--------------
+
+.. index::
+   single:  ORTS_AIR_FLOW_METER
+
+This cabview control is used on some locomotives, particularly in North America, to show the
+volumetric flow rate of air moving from the main res to the brake pipe during release/recharge.
+Such an indication can be used to determine when brake pipe charging is complete,
+measure the amount of brake pipe leakage, and so on.
+The control will only function on locomotives with air brakes.
+
+Here is an example implementation of ORTS_AIR_FLOW_METER as an analog dial::
+
+
+		Dial (
+			Type ( ORTS_AIR_FLOW_METER DIAL )
+			Position ( 258 271 1 32 )
+			Graphic ( "white_needle.ace" )
+			Style ( NEEDLE )
+			ScaleRange ( 0 150 )
+			ScalePos ( 295 65 )
+			Units ( CUBIC_FT_MIN )
+			Pivot ( 24 )
+			DirIncrease ( 0 )
+		)
+
+Applicable user-defined units are CUBIC_FT_MIN and LITRES_S. Cubic meters per second will be
+used if no units are specified.
+
+
 Animated 2D Wipers
 ------------------
 

--- a/Source/Documentation/Manual/cabs.rst
+++ b/Source/Documentation/Manual/cabs.rst
@@ -706,8 +706,8 @@ Here is an example implementation of ORTS_AIR_FLOW_METER as an analog dial::
 			DirIncrease ( 0 )
 		)
 
-Applicable user-defined units are CUBIC_FT_MIN and LITRES_S. Cubic meters per second will be
-used if no units are specified.
+Applicable user-defined units are CUBIC_FT_MIN, LITRES_S, and CUBIC_M_S. Cubic meters per
+second will be used if no units are specified.
 
 
 Animated 2D Wipers

--- a/Source/Documentation/Manual/cabs.rst
+++ b/Source/Documentation/Manual/cabs.rst
@@ -706,7 +706,7 @@ Here is an example implementation of ORTS_AIR_FLOW_METER as an analog dial::
 			DirIncrease ( 0 )
 		)
 
-Applicable user-defined units are CUBIC_FT_MIN, LITRES_S, and CUBIC_M_S. Cubic meters per
+Applicable user-defined units are CUBIC_FT_MIN, LITERS_S, LITERS_MIN, and CUBIC_M_S. Cubic meters per
 second will be used if no units are specified.
 
 

--- a/Source/Documentation/Manual/driving.rst
+++ b/Source/Documentation/Manual/driving.rst
@@ -764,7 +764,9 @@ The following information is displayed in the basic display:
   Train brake HUD line has two Brake Reservoir pressure numbers: the first is 
   the Equalization Reservoir (EQ) and the second is the Brake Cylinder (BC) 
   pressure. The two BP numbers report the brake pressure in the lead engine 
-  and in the last car of the train. The unit of measure used for brake 
+  and in the last car of the train. Additionally, the brake flow is shown,
+  which measures the rate of air flowing into the brake pipe during release
+  and recharge. The unit of measure used for brake 
   pressure is defined by the option :ref:`Pressure unit <options-pressure>`.
 - Engine Brake = percentage of independent engine brake. Not fully 
   releasing the engine brake will affect train brake pressures.

--- a/Source/ORTS.Common/Conversions.cs
+++ b/Source/ORTS.Common/Conversions.cs
@@ -550,6 +550,7 @@ namespace ORTS.Common
         public static string inhg = Catalog.GetString("inHg");
         public static string kgfpcm2 = Catalog.GetString("kgf/cm²");
         public static string lps = Catalog.GetString("L/s");
+        public static string lpm = Catalog.GetString("L/min");
         public static string cfm = Catalog.GetString("cfm");
         public static string kg = Catalog.GetString("kg");
         public static string t = Catalog.GetString("t");

--- a/Source/ORTS.Common/Conversions.cs
+++ b/Source/ORTS.Common/Conversions.cs
@@ -549,6 +549,8 @@ namespace ORTS.Common
         public static string psi = Catalog.GetString("psi");
         public static string inhg = Catalog.GetString("inHg");
         public static string kgfpcm2 = Catalog.GetString("kgf/cm²");
+        public static string lps = Catalog.GetString("L/s");
+        public static string cfm = Catalog.GetString("cfm");
         public static string kg = Catalog.GetString("kg");
         public static string t = Catalog.GetString("t");
         public static string tonUK = Catalog.GetString("t-uk");
@@ -812,6 +814,12 @@ namespace ORTS.Common
             }
 
             return String.Format(CultureInfo.CurrentCulture, format, pressureOut);
+        }
+
+        public static string FormatAirFlow(float flowM3pS, bool isMetric)
+        {
+            var flow = isMetric ? flowM3pS * 1000.0f : flowM3pS * 35.3147f * 60.0f;
+            return String.Format(CultureInfo.CurrentCulture, "{0:F0} {1}", flow, isMetric ? lps : cfm);
         }
 
         /// <summary>

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -321,6 +321,7 @@ namespace Orts.Formats.Msts
         KILO_LBS,
         METRES_PER_SEC,
         LITRES,
+        LITERS,
         GALLONS,
         INCHES_OF_MERCURY,
         MILI_AMPS,
@@ -334,6 +335,8 @@ namespace Orts.Formats.Msts
         YARDS,
 
         CUBIC_FT_MIN,
+        LITRES_MIN,
+        LITERS_MIN,
         LITRES_S,
         LITERS_S,
         CUBIC_M_S

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -335,7 +335,8 @@ namespace Orts.Formats.Msts
 
         CUBIC_FT_MIN,
         LITRES_S,
-        LITERS_S
+        LITERS_S,
+        CUBIC_M_S
     }
 
     public enum DiscreteStates

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -194,6 +194,7 @@ namespace Orts.Formats.Msts
         ORTS_BAILOFF,
         ORTS_QUICKRELEASE,
         ORTS_OVERCHARGE,
+        ORTS_AIR_FLOW_METER,
         ORTS_BATTERY_SWITCH_COMMAND_SWITCH,
         ORTS_BATTERY_SWITCH_COMMAND_BUTTON_CLOSE,
         ORTS_BATTERY_SWITCH_COMMAND_BUTTON_OPEN,
@@ -330,7 +331,10 @@ namespace Orts.Formats.Msts
         METRES,
         MILES,
         FEET,
-        YARDS
+        YARDS,
+
+        CUBIC_FT_MIN,
+        LITRES_S
     }
 
     public enum DiscreteStates

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -334,7 +334,8 @@ namespace Orts.Formats.Msts
         YARDS,
 
         CUBIC_FT_MIN,
-        LITRES_S
+        LITRES_S,
+        LITERS_S
     }
 
     public enum DiscreteStates

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
@@ -1175,11 +1175,11 @@ namespace Orts.Simulation.RollingStocks
             status.AppendFormat((data < 0 ? "???" : " ") + "\t");
 
             // BP
-            var brakeInfoValue = brakeValue(Simulator.Catalog.GetString("BP"), Simulator.Catalog.GetString("EOT"));
+            var brakeInfoValue = brakeValue(Simulator.Catalog.GetString("BP"), Simulator.Catalog.GetString("Flow"));
             status.AppendFormat("{0:F0}\t", brakeInfoValue);
-
-            // Flow.
-            // TODO:The BP air flow that feeds the brake tube is not yet modeled in Open Rails.
+            // Air flow meter
+            brakeInfoValue = brakeValue(Simulator.Catalog.GetString("Flow"), Simulator.Catalog.GetString("EOT"));
+            status.AppendFormat("{0:F0}\t", brakeInfoValue);
 
             // Remote
             if (dataDpu)
@@ -1277,6 +1277,7 @@ namespace Orts.Simulation.RollingStocks
             labels.AppendFormat("{0}\t", Simulator.Catalog.GetString("Throttle"));
             labels.AppendFormat("{0}\t", Simulator.Catalog.GetString("Load"));
             labels.AppendFormat("{0}\t", Simulator.Catalog.GetString("BP"));
+            labels.AppendFormat("{0}\t", Simulator.Catalog.GetString("Flow"));
             if (!dpuFull)
             {
                 labels.AppendFormat("{0}", Simulator.Catalog.GetString("Remote"));

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -5429,6 +5429,7 @@ namespace Orts.Simulation.RollingStocks
                                 data = this.FilteredBrakePipeFlowM3pS * 1000.0f;
                                 break;
 
+                            case CABViewControlUnits.CUBIC_M_S:
                             default:
                                 data = this.FilteredBrakePipeFlowM3pS;
                                 break;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -5425,6 +5425,7 @@ namespace Orts.Simulation.RollingStocks
                                 break;
 
                             case CABViewControlUnits.LITRES_S:
+                            case CABViewControlUnits.LITERS_S:
                                 data = this.FilteredBrakePipeFlowM3pS * 1000.0f;
                                 break;
 
@@ -5558,7 +5559,6 @@ namespace Orts.Simulation.RollingStocks
 
                                 }
                             }
-
                         }
                         else
                         {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -5429,6 +5429,11 @@ namespace Orts.Simulation.RollingStocks
                                 data = this.FilteredBrakePipeFlowM3pS * 1000.0f;
                                 break;
 
+                            case CABViewControlUnits.LITRES_MIN:
+                            case CABViewControlUnits.LITERS_MIN:
+                                data = this.FilteredBrakePipeFlowM3pS * 1000.0f * 60.0f;
+                                break;
+
                             case CABViewControlUnits.CUBIC_M_S:
                             default:
                                 data = this.FilteredBrakePipeFlowM3pS;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -33,6 +33,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
     public class AirSinglePipe : MSTSBrakeSystem
     {
         protected TrainCar Car;
+        readonly static float OneAtmospherePSI = 14.696f;
         protected float HandbrakePercent;
         protected float CylPressurePSI = 64;
         public float AutoCylPressurePSI { get; protected set; } = 64;
@@ -180,9 +181,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         // Get Brake information for train
         public override string GetFullStatus(BrakeSystem lastCarBrakeSystem, Dictionary<BrakeSystemComponent, PressureUnit> units)
         {
+            var loco = Car as MSTSLocomotive;
             var s = $" {Simulator.Catalog.GetString("EQ")} {FormatStrings.FormatPressure(Car.Train.EqualReservoirPressurePSIorInHg, PressureUnit.PSI, units[BrakeSystemComponent.EqualizingReservoir], true)}"
                 + $" {Simulator.Catalog.GetString("BC")} {FormatStrings.FormatPressure(Car.Train.HUDWagonBrakeCylinderPSI, PressureUnit.PSI, units[BrakeSystemComponent.BrakeCylinder], true)}"
-                + $" {Simulator.Catalog.GetString("BP")} {FormatStrings.FormatPressure(BrakeLine1PressurePSI, PressureUnit.PSI, units[BrakeSystemComponent.BrakePipe], true)}";
+                + $" {Simulator.Catalog.GetString("BP")} {FormatStrings.FormatPressure(BrakeLine1PressurePSI, PressureUnit.PSI, units[BrakeSystemComponent.BrakePipe], true)}"
+                + $" {Simulator.Catalog.GetString("Flow")} {FormatStrings.FormatAirFlow(loco.FilteredBrakePipeFlowM3pS, loco.IsMetric)}";
             if (lastCarBrakeSystem != null && lastCarBrakeSystem != this)
                 s += $" {Simulator.Catalog.GetString("EOT")} {lastCarBrakeSystem.GetStatus(units)}";
             if (HandbrakePercent > 0)
@@ -1094,6 +1097,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             var lead = trainCar as MSTSLocomotive;
             train.FindLeadLocomotives(out int first, out int last);
 
+            float tempBrakePipeFlow = 0.0f; // Flow calculation will assume 0 flow unless calculated otherwise
+
             // Propagate brake line (1) data if pressure gradient disabled
             if (lead != null && lead.BrakePipeChargingRatePSIorInHgpS >= 1000)
             {   // pressure gradient disabled
@@ -1101,6 +1106,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 {
                     var dp1 = train.EqualReservoirPressurePSIorInHg - lead.BrakeSystem.BrakeLine1PressurePSI;
                     lead.MainResPressurePSI -= dp1 * lead.BrakeSystem.BrakePipeVolumeM3 / lead.MainResVolumeM3;
+
+                    tempBrakePipeFlow = (dp1 * lead.BrakeSystem.BrakePipeVolumeM3) / (OneAtmospherePSI * elapsedClockSeconds); // Instantaneous flow rate from MR to BP
                 }
                 foreach (TrainCar car in train.Cars)
                 {
@@ -1109,6 +1116,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     if (car.BrakeSystem.TwoPipes)
                         car.BrakeSystem.BrakeLine2PressurePSI = Math.Min(lead.MainResPressurePSI, lead.MaximumMainReservoirPipePressurePSI);
                 }
+
+                lead.BrakePipeFlowM3pS = tempBrakePipeFlow;
+                lead.FilteredBrakePipeFlowM3pS = lead.AFMFilter.Filter(lead.BrakePipeFlowM3pS, elapsedClockSeconds); // Actual flow rate displayed by air flow meter
             }
             else
             {   // approximate pressure gradient in train pipe line1
@@ -1121,6 +1131,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 {
                     if (lead != null)
                     {
+                        tempBrakePipeFlow = 0.0f;
+
                         // Allow for leaking train air brakepipe
                         if (lead.BrakeSystem.BrakeLine1PressurePSI - trainPipeLeakLossPSI > 0 && lead.TrainBrakePipeLeakPSIorInHgpS != 0) // if train brake pipe has pressure in it, ensure result will not be negative if loss is subtracted
                         {
@@ -1140,8 +1152,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                                 }
                                 float PressureDiffEqualToPipePSI = trainPipeTimeVariationS * chargingRatePSIpS; // default condition - if EQ Res is higher then Brake Pipe Pressure
 
-                                if (train.EqualReservoirPressurePSIorInHg < lead.BrakeSystem.BrakeLine1PressurePSI + 1)
-                                    PressureDiffEqualToPipePSI *= MathHelper.Clamp(train.EqualReservoirPressurePSIorInHg - lead.BrakeSystem.BrakeLine1PressurePSI, 0.1f, 1.0f); // Reduce recharge rate if near EQ pressure to prevent air pulsing
+                                if (train.EqualReservoirPressurePSIorInHg - lead.BrakeSystem.BrakeLine1PressurePSI < 5.0f) // Reduce recharge rate if near EQ to simulate feed valve behavior
+                                    PressureDiffEqualToPipePSI *= Math.Min((float)Math.Sqrt((train.EqualReservoirPressurePSIorInHg - lead.BrakeSystem.BrakeLine1PressurePSI) / 5.0f), 1.0f);
+                                if (lead.MainResPressurePSI - train.EqualReservoirPressurePSIorInHg < 15.0f) // Reduce recharge rate if near MR pressure as per reality
+                                    PressureDiffEqualToPipePSI *= Math.Min((lead.MainResPressurePSI - train.EqualReservoirPressurePSIorInHg) / 15.0f, 1.0f);
 
                                 if (lead.BrakeSystem.BrakeLine1PressurePSI + PressureDiffEqualToPipePSI > train.EqualReservoirPressurePSIorInHg)
                                     PressureDiffEqualToPipePSI = train.EqualReservoirPressurePSIorInHg - lead.BrakeSystem.BrakeLine1PressurePSI;
@@ -1157,6 +1171,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                                 {
                                     lead.BrakeSystem.BrakeLine1PressurePSI += PressureDiffEqualToPipePSI;
                                     lead.MainResPressurePSI -= PressureDiffEqualToPipePSI * lead.BrakeSystem.BrakePipeVolumeM3 / lead.MainResVolumeM3;
+
+                                    tempBrakePipeFlow = (PressureDiffEqualToPipePSI * lead.BrakeSystem.BrakePipeVolumeM3) / (OneAtmospherePSI * trainPipeTimeVariationS); // Instantaneous flow rate from MR to BP
                                 }
                             }
                             // reduce pressure in lead brake line if brake pipe pressure is above equalising pressure - apply brakes
@@ -1165,13 +1181,17 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                                 float serviceVariationFactor = Math.Min(trainPipeTimeVariationS / serviceTimeFactor, 0.95f);
                                 float pressureDiffPSI = serviceVariationFactor * lead.BrakeSystem.BrakeLine1PressurePSI;
 
-                                if (train.EqualReservoirPressurePSIorInHg > lead.BrakeSystem.BrakeLine1PressurePSI - 1)
-                                    pressureDiffPSI *= MathHelper.Clamp(lead.BrakeSystem.BrakeLine1PressurePSI - train.EqualReservoirPressurePSIorInHg, 0.1f, 1.0f); // Reduce exhausting rate if near EQ pressure to prevent air pulsing
+                                if (train.EqualReservoirPressurePSIorInHg > lead.BrakeSystem.BrakeLine1PressurePSI - 5.0f) // Reduce exhausting rate if near EQ pressure to simulate feed valve
+                                    pressureDiffPSI *= Math.Min((float)Math.Sqrt((lead.BrakeSystem.BrakeLine1PressurePSI - train.EqualReservoirPressurePSIorInHg) / 5.0f), 1.0f);
                                 if (lead.BrakeSystem.BrakeLine1PressurePSI - pressureDiffPSI < train.EqualReservoirPressurePSIorInHg)
                                     pressureDiffPSI = lead.BrakeSystem.BrakeLine1PressurePSI - train.EqualReservoirPressurePSIorInHg;
                                 lead.BrakeSystem.BrakeLine1PressurePSI -= pressureDiffPSI;
                             }
                         }
+
+                        // Finish updating air flow meter
+                        lead.BrakePipeFlowM3pS = tempBrakePipeFlow;
+                        lead.FilteredBrakePipeFlowM3pS = lead.AFMFilter.Filter(lead.BrakePipeFlowM3pS, trainPipeTimeVariationS); // Actual flow rate displayed by air flow meter
 
                         train.LeadPipePressurePSI = lead.BrakeSystem.BrakeLine1PressurePSI;  // Keep a record of current train pipe pressure in lead locomotive
                     }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
@@ -16,7 +16,6 @@
 // along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using Microsoft.Xna.Framework;
 using ORTS.Scripting.Api;
 
 namespace Orts.Simulation.RollingStocks.SubSystems.Controllers

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
@@ -415,7 +415,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             {
                 float dp = rateBarpS * elapsedSeconds;
                 if (targetBar - pressureBar < 0.5f) // Slow down increase when nearing target to simulate chokes in brake valve
-                    dp *= Math.Min((targetBar - pressureBar) / 0.5f + 0.1f, 1.0f);
+                    dp *= Math.Min(((targetBar - pressureBar) / 0.5f) + 0.1f, 1.0f);
                 pressureBar += dp;
                 if (pressureBar > targetBar)
                     pressureBar = targetBar;
@@ -428,7 +428,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             {
                 float dp = rateBarpS * elapsedSeconds;
                 if (pressureBar - targetBar < 0.5f) // Slow down decrease when nearing target to simulate chokes in brake valve
-                    dp *= Math.Min((pressureBar - targetBar) / 0.5f + 0.1f, 1.0f);
+                    dp *= Math.Min(((pressureBar - targetBar) / 0.5f) + 0.1f, 1.0f);
                 pressureBar -= dp;
                 if (pressureBar < targetBar)
                     pressureBar = targetBar;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Controllers/MSTSBrakeController.cs
@@ -16,6 +16,7 @@
 // along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using Microsoft.Xna.Framework;
 using ORTS.Scripting.Api;
 
 namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
@@ -409,23 +410,29 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Controllers
             }
         }
 
-        static void IncreasePressure(ref float pressurePSI, float targetPSI, float ratePSIpS, float elapsedSeconds)
+        static void IncreasePressure(ref float pressureBar, float targetBar, float rateBarpS, float elapsedSeconds)
         {
-            if (pressurePSI < targetPSI)
+            if (pressureBar < targetBar)
             {
-                pressurePSI += ratePSIpS * elapsedSeconds;
-                if (pressurePSI > targetPSI)
-                    pressurePSI = targetPSI;
+                float dp = rateBarpS * elapsedSeconds;
+                if (targetBar - pressureBar < 0.5f) // Slow down increase when nearing target to simulate chokes in brake valve
+                    dp *= Math.Min((targetBar - pressureBar) / 0.5f + 0.1f, 1.0f);
+                pressureBar += dp;
+                if (pressureBar > targetBar)
+                    pressureBar = targetBar;
             }
         }
 
-        static void DecreasePressure(ref float pressurePSI, float targetPSI, float ratePSIpS, float elapsedSeconds)
+        static void DecreasePressure(ref float pressureBar, float targetBar, float rateBarpS, float elapsedSeconds)
         {
-            if (pressurePSI > targetPSI)
+            if (pressureBar > targetBar)
             {
-                pressurePSI -= ratePSIpS * elapsedSeconds;
-                if (pressurePSI < targetPSI)
-                    pressurePSI = targetPSI;
+                float dp = rateBarpS * elapsedSeconds;
+                if (pressureBar - targetBar < 0.5f) // Slow down decrease when nearing target to simulate chokes in brake valve
+                    dp *= Math.Min((pressureBar - targetBar) / 0.5f + 0.1f, 1.0f);
+                pressureBar -= dp;
+                if (pressureBar < targetBar)
+                    pressureBar = targetBar;
             }
         }
     }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
@@ -469,7 +469,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             result.AppendFormat("\t{0}", FormatStrings.FormatPower(eng.CurrentDieselOutputPowerW, Locomotive.IsMetric, false, false));
             result.AppendFormat("\t{0:F1}%", eng.LoadPercent);
             result.AppendFormat("\t{0:F0} {1}", eng.RealRPM, FormatStrings.rpm);
-            result.AppendFormat("\t{0}/{1}", FormatStrings.FormatFuelVolume(pS.TopH(eng.DieselFlowLps), Locomotive.IsMetric, Locomotive.IsUK), FormatStrings.h);
+            result.AppendFormat("\t{0}", FormatStrings.FormatAirFlow(Locomotive.FilteredBrakePipeFlowM3pS, Locomotive.IsMetric));
             result.AppendFormat("\t{0}", FormatStrings.FormatTemperature(eng.DieselTemperatureDeg, Locomotive.IsMetric, false));
             result.AppendFormat("\t{0}", FormatStrings.FormatPressure(eng.DieselOilPressurePSI, PressureUnit.PSI, Locomotive.MainPressureUnit, true));
 

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -867,12 +867,14 @@ namespace Orts.Viewer3D.Popups
                     else
                     {
 
-                        TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}",
+                        TableAddLines(table, String.Format("{0}\t\t{1}\t\t{2}\t{3}\t\t{4}\t\t{5}\t\t{6}",
                             Viewer.Catalog.GetString("PlayerLoco"),
                             Viewer.Catalog.GetString("Main reservoir"),
                             FormatStrings.FormatPressure((Viewer.PlayerLocomotive as MSTSLocomotive).MainResPressurePSI, PressureUnit.PSI, (Viewer.PlayerLocomotive as MSTSLocomotive).BrakeSystemPressureUnits[BrakeSystemComponent.MainReservoir], true),
                             Viewer.Catalog.GetString("Compressor"),
-                            (Viewer.PlayerLocomotive as MSTSLocomotive).CompressorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off")));
+                            (Viewer.PlayerLocomotive as MSTSLocomotive).CompressorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
+                            Viewer.Catalog.GetString("Flow"),
+                            FormatStrings.FormatAirFlow((Viewer.PlayerLocomotive as MSTSLocomotive).FilteredBrakePipeFlowM3pS, mstsLocomotive.IsMetric)));
                     }
 
 
@@ -895,14 +897,16 @@ namespace Orts.Viewer3D.Popups
                         }
                         else
                         {
-                            TableAddLines(table, String.Format("{0}\t{1}\t{2}\t\t{3}\t{4}\t\t{5}",
+                            TableAddLines(table, String.Format("{0}\t{1}\t{2}\t\t{3}\t{4}\t\t{5}\t\t{6}\t\t{7}",
                             Viewer.Catalog.GetString("Loco"),
                             car.CarID,
 
                             Viewer.Catalog.GetString("Main reservoir"),
                             FormatStrings.FormatPressure((car as MSTSLocomotive).MainResPressurePSI, PressureUnit.PSI, (car as MSTSLocomotive).BrakeSystemPressureUnits[BrakeSystemComponent.MainReservoir], true),
                             Viewer.Catalog.GetString("Compressor"),
-                            (car as MSTSLocomotive).CompressorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off")));                            
+                            (car as MSTSLocomotive).CompressorIsOn ? Viewer.Catalog.GetString("on") : Viewer.Catalog.GetString("off"),
+                            Viewer.Catalog.GetString("Flow"),
+                            FormatStrings.FormatAirFlow((car as MSTSLocomotive).FilteredBrakePipeFlowM3pS, mstsLocomotive.IsMetric)));
                         }
                     }
                 }

--- a/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
@@ -26,7 +26,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Xna.Framework;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace Orts.Viewer3D.Popups
 {

--- a/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Xna.Framework;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace Orts.Viewer3D.Popups
 {
@@ -636,6 +637,8 @@ namespace Orts.Viewer3D.Popups
                       .Replace(Viewer.Catalog.GetString("kgf/cm²"), string.Empty)
                       .Replace(Viewer.Catalog.GetString("kPa"), string.Empty)
                       .Replace(Viewer.Catalog.GetString("psi"), string.Empty)
+                      .Replace(Viewer.Catalog.GetString("cfm"), string.Empty)
+                      .Replace(Viewer.Catalog.GetString("L/s"), string.Empty)
                       .Replace(Viewer.Catalog.GetString("lib./pal."), string.Empty)//cs locales
                       .Replace(Viewer.Catalog.GetString("pal.rtuti"), string.Empty)
                       .ToString();
@@ -840,34 +843,53 @@ namespace Orts.Viewer3D.Popups
                     LastCol = brakeInfoValue,
                 });
 
-                if (trainBrakeStatus.Contains(Viewer.Catalog.GetString("EOT")))
+                int endIndex;
+                if (trainBrakeStatus.Contains(Viewer.Catalog.GetString("Flow")))
                 {
-                    int indexOffset = Viewer.Catalog.GetString("EOT").Length + 1; 
-                    if (trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("V"), index) > 0)
-                        index = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("V"), index);
-                    else
-                        index = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("BC"));
+                    endIndex = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("Flow"));
+                }
+                else if (trainBrakeStatus.Contains(Viewer.Catalog.GetString("EOT")))
+                {
+                    endIndex = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("EOT"));
+                }
+                else
+                {
+                    endIndex = trainBrakeStatus.Length;
+                }
 
-                    brakeInfoValue = trainBrakeStatus.Substring(index, trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("EOT")) - index).TrimEnd();
-                    AddLabel(new ListLabel
-                    {
-                        LastCol = brakeInfoValue,
-                    });
-                    index = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("EOT")) + indexOffset;
-                    brakeInfoValue = trainBrakeStatus.Substring(index, trainBrakeStatus.Length - index).TrimStart();
+                if (trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("V"), index) > 0)
+                    index = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("V"), index);
+                else
+                    index = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("BC"));
+
+                brakeInfoValue = trainBrakeStatus.Substring(index, endIndex - index).TrimEnd();
+                AddLabel(new ListLabel
+                {
+                    LastCol = brakeInfoValue,
+                });
+                
+                if (trainBrakeStatus.Contains(Viewer.Catalog.GetString("Flow")))
+                {
+                    index = endIndex;
+
+                    if (trainBrakeStatus.Contains(Viewer.Catalog.GetString("EOT")))
+                        endIndex = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("EOT"));
+                    else
+                        endIndex = trainBrakeStatus.Length;
+
+                    brakeInfoValue = trainBrakeStatus.Substring(index, endIndex - index).TrimEnd();
                     AddLabel(new ListLabel
                     {
                         LastCol = brakeInfoValue,
                     });
                 }
-                else
-                {
-                    if (trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("V"), index) > 0)
-                        index = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("V"), index);
-                    else
-                        index = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("BC"));
 
-                    brakeInfoValue = trainBrakeStatus.Substring(index, trainBrakeStatus.Length - index).TrimEnd();
+                if (trainBrakeStatus.Contains(Viewer.Catalog.GetString("EOT")))
+                {
+                    int indexOffset = Viewer.Catalog.GetString("EOT").Length + 1;
+
+                    index = trainBrakeStatus.IndexOf(Viewer.Catalog.GetString("EOT")) + indexOffset;
+                    brakeInfoValue = trainBrakeStatus.Substring(index, trainBrakeStatus.Length - index).TrimStart();
                     AddLabel(new ListLabel
                     {
                         LastCol = brakeInfoValue,


### PR DESCRIPTION
This pull request covers the work I've done to add air flow meters for the air braking system. This type of gauge measures the volumetric flow rate of air out of the main res into the brake pipe, useful for gauging train brake behavior during recharge and release (though does nothing during applications).

Discuss observations about this change [here on E-T.](http://www.elvastower.com/forums/index.php?/topic/34527-wishes-for-improvement-of-braking-systems/page__view__findpost__p__299318)
[Trello card](https://trello.com/c/hSZFdMLl)

- Added air flow meter to all relevant HUD components (Alt + F5 HUD, F5 HUD, DPU HUD, control confirmations). Shows cubic feet per minute (cfm) in imperial, liters per second in metric. This will appear on the HUD for any air-braked locomotive with an equalizing res, even if the real locomotive doesn't actually have a flow meter.
- Added "ORTS_AIR_FLOW_METER" cabview control type. Default units are cubic meters per second (this is what's used under the hood) but custom units are CUBIC_FT_MIN for cubic feet per minute, LITERS_MIN for liters per minute, and LITERS_S for liters per second.
- Changed behavior of equalizing reservoir and brake pipe exhausting/recharging to have some smoothing, trying to replicate some behaviors I observed in test reports and make the behavior of the airflow meter more convincing. This will affect all air braked content, even MSTS original, but I did some testing and found it works quite well across a bunch of different routes, new and old.

Air flow meters are particularly common in North American designs but appear rarely elsewhere, so I'm curious to know if there are meters out there that use units other than cfm and L/s. Also, word of warning, the air flow rates show what is actually going on in the air brake physics, but this flow is limited by the setting of `ORTSBrakePipeChargingRate`. The flow meter does not lie, so if you are seeing flows different than what's expected, that means the brake pipe charging rate isn't right.