### PR TITLE
Fixes for Undesired Emergency Applications

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/BrakeSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/BrakeSystem.cs
@@ -40,6 +40,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes
         public float BrakePipeVolumeM3 = 1.4e-2f;      // volume of a single brake line
         public bool ControllerRunningLock = false;  // Stops Running controller from becoming active until BP = EQ Res, used in EQ vacuum brakes
         public float BrakeCylFraction;
+        public float AngleCockOpeningTime = 30.0f;  // Time taken to fully open a closed anglecock
 
         /// <summary>
         /// Front brake hoses connection status
@@ -49,10 +50,14 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes
         /// Front angle cock opened/closed status
         /// </summary>
         public bool AngleCockAOpen = true;
+        public float AngleCockAOpenAmount = 1.0f; // 0 - anglecock fully closed, 1 - anglecock fully open, allows for partial opening
+        public float? AngleCockAOpenTime = null;   // Time elapsed since anglecock open command was sent
         /// <summary>
         /// Rear angle cock opened/closed status
         /// </summary>
         public bool AngleCockBOpen = true;
+        public float AngleCockBOpenAmount = 1.0f; // 0 - anglecock fully closed, 1 - anglecock fully open, allows for partial opening
+        public float? AngleCockBOpenTime = null;   // Time elapsed since anglecock open command was sent
         /// <summary>
         /// Auxiliary brake reservoir vent valve open/closed status
         /// </summary>

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -670,7 +670,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 }
                 if (BrakeLine1PressurePSI - dpPipe < 0)
                 {
+                    // Prevent pipe pressure from going negative, also reset quick service to prevent runaway condition
                     dpPipe = BrakeLine1PressurePSI;
+                    QuickServiceActive = false;
                 }
 
                 if (TripleValveState != ValveState.Emergency && BrakeLine1PressurePSI < AuxResPressurePSI + 1)
@@ -694,7 +696,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 AutoCylPressurePSI += dp;
                 BrakeLine1PressurePSI -= dpPipe;
 
-                if (QuickServiceActive && AutoCylPressurePSI > QuickServiceLimitPSI) // Reset quick service if brake cylinder is above limiting valve setting
+                // Reset quick service if brake cylinder is above limiting valve setting
+                // Also reset quick service if cylinders manage to equalize to prevent runaway condition
+                if (QuickServiceActive && (AutoCylPressurePSI > QuickServiceLimitPSI || AutoCylPressurePSI >= AuxResPressurePSI)) 
                     QuickServiceActive = false;
 
                 if (TripleValveState == ValveState.Emergency)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -91,6 +91,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         protected float prevBrakePipePressurePSI = 0f;
         protected float prevBrakePipePressurePSI_sound = 0f;
 
+        protected float BrakePipeChangePSIpS;
+        protected SmoothedData SmoothedBrakePipeChangePSIpS;
+
 
         /// <summary>
         /// EP brake holding valve. Needs to be closed (Lap) in case of brake application or holding.
@@ -113,6 +116,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             // taking into account very short (fake) cars to prevent NaNs in brake line pressures
             BrakePipeVolumeM3 = (0.032f * 0.032f * (float)Math.PI / 4f) * Math.Max ( 5.0f, (1 + car.CarLengthM)); // Using DN32 (1-1/4") pipe
             DebugType = "1P";
+
+            SmoothedBrakePipeChangePSIpS = new SmoothedData(0.25f);
 
             // Force graduated releasable brakes. Workaround for MSTS with bugs preventing to set eng/wag files correctly for this.
             if (Car.Simulator.Settings.GraduatedRelease) (Car as MSTSWagon).BrakeValve = MSTSWagon.BrakeValveType.Distributor;
@@ -205,7 +210,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 string.Empty, // Spacer because the state above needs 2 columns.
                 (Car as MSTSWagon).HandBrakePresent ? string.Format("{0:F0}%", HandbrakePercent) : string.Empty,
                 FrontBrakeHoseConnected ? "I" : "T",
-                string.Format("A{0} B{1}", AngleCockAOpen ? "+" : "-", AngleCockBOpen ? "+" : "-"),
+                string.Format("A{0} B{1}", AngleCockAOpenAmount >= 1 ? "+" : AngleCockAOpenAmount <= 0 ? "-" : "/", AngleCockBOpenAmount >= 1 ? "+" : AngleCockBOpenAmount <= 0 ? "-" : "/"),
                 BleedOffValveOpen ? Simulator.Catalog.GetString("Open") : string.Empty,
             };
 
@@ -329,7 +334,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             outf.Write((int)TripleValveState);
             outf.Write(FrontBrakeHoseConnected);
             outf.Write(AngleCockAOpen);
+            outf.Write(AngleCockAOpenAmount);
             outf.Write(AngleCockBOpen);
+            outf.Write(AngleCockBOpenAmount);
             outf.Write(BleedOffValveOpen);
             outf.Write((int)HoldingValve);
             outf.Write(UniformChargingActive);
@@ -352,7 +359,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             TripleValveState = (ValveState)inf.ReadInt32();
             FrontBrakeHoseConnected = inf.ReadBoolean();
             AngleCockAOpen = inf.ReadBoolean();
+            AngleCockAOpenAmount = inf.ReadSingle();
             AngleCockBOpen = inf.ReadBoolean();
+            AngleCockBOpenAmount = inf.ReadSingle();
             BleedOffValveOpen = inf.ReadBoolean();
             HoldingValve = (ValveState)inf.ReadInt32();
             UniformChargingActive = inf.ReadBoolean();
@@ -380,6 +389,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             {
                 loco.MainResPressurePSI = loco.MaxMainResPressurePSI;
             }
+
+            SmoothedBrakePipeChangePSIpS.ForceSmoothValue(0);
         }
 
         public override void Initialize()
@@ -455,12 +466,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             var prevState = TripleValveState;
             var valveType = (Car as MSTSWagon).BrakeValve;
             bool disableGradient = !(Car.Train.LeadLocomotive is MSTSLocomotive) && Car.Train.TrainType != Orts.Simulation.Physics.Train.TRAINTYPE.STATIC;
+            // Small workaround to allow trains to more reliably go into emergency after uncoupling
+            bool emergencyTripped = (Car.Train.TrainType == Orts.Simulation.Physics.Train.TRAINTYPE.STATIC) ?
+                BrakeLine1PressurePSI <= EmergResPressurePSI * AuxCylVolumeRatio / (AuxCylVolumeRatio + 1) : Math.Max(-SmoothedBrakePipeChangePSIpS.SmoothedValue, 0) > EmergencyValveActuationRatePSIpS;
 
             if (valveType == MSTSWagon.BrakeValveType.Distributor)
             {
                 float applicationPSI = ControlResPressurePSI - BrakeLine1PressurePSI;
                 float targetPressurePSI = applicationPSI * AuxCylVolumeRatio;
-                if (!disableGradient && EmergencyValveActuationRatePSIpS > 0 && (prevBrakePipePressurePSI - BrakeLine1PressurePSI) > Math.Max(elapsedClockSeconds, 0.0001f) * EmergencyValveActuationRatePSIpS)
+                if (!disableGradient && EmergencyValveActuationRatePSIpS > 0 && emergencyTripped)
                 {
                     if (prevState == ValveState.Release) // If valve transitions from release to emergency, quick service activates
                     {
@@ -497,7 +511,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             }
             else if (valveType == MSTSWagon.BrakeValveType.TripleValve || valveType == MSTSWagon.BrakeValveType.DistributingValve)
             {
-                if (!disableGradient && EmergencyValveActuationRatePSIpS > 0 && (prevBrakePipePressurePSI - BrakeLine1PressurePSI) > Math.Max(elapsedClockSeconds, 0.0001f) * EmergencyValveActuationRatePSIpS)
+                if (!disableGradient && EmergencyValveActuationRatePSIpS > 0 && emergencyTripped)
                 {
                     if (prevState == ValveState.Release) // If valve transitions from release to emergency, quick service activates
                     {
@@ -547,10 +561,52 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             else EmergencyDumpStartTime = null;
         }
 
+        public void UpdateAngleCockState(bool AngleCockOpen, ref float AngleCockOpenAmount, ref float? AngleCockOpenTime)
+        {
+            float currentTime = (float)this.Car.Simulator.GameTime;
+
+            if (AngleCockOpen && AngleCockOpenAmount < 1.0f)
+            {
+                if (AngleCockOpenTime == null)
+                {
+                    AngleCockOpenTime = currentTime;
+                }
+                else if (currentTime - AngleCockOpenTime > AngleCockOpeningTime)
+                {
+                    // Finish opening anglecock at a faster rate once time has elapsed
+                    AngleCockOpenAmount = (currentTime - ((float)AngleCockOpenTime + AngleCockOpeningTime)) / 5 + 0.3f;
+
+                    if (AngleCockOpenAmount >= 1.0f)
+                    {
+                        AngleCockOpenAmount = 1.0f;
+                        AngleCockOpenTime = null;
+                    }
+                }
+                else
+                {
+                    // Gradually open anglecock toward 30% over 30 seconds
+                    AngleCockOpenAmount = 0.3f * (currentTime - (float)AngleCockOpenTime) / AngleCockOpeningTime;
+                }
+            }
+            else if (!AngleCockOpen && AngleCockOpenAmount > 0.0f)
+            {
+                AngleCockOpenAmount = 0.0f;
+                AngleCockOpenTime = null;
+            }
+        }
+
         public override void Update(float elapsedClockSeconds)
         {
             var valveType = (Car as MSTSWagon).BrakeValve;
             float threshold = valveType == MSTSWagon.BrakeValveType.Distributor ? Math.Max((ControlResPressurePSI - BrakeLine1PressurePSI) * AuxCylVolumeRatio, 0) : 0;
+
+            BrakePipeChangePSIpS = (BrakeLine1PressurePSI - prevBrakePipePressurePSI) / Math.Max(elapsedClockSeconds, 0.0001f);
+            SmoothedBrakePipeChangePSIpS.Update(Math.Max(elapsedClockSeconds, 0.0001f), BrakePipeChangePSIpS);
+
+            // Update anglecock opening. Anglecocks set to gradually open over 30 seconds, but close instantly.
+            // Gradual opening prevents undesired emergency applications
+            UpdateAngleCockState(AngleCockAOpen, ref AngleCockAOpenAmount, ref AngleCockAOpenTime);
+            UpdateAngleCockState(AngleCockBOpen, ref AngleCockBOpenAmount, ref AngleCockBOpenTime);
 
             if (BleedOffValveOpen)
             {
@@ -591,7 +647,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             {
                 float dp = 0;
                 float dpPipe = 0;
-                float brakePipeChange = Math.Max(prevBrakePipePressurePSI - BrakeLine1PressurePSI, 0);
                 if (QuickServiceActive) // Quick service: Brake pipe pressure is locally reduced to speed up initial reduction
                 {
                     if (QuickServiceVentRatePSIpS > 0)
@@ -608,7 +663,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 {
                     if (AcceleratedApplicationFactor > 0) // Accelerated application: Air is vented from the brake pipe to speed up service applications
                     {
-                        dpPipe = Math.Min(brakePipeChange * AcceleratedApplicationFactor, elapsedClockSeconds * AcceleratedApplicationLimitPSIpS); // Amount of air vented is proportional to pressure reduction from external sources
+                        // Amount of air vented is proportional to pressure reduction from external sources
+                        dpPipe = MathHelper.Clamp(-SmoothedBrakePipeChangePSIpS.SmoothedValue * AcceleratedApplicationFactor, 0, AcceleratedApplicationLimitPSIpS) * elapsedClockSeconds;
                     }
                     dp = elapsedClockSeconds * MaxApplicationRatePSIpS;
                 }
@@ -1116,7 +1172,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 int nSteps = (int)(elapsedClockSeconds / brakePipeTimeFactorS + 1);
                 float trainPipeTimeVariationS = elapsedClockSeconds / nSteps;
                 float trainPipeLeakLossPSI = lead == null ? 0.0f : (trainPipeTimeVariationS * lead.TrainBrakePipeLeakPSIorInHgpS);
-                float serviceTimeFactor = lead != null ? lead.TrainBrakeController != null && lead.TrainBrakeController.EmergencyBraking ? lead.BrakeEmergencyTimeFactorPSIpS : lead.BrakeServiceTimeFactorPSIpS : 0;
+                float serviceTimeFactor = lead != null && lead.TrainBrakeController != null ? lead.BrakeServiceTimeFactorPSIpS : 0.001f;
+                float emergencyTimeFactor = lead != null && lead.TrainBrakeController != null ? lead.BrakeEmergencyTimeFactorPSIpS : 0.001f;
                 for (int i = 0; i < nSteps; i++)
                 {
                     if (lead != null)
@@ -1127,7 +1184,17 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                             lead.BrakeSystem.BrakeLine1PressurePSI -= trainPipeLeakLossPSI;
                         }
 
-                        if (lead.TrainBrakeController.TrainBrakeControllerState != ControllerState.Neutral)
+                        // Emergency brake - vent brake pipe to 0 psi regardless of equalizing res pressure
+                        if (lead.TrainBrakeController.EmergencyBraking)
+                        {
+                            float emergencyVariationFactor = Math.Min(trainPipeTimeVariationS / emergencyTimeFactor, 0.95f);
+                            float pressureDiffPSI = emergencyVariationFactor * lead.BrakeSystem.BrakeLine1PressurePSI;
+
+                            if (lead.BrakeSystem.BrakeLine1PressurePSI - pressureDiffPSI < 0)
+                                pressureDiffPSI = lead.BrakeSystem.BrakeLine1PressurePSI;
+                            lead.BrakeSystem.BrakeLine1PressurePSI -= pressureDiffPSI;
+                        }
+                        else if (lead.TrainBrakeController.TrainBrakeControllerState != ControllerState.Neutral)
                         {
                             // Charge train brake pipe - adjust main reservoir pressure, and lead brake pressure line to maintain brake pipe equal to equalising resevoir pressure - release brakes
                             if (lead.BrakeSystem.BrakeLine1PressurePSI < train.EqualReservoirPressurePSIorInHg)
@@ -1203,6 +1270,13 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                                 // The sign in the equation determines the direction of air flow.
                                 float trainPipePressureDiffPropagationPSI = pressureDiffPSI * Math.Min(trainPipeTimeVariationS / brakePipeTimeFactorS, 1);
 
+                                // Flow is restricted when either anglecock is not opened fully
+                                if (car.BrakeSystem.AngleCockAOpenAmount < 1 || prevCar.BrakeSystem.AngleCockBOpenAmount < 1)
+                                {
+                                    trainPipePressureDiffPropagationPSI *= MathHelper.Min((float)Math.Pow(car.BrakeSystem.AngleCockAOpenAmount * prevCar.BrakeSystem.AngleCockBOpenAmount, 2), 1.0f);
+
+                                }
+
                                 // Air flows from high pressure to low pressure, until pressure is equal in both cars.
                                 // Brake pipe volumes of both cars are taken into account, so pressure increase/decrease is proportional to relative volumes.
                                 // If TrainPipePressureDiffPropagationPSI equals to p1-p0 the equalization is achieved in one step.
@@ -1221,11 +1295,25 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         // Empty the brake pipe if the brake hose is not connected and angle cocks are open
                         if (!car.BrakeSystem.FrontBrakeHoseConnected && car.BrakeSystem.AngleCockAOpen)
                         {
-                            car.BrakeSystem.BrakeLine1PressurePSI = Math.Max(car.BrakeSystem.BrakeLine1PressurePSI * (1 - trainPipeTimeVariationS / brakePipeTimeFactorS), 0);
+                            float dp = car.BrakeSystem.BrakeLine1PressurePSI * trainPipeTimeVariationS / brakePipeTimeFactorS;
+
+                            if (car.BrakeSystem.AngleCockAOpenAmount < 1)
+                                dp *= MathHelper.Clamp((float)Math.Pow(car.BrakeSystem.AngleCockAOpenAmount, 2), 0.0f, 1.0f);
+
+                            if (car.BrakeSystem.BrakeLine1PressurePSI - dp < 0)
+                                dp = car.BrakeSystem.BrakeLine1PressurePSI;
+                            car.BrakeSystem.BrakeLine1PressurePSI -= dp;
                         }
                         if ((nextCar == null || !nextCar.BrakeSystem.FrontBrakeHoseConnected) && car.BrakeSystem.AngleCockBOpen)
                         {
-                            car.BrakeSystem.BrakeLine1PressurePSI = Math.Max(car.BrakeSystem.BrakeLine1PressurePSI * (1 - trainPipeTimeVariationS / brakePipeTimeFactorS), 0);
+                            float dp = car.BrakeSystem.BrakeLine1PressurePSI * trainPipeTimeVariationS / brakePipeTimeFactorS;
+
+                            if (car.BrakeSystem.AngleCockBOpenAmount < 1)
+                                dp *= MathHelper.Clamp((float)Math.Pow(car.BrakeSystem.AngleCockBOpenAmount, 2), 0.0f, 1.0f);
+
+                            if (car.BrakeSystem.BrakeLine1PressurePSI - dp < 0)
+                                dp = car.BrakeSystem.BrakeLine1PressurePSI;
+                            car.BrakeSystem.BrakeLine1PressurePSI -= dp;
                         }
                     }
 #if DEBUG_TRAIN_PIPE_LEAK

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -807,13 +807,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         EmergResPressurePSI -= dp;
                         BrakeLine1PressurePSI += dp * EmergBrakeLineVolumeRatio;
                     }
-                    else // Quick recharge: Emergency res air used to recharge aux res on older control valves
+                    else if (!EmergResQuickRelease) // Quick recharge: Emergency res air used to recharge aux res on older control valves
                     {
                         float dp = elapsedClockSeconds * MaxAuxilaryChargingRatePSIpS;
                         if (AuxResPressurePSI + dp > EmergResPressurePSI - dp / EmergAuxVolumeRatio)
                             dp = (EmergResPressurePSI - AuxResPressurePSI) * EmergAuxVolumeRatio / (1 + EmergAuxVolumeRatio);
                         if (BrakeLine1PressurePSI < AuxResPressurePSI + dp)
                             dp = (BrakeLine1PressurePSI - AuxResPressurePSI);
+                        if (dp < 0)
+                            dp = 0;
                         AuxResPressurePSI += dp;
                         EmergResPressurePSI -= dp / EmergAuxVolumeRatio;
                     }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -407,6 +407,13 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 Trace.TraceWarning("{0} does not define a brake valve, defaulting to a plain triple valve", (Car as MSTSWagon).WagFilePath);
             }
 
+            // Reducing reservoir charging rates when set unrealistically high
+            if (Car.Simulator.Settings.CorrectQuestionableBrakingParams && (MaxAuxilaryChargingRatePSIpS > 10 || EmergResChargingRatePSIpS > 10))
+            {
+                MaxAuxilaryChargingRatePSIpS = Math.Min(MaxAuxilaryChargingRatePSIpS, 10.0f);
+                EmergResChargingRatePSIpS = Math.Min(EmergResChargingRatePSIpS, 10.0f);
+            }
+
             // In simple brake mode set emergency reservoir volume, override high volume values to allow faster brake release.
             if (Car.Simulator.Settings.SimpleControlPhysics && EmergResVolumeM3 > 2.0)
                 EmergResVolumeM3 = 0.7f;
@@ -468,7 +475,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             bool disableGradient = !(Car.Train.LeadLocomotive is MSTSLocomotive) && Car.Train.TrainType != Orts.Simulation.Physics.Train.TRAINTYPE.STATIC;
             // Small workaround to allow trains to more reliably go into emergency after uncoupling
             bool emergencyTripped = (Car.Train.TrainType == Orts.Simulation.Physics.Train.TRAINTYPE.STATIC) ?
-                BrakeLine1PressurePSI <= EmergResPressurePSI * AuxCylVolumeRatio / (AuxCylVolumeRatio + 1) : Math.Max(-SmoothedBrakePipeChangePSIpS.SmoothedValue, 0) > EmergencyValveActuationRatePSIpS;
+                BrakeLine1PressurePSI <= 0.75f * EmergResPressurePSI * AuxCylVolumeRatio / (AuxCylVolumeRatio + 1) : Math.Max(-SmoothedBrakePipeChangePSIpS.SmoothedValue, 0) > EmergencyValveActuationRatePSIpS;
 
             if (valveType == MSTSWagon.BrakeValveType.Distributor)
             {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -797,9 +797,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             // Manage emergency res charging
             if ((Car as MSTSWagon).EmergencyReservoirPresent)
             {
-                if (TripleValveState == ValveState.Release && EmergResPressurePSI > BrakeLine1PressurePSI && AutoCylPressurePSI > 5)
+                if (TripleValveState == ValveState.Release && EmergResPressurePSI > BrakeLine1PressurePSI)
                 {
-                    if (EmergResQuickRelease) // Quick release: Emergency res charges brake pipe during release
+                    if (EmergResQuickRelease && AutoCylPressurePSI > 5) // Quick release: Emergency res charges brake pipe during release
                     {
                         float dp = elapsedClockSeconds * EmergResChargingRatePSIpS;
                         if (EmergResPressurePSI - dp < BrakeLine1PressurePSI + dp * EmergBrakeLineVolumeRatio)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/SingleTransferPipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/SingleTransferPipe.cs
@@ -162,6 +162,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             float brakeShoeFriction = Car.GetBrakeShoeFrictionFactor();
             Car.HuDBrakeShoeFriction = Car.GetBrakeShoeFrictionCoefficientHuD();
 
+            // Update anglecock opening. Anglecocks set to gradually open over 30 seconds, but close instantly.
+            // Gradual opening prevents undesired emergency applications
+            UpdateAngleCockState(AngleCockAOpen, ref AngleCockAOpenAmount, ref AngleCockAOpenTime);
+            UpdateAngleCockState(AngleCockBOpen, ref AngleCockBOpenAmount, ref AngleCockBOpenTime);
+
             Car.BrakeRetardForceN = ( Car.MaxHandbrakeForceN * HandbrakePercent / 100) * brakeShoeFriction; // calculates value of force applied to wheel, independent of wheel skid
             if (Car.BrakeSkid) // Test to see if wheels are skiding to excessive brake force
             {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/EOT.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/EOT.cs
@@ -123,9 +123,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems
             if (Train.Simulator.PlayerLocomotive.Train == Train && EOTState == EOTstate.ArmedTwoWay &&
                 (EOTEmergencyBrakingOn ||
                 (Train.Simulator.PlayerLocomotive as MSTSLocomotive).TrainBrakeController.GetStatus().ToLower().StartsWith("emergency")))
-                Train.Cars.Last().BrakeSystem.AngleCockBOpen = true;
+            {
+                // Simulate EOT opening brake pipe to atmosphere by instantly opening rear anglecock
+                this.BrakeSystem.AngleCockBOpen = true;
+                this.BrakeSystem.AngleCockBOpenAmount = 1;
+            }
             else
-                Train.Cars.Last().BrakeSystem.AngleCockBOpen = false;
+            {
+                this.BrakeSystem.AngleCockBOpen = false;
+            }
             base.Update(elapsedClockSeconds);
         }
 


### PR DESCRIPTION
Some fixes/enhancements for emergency braking to reduce the chance of emergency braking occurring when not intended, and increase the change of emergency braking occurring when intended.

Expands upon PR #829
Related to https://blueprints.launchpad.net/or/+spec/braking-enhancement
Bug report: https://www.elvastower.com/forums/index.php?/topic/34527-wishes-for-improvement-of-braking-systems/page__view__findpost__p__299828

- When an anglecock is opened, rather than opening instantly it is (automatically) gradually opened over 30 seconds to limit flow rate between the two segments of brake pipe. This happens whether the anglecock was opened manually with the F9 menu or automatically with brake initialization/connect brake hose keybinds. This simulates real life switching practice, where the conductor will open an anglecock only partially for some moments after coupling (with some deviations to accommodate inaccuracies in the brake pipe flow model). In my testing, this is enough to prevent emergency braking from occurring when coupling to a train with an empty brake pipe without interfering with regular operations. A partially open anglecock will be indicated on the brake hud with "/" instead of the usual "+" and "-".
- Rather than using instantaneous change in brake pipe pressure to determine when to make an emergency application, the change is averaged over a quarter of a second. This prevents small reductions in brake pipe over short periods of time from triggering an emergency application. Instead, the reduction must be sustained, which is a sign that the emergency application should actually be happening. Similar has been done in real brake valve designs to intentionally reduce emergency sensitivity.
- Change to emergency detection to more reliably get consists that have been uncoupled from the player train to go into emergency (unless air has been bottled) without using CPU power to fully simulate the static consist.
- Slightly off-topic change to accelerated application so it too uses the averaged brake pipe change. This significantly improves the stability of accelerated application, reducing the chance that accelerated application causes an emergency application (also reduces the chance of accelerated application venting brake pipe below the selected pressure).
- Tweak to locomotive brake valve code to allow emergency braking to bypass the equalizing reservoir. In real locomotives, emergency braking opens up a hole in the brake pipe that lets air out regardless of the equalizing reservoir. (Previously, emergency braking would not vent air below the ER pressure, and would even recharge the brake pipe during emergency braking if the brake pipe pressure managed to drop below the ER, this had no bearing on real life.) For most engine files, this will only slightly accelerate emergency applications, but every bit helps.
- Restore the pre-version 1.5 emergency brake behavior for train cars which haven't been updated with new emergency brake features, to ensure those train cars go to emergency when expected (ie: when brake pipe pressure drops too low).

No changes require any file editing, but this will impact all air braked locomotives even back to MSTS. Recommend testing switching scenarios, coupling to cars and charging the brake pipe by setting anglecocks rather than using the initialize brakes cheat, and seeing if triple valves go to emergency due to coupling (shouldn't happen ever). Also try uncoupling from a train without closing the anglecocks, then recouple and verify that the brake pipe pressure dropped and triple valves changed to emergency in the static consist. Apply and release brakes on a variety of content, and check that triple valves don't go to emergency unless an emergency application is commanded from the locomotive or opening in brake pipe.