### PR TITLE
Extra line with all the arguments for debugging purposes in logfile

### DIFF
--- a/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
+++ b/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
@@ -231,7 +231,7 @@ namespace Orts.Viewer3D.Processes
                     default:
                         MessageBox.Show("To start " + Application.ProductName + ", please run 'OpenRails.exe'.\n\n"
                                 + "If you are attempting to debug this component, please run 'OpenRails.exe' and execute the scenario you are interested in. "
-                                + "In the log file, the command-line arguments used will be listed at the top. "
+                                + "In the log file, a line with the command-line arguments used will be listed at the top. "
                                 + "You should then configure your debug environment to execute this component with those command-line arguments.",
                                 Application.ProductName + " " + VersionInfo.VersionOrBuild);
                         Game.Exit();
@@ -819,7 +819,7 @@ namespace Orts.Viewer3D.Processes
                 Console.WriteLine("Executable = {0}", Path.GetFileName(Application.ExecutablePath));
                 foreach (var arg in args)
                     Console.WriteLine("Argument   = {0}", arg);
-#if DEBUG
+
                 string debugArgline = "";
                 foreach (var arg in args)
                 {
@@ -831,7 +831,7 @@ namespace Orts.Viewer3D.Processes
                     }
                  }
                 Console.WriteLine("Arguments  = {0}", debugArgline.TrimEnd());
-#endif
+
                 LogSeparator();
                 settings.Log();
                 LogSeparator();

--- a/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
+++ b/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
@@ -823,9 +823,11 @@ namespace Orts.Viewer3D.Processes
                 string debugArgline = "";
                 foreach (var arg in args)
                 {
-                    if (arg.Contains(" ")) {
+                    if (arg.Contains(" ")) 
+                    {
                         debugArgline += "\"" + arg + "\" ";
-                    } else
+                    } 
+                    else
                     {
                         debugArgline += arg + " ";
                     }

--- a/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
+++ b/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
@@ -819,6 +819,19 @@ namespace Orts.Viewer3D.Processes
                 Console.WriteLine("Executable = {0}", Path.GetFileName(Application.ExecutablePath));
                 foreach (var arg in args)
                     Console.WriteLine("Argument   = {0}", arg);
+#if DEBUG
+                string debugArgline = "";
+                foreach (var arg in args)
+                {
+                    if (arg.Contains(" ")) {
+                        debugArgline += "\"" + arg + "\" ";
+                    } else
+                    {
+                        debugArgline += arg + " ";
+                    }
+                 }
+                Console.WriteLine("Arguments  = {0}", debugArgline.TrimEnd());
+#endif
                 LogSeparator();
                 settings.Log();
                 LogSeparator();


### PR DESCRIPTION
When debugging in Visual Studio all the parameters in one line are needed as Debug Property. Parameters can be found in the logfile, however in separate lines and without quotes. Now one line to be used in Visual Studio can be found with the keyword "Arguments". Only when the Runactivity is compiled in debug mode (#if DEBUG).

Trello card https://trello.com/c/VkoqrKbH/575-extra-line-with-all-the-arguments-for-debugging-purposes-in-logfile