### PR TITLE
Lighting Configuration Enhancements

### DIFF
--- a/Source/Documentation/Manual/features-rollingstock.rst
+++ b/Source/Documentation/Manual/features-rollingstock.rst
@@ -91,6 +91,49 @@ implementation takes up much less space and guarentees that both modes of the
 light have the exact same ``States``. There is no hard limit on the number
 of conditions a light can have.
 
+Lights attached to shape sub-objects
+------------------------------------
+
+The standard lighting configuration attaches all lights to the main body of the
+locomotive or wagon. While this allows lights to move and rotate as the vehicle
+itself moves, the approach has proven insufficient for more complicated rail
+vehicles such as articulated steam locomotives.
+
+.. index::
+   single: ShapeHierarchy
+
+To facilitate lighting on such locomotives and wagons, Open Rails now allows
+for attachment of lights to any sub-object of the shape file. With the
+``ShapeHierarchy`` token placed in a ``Light ()`` block, the object the light
+will rotate and translate with can be defined using the hierarchy name of said
+object. Tools such as Shape Viewer can be used to determine the hierarchy name
+of a particular object in the shape file. For example, *"BOGIE1"* is the standard
+name for the frontmost bogie. A light attached to this bogie could be created
+like so::
+
+	Light	(
+		comment( CNDR Side Front Truck Light )
+		ShapeHierarchy ( "BOGIE1" )
+		States	(	1
+			State	(
+				LightColour ( 91fedf91 )
+				Position ( -1.427 0.583 -0.330 )
+				Azimuth ( -90 -90 -90 )
+				Radius ( 0.2 )
+			)
+		)
+	)
+
+Be aware that the ``Position`` of a light is measured relative to the center of
+the object to which the light is attached, not to the center of the locomotive
+itself. Furthermore, the naming of shape parts is not consistent between all
+shape files. If the shape name entered in ``ShapeHierarchy`` is invalid, a
+warning will be produced in the log file and the light will attach to the
+main body of the locomotive or wagon.
+
+If ``ShapeHierarchy`` is not specified in a light, the light will attach
+to the main body of the locomotive or wagon by default.
+
 .. _features-light-conditions:
 
 Open Rails specific lighting conditions

--- a/Source/Documentation/Manual/news.rst
+++ b/Source/Documentation/Manual/news.rst
@@ -24,6 +24,7 @@ What's been added
 - Distributed Power display, in-cab and on webpage
 - Progress bar for timetable "pre-run"
 - HUD extended for diesel-mechanical loco
+- New features for loco/wagon lighting, including horn-activated flashing ditch lights
 
 
 

--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -4560,7 +4560,8 @@ Example::
       )
     )
 
-The state of the battery switch can be used in the :ref:`power supply scripts <features-scripting-powersupply>` and the :ref:`cabview controls <cabs-battery-switch>`.
+The state of the battery switch can be used in the :ref:`power supply scripts <features-scripting-powersupply>`,
+:ref:`cabview controls <cabs-battery-switch>`, and :ref:`train car lighting <features-light-conditions>`.
 
 .. _physics-master-key:
 

--- a/Source/Orts.Formats.Msts/LightCollection.cs
+++ b/Source/Orts.Formats.Msts/LightCollection.cs
@@ -65,6 +65,7 @@ namespace Orts.Formats.Msts
             Transition = state.Transition;
             Angle = state.Angle;
 
+            // Automatic creation of reversed light cone
             if (reverse)
             {
                 Azimuth.X += 180;
@@ -188,16 +189,81 @@ namespace Orts.Formats.Msts
         On,
         Off,
     }
+
+    /// <summary>
+    /// Specifies in which friction brake states (released, applied) the wagon light is illuminated.
+    /// </summary>
+    public enum LightBrakeCondition
+    {
+        Ignore,
+        Released,
+        Applied,
+    }
+
+    /// <summary>
+    /// Specifies in which reverser states (forward, reverse, neutral, or other combinations) the wagon light is illuminated.
+    /// </summary>
+    public enum LightReverserCondition
+    {
+        Ignore,
+        Forward,
+        Reverse,
+        Neutral,
+        ForwardReverse,
+        ForwardNeutral,
+        ReverseNeutral,
+    }
+
+    /// <summary>
+    /// Specifies in which passenger door states (left, right, or both doors open) the wagon light is illuminated.
+    /// </summary>
+    public enum LightDoorsCondition
+    {
+        Ignore,
+        Closed,
+        Left,
+        Right,
+        Both,
+        LeftRight, // Either left or right
+    }
+
+    /// <summary>
+    /// Specifies in which horn states (off, on*) *horn has been sounded recently, the wagon light is illuminated.
+    /// </summary>
+    public enum LightHornCondition
+    {
+        Ignore,
+        Off,
+        Sounding,
+    }
+
+    /// <summary>
+    /// Specifies in which bell states (off, on) the wagon light is illuminated.
+    /// </summary>
+    public enum LightBellCondition
+    {
+        Ignore,
+        Off,
+        Ringing,
+    }
+
+    /// <summary>
+    /// Specifies in which multiple unit states (connected or disconnected from lead loco) the wagon light is illuminated.
+    /// </summary>
+    public enum LightMUCondition
+    {
+        Ignore,
+        Lead, // Special case for when this vehicle is the lead locomotive itself
+        Local,
+        Remote,
+    }
     #endregion
 
     /// <summary>
-    /// The Light class encapsulates the data for each Light object 
-    /// in the Lights block of an ENG/WAG file. 
+    /// A LightConditions object encapsulates the data for each Condition in the Conditions subblock.
     /// </summary>
-    public class Light
+    public class LightCondition
     {
-        public int Index;
-        public LightType Type;
         public LightHeadlightCondition Headlight;
         public LightUnitCondition Unit;
         public LightPenaltyCondition Penalty;
@@ -207,10 +273,77 @@ namespace Orts.Formats.Msts
         public LightWeatherCondition Weather;
         public LightCouplingCondition Coupling;
         public LightBatteryCondition Battery;
+        public LightBrakeCondition Brake;
+        public LightReverserCondition Reverser;
+        public LightDoorsCondition Doors;
+        public LightHornCondition Horn;
+        public LightBellCondition Bell;
+        public LightMUCondition MU;
+
+        public LightCondition(STFReader stf)
+        {
+            stf.MustMatch("(");
+            stf.ParseBlock(new[] {
+                new STFReader.TokenProcessor("headlight", ()=>{ Headlight = (LightHeadlightCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("unit", ()=>{ Unit = (LightUnitCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("penalty", ()=>{ Penalty = (LightPenaltyCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("control", ()=>{ Control = (LightControlCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("service", ()=>{ Service = (LightServiceCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("timeofday", ()=>{ TimeOfDay = (LightTimeOfDayCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("weather", ()=>{ Weather = (LightWeatherCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("coupling", ()=>{ Coupling = (LightCouplingCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("ortsbattery", ()=>{ Battery = (LightBatteryCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("brake", ()=>{ Brake = (LightBrakeCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("reverser", ()=>{ Reverser = (LightReverserCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("doors", ()=>{ Doors = (LightDoorsCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("horn", ()=>{ Horn = (LightHornCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("bell", ()=>{ Bell = (LightBellCondition)stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("mu", ()=>{ MU = (LightMUCondition)stf.ReadIntBlock(null); }),
+            });
+        }
+
+        public LightCondition(LightCondition condition, bool reverse)
+        {
+            Headlight = condition.Headlight;
+            Unit = condition.Unit;
+            Penalty = condition.Penalty;
+            Control = condition.Control;
+            Service = condition.Service;
+            TimeOfDay = condition.TimeOfDay;
+            Weather = condition.Weather;
+            Coupling = condition.Coupling;
+            Battery = condition.Battery;
+            Brake = condition.Brake;
+            Reverser = condition.Reverser;
+            Doors = condition.Doors;
+            Horn = condition.Horn;
+            Bell = condition.Bell;
+            MU = condition.MU;
+
+            // Automatic creation of reversed light cone
+            if (reverse)
+            {
+                if (Unit == LightUnitCondition.First)
+                    Unit = LightUnitCondition.FirstRev;
+                else if (Unit == LightUnitCondition.Last)
+                    Unit = LightUnitCondition.LastRev;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The Light class encapsulates the data for each Light object 
+    /// in the Lights block of an ENG/WAG file. 
+    /// </summary>
+    public class Light
+    {
+        public int Index;
+        public LightType Type;
         public bool Cycle;
         public float FadeIn;
         public float FadeOut;
         public List<LightState> States = new List<LightState>();
+        public List<LightCondition> Conditions = new List<LightCondition>();
 
         public Light(int index, STFReader stf)
         {
@@ -218,17 +351,7 @@ namespace Orts.Formats.Msts
             stf.MustMatch("(");
             stf.ParseBlock(new[] {
                 new STFReader.TokenProcessor("type", ()=>{ Type = (LightType)stf.ReadIntBlock(null); }),
-                new STFReader.TokenProcessor("conditions", ()=>{ stf.MustMatch("("); stf.ParseBlock(new[] {
-                    new STFReader.TokenProcessor("headlight", ()=>{ Headlight = (LightHeadlightCondition)stf.ReadIntBlock(null); }),
-                    new STFReader.TokenProcessor("unit", ()=>{ Unit = (LightUnitCondition)stf.ReadIntBlock(null); }),
-                    new STFReader.TokenProcessor("penalty", ()=>{ Penalty = (LightPenaltyCondition)stf.ReadIntBlock(null); }),
-                    new STFReader.TokenProcessor("control", ()=>{ Control = (LightControlCondition)stf.ReadIntBlock(null); }),
-                    new STFReader.TokenProcessor("service", ()=>{ Service = (LightServiceCondition)stf.ReadIntBlock(null); }),
-                    new STFReader.TokenProcessor("timeofday", ()=>{ TimeOfDay = (LightTimeOfDayCondition)stf.ReadIntBlock(null); }),
-                    new STFReader.TokenProcessor("weather", ()=>{ Weather = (LightWeatherCondition)stf.ReadIntBlock(null); }),
-                    new STFReader.TokenProcessor("coupling", ()=>{ Coupling = (LightCouplingCondition)stf.ReadIntBlock(null); }),
-                    new STFReader.TokenProcessor("ortsbattery", ()=>{ Battery = (LightBatteryCondition)stf.ReadIntBlock(null); }),
-                });}),
+                new STFReader.TokenProcessor("conditions", ()=>{ Conditions.Add(new LightCondition(stf)); }),
                 new STFReader.TokenProcessor("cycle", ()=>{ Cycle = 0 != stf.ReadIntBlock(null); }),
                 new STFReader.TokenProcessor("fadein", ()=>{ FadeIn = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("fadeout", ()=>{ FadeOut = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
@@ -253,28 +376,13 @@ namespace Orts.Formats.Msts
         {
             Index = light.Index;
             Type = light.Type;
-            Headlight = light.Headlight;
-            Unit = light.Unit;
-            Penalty = light.Penalty;
-            Control = light.Control;
-            Service = light.Service;
-            TimeOfDay = light.TimeOfDay;
-            Weather = light.Weather;
-            Coupling = light.Coupling;
-            Battery = light.Battery;
             Cycle = light.Cycle;
             FadeIn = light.FadeIn;
             FadeOut = light.FadeOut;
             foreach (var state in light.States)
                 States.Add(new LightState(state, reverse));
-
-            if (reverse)
-            {
-                if (Unit == LightUnitCondition.First)
-                    Unit = LightUnitCondition.FirstRev;
-                else if (Unit == LightUnitCondition.Last)
-                    Unit = LightUnitCondition.LastRev;
-            }
+            foreach (var condition in light.Conditions)
+                Conditions.Add(new LightCondition(condition, reverse));
         }
     }
 

--- a/Source/Orts.Formats.Msts/LightCollection.cs
+++ b/Source/Orts.Formats.Msts/LightCollection.cs
@@ -423,21 +423,30 @@ namespace Orts.Formats.Msts
                     Lights.Add(new Light(light, true));
 
             // Determine which, if any, conditions are ignored by all conditions of all lights
-            IgnoredConditions[0]  = Lights.All(light => light.Conditions.All(cond => cond.Headlight == LightHeadlightCondition.Ignore));
-            IgnoredConditions[1]  = Lights.All(light => light.Conditions.All(cond => cond.Unit == LightUnitCondition.Ignore));
-            IgnoredConditions[2]  = Lights.All(light => light.Conditions.All(cond => cond.Penalty == LightPenaltyCondition.Ignore));
-            IgnoredConditions[3]  = Lights.All(light => light.Conditions.All(cond => cond.Control == LightControlCondition.Ignore));
-            IgnoredConditions[4]  = Lights.All(light => light.Conditions.All(cond => cond.Service == LightServiceCondition.Ignore));
-            IgnoredConditions[5]  = Lights.All(light => light.Conditions.All(cond => cond.TimeOfDay == LightTimeOfDayCondition.Ignore));
-            IgnoredConditions[6]  = Lights.All(light => light.Conditions.All(cond => cond.Weather == LightWeatherCondition.Ignore));
-            IgnoredConditions[7]  = Lights.All(light => light.Conditions.All(cond => cond.Coupling == LightCouplingCondition.Ignore));
-            IgnoredConditions[8]  = Lights.All(light => light.Conditions.All(cond => cond.Battery == LightBatteryCondition.Ignore));
-            IgnoredConditions[9]  = Lights.All(light => light.Conditions.All(cond => cond.Brake == LightBrakeCondition.Ignore));
-            IgnoredConditions[10] = Lights.All(light => light.Conditions.All(cond => cond.Reverser == LightReverserCondition.Ignore));
-            IgnoredConditions[11] = Lights.All(light => light.Conditions.All(cond => cond.Doors == LightDoorsCondition.Ignore));
-            IgnoredConditions[12] = Lights.All(light => light.Conditions.All(cond => cond.Horn == LightHornCondition.Ignore));
-            IgnoredConditions[13] = Lights.All(light => light.Conditions.All(cond => cond.Bell == LightBellCondition.Ignore));
-            IgnoredConditions[14] = Lights.All(light => light.Conditions.All(cond => cond.MU == LightMUCondition.Ignore));
+            // Assume all conditions are ignored unless determined otherwise
+            for (int i = 0; i < IgnoredConditions.Length; i++)
+                IgnoredConditions[i] = true;
+            foreach (Light light in Lights)
+            {
+                foreach (LightCondition condition in light.Conditions)
+                {
+                    IgnoredConditions[0] &= condition.Headlight == LightHeadlightCondition.Ignore;
+                    IgnoredConditions[1] &= condition.Unit == LightUnitCondition.Ignore;
+                    IgnoredConditions[2] &= condition.Penalty == LightPenaltyCondition.Ignore;
+                    IgnoredConditions[3] &= condition.Control == LightControlCondition.Ignore;
+                    IgnoredConditions[4] &= condition.Service == LightServiceCondition.Ignore;
+                    IgnoredConditions[5] &= condition.TimeOfDay == LightTimeOfDayCondition.Ignore;
+                    IgnoredConditions[6] &= condition.Weather == LightWeatherCondition.Ignore;
+                    IgnoredConditions[7] &= condition.Coupling == LightCouplingCondition.Ignore;
+                    IgnoredConditions[8] &= condition.Battery == LightBatteryCondition.Ignore;
+                    IgnoredConditions[9] &= condition.Brake == LightBrakeCondition.Ignore;
+                    IgnoredConditions[10] &= condition.Reverser == LightReverserCondition.Ignore;
+                    IgnoredConditions[11] &= condition.Doors == LightDoorsCondition.Ignore;
+                    IgnoredConditions[12] &= condition.Horn == LightHornCondition.Ignore;
+                    IgnoredConditions[13] &= condition.Bell == LightBellCondition.Ignore;
+                    IgnoredConditions[14] &= condition.MU == LightMUCondition.Ignore;
+                }
+            }
         }
     }
 }

--- a/Source/Orts.Formats.Msts/LightCollection.cs
+++ b/Source/Orts.Formats.Msts/LightCollection.cs
@@ -338,6 +338,8 @@ namespace Orts.Formats.Msts
     public class Light
     {
         public int Index;
+        public int ShapeIndex = -1;
+        public string ShapeHierarchy;
         public LightType Type;
         public bool Cycle;
         public float FadeIn;
@@ -369,12 +371,16 @@ namespace Orts.Formats.Msts
                     if (States.Count < count)
                         STFException.TraceWarning(stf, (count - States.Count).ToString() + " missing State(s)");
                 }),
+                new STFReader.TokenProcessor("shapeindex", ()=>{ ShapeIndex = stf.ReadIntBlock(null); }),
+                new STFReader.TokenProcessor("shapehierarchy", ()=>{ ShapeHierarchy = stf.ReadStringBlock(null).ToUpper(); }),
             });
         }
 
         public Light(Light light, bool reverse)
         {
             Index = light.Index;
+            ShapeIndex = light.ShapeIndex;
+            ShapeHierarchy = light.ShapeHierarchy;
             Type = light.Type;
             Cycle = light.Cycle;
             FadeIn = light.FadeIn;
@@ -396,6 +402,11 @@ namespace Orts.Formats.Msts
     {
         public List<Light> Lights = new List<Light>();
 
+        // Array of bools, one per type of condition in the same order as presented in the 'LightCondition' class
+        // A 'true' indicates all lights in this set ignore the corresponding condition, so we don't need to waste time thinking about it
+        // Remember to expand this if more conditions are added!
+        public bool[] IgnoredConditions = new bool[15];
+
         public LightCollection(STFReader stf)
         {
             stf.MustMatch("(");
@@ -410,6 +421,23 @@ namespace Orts.Formats.Msts
             foreach (var light in Lights.ToArray())
                 if (light.Type == LightType.Cone)
                     Lights.Add(new Light(light, true));
+
+            // Determine which, if any, conditions are ignored by all conditions of all lights
+            IgnoredConditions[0]  = Lights.All(light => light.Conditions.All(cond => cond.Headlight == LightHeadlightCondition.Ignore));
+            IgnoredConditions[1]  = Lights.All(light => light.Conditions.All(cond => cond.Unit == LightUnitCondition.Ignore));
+            IgnoredConditions[2]  = Lights.All(light => light.Conditions.All(cond => cond.Penalty == LightPenaltyCondition.Ignore));
+            IgnoredConditions[3]  = Lights.All(light => light.Conditions.All(cond => cond.Control == LightControlCondition.Ignore));
+            IgnoredConditions[4]  = Lights.All(light => light.Conditions.All(cond => cond.Service == LightServiceCondition.Ignore));
+            IgnoredConditions[5]  = Lights.All(light => light.Conditions.All(cond => cond.TimeOfDay == LightTimeOfDayCondition.Ignore));
+            IgnoredConditions[6]  = Lights.All(light => light.Conditions.All(cond => cond.Weather == LightWeatherCondition.Ignore));
+            IgnoredConditions[7]  = Lights.All(light => light.Conditions.All(cond => cond.Coupling == LightCouplingCondition.Ignore));
+            IgnoredConditions[8]  = Lights.All(light => light.Conditions.All(cond => cond.Battery == LightBatteryCondition.Ignore));
+            IgnoredConditions[9]  = Lights.All(light => light.Conditions.All(cond => cond.Brake == LightBrakeCondition.Ignore));
+            IgnoredConditions[10] = Lights.All(light => light.Conditions.All(cond => cond.Reverser == LightReverserCondition.Ignore));
+            IgnoredConditions[11] = Lights.All(light => light.Conditions.All(cond => cond.Doors == LightDoorsCondition.Ignore));
+            IgnoredConditions[12] = Lights.All(light => light.Conditions.All(cond => cond.Horn == LightHornCondition.Ignore));
+            IgnoredConditions[13] = Lights.All(light => light.Conditions.All(cond => cond.Bell == LightBellCondition.Ignore));
+            IgnoredConditions[14] = Lights.All(light => light.Conditions.All(cond => cond.MU == LightMUCondition.Ignore));
         }
     }
 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -110,10 +110,18 @@ namespace Orts.Simulation.RollingStocks
         public bool Horn = false;
         protected bool PreviousHorn = false;
 
+        protected float HornTimerS = 30.0f;
+        protected float? HornStartTime;
+        public bool HornRecent { get; private set; }
+
         public bool ManualBell = false;
         public SoundState BellState = SoundState.Stopped;
         public bool Bell = false;
         protected bool PreviousBell = false;
+
+        protected float BellTimerS;
+        protected float? BellStartTime;
+        public bool BellRecent { get; private set; }
 
         public bool VacuumExhausterPressed = false;
         public bool FastVacuumExhausterFitted = false;
@@ -1063,6 +1071,8 @@ namespace Orts.Simulation.RollingStocks
                 case "engine(ortsbrakecutspoweratbrakepipepressure": BrakeCutsPowerAtBrakePipePressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, null); break;
                 case "engine(ortsbrakerestorespoweratbrakepipepressure": BrakeRestoresPowerAtBrakePipePressurePSI = stf.ReadFloatBlock(STFReader.UNITS.PressureDefaultPSI, null); break;
                 case "engine(doeshorntriggerbell": DoesHornTriggerBell = stf.ReadBoolBlock(false); break;
+                case "engine(ortshornlightstimer": HornTimerS = stf.ReadFloatBlock(STFReader.UNITS.Time, null); break;
+                case "engine(ortsbelllightstimer": BellTimerS = stf.ReadFloatBlock(STFReader.UNITS.Time, null); break;
                 case "engine(brakesenginecontrollers":
                     foreach (var brakesenginecontrollers in stf.ReadStringBlock("").ToLower().Replace(" ", "").Split(','))
                     {
@@ -1202,6 +1212,8 @@ namespace Orts.Simulation.RollingStocks
             EmergencyCausesPowerDown = locoCopy.EmergencyCausesPowerDown;
             EmergencyCausesThrottleDown = locoCopy.EmergencyCausesThrottleDown;
             EmergencyEngagesHorn = locoCopy.EmergencyEngagesHorn;
+            HornTimerS = locoCopy.HornTimerS;
+            BellTimerS = locoCopy.BellTimerS;
 
             WheelslipCausesThrottleDown = locoCopy.WheelslipCausesThrottleDown;
 
@@ -2706,13 +2718,22 @@ namespace Orts.Simulation.RollingStocks
             Horn = ManualHorn || TCSHorn;
             if (Horn && !PreviousHorn)
             {
+                HornRecent = true;
                 SignalEvent(Event.HornOn);
                 if (MPManager.IsMultiPlayer()) MPManager.Notify((new MSGEvent(MPManager.GetUserName(), "HORN", 1)).ToString());
             }
             else if (!Horn && PreviousHorn)
             {
+                // Research indicates ditch light horn timer starts when horn button is released
+                HornStartTime = (float)Simulator.GameTime;
                 SignalEvent(Event.HornOff);
                 if (MPManager.IsMultiPlayer()) MPManager.Notify((new MSGEvent(MPManager.GetUserName(), "HORN", 0)).ToString());
+            }
+
+            if (HornStartTime != null && !Horn && Simulator.GameTime - HornStartTime > HornTimerS)
+            {
+                HornRecent = false;
+                HornStartTime = null;
             }
 
             if (ManualBell)
@@ -2731,6 +2752,8 @@ namespace Orts.Simulation.RollingStocks
             Bell = BellState != SoundState.Stopped;
             if (Bell && !PreviousBell)
             {
+                BellRecent = true;
+                BellStartTime = (float)Simulator.GameTime;
                 SignalEvent(Event.BellOn);
                 if (Train.TrainType != Train.TRAINTYPE.REMOTE && MPManager.IsMultiPlayer()) MPManager.Notify((new MSGEvent(MPManager.GetUserName(), "BELL", 1)).ToString());
             }
@@ -2738,6 +2761,12 @@ namespace Orts.Simulation.RollingStocks
             {
                 SignalEvent(Event.BellOff);
                 if (Train.TrainType != Train.TRAINTYPE.REMOTE && MPManager.IsMultiPlayer()) MPManager.Notify((new MSGEvent(MPManager.GetUserName(), "BELL", 0)).ToString());
+            }
+
+            if (BellStartTime != null && !Bell && Simulator.GameTime - BellStartTime > BellTimerS)
+            {
+                BellRecent = false;
+                BellStartTime = null;
             }
 
             PreviousHorn = Horn;

--- a/Source/RunActivity/Viewer3D/Lights.cs
+++ b/Source/RunActivity/Viewer3D/Lights.cs
@@ -28,6 +28,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Orts.Formats.Msts;
 using Orts.Simulation.Physics;
 using Orts.Simulation.RollingStocks;
+using Orts.Simulation.RollingStocks.SubSystems;
 using Orts.Viewer3D.Processes;
 using ORTS.Common;
 using ORTS.Scripting.Api;
@@ -57,6 +58,18 @@ namespace Orts.Viewer3D
         public bool CarCoupledFront;
         public bool CarCoupledRear;
         public bool CarBatteryOn;
+        public bool BrakeOn;
+        public int ReverserState;
+        public bool LeftDoorOpen;
+        public bool RightDoorOpen;
+        public bool HornOn;
+        public bool BellOn;
+        public int MU;
+
+        // Array of bools, one per type of condition in the same order as presented in the 'LightCondition' class
+        // A 'true' indicates all lights in this set ignore the corresponding condition, so we don't need to waste time thinking about it
+        // Remember to expand this if more conditions are added!
+        public bool[] IgnoredConditions = new bool[15];
 
         public bool IsLightConeActive { get { return ActiveLightCone != null; } }
         List<LightPrimitive> LightPrimitives = new List<LightPrimitive>();
@@ -98,6 +111,34 @@ namespace Orts.Viewer3D
 #if DEBUG_LIGHT_STATES
             Console.WriteLine();
 #endif
+            // Determine which, if any, conditions are ignored by all lights
+            // Assume everything is ignored at the start
+            for (int i = 0; i < IgnoredConditions.Length; i++)
+            {
+                IgnoredConditions[i] = true;
+            }
+            foreach (LightPrimitive lightPrim in LightPrimitives)
+            {
+                foreach (LightCondition condition in lightPrim.Light.Conditions)
+                {
+                    IgnoredConditions[0] &= condition.Headlight == LightHeadlightCondition.Ignore;
+                    IgnoredConditions[1] &= condition.Unit == LightUnitCondition.Ignore;
+                    IgnoredConditions[2] &= condition.Penalty == LightPenaltyCondition.Ignore;
+                    IgnoredConditions[3] &= condition.Control == LightControlCondition.Ignore;
+                    IgnoredConditions[4] &= condition.Service == LightServiceCondition.Ignore;
+                    IgnoredConditions[5] &= condition.TimeOfDay == LightTimeOfDayCondition.Ignore;
+                    IgnoredConditions[6] &= condition.Weather == LightWeatherCondition.Ignore;
+                    IgnoredConditions[7] &= condition.Coupling == LightCouplingCondition.Ignore;
+                    IgnoredConditions[8] &= condition.Battery == LightBatteryCondition.Ignore;
+                    IgnoredConditions[9] &= condition.Brake == LightBrakeCondition.Ignore;
+                    IgnoredConditions[10] &= condition.Reverser == LightReverserCondition.Ignore;
+                    IgnoredConditions[11] &= condition.Doors == LightDoorsCondition.Ignore;
+                    IgnoredConditions[12] &= condition.Horn == LightHornCondition.Ignore;
+                    IgnoredConditions[13] &= condition.Bell == LightBellCondition.Ignore;
+                    IgnoredConditions[14] &= condition.MU == LightMUCondition.Ignore;
+                }
+            }
+
             UpdateActiveLightCone();
         }
 
@@ -214,38 +255,58 @@ namespace Orts.Viewer3D
         {
 			Debug.Assert(Viewer.PlayerTrain.LeadLocomotive == Viewer.PlayerLocomotive ||Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING ||
                 Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.REMOTE || Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.STATIC, "PlayerTrain.LeadLocomotive must be PlayerLocomotive.");
-			var locomotive = Car.Train != null && Car.Train.IsActualPlayerTrain ? Viewer.PlayerLocomotive : null;
-            if (locomotive == null && Car.Train != null && Car.Train.TrainType == Train.TRAINTYPE.REMOTE && Car is MSTSLocomotive && (Car as MSTSLocomotive) == Car.Train.LeadLocomotive)
-                locomotive = Car.Train.LeadLocomotive;
-			var mstsLocomotive = locomotive as MSTSLocomotive;
+			var leadLocomotiveCar = Car.Train?.LeadLocomotive;
+            if (leadLocomotiveCar == null && Car.Train?.Cars[0] is MSTSLocomotive) // AI trains have no lead locomotive
+                leadLocomotiveCar = Car.Train.Cars[0];
+			var leadLocomotive = leadLocomotiveCar as MSTSLocomotive;
+
+            // There are a lot of conditions now! IgnoredConditions[] stores which conditions are ignored, allowing shortcutting of many of these calculations
+            // Should prevent some unneeded computation, but is a little messy. May revise in the future
 
             // Headlight
-			var newTrainHeadlight = locomotive != null ? locomotive.Headlight : Car.Train != null && Car.Train.TrainType != Train.TRAINTYPE.STATIC ? 2 : 0;
+			int newTrainHeadlight = !IgnoredConditions[0] ? (Car.Train != null ? Car.Train.TrainType != Train.TRAINTYPE.STATIC ? leadLocomotiveCar.Headlight : 0 : 0) : 0;
             // Unit
-			var locomotiveFlipped = locomotive != null && locomotive.Flipped;
-			var locomotiveReverseCab = mstsLocomotive != null && mstsLocomotive.UsingRearCab;
-            var newCarIsReversed = Car.Flipped ^ locomotiveFlipped ^ locomotiveReverseCab;
-			var newCarIsFirst = Car.Train == null || (locomotiveFlipped ^ locomotiveReverseCab ? Car.Train.LastCar : Car.Train.FirstCar) == Car;
-			var newCarIsLast = Car.Train == null || (locomotiveFlipped ^ locomotiveReverseCab ? Car.Train.FirstCar : Car.Train.LastCar) == Car;
+            bool locomotiveFlipped = leadLocomotiveCar != null && leadLocomotiveCar.Flipped;
+            bool locomotiveReverseCab = leadLocomotive != null && leadLocomotive.UsingRearCab;
+            bool newCarIsReversed = Car.Flipped ^ locomotiveFlipped ^ locomotiveReverseCab;
+            bool newCarIsFirst = !IgnoredConditions[1] && Car.Train == null || (locomotiveFlipped ^ locomotiveReverseCab ? Car.Train.LastCar : Car.Train.FirstCar) == Car;
+            bool newCarIsLast = !IgnoredConditions[1] && Car.Train == null || (locomotiveFlipped ^ locomotiveReverseCab ? Car.Train.FirstCar : Car.Train.LastCar) == Car;
             // Penalty
-			var newPenalty = mstsLocomotive != null && mstsLocomotive.TrainBrakeController.EmergencyBraking;
+			var newPenalty = !IgnoredConditions[2] && leadLocomotive != null && leadLocomotive.TrainBrakeController.EmergencyBraking;
             // Control
-            var newCarIsPlayer = (Car.Train != null && Car.Train == Viewer.PlayerTrain) || (Car.Train != null && Car.Train.TrainType == Train.TRAINTYPE.REMOTE);
+            bool newCarIsPlayer = !IgnoredConditions[3] && Car.Train != null && (Car.Train == Viewer.PlayerTrain || Car.Train.TrainType == Train.TRAINTYPE.REMOTE);
             // Service - if a player or AI train, then will considered to be in servie, loose consists will not be considered to be in service.
-            var newCarInService = (Car.Train != null && Car.Train == Viewer.PlayerTrain) || (Car.Train != null && Car.Train.TrainType == Train.TRAINTYPE.REMOTE) || (Car.Train != null && Car.Train.TrainType == Train.TRAINTYPE.AI);
+            bool newCarInService = !IgnoredConditions[4] && Car.Train != null && (Car.Train == Viewer.PlayerTrain || Car.Train.TrainType == Train.TRAINTYPE.REMOTE || Car.Train.TrainType == Train.TRAINTYPE.AI);
             // Time of day
             bool newIsDay = false;
-            if (Viewer.Settings.UseMSTSEnv == false)
-                newIsDay = Viewer.World.Sky.SolarDirection.Y > 0;
-            else
-                newIsDay = Viewer.World.MSTSSky.mstsskysolarDirection.Y > 0;
+            if (!IgnoredConditions[5])
+            {
+                if (Viewer.Settings.UseMSTSEnv == false)
+                    newIsDay = Viewer.World.Sky.SolarDirection.Y > 0;
+                else
+                    newIsDay = Viewer.World.MSTSSky.mstsskysolarDirection.Y > 0;
+
+            }
             // Weather
-            var newWeather = Viewer.Simulator.WeatherType;
+            WeatherType newWeather = !IgnoredConditions[6] ? Viewer.Simulator.WeatherType : WeatherType.Clear;
             // Coupling
-            var newCarCoupledFront = Car.Train != null && (Car.Train.Cars.Count > 1) && ((Car.Flipped ? Car.Train.LastCar : Car.Train.FirstCar) != Car);
-            var newCarCoupledRear = Car.Train != null && (Car.Train.Cars.Count > 1) && ((Car.Flipped ? Car.Train.FirstCar : Car.Train.LastCar) != Car);
-            // Nattery
-            var newCarBatteryOn = Car is MSTSWagon wagon ? wagon.PowerSupply?.BatteryState == PowerSupplyState.PowerOn : true;
+            bool newCarCoupledFront = !IgnoredConditions[7] && Car.Train != null && (Car.Train.Cars.Count > 1) && ((Car.Flipped ? Car.Train.LastCar : Car.Train.FirstCar) != Car);
+            bool newCarCoupledRear = !IgnoredConditions[7] && Car.Train != null && (Car.Train.Cars.Count > 1) && ((Car.Flipped ? Car.Train.FirstCar : Car.Train.LastCar) != Car);
+            // Battery
+            bool newCarBatteryOn = !IgnoredConditions[8] && Car is MSTSWagon wagon ? wagon.PowerSupply?.BatteryState == PowerSupplyState.PowerOn : true;
+            // Friction brakes, activation force is arbitrary
+            bool newBrakeOn = !IgnoredConditions[9] && Car.BrakeForceN > 250.0f;
+            // Reverser: -1: reverse, 0: within 10% of neutral, 1: forwards. Automatically swaps if this car is reversed
+            int newReverserState = !IgnoredConditions[10] ? ((Car.Train.MUDirection == Direction.N || Math.Abs(Car.Train.MUReverserPercent) < 10.0f) ? 0 : 
+                Car.Train.MUDirection == Direction.Forward ? 1 : -1) * (Car.Flipped ? -1 : 1) : 0;
+            // Passenger doors
+            bool newLeftDoorOpen = !IgnoredConditions[11] && Car.Train.DoorState(DoorSide.Left) != DoorState.Closed;
+            bool newRightDoorOpen = !IgnoredConditions[11] && Car.Train.DoorState(DoorSide.Right) != DoorState.Closed;
+            // Horn and bell (for flashing ditch lights)
+            bool newHornOn = !IgnoredConditions[12] && leadLocomotive != null && leadLocomotive.HornRecent;
+            bool newBellOn = !IgnoredConditions[13] && leadLocomotive != null && leadLocomotive.BellRecent;
+            // Multiple unit configuration, -1: this loco is the lead loco, 0: this loco is not directly connected to the lead loco (distributed power), 1: this loco is directly connected to the lead loco
+            int newMU = !IgnoredConditions[14] ? (Car is MSTSLocomotive loco && leadLocomotive != null && loco.DPUnitID == leadLocomotive.DPUnitID ? loco == leadLocomotive ? -1 : 1 : 0) : 0;
 
             if (
                 (TrainHeadlight != newTrainHeadlight) ||
@@ -259,7 +320,15 @@ namespace Orts.Viewer3D
                 (Weather != newWeather) ||
                 (CarCoupledFront != newCarCoupledFront) ||
                 (CarCoupledRear != newCarCoupledRear) ||
-                (CarBatteryOn != newCarBatteryOn))
+                (CarBatteryOn != newCarBatteryOn) ||
+                (BrakeOn != newBrakeOn) ||
+                (ReverserState != newReverserState) ||
+                (LeftDoorOpen != newLeftDoorOpen) ||
+                (RightDoorOpen != newRightDoorOpen) ||
+                (HornOn != newHornOn) ||
+                (BellOn != newBellOn) ||
+                (MU != newMU)
+                )
             {
                 TrainHeadlight = newTrainHeadlight;
                 CarIsReversed = newCarIsReversed;
@@ -273,6 +342,13 @@ namespace Orts.Viewer3D
                 CarCoupledFront = newCarCoupledFront;
                 CarCoupledRear = newCarCoupledRear;
                 CarBatteryOn = newCarBatteryOn;
+                BrakeOn = newBrakeOn;
+                ReverserState = newReverserState;
+                LeftDoorOpen = newLeftDoorOpen;
+                RightDoorOpen = newRightDoorOpen;
+                HornOn = newHornOn;
+                BellOn = newBellOn;
+                MU = newMU;
 
 #if DEBUG_LIGHT_STATES
                 Console.WriteLine();
@@ -351,105 +427,175 @@ namespace Orts.Viewer3D
         internal void UpdateState(LightViewer lightViewer)
         {
             var oldEnabled = Enabled;
-            Enabled = true;
-            if (Light.Headlight != LightHeadlightCondition.Ignore)
+            Enabled = false;
+
+            // Assume light is unconditionally turned on if there are no conditions
+            if (Light.Conditions.Count == 0)
+                Enabled = true;
+
+            foreach (var condition in Light.Conditions)
             {
-                if (Light.Headlight == LightHeadlightCondition.Off)
-                    Enabled &= lightViewer.TrainHeadlight == 0;
-                else if (Light.Headlight == LightHeadlightCondition.Dim)
-                    Enabled &= lightViewer.TrainHeadlight == 1;
-                else if (Light.Headlight == LightHeadlightCondition.Bright)
-                    Enabled &= lightViewer.TrainHeadlight == 2;
-                else if (Light.Headlight == LightHeadlightCondition.DimBright)
-                    Enabled &= lightViewer.TrainHeadlight >= 1;
-                else if (Light.Headlight == LightHeadlightCondition.OffDim)
-                    Enabled &= lightViewer.TrainHeadlight <= 1;
-                else if (Light.Headlight == LightHeadlightCondition.OffBright)
-                    Enabled &= lightViewer.TrainHeadlight != 1;
-                else
-                    Enabled &= false;
-            }
-            if (Light.Unit != LightUnitCondition.Ignore)
-            {
-                if (Light.Unit == LightUnitCondition.Middle)
-                    Enabled &= !lightViewer.CarIsFirst && !lightViewer.CarIsLast;
-                else if (Light.Unit == LightUnitCondition.First)
-                    Enabled &= lightViewer.CarIsFirst && !lightViewer.CarIsReversed;
-                else if (Light.Unit == LightUnitCondition.Last)
-                    Enabled &= lightViewer.CarIsLast && !lightViewer.CarIsReversed;
-                else if (Light.Unit == LightUnitCondition.LastRev)
-                    Enabled &= lightViewer.CarIsLast && lightViewer.CarIsReversed;
-                else if (Light.Unit == LightUnitCondition.FirstRev)
-                    Enabled &= lightViewer.CarIsFirst && lightViewer.CarIsReversed;
-                else
-                    Enabled &= false;
-            }
-            if (Light.Penalty != LightPenaltyCondition.Ignore)
-            {
-                if (Light.Penalty == LightPenaltyCondition.No)
-                    Enabled &= !lightViewer.Penalty;
-                else if (Light.Penalty == LightPenaltyCondition.Yes)
-                    Enabled &= lightViewer.Penalty;
-                else
-                    Enabled &= false;
-            }
-            if (Light.Control != LightControlCondition.Ignore)
-            {
-                if (Light.Control == LightControlCondition.AI)
-                    Enabled &= !lightViewer.CarIsPlayer;
-                else if (Light.Control == LightControlCondition.Player)
-                    Enabled &= lightViewer.CarIsPlayer;
-                else
-                    Enabled &= false;
-            }
-            if (Light.Service != LightServiceCondition.Ignore)
-            {
-                if (Light.Service == LightServiceCondition.No)
-                    Enabled &= !lightViewer.CarInService;
-                else if (Light.Service == LightServiceCondition.Yes)
-                    Enabled &= lightViewer.CarInService;
-                else
-                    Enabled &= false;
-            }
-            if (Light.TimeOfDay != LightTimeOfDayCondition.Ignore)
-            {
-                if (Light.TimeOfDay == LightTimeOfDayCondition.Day)
-                    Enabled &= lightViewer.IsDay;
-                else if (Light.TimeOfDay == LightTimeOfDayCondition.Night)
-                    Enabled &= !lightViewer.IsDay;
-                else
-                    Enabled &= false;
-            }
-            if (Light.Weather != LightWeatherCondition.Ignore)
-            {
-                if (Light.Weather == LightWeatherCondition.Clear)
-                    Enabled &= lightViewer.Weather == WeatherType.Clear;
-                else if (Light.Weather == LightWeatherCondition.Rain)
-                    Enabled &= lightViewer.Weather == WeatherType.Rain;
-                else if (Light.Weather == LightWeatherCondition.Snow)
-                    Enabled &= lightViewer.Weather == WeatherType.Snow;
-                else
-                    Enabled &= false;
-            }
-            if (Light.Coupling != LightCouplingCondition.Ignore)
-            {
-                if (Light.Coupling == LightCouplingCondition.Front)
-                    Enabled &= lightViewer.CarCoupledFront && !lightViewer.CarCoupledRear;
-                else if (Light.Coupling == LightCouplingCondition.Rear)
-                    Enabled &= !lightViewer.CarCoupledFront && lightViewer.CarCoupledRear;
-                else if (Light.Coupling == LightCouplingCondition.Both)
-                    Enabled &= lightViewer.CarCoupledFront && lightViewer.CarCoupledRear;
-                else
-                    Enabled &= false;
-            }
-            if (Light.Battery != LightBatteryCondition.Ignore)
-            {
-                if (Light.Battery == LightBatteryCondition.On)
-                    Enabled &= lightViewer.CarBatteryOn;
-                else if (Light.Battery == LightBatteryCondition.Off)
-                    Enabled &= !lightViewer.CarBatteryOn;
-                else
-                    Enabled &= false;
+                bool thisEnabled = true;
+
+                if (thisEnabled && condition.Headlight != LightHeadlightCondition.Ignore)
+                {
+                    switch (condition.Headlight)
+                    {
+                        case LightHeadlightCondition.Off:       thisEnabled &= lightViewer.TrainHeadlight == 0; break;
+                        case LightHeadlightCondition.Dim:       thisEnabled &= lightViewer.TrainHeadlight == 1; break;
+                        case LightHeadlightCondition.Bright:    thisEnabled &= lightViewer.TrainHeadlight == 2; break;
+                        case LightHeadlightCondition.DimBright: thisEnabled &= lightViewer.TrainHeadlight >= 1; break;
+                        case LightHeadlightCondition.OffDim:    thisEnabled &= lightViewer.TrainHeadlight <= 1; break;
+                        case LightHeadlightCondition.OffBright: thisEnabled &= lightViewer.TrainHeadlight != 1; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Unit != LightUnitCondition.Ignore)
+                {
+                    switch (condition.Unit)
+                    {
+                        case LightUnitCondition.Middle:         thisEnabled &= !lightViewer.CarIsFirst && !lightViewer.CarIsLast; break;
+                        case LightUnitCondition.First:          thisEnabled &= lightViewer.CarIsFirst && !lightViewer.CarIsReversed; break;
+                        case LightUnitCondition.Last:           thisEnabled &= lightViewer.CarIsLast && !lightViewer.CarIsReversed; break;
+                        case LightUnitCondition.LastRev:        thisEnabled &= lightViewer.CarIsLast && lightViewer.CarIsReversed; break;
+                        case LightUnitCondition.FirstRev:       thisEnabled &= lightViewer.CarIsFirst && lightViewer.CarIsReversed; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Penalty != LightPenaltyCondition.Ignore)
+                {
+                    switch (condition.Penalty)
+                    {
+                        case LightPenaltyCondition.No:          thisEnabled &= !lightViewer.Penalty; break;
+                        case LightPenaltyCondition.Yes:         thisEnabled &= lightViewer.Penalty; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Control != LightControlCondition.Ignore)
+                {
+                    switch (condition.Control)
+                    {
+                        case LightControlCondition.AI:          thisEnabled &= !lightViewer.CarIsPlayer; break;
+                        case LightControlCondition.Player:      thisEnabled &= lightViewer.CarIsPlayer; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Service != LightServiceCondition.Ignore)
+                {
+                    switch (condition.Service)
+                    {
+                        case LightServiceCondition.No:          thisEnabled &= !lightViewer.CarInService; break;
+                        case LightServiceCondition.Yes:         thisEnabled &= lightViewer.CarInService; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.TimeOfDay != LightTimeOfDayCondition.Ignore)
+                {
+                    switch (condition.TimeOfDay)
+                    {
+                        case LightTimeOfDayCondition.Day:       thisEnabled &= lightViewer.IsDay; break;
+                        case LightTimeOfDayCondition.Night:     thisEnabled &= !lightViewer.IsDay; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Weather != LightWeatherCondition.Ignore)
+                {
+                    switch (condition.Weather)
+                    {
+                        case LightWeatherCondition.Clear:       thisEnabled &= lightViewer.Weather == WeatherType.Clear; break;
+                        case LightWeatherCondition.Rain:        thisEnabled &= lightViewer.Weather == WeatherType.Rain; break;
+                        case LightWeatherCondition.Snow:        thisEnabled &= lightViewer.Weather == WeatherType.Snow; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Coupling != LightCouplingCondition.Ignore)
+                {
+                    switch (condition.Coupling)
+                    {
+                        case LightCouplingCondition.Front:      thisEnabled &= lightViewer.CarCoupledFront && !lightViewer.CarCoupledRear; break;
+                        case LightCouplingCondition.Rear:       thisEnabled &= !lightViewer.CarCoupledFront && lightViewer.CarCoupledRear; break;
+                        case LightCouplingCondition.Both:       thisEnabled &= lightViewer.CarCoupledFront && lightViewer.CarCoupledRear; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Battery != LightBatteryCondition.Ignore)
+                {
+                    switch (condition.Battery)
+                    {
+                        case LightBatteryCondition.On:          thisEnabled &= lightViewer.CarBatteryOn; break;
+                        case LightBatteryCondition.Off:         thisEnabled &= !lightViewer.CarBatteryOn; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Brake != LightBrakeCondition.Ignore)
+                {
+                    switch (condition.Brake)
+                    {
+                        case LightBrakeCondition.Released:      thisEnabled &= !lightViewer.BrakeOn; break;
+                        case LightBrakeCondition.Applied:       thisEnabled &= lightViewer.BrakeOn; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Reverser != LightReverserCondition.Ignore)
+                {
+                    switch (condition.Reverser)
+                    {
+                        case LightReverserCondition.Forward:    thisEnabled &= lightViewer.ReverserState == 1; break;
+                        case LightReverserCondition.Reverse:    thisEnabled &= lightViewer.ReverserState == -1; break;
+                        case LightReverserCondition.Neutral:    thisEnabled &= lightViewer.ReverserState == 0; break;
+                        case LightReverserCondition.ForwardReverse: thisEnabled &= lightViewer.ReverserState != 0; break;
+                        case LightReverserCondition.ForwardNeutral: thisEnabled &= lightViewer.ReverserState >= 0; break;
+                        case LightReverserCondition.ReverseNeutral: thisEnabled &= lightViewer.ReverserState <= 0; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Doors != LightDoorsCondition.Ignore)
+                {
+                    switch (condition.Doors)
+                    {
+                        case LightDoorsCondition.Closed:        thisEnabled &= !lightViewer.RightDoorOpen && !lightViewer.LeftDoorOpen; break;
+                        case LightDoorsCondition.Left:          thisEnabled &= lightViewer.LeftDoorOpen; break;
+                        case LightDoorsCondition.Right:         thisEnabled &= lightViewer.RightDoorOpen; break;
+                        case LightDoorsCondition.Both:          thisEnabled &= lightViewer.RightDoorOpen && lightViewer.LeftDoorOpen; break;
+                        case LightDoorsCondition.LeftRight:     thisEnabled &= lightViewer.RightDoorOpen || lightViewer.LeftDoorOpen; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Horn != LightHornCondition.Ignore)
+                {
+                    switch (condition.Horn)
+                    {
+                        case LightHornCondition.Off:            thisEnabled &= !lightViewer.HornOn; break;
+                        case LightHornCondition.Sounding:       thisEnabled &= lightViewer.HornOn; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.Bell != LightBellCondition.Ignore)
+                {
+                    switch (condition.Bell)
+                    {
+                        case LightBellCondition.Off:            thisEnabled &= !lightViewer.BellOn; break;
+                        case LightBellCondition.Ringing:        thisEnabled &= lightViewer.BellOn; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+                if (thisEnabled && condition.MU != LightMUCondition.Ignore)
+                {
+                    switch (condition.MU)
+                    {
+                        case LightMUCondition.Lead:             thisEnabled &= lightViewer.MU == -1; break;
+                        case LightMUCondition.Local:            thisEnabled &= lightViewer.MU != 0; break;
+                        case LightMUCondition.Remote:           thisEnabled &= lightViewer.MU == 0; break;
+                        default: thisEnabled = false; break;
+                    }
+                }
+
+                // If ANY set of conditions are enabled, the entire thing is enabled
+                Enabled |= thisEnabled;
+
+                // No need to waste time checking other conditions once one is enabled
+                if (Enabled)
+                    break;
             }
 
             if (oldEnabled != Enabled)

--- a/Source/RunActivity/Viewer3D/Lights.cs
+++ b/Source/RunActivity/Viewer3D/Lights.cs
@@ -112,9 +112,11 @@ namespace Orts.Viewer3D
                     if (light.ShapeIndex != -1)
                     {
                         if (light.ShapeIndex < 0 || light.ShapeIndex >= (CarViewer as MSTSWagonViewer).TrainCarShape.XNAMatrices.Count())
+                        {
                             Trace.TraceWarning("Light in car {0} has invalid shape index defined, shape index {1} does not exist",
                                 (Car as MSTSWagon).WagFilePath, light.ShapeIndex);
-                        light.ShapeIndex = 0;
+                            light.ShapeIndex = 0;
+                        }
                     }
                     else
                     {

--- a/Source/RunActivity/Viewer3D/Lights.cs
+++ b/Source/RunActivity/Viewer3D/Lights.cs
@@ -270,6 +270,10 @@ namespace Orts.Viewer3D
 
         bool UpdateState()
         {
+            // No need to update lights if there are none
+            if (Car.Lights == null)
+                return false;
+
 			Debug.Assert(Viewer.PlayerTrain.LeadLocomotive == Viewer.PlayerLocomotive ||Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING ||
                 Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.REMOTE || Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.STATIC, "PlayerTrain.LeadLocomotive must be PlayerLocomotive.");
 			var leadLocomotiveCar = Car.Train?.LeadLocomotive;

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSWagonViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSWagonViewer.cs
@@ -38,7 +38,7 @@ namespace Orts.Viewer3D.RollingStock
 {
     public class MSTSWagonViewer : TrainCarViewer
     {
-        protected PoseableShape TrainCarShape;
+        public PoseableShape TrainCarShape { get; protected set; }
         protected AnimatedShape FreightShape;
         protected AnimatedShape InteriorShape;
         AnimatedShape FrontCouplerShape;

--- a/Source/RunActivity/Viewer3D/Trains.cs
+++ b/Source/RunActivity/Viewer3D/Trains.cs
@@ -158,7 +158,7 @@ namespace Orts.Viewer3D
                 car is MSTSLocomotive ? new MSTSLocomotiveViewer(Viewer, car as MSTSLocomotive) :
                 car is MSTSWagon ? new MSTSWagonViewer(Viewer, car as MSTSWagon) :
                 null;
-            carViewer.lightDrawer = new LightViewer(Viewer, car);
+            carViewer.lightDrawer = new LightViewer(Viewer, car, carViewer);
             return carViewer;
         }
     }

--- a/Source/RunActivity/Viewer3D/Trains.cs
+++ b/Source/RunActivity/Viewer3D/Trains.cs
@@ -102,8 +102,7 @@ namespace Orts.Viewer3D
             foreach (var car in cars.Values)
             {
                 car.Mark();
-                if (car.lightDrawer != null)
-                    car.lightDrawer.Mark();
+                car.lightDrawer?.Mark();
             }
             CABTextureManager.Mark(Viewer);
         }
@@ -144,8 +143,7 @@ namespace Orts.Viewer3D
                 car.PrepareFrame(frame, elapsedTime);
             // Do the lights separately for proper alpha sorting
             foreach (var car in cars.Values)
-                if (car.lightDrawer != null)
-                    car.lightDrawer.PrepareFrame(frame, elapsedTime);
+                car.lightDrawer?.PrepareFrame(frame, elapsedTime);
         }
 
         TrainCarViewer LoadCar(TrainCar car)
@@ -158,7 +156,8 @@ namespace Orts.Viewer3D
                 car is MSTSLocomotive ? new MSTSLocomotiveViewer(Viewer, car as MSTSLocomotive) :
                 car is MSTSWagon ? new MSTSWagonViewer(Viewer, car as MSTSWagon) :
                 null;
-            carViewer.lightDrawer = new LightViewer(Viewer, car, carViewer);
+            if (car.Lights != null) // Don't make a light viewer when there are no lights
+                carViewer.lightDrawer = new LightViewer(Viewer, car, carViewer);
             return carViewer;
         }
     }


### PR DESCRIPTION
A bunch of new features for loco and wagon lights which have been requested by the community and allow for significantly more complicated lighting configurations than previously possible.

(There are a lot of feature requests for lighting this addresses)
[The trello card](https://trello.com/c/djPB4R7K/561-new-lighting-conditions)
[Additional trello card](https://trello.com/c/v8CeqTvE)
[Another related trello card](https://trello.com/c/8rPMJLa0)
[Elvas Tower thread](https://www.elvastower.com/forums/index.php?/topic/37030-proposal-for-new-lighting-conditions/page__view__findpost__p__305488)

A bunch of new lighting conditions were added, so some significant refactoring was done in LightCollection.cs and Lights.cs to better facilitate the new conditions, as well as making it easier to add even more conditions in the future:
- Split management of light activation conditions into a new `LightCondition` class in LightCollection.cs
- Multiple sets of light conditions are now allowed in order to increase flexibility-a single Light in the .eng or .wag file can now have more than one `Conditions ( )` block and if _any_ of the sets of conditions are satisfied, the light will be enabled.
- Rewrote `UpdateState(LightViewer)` in Lights.cs to be easier to read (switch statements instead of endless if else if else chains), support multiple conditions, and to support the new conditions
- Rewrote `UpdateState()` in Lights.cs to detect activation of the new light conditions, and added an optimization to ignore changes in any light conditions that won't affect the current train car (with the increase in number of conditions, it's significantly likely that time would be wasted updating light states for a conditions every single light ignored)

The main focus is the new lighting conditions:
- `Brake` lets lights be enabled or disabled by friction brake applications
- `Reverser` can enable or disable lights based on the vehicle's direction of travel
- `Doors` ties into the passenger doors state to indicate when left/right doors are open
- `Horn` gives the ability to make automatic flashing ditch lights a reality, which is often requested
- `Bell` works the same as Horn, but is triggered by the bell instead
- `MU` customizes light behavior depending if the attached vehicle is the lead locomotive, connected to the lead locomotive, or remote to the lead locomotive
Exact usage for each condition is in the documentation and the linked E-T thread.

Also added is the ability to attach lights to parts of the shape file other than the main body. This is achieved by using the `ShapeHierarchy` token in the Light block. As a string, enter the name of the shape sub-object you want to attach the light to as the name appears in a program like Shape Viewer. `Light ( ShapeHierarchy ( "BOGIE1" )` would attach this light to the first bogie, for example. Any sub-object can be used, even nonsensical things like wheels or wiper blades.

The addition of a second headlights switch (rear headlights switch, aux headlights switch, light mode selector, or other similar switch) is out of scope for this PR but will be easier to implement in the future.