### PR TITLE
Allow building code using .NET 6 (Windows)

### DIFF
--- a/Source/ContentChecker/ContentChecker.csproj
+++ b/Source/ContentChecker/ContentChecker.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>

--- a/Source/Contrib/ActivityEditor/ActivityEditor/ActivityEditor.csproj
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/ActivityEditor.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>Contrib.ActivityEditor</AssemblyName>
     <ApplicationIcon>..\..\..\ORTS.ico</ApplicationIcon>

--- a/Source/Contrib/ActivityEditor/LibAE/LibAE.csproj
+++ b/Source/Contrib/ActivityEditor/LibAE/LibAE.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AssemblyName>Contrib.LibAE</AssemblyName>
     <IsPublishable>False</IsPublishable>

--- a/Source/Contrib/ContentManager/ContentManager.csproj
+++ b/Source/Contrib/ContentManager/ContentManager.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ORTS.ContentManager</RootNamespace>
     <AssemblyName>Contrib.ContentManager</AssemblyName>

--- a/Source/Contrib/DataCollector/DataCollector.csproj
+++ b/Source/Contrib/DataCollector/DataCollector.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>ORTS.DataCollector</RootNamespace>
     <AssemblyName>Contrib.DataCollector</AssemblyName>

--- a/Source/Contrib/DataConverter/DataConverter.csproj
+++ b/Source/Contrib/DataConverter/DataConverter.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Orts.DataConverter</RootNamespace>
     <AssemblyName>Contrib.DataConverter</AssemblyName>

--- a/Source/Contrib/DataValidator/DataValidator.csproj
+++ b/Source/Contrib/DataValidator/DataValidator.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Contrib.DataValidator</AssemblyName>
     <IsPublishable>False</IsPublishable>

--- a/Source/Contrib/SimulatorTester/SimulatorTester.csproj
+++ b/Source/Contrib/SimulatorTester/SimulatorTester.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Orts.SimulatorTester</RootNamespace>
     <AssemblyName>Contrib.SimulatorTester</AssemblyName>

--- a/Source/Contrib/TrackViewer/TrackViewer.csproj
+++ b/Source/Contrib/TrackViewer/TrackViewer.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ORTS.TrackViewer</RootNamespace>
     <AssemblyName>Contrib.TrackViewer</AssemblyName>

--- a/Source/Launcher/Launcher.csproj
+++ b/Source/Launcher/Launcher.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net20</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net20</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ORTS</RootNamespace>
     <AssemblyName>OpenRails</AssemblyName>

--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -31,8 +31,8 @@ using System.IO;
 using System.Linq;
 using System.Resources;
 using System.Runtime.InteropServices;
-using System.Threading;
 using System.Windows.Forms;
+using Activity = ORTS.Menu.Activity;
 using Path = ORTS.Menu.Path;
 
 namespace ORTS

--- a/Source/Menu/Menu.csproj
+++ b/Source/Menu/Menu.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ORTS</RootNamespace>
     <ApplicationIcon>..\ORTS.ico</ApplicationIcon>

--- a/Source/Menu/ResumeForm.cs
+++ b/Source/Menu/ResumeForm.cs
@@ -50,7 +50,6 @@ Some problems remain (see comments in the code):
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;

--- a/Source/Menu/TestingForm.cs
+++ b/Source/Menu/TestingForm.cs
@@ -18,17 +18,16 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using GNU.Gettext;
 using GNU.Gettext.WinForms;
 using ORTS.Menu;
 using ORTS.Settings;
+using Activity = ORTS.Menu.Activity;
 using Path = System.IO.Path;
 
 namespace ORTS

--- a/Source/ORTS.Common/ORTS.Common.csproj
+++ b/Source/ORTS.Common/ORTS.Common.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>

--- a/Source/ORTS.Content/ORTS.Content.csproj
+++ b/Source/ORTS.Content/ORTS.Content.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
     <AssemblyTitle>Open Rails Content Library</AssemblyTitle>

--- a/Source/ORTS.Content/ORTS.Content.csproj
+++ b/Source/ORTS.Content/ORTS.Content.csproj
@@ -18,5 +18,6 @@
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/Source/ORTS.IO/ORTS.IO.csproj
+++ b/Source/ORTS.IO/ORTS.IO.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
     <AssemblyTitle>Open Rails IO Library</AssemblyTitle>

--- a/Source/ORTS.Menu/ORTS.Menu.csproj
+++ b/Source/ORTS.Menu/ORTS.Menu.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
     <AssemblyTitle>Open Rails Menu Library</AssemblyTitle>

--- a/Source/ORTS.Settings/ORTS.Settings.csproj
+++ b/Source/ORTS.Settings/ORTS.Settings.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Source/ORTS.Updater/ORTS.Updater.csproj
+++ b/Source/ORTS.Updater/ORTS.Updater.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Source/Orts.Formats.Msts/Orts.Formats.Msts.csproj
+++ b/Source/Orts.Formats.Msts/Orts.Formats.Msts.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
     <AssemblyTitle>Open Rails MSTS Formats Library</AssemblyTitle>

--- a/Source/Orts.Formats.OR/Orts.Formats.OR.csproj
+++ b/Source/Orts.Formats.OR/Orts.Formats.OR.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
     <AssemblyTitle>Open Rails OR Formats Library</AssemblyTitle>

--- a/Source/Orts.Parsers.Msts/Orts.Parsers.Msts.csproj
+++ b/Source/Orts.Parsers.Msts/Orts.Parsers.Msts.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
     <AssemblyTitle>Open Rails MSTS Parsers Library</AssemblyTitle>

--- a/Source/Orts.Parsers.OR/Orts.Parsers.OR.csproj
+++ b/Source/Orts.Parsers.OR/Orts.Parsers.OR.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
     <AssemblyTitle>Open Rails OR Parsers Library</AssemblyTitle>

--- a/Source/Orts.Simulation/Orts.Simulation.csproj
+++ b/Source/Orts.Simulation/Orts.Simulation.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
     <AssemblyTitle>Open Rails Simulation Library</AssemblyTitle>

--- a/Source/RunActivity/RunActivity.csproj
+++ b/Source/RunActivity/RunActivity.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <RootNamespace>Orts</RootNamespace>
     <ApplicationIcon>..\ORTS.ico</ApplicationIcon>

--- a/Source/RunActivity/Viewer3D/Processes/WatchdogProcess.cs
+++ b/Source/RunActivity/Viewer3D/Processes/WatchdogProcess.cs
@@ -276,6 +276,10 @@ namespace Orts.Viewer3D.Processes
 
         StackTrace GetStackTrace()
         {
+#if NET5_0_OR_GREATER
+            // TODO: https://github.com/microsoft/clrmd is likely the best option to reimplement this in .NET 5+
+            throw new ThreadStateException("This is not implemented");
+#else
             // Yes, I know this is deprecated. Sorry. This code needs to collect the stack trace from a *different*
             // thread and this seems to be the only option - three seperate, deprecated APIs. :(
 #pragma warning disable 0618
@@ -289,6 +293,7 @@ namespace Orts.Viewer3D.Processes
                 Thread.Resume();
             }
 #pragma warning restore 0618
+#endif
         }
 
         bool StacksAreWaits()

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPublishable>False</IsPublishable>
     <AssemblyTitle>Open Rails Tests</AssemblyTitle>

--- a/Source/Updater/Updater.csproj
+++ b/Source/Updater/Updater.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <ApplicationIcon>..\ORTS.ico</ApplicationIcon>
     <UseWindowsForms>true</UseWindowsForms>


### PR DESCRIPTION
### We are not upgrading to .NET 6 yet! Windows 7 is still supported!

Roadmap: https://trello.com/c/TrIB2nUc/533-cross-platform-portability-support-for-linux-macos

The changes we will need to make to upgrade from .NET Framework to .NET 5+ are potentially wide-ranging, but unknown to us at present. Many of the changes will also be portability issues, i.e. things which affect non-Windows compatibility.

This PR allows us to get started on making things work in .NET 6 and non-Windows systems **without** changing our system requirements for official builds.

**All build methods** (Visual Studio, `Build.cmd`, `MSBuild`, `dotnet build`, etc.) will continue to target .NET Framework 4.7.2 by default.

**Adding the parameter `-p:BuildDotNet=true`** to `MSBuild` or `dotnet build` will target .NET 6 (Windows) instead.

At present, this will compile successfully, with ~600 warnings, but not run correctly.

When addressing issues with this .NET 6 (Windows) build, for the moment you can use conditions like in `Source/RunActivity/Viewer3D/Processes/WatchdogProcess.cs`:

```
#if NET5_0_OR_GREATER
#else
#endif
```

I may also provide shims for e.g. `OperatingSystem.IsWindows()` in a subsequent PR so that less conditional compilation is needed.