### PR TITLE
Fix Retainer State Disappearing from HUD on Restore

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -321,6 +321,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             outf.Write(HandbrakePercent);
             outf.Write(ReleaseRatePSIpS);
             outf.Write(RetainerPressureThresholdPSI);
+            outf.Write(RetainerDebugState);
             outf.Write(AutoCylPressurePSI);
             outf.Write(AuxResPressurePSI);
             outf.Write(EmergResPressurePSI);
@@ -344,6 +345,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             HandbrakePercent = inf.ReadSingle();
             ReleaseRatePSIpS = inf.ReadSingle();
             RetainerPressureThresholdPSI = inf.ReadSingle();
+            RetainerDebugState = inf.ReadString();
             AutoCylPressurePSI = inf.ReadSingle();
             AuxResPressurePSI = inf.ReadSingle();
             EmergResPressurePSI = inf.ReadSingle();


### PR DESCRIPTION
Fix for http://www.elvastower.com/forums/index.php?/topic/37438-retainer-state-not-updated-on-restore/page__pid__300516#entry300516

The retainer state on the Alt + F5 brake HUD would fail to show the retainer state after loading from a saved game (the "RetValve" column would be blank, regardless of the presence/lack of retaining valves on the equipment in the activity). This is because the retainer debug state is only updated when the retainer state changes (and the state is not changed upon loading). Note that this is not an issue with the functionality of the retaining valves, just a bug with displaying them.

Fixed by simply adding the **RetainerDebugState** to save and restore. Whatever the state is will automatically be recovered when loading a save without the need to re-initialize the variable.