### PR TITLE
fix: adds downgrade to low precision

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
@@ -431,7 +431,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         /// <summary>
         /// switch between Polach and Pacha adhesion calculation
         /// </summary>
-        bool UsePolachAdhesion = false;
+        public static bool UsePolachAdhesion = false; // "static" so it's shared by all axles of the Player's loco
 
         /// <summary>
         /// Pre-calculation of slip characteristics at 0 slip speed
@@ -1122,22 +1122,25 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             // into HelpWindow.PrepareFrame() temporarily.
             public static bool IsPrecisionHigh(float elapsedSeconds)
             {
-                // Switches between Polach (high precision) adhesion model and Pacha (low precision) adhesion model depending upon the PC performance
-                switch (PrecisionLevel)
+                if (elapsedSeconds > 0) // Ignore period with elapsedSeconds == 0 until user starts game.
                 {
-                    case AdhesionPrecisionLevel.High:
-                        if (elapsedSeconds > UpperLimitS)
-                        {
-                            var screenFrameRate = 1 / elapsedSeconds;
+                    // Switches between Polach (high precision) adhesion model and Pacha (low precision) adhesion model depending upon the PC performance
+                    switch (PrecisionLevel)
+                    {
+                        case AdhesionPrecisionLevel.High:
+                            if (elapsedSeconds > UpperLimitS)
                             {
-                                Trace.TraceInformation($"Advanced adhesion model switched to low precision permanently after low frame rate {screenFrameRate:F1} below limit {1 / UpperLimitS:F0}");
-                                PrecisionLevel = AdhesionPrecisionLevel.Low;
+                                var screenFrameRate = 1 / elapsedSeconds;
+                                {
+                                    Trace.TraceInformation($"Advanced adhesion model switched to low precision permanently after low frame rate {screenFrameRate:F1} below limit {1 / UpperLimitS:F0}");
+                                    PrecisionLevel = AdhesionPrecisionLevel.Low;
+                                }
                             }
-                        }
-                        break;
+                            break;
 
-                    case AdhesionPrecisionLevel.Low:
-                        break;
+                        case AdhesionPrecisionLevel.Low:
+                            break;
+                    }
                 }
                 return (PrecisionLevel == AdhesionPrecisionLevel.High);
             }

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -27,6 +27,7 @@ using Orts.Simulation.RollingStocks.SubSystems;
 using Orts.Simulation.RollingStocks.SubSystems.Brakes;
 using Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS;
 using Orts.Simulation.RollingStocks.SubSystems.PowerSupplies;
+using Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions;
 using Orts.Viewer3D.Processes;
 using ORTS.Common;
 using ORTS.Scripting.Api;
@@ -1078,7 +1079,9 @@ namespace Orts.Viewer3D.Popups
                 {
                     if (mstsLocomotive.AdvancedAdhesionModel)
                     {
-                        TableAddLine(table, Viewer.Catalog.GetString("(Advanced adhesion model)"));
+                        var text = Viewer.Catalog.GetString("(Advanced adhesion model)");
+                        if (Axle.UsePolachAdhesion == false) text += "???";
+                        TableAddLine(table, text);
                         int row0 = table.CurrentRow;
                         TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Wheel slip (Thres)"));
                         TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Conditions"));

--- a/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
@@ -1216,6 +1216,8 @@ namespace Orts.Viewer3D.Popups
         
         public override void PrepareFrame(ElapsedTime elapsedTime, bool updateFull)
         {
+            // Uncomment this statement to reduce framerate during play for testing
+            //System.Threading.Thread.Sleep(40); // Press F1 to force framerate below 25 fps
 
             base.PrepareFrame(elapsedTime, updateFull);
 


### PR DESCRIPTION
Bug report: https://www.elvastower.com/forums/index.php?/topic/37671-advanced-adhesion-model-switched-to-low-performance-option-due-to-low-frame-rate

This is a fix to merged PR 878.
It switches the Advanced Adhesion down from Polach to Pacha's if the framerate falls below 30 fps.
Also it only logs a single statement.

A further PR is following to extend this one with support for switching back to Polach provided transitions are not too frequent.