### PR TITLE
Fix Articulation For 0-Axle Train Cars

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -2718,7 +2718,7 @@ namespace Orts.Simulation.RollingStocks
             var carIndex = Train.Cars.IndexOf(this);
             //Certain locomotives are testing as articulated wagons for some reason.
             if (WagonType != WagonTypes.Engine)
-                if (articulatedFront || articulatedRear)
+                if (WheelAxles.Count != 1 && (articulatedFront || articulatedRear))
                 {
                     WheelAxlesLoaded = true;
                     SetUpWheelsArticulation(carIndex);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -2718,12 +2718,11 @@ namespace Orts.Simulation.RollingStocks
             var carIndex = Train.Cars.IndexOf(this);
             //Certain locomotives are testing as articulated wagons for some reason.
             if (WagonType != WagonTypes.Engine)
-                if (WheelAxles.Count >= 2)
-                    if (articulatedFront || articulatedRear)
-                    {
-                        WheelAxlesLoaded = true;
-                        SetUpWheelsArticulation(carIndex);
-                    }
+                if (articulatedFront || articulatedRear)
+                {
+                    WheelAxlesLoaded = true;
+                    SetUpWheelsArticulation(carIndex);
+                }
         } // end SetUpWheels()
 
         protected void SetUpWheelsArticulation(int carIndex)


### PR DESCRIPTION
Potential bug fix for this issue I noticed: http://www.elvastower.com/forums/index.php?/topic/37404-possible-issue-with-articulated-wagons-with-0-axles/

Some content creators will elect to create articulated train cars where some of the articulated components are represented as platforms with no bogies or axles, and on occasion, this may be the only feasible way to depict the articulated car in question. However, the way the code has been set up means that only train cars with 2 or more axles will be processed as articulated cars (this usually means a train car modeled with a bogie at one end, but no bogie at the other end, which is another strategy sometimes used for articulated units). As a result, articulated cars with no axles in the model are failing to be treated as articulated, resulting in unintended behavior.

The fix to this seems to be removing the check for having 2 or more axles, as getting rid of that results in the 0-axle units in question articulating as expected. This could cause things to articulate which should not articulate, in which case a more sophisticated solution may be needed.