### PR TITLE
feat: supports switching adhesion precisions

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -2784,7 +2784,7 @@ namespace Orts.Simulation.RollingStocks
                 axle.CurrentCurveRadiusM = CurrentCurveRadiusM;
                 axle.BogieRigidWheelBaseM = RigidWheelBaseM;
                 axle.CurtiusKnifflerZeroSpeed = ZeroSpeedAdhesionBase;
-                axle.ClockTime = Simulator.ClockTime;   // Used by Axle.Update() log messages
+                axle.GameTime = Simulator.GameTime;   // Used by Axle.Update() log messages
             }
 
             LocomotiveAxles.Update(elapsedClockSeconds);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -2784,6 +2784,7 @@ namespace Orts.Simulation.RollingStocks
                 axle.CurrentCurveRadiusM = CurrentCurveRadiusM;
                 axle.BogieRigidWheelBaseM = RigidWheelBaseM;
                 axle.CurtiusKnifflerZeroSpeed = ZeroSpeedAdhesionBase;
+                axle.ClockTime = Simulator.ClockTime;   // Used by Axle.Update() log messages
             }
 
             LocomotiveAxles.Update(elapsedClockSeconds);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
@@ -29,6 +29,8 @@ using Orts.Parsers.Msts;
 using Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions;
 using SharpDX.Direct2D1;
 using SharpDX.Direct3D9;
+using Orts.Formats.OR;
+using static Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions.Axle;
 
 namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
 {
@@ -715,6 +717,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
 
         public List<string> AnimatedParts = new List<string>();
 
+        public double ClockTime;
+
         /// <summary>
         /// Nonparametric constructor of Axle class instance
         /// - sets motor parameter to null
@@ -996,37 +1000,13 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         /// - computes axle dynamic model according to its driveType
         /// - computes wheelslip indicators
         /// </summary>
-        /// <param name="timeSpan"></param>
-        public virtual void Update(float timeSpan)
+        /// <param name="elapsedSeconds"></param>
+        public virtual void Update(float elapsedSeconds)
         {
-            // Test to determine whether to use Polach or Pacha adhesion
-                        
-            // Switches between Polach (high performance) adhesion model and Pacha (low performance) adhesion model depending upon the PC performance
-            if(timeSpan < 0.025) // timespan 0.025 = 40 fps screen rate, low timeSpan and high FPS
-            {
-                UsePolachAdhesion = true;
-            }
-            else if(timeSpan > 0.033) // timespan 0.033 = 30 fps screen rate, high timeSpan and low FPS
-            {
-                UsePolachAdhesion = false;
-                if (TrainSpeedMpS > 0 )
-                {
-                    var ScreenFrameRate = 1 / timeSpan;
-                    Trace.TraceInformation("Advanced adhesion model switched to low performance option due to low frame rate {0} at ElapsedClockSeconds of {1}", ScreenFrameRate, timeSpan);
-
-                }
-
-                // Set values for Pacha adhesion
-                WheelSlipThresholdMpS = MpS.FromKpH(AdhesionK / AdhesionLimit);
-                WheelAdhesion = 0.99f;
-                MaximumPolachWheelAdhesion = 0.99f;
-
-            }
-            
-            forceToAccelerationFactor = WheelRadiusM * WheelRadiusM / totalInertiaKgm2;        
-
+            UsePolachAdhesion = AdhesionPrecision.IsPrecisionHigh(elapsedSeconds, ClockTime);
             if (UsePolachAdhesion)
             {
+                forceToAccelerationFactor = WheelRadiusM * WheelRadiusM / totalInertiaKgm2;
 
                 Polach.Update();
                 axleStaticForceN = AxleWeightN * SlipCharacteristicsPolach(0);
@@ -1038,6 +1018,15 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                     Polach.Update();
                     axleStaticForceN = AxleWeightN * SlipCharacteristicsPolach(0);
                 }
+            }
+            else
+            {
+                // Set values for Pacha adhesion
+                WheelSlipThresholdMpS = MpS.FromKpH(AdhesionK / AdhesionLimit);
+                WheelAdhesion = 0.99f;
+                MaximumPolachWheelAdhesion = 0.99f;
+
+                forceToAccelerationFactor = WheelRadiusM * WheelRadiusM / totalInertiaKgm2;
             }
 
 #if DEBUG_ADHESION
@@ -1063,9 +1052,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             Console.WriteLine("");
 #endif
 
-            motor?.Update(timeSpan);
+            motor?.Update(elapsedSeconds);
 
-            Integrate(timeSpan);
+            Integrate(elapsedSeconds);
             // TODO: We should calculate brake force here
             // Adding and substracting the brake force is correct for normal operation,
             // but during wheelslip this will produce wrong results.
@@ -1084,14 +1073,14 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                 {
                     IsWheelSlip = IsWheelSlipWarning = true;
                 }
-                WheelSlipTimeS += timeSpan;
+                WheelSlipTimeS += elapsedSeconds;
             }
             else if (Math.Abs(SlipSpeedPercent) > SlipWarningTresholdPercent)
             {
                 // Wait some time before indicating wheelslip to avoid false triggers
                 if (WheelSlipWarningTimeS > 1) IsWheelSlipWarning = true;
                 IsWheelSlip = false;
-                WheelSlipWarningTimeS += timeSpan;
+                WheelSlipWarningTimeS += elapsedSeconds;
             }
             else
             {
@@ -1100,13 +1089,83 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                 WheelSlipWarningTimeS = WheelSlipTimeS = 0;
             }
 
-            if (timeSpan > 0.0f)
+            if (elapsedSeconds > 0.0f)
             {
-                slipDerivationMpSS = (SlipSpeedMpS - previousSlipSpeedMpS) / timeSpan;
+                slipDerivationMpSS = (SlipSpeedMpS - previousSlipSpeedMpS) / elapsedSeconds;
                 previousSlipSpeedMpS = SlipSpeedMpS;
 
-                slipDerivationPercentpS = (SlipSpeedPercent - previousSlipPercent) / timeSpan;
+                slipDerivationPercentpS = (SlipSpeedPercent - previousSlipPercent) / elapsedSeconds;
                 previousSlipPercent = SlipSpeedPercent;
+            }
+        }
+
+        static class AdhesionPrecision  // "static" so all "Axle"s share the same level of precision
+        {
+            enum AdhesionPrecisionLevel
+            {
+                /// <summary>
+                /// Initial level uses Polach algorithm
+                /// </summary>
+                High = 0,
+                /// <summary>
+                /// Low-performance PCs use Pacha's algorithm
+                /// </summary>
+                Low = 1,
+                /// <summary>
+                /// After frequent transitions, low-performance PCs are locked to Pacha's algorithm
+                /// </summary>
+                LowLocked = 2
+            }
+
+            static AdhesionPrecisionLevel PrecisionLevel = AdhesionPrecisionLevel.High;
+            static double TimeOfLatestDowngrade = 0;
+
+            // Adjustable limits
+            const float LowerLimitS = 0.025f;   // timespan 0.025 = 40 fps screen rate, low timeSpan and high FPS
+            const float UpperLimitS = 0.033f;   // timespan 0.033 = 30 fps screen rate, high timeSpan and low FPS
+            const double IntervalBetweenDowngradesLimitS = 60 * 5; // Locks in low precision if < 5 mins between downgrades
+
+            // Tested by varying the framerate interactively. Did this by opening and closing the HelpWindow after inserting
+            //   Threading.Thread.Sleep(40);
+            // into HelpWindow.PrepareFrame() temporarily.
+            public static bool IsPrecisionHigh(float elapsedSeconds, double clockTime)
+            {
+                // Switches between Polach (high precision) adhesion model and Pacha (low precision) adhesion model depending upon the PC performance
+                switch (PrecisionLevel)
+                {
+                    case AdhesionPrecisionLevel.High:
+                        if (elapsedSeconds > UpperLimitS)
+                        {
+                            var screenFrameRate = 1 / elapsedSeconds;
+                            var timeSincePreviousDowngradeS = clockTime - TimeOfLatestDowngrade;
+                            if (timeSincePreviousDowngradeS < IntervalBetweenDowngradesLimitS)
+                            {
+                                Trace.TraceInformation($"At {clockTime:F0} secs, advanced adhesion model switched to low precision permanently after {timeSincePreviousDowngradeS:F0} secs since previous switch (less than limit of {IntervalBetweenDowngradesLimitS})");
+                                PrecisionLevel = AdhesionPrecisionLevel.LowLocked;
+                            }
+                            else
+                            {
+                                TimeOfLatestDowngrade = clockTime;
+                                Trace.TraceInformation($"At {clockTime:F0} secs, advanced adhesion model switched to low precision after low frame rate {screenFrameRate:F1} below limit {1 / UpperLimitS:F0}");
+                                PrecisionLevel = AdhesionPrecisionLevel.Low;
+                            }
+                        }
+                        break;
+
+                    case AdhesionPrecisionLevel.Low:
+                        if (elapsedSeconds > 0 // When debugging step by step, elapsedSeconds == 0, so test for that
+                            && elapsedSeconds < LowerLimitS)
+                        {
+                            PrecisionLevel = AdhesionPrecisionLevel.High;
+                            var ScreenFrameRate = 1 / elapsedSeconds;
+                            Trace.TraceInformation($"At {clockTime:F0} secs, advanced adhesion model switched to high precision after high frame rate {ScreenFrameRate:F1} above limit {1 / LowerLimitS:F0}");
+                        }
+                        break;
+
+                    case AdhesionPrecisionLevel.LowLocked:
+                        break;
+                }
+                return (PrecisionLevel == AdhesionPrecisionLevel.High);
             }
         }
 
@@ -1200,6 +1259,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                 polach_Ks = (1.2 * zeroSpeedAdhesion) - 0.26;
                 if (polach_Ks < 0.1) polach_Ks = 0.1f;
             }
+
             public double SlipCharacteristics(double slipSpeedMpS)
             {
                 var polach_uadhesion = zeroSpeedAdhesion * (((1 - polach_A) * Math.Exp(-polach_B * slipSpeedMpS)) + polach_A);

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -27,6 +27,7 @@ using Orts.Simulation.RollingStocks.SubSystems;
 using Orts.Simulation.RollingStocks.SubSystems.Brakes;
 using Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS;
 using Orts.Simulation.RollingStocks.SubSystems.PowerSupplies;
+using Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions;
 using Orts.Viewer3D.Processes;
 using ORTS.Common;
 using ORTS.Scripting.Api;
@@ -1078,7 +1079,9 @@ namespace Orts.Viewer3D.Popups
                 {
                     if (mstsLocomotive.AdvancedAdhesionModel)
                     {
-                        TableAddLine(table, Viewer.Catalog.GetString("(Advanced adhesion model)"));
+                        var text = Viewer.Catalog.GetString("(Advanced adhesion model)");
+                        if (Axle.UsePolachAdhesion == false) text += "???";
+                        TableAddLine(table, text);
                         int row0 = table.CurrentRow;
                         TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Wheel slip (Thres)"));
                         TableSetCell(table, table.CurrentRow++, table.CurrentLabelColumn, Viewer.Catalog.GetString("Conditions"));

--- a/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
@@ -1216,6 +1216,8 @@ namespace Orts.Viewer3D.Popups
         
         public override void PrepareFrame(ElapsedTime elapsedTime, bool updateFull)
         {
+            // Uncomment this to test reducing the framerate during play by pressing F1
+            System.Threading.Thread.Sleep(40);
 
             base.PrepareFrame(elapsedTime, updateFull);
 

--- a/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
@@ -1216,8 +1216,8 @@ namespace Orts.Viewer3D.Popups
         
         public override void PrepareFrame(ElapsedTime elapsedTime, bool updateFull)
         {
-            // Uncomment this to test reducing the framerate during play by pressing F1
-            System.Threading.Thread.Sleep(40);
+            // Uncomment this statement to reduce the framerate during play for testing
+            // System.Threading.Thread.Sleep(40); // Press F1 to reduce the framerate
 
             base.PrepareFrame(elapsedTime, updateFull);
 

--- a/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
@@ -1216,8 +1216,8 @@ namespace Orts.Viewer3D.Popups
         
         public override void PrepareFrame(ElapsedTime elapsedTime, bool updateFull)
         {
-            // Uncomment this statement to reduce the framerate during play for testing
-            // System.Threading.Thread.Sleep(40); // Press F1 to reduce the framerate
+            // Uncomment this statement to reduce framerate during play for testing
+            System.Threading.Thread.Sleep(40); // Press F1 to force framerate below 25 fps
 
             base.PrepareFrame(elapsedTime, updateFull);
 


### PR DESCRIPTION
Forum: [https://www.elvastower.com/forums/index.php?/topic/37671-advanced-adhesion-model-switched-to-low-performance-option-due-to-low-frame-rate](url)
Extends PR 904 to switch back adhesion back to high precision Polach method from low precision Pacha's method, provided switching is not too frequent.

Currently switches to high precision if framerate exceeds 40 fps.
If switching to low precision happens more quickly than a 5 minute interval, then the switch is made permanent.

This is still DRAFT as lacks an entry for the Manual.