### PR TITLE
SwitchPanel disconnect/connect handling

### DIFF
--- a/Source/RunActivity/Viewer3D/WebServices/Web/SwitchPanel/index2.css
+++ b/Source/RunActivity/Viewer3D/WebServices/Web/SwitchPanel/index2.css
@@ -69,3 +69,17 @@ label {
     min-width: 1px;
 }
 
+#overlay {
+    position: fixed; /* Sit on top of the page content */
+    display: none; /* Hidden by default */
+    width: 100%; /* Full width (cover the whole page) */
+    height: 100%; /* Full height (cover the whole page) */
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0,0,0,0.6); /* Black background with opacity */
+    z-index: 2; /* Specify a stack order in case you're using a different order for other elements */
+    cursor: pointer; /* Add a pointer on hover */
+}
+

--- a/Source/RunActivity/Viewer3D/WebServices/Web/SwitchPanel/index2.html
+++ b/Source/RunActivity/Viewer3D/WebServices/Web/SwitchPanel/index2.html
@@ -25,6 +25,7 @@ along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
     </head>
 
     <body style="background-color: white">
+        <div id="overlay"></div>
         <table id="tableSwitchPanel"></table>
         <script src="index2.js"></script>
     </body>

--- a/Source/RunActivity/Viewer3D/WebServices/Web/SwitchPanel/index2.js
+++ b/Source/RunActivity/Viewer3D/WebServices/Web/SwitchPanel/index2.js
@@ -30,12 +30,14 @@ function createSocket() {
     const connection = new WebSocket(uri, "json");
 
     connection.onopen = function (evt) {
-        console.log("websocket opened: " + evt.type);
+        console.log("Websocket opened: " + evt.type);
+        // connected, turn off the dark overlay
+        document.getElementById("overlay").style.display = "none"; 
     };
 
     connection.onmessage = function (evt) {
         const json = JSON.parse(evt.data);
-        console.log("websocket message received: ", json);
+        console.log("Websocket message received: ", json);
         if (initStillToBeDone) {
             if (json.type == "init") {
                 initReceived(json.data);
@@ -48,12 +50,27 @@ function createSocket() {
     }
 
     connection.onerror = function (evt) {
-        console.error("websocket error: ", evt.type);
+        console.error("Websocket error: ", evt.type);
+        // this will also fire the onclose after this
     }
 
     connection.onclose = function (evt) {
-        console.log("WebSocket is closed now: " + evt.type);
+        console.log("WebSocket is closed: ", evt.type);
+        // dark overlay displayed so that it's clear the connection has gone
+        document.getElementById("overlay").style.display = "block"; 
+        // try to reconnect after 1 second
+        setTimeout(function () {
+            websocket = createSocket();
+        }, 1000);
     };
+
+    setTimeout(function () {
+        // close the socket if no connection established after 1 second
+        // otherwise it will wait with the reconnect after a timeout of 2 minutes
+        if (websocket.readyState != 1) {
+            websocket.close();
+        }
+    }, 1000);
 
     return connection;
 }

--- a/Source/RunActivity/Viewer3D/WebServices/Web/SwitchPanel/index2.js
+++ b/Source/RunActivity/Viewer3D/WebServices/Web/SwitchPanel/index2.js
@@ -65,12 +65,12 @@ function createSocket() {
     };
 
     setTimeout(function () {
-        // close the socket if no connection established after 1 second
+        // close the socket if no connection established after 3 seconds
         // otherwise it will wait with the reconnect after a timeout of 2 minutes
         if (websocket.readyState != 1) {
             websocket.close();
         }
-    }, 1000);
+    }, 3000);
 
     return connection;
 }


### PR DESCRIPTION
When switch panel gets disconnected because off ending open rails add dark overlay to the webpage. And try to reconnect.

Has been tested on the following browsers:
- Windows 10:
         Chrome: Version 118.0.5993.89 (Official Build) (64-bit) 
         Opera: 103.0.4928.34 
         Firefox: 118.0.2 (64-bit)
         Vivaldi: 6.2.3105.58 (Stable channel) (64-bit)
         Microsoft Edge Version 118.0.2088.57 (Official build) (64-bit) 
- Android 10:
        Chrome: 118.0.5993.80
        Opera: 77.5.4095.75179
        Firefox: 118.2.0 does NOT work properly
        Vivaldi: 6.2.3110.143

The tablet I used is a Galaxy Tab A (2018, 105), model number SM-T590. Has a resolution 1920x1200 (WUXGA). Used in landscape mode.

Feature request: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)