### PR TITLE
AI Train Power Supply/Lights Fix

### DIFF
--- a/Source/Orts.Simulation/Simulation/AIs/AI.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AI.cs
@@ -926,18 +926,11 @@ namespace Orts.Simulation.AIs
                             mstsSteamLocomotive.TenderCoalMassKG = mstsSteamLocomotive.MaxTenderCoalMassKG * Simulator.Activity.Tr_Activity.Tr_Activity_Header.FuelCoal / 100.0f;
                         }
 
-                        if (train.InitialSpeed != 0)
-                        {
-                            car.SignalEvent(PowerSupplyEvent.RaisePantograph, 1);
-
-                            if (car is MSTSLocomotive loco)
-                                loco.SetPower(true);
-                        }
+                        if (train.InitialSpeed != 0 && car is MSTSLocomotive loco)
+                            loco.SetPower(true);
                     }
                     else
                     {
-                        car.SignalEvent(PowerSupplyEvent.RaisePantograph, 1);
-
                         if (car is MSTSLocomotive loco)
                             loco.SetPower(true);
 

--- a/Source/Orts.Simulation/Simulation/AIs/AI.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AI.cs
@@ -927,11 +927,20 @@ namespace Orts.Simulation.AIs
                         }
 
                         if (train.InitialSpeed != 0)
+                        {
                             car.SignalEvent(PowerSupplyEvent.RaisePantograph, 1);
+
+                            if (car is MSTSLocomotive loco)
+                                loco.SetPower(true);
+                        }
                     }
                     else
                     {
                         car.SignalEvent(PowerSupplyEvent.RaisePantograph, 1);
+
+                        if (car is MSTSLocomotive loco)
+                            loco.SetPower(true);
+
                         car.CarID = "AI" + train.Number.ToString() + " - " + (train.Cars.Count - 1).ToString();
                     }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs
@@ -1392,7 +1392,7 @@ namespace Orts.Simulation.RollingStocks
         public override void SwitchToAutopilotControl()
         {
             SetDirection(Direction.Forward);
-            if (!LocomotivePowerSupply.MainPowerSupplyOn)
+            if (!LocomotivePowerSupply.MainPowerSupplyOn || !LocomotivePowerSupply.BatteryOn || !LocomotivePowerSupply.MasterKey.On)
             {
                 LocomotivePowerSupply.HandleEvent(PowerSupplyEvent.QuickPowerOn);
             }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -2047,6 +2047,7 @@ namespace Orts.Simulation.RollingStocks
 
             TrainControlSystem.Update(elapsedClockSeconds);
 
+            LocomotivePowerSupply?.Update(elapsedClockSeconds);
             UpdateControllers(elapsedClockSeconds);
 
             // Train Heading - only check the lead locomotive otherwise flipped locomotives further in consist will overwrite the train direction
@@ -2203,9 +2204,6 @@ namespace Orts.Simulation.RollingStocks
 
                     //Force to display
                     FilteredMotiveForceN = CurrentFilter.Filter(MotiveForceN, elapsedClockSeconds);
-
-                    // Only update power supply for player driven locomotives
-                    LocomotivePowerSupply?.Update(elapsedClockSeconds);
                     break;
                 default:
                     break;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -2047,7 +2047,6 @@ namespace Orts.Simulation.RollingStocks
 
             TrainControlSystem.Update(elapsedClockSeconds);
 
-            LocomotivePowerSupply?.Update(elapsedClockSeconds);
             UpdateControllers(elapsedClockSeconds);
 
             // Train Heading - only check the lead locomotive otherwise flipped locomotives further in consist will overwrite the train direction
@@ -2204,6 +2203,9 @@ namespace Orts.Simulation.RollingStocks
 
                     //Force to display
                     FilteredMotiveForceN = CurrentFilter.Filter(MotiveForceN, elapsedClockSeconds);
+
+                    // Only update power supply for player driven locomotives
+                    LocomotivePowerSupply?.Update(elapsedClockSeconds);
                     break;
                 default:
                     break;


### PR DESCRIPTION
AI trains that use the low voltage power supply feature of OR would behave as if the power supply was off all the time. This would cause said AI trains to turn off their lights (if the setting to control headlights with the master key was enabled).

[Reported on Elvas Tower](https://www.elvastower.com/forums/index.php?/topic/32640-or-newyear-mg/page__view__findpost__p__306793)

Added some additional ways for the power supply to be activated, which should guarantee that all AI trains turn on the power supply.