### PR TITLE
Fix Missing Initializations From Copy in MSTSLocomotive

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1243,7 +1243,7 @@ namespace Orts.Simulation.RollingStocks
             DynamicBrakeBlendingEnabled = locoCopy.DynamicBrakeBlendingEnabled;
             DynamicBrakeAvailable = locoCopy.DynamicBrakeAvailable;
             airPipeSystem = locoCopy.airPipeSystem;
-            DoesVacuumBrakeCutPower = locoCopy.DoesBrakeCutPower;
+            DoesVacuumBrakeCutPower = locoCopy.DoesVacuumBrakeCutPower;
             DoesBrakeCutPower = locoCopy.DoesBrakeCutPower;
             BrakeCutsPowerAtBrakeCylinderPressurePSI = locoCopy.BrakeCutsPowerAtBrakeCylinderPressurePSI;
             BrakeCutsPowerAtBrakePipePressurePSI = locoCopy.BrakeCutsPowerAtBrakePipePressurePSI;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1226,16 +1226,28 @@ namespace Orts.Simulation.RollingStocks
             CompressorRestartPressurePSI = locoCopy.CompressorRestartPressurePSI;
             CompressorIsMUControlled = locoCopy.CompressorIsMUControlled;
             TrainBrakePipeLeakPSIorInHgpS = locoCopy.TrainBrakePipeLeakPSIorInHgpS;
+            BrakePipeTimeFactorS = locoCopy.BrakePipeTimeFactorS;
+            BrakeServiceTimeFactorPSIpS = locoCopy.BrakeServiceTimeFactorPSIpS;
+            BrakeEmergencyTimeFactorPSIpS = locoCopy.BrakeEmergencyTimeFactorPSIpS;
+            BrakePipeChargingRatePSIorInHgpS = locoCopy.BrakePipeChargingRatePSIorInHgpS;
+            BrakePipeQuickChargingRatePSIpS = locoCopy.BrakePipeQuickChargingRatePSIpS;
             MaxMainResPressurePSI = locoCopy.MaxMainResPressurePSI;
             MainResPressurePSI = locoCopy.MaxMainResPressurePSI;
             MaximumMainReservoirPipePressurePSI = locoCopy.MaximumMainReservoirPipePressurePSI;
             MainResVolumeM3 = locoCopy.MainResVolumeM3;
             MainResChargingRatePSIpS = locoCopy.MainResChargingRatePSIpS;
+            EngineBrakeApplyRatePSIpS = locoCopy.EngineBrakeApplyRatePSIpS;
+            EngineBrakeReleaseRatePSIpS = locoCopy.EngineBrakeReleaseRatePSIpS;
             BrakePipeDischargeTimeFactor = locoCopy.BrakePipeDischargeTimeFactor;
             DriveWheelOnlyBrakes = locoCopy.DriveWheelOnlyBrakes;
             DynamicBrakeBlendingEnabled = locoCopy.DynamicBrakeBlendingEnabled;
             DynamicBrakeAvailable = locoCopy.DynamicBrakeAvailable;
             airPipeSystem = locoCopy.airPipeSystem;
+            DoesVacuumBrakeCutPower = locoCopy.DoesBrakeCutPower;
+            DoesBrakeCutPower = locoCopy.DoesBrakeCutPower;
+            BrakeCutsPowerAtBrakeCylinderPressurePSI = locoCopy.BrakeCutsPowerAtBrakeCylinderPressurePSI;
+            BrakeCutsPowerAtBrakePipePressurePSI = locoCopy.BrakeCutsPowerAtBrakePipePressurePSI;
+            BrakeRestoresPowerAtBrakePipePressurePSI = locoCopy.BrakeRestoresPowerAtBrakePipePressurePSI;
             DynamicBrakeCommandStartTime = locoCopy.DynamicBrakeCommandStartTime;
             DynamicBrakeBlendingOverride = locoCopy.DynamicBrakeBlendingOverride;
             DynamicBrakeBlendingForceMatch = locoCopy.DynamicBrakeBlendingForceMatch;
@@ -1244,6 +1256,7 @@ namespace Orts.Simulation.RollingStocks
             MainPressureUnit = locoCopy.MainPressureUnit;
             BrakeSystemPressureUnits = locoCopy.BrakeSystemPressureUnits;
             IsDriveable = copy.IsDriveable;
+            EngineOperatingProcedures = locoCopy.EngineOperatingProcedures;
 
             ThrottleController = (MSTSNotchController)locoCopy.ThrottleController.Clone();
             SteamHeatController = (MSTSNotchController)locoCopy.SteamHeatController.Clone();
@@ -1261,9 +1274,14 @@ namespace Orts.Simulation.RollingStocks
             }
             else
                 DPDynamicBrakeController = null;
+            DPSyncTrainApplication = locoCopy.DPSyncTrainApplication;
+            DPSyncTrainRelease = locoCopy.DPSyncTrainRelease;
+            DPSyncEmergency = locoCopy.DPSyncEmergency;
+            DPSyncIndependent = locoCopy.DPSyncIndependent;
 
             LocomotivePowerSupply.Copy(locoCopy.LocomotivePowerSupply);
             TrainControlSystem.Copy(locoCopy.TrainControlSystem);
+            VigilanceMonitor = locoCopy.VigilanceMonitor;
             LocomotiveName = locoCopy.LocomotiveName;
             MaxVaccuumMaxPressurePSI = locoCopy.MaxVaccuumMaxPressurePSI;
             VacuumBrakeEQFitted = locoCopy.VacuumBrakeEQFitted;
@@ -1277,6 +1295,8 @@ namespace Orts.Simulation.RollingStocks
             WaterScoopWidthM = locoCopy.WaterScoopWidthM;
             CruiseControl = locoCopy.CruiseControl?.Clone(this);
             MultiPositionControllers = locoCopy.CloneMPC(this);
+            OnLineCabRadio = locoCopy.OnLineCabRadio;
+            OnLineCabRadioURL = locoCopy.OnLineCabRadioURL;
         }
 
         /// <summary>


### PR DESCRIPTION
I noticed in some testing that locomotives initialized from a copy were not synchronizing DP brake commands (PR #916) as expected. Failed to notice this earlier as I had done all of my testing using consists formed of unique locomotives, never locomotives that were duplicates.

In the process of adding DP brake synchronization to the Copy() function, I noticed many other user inputs would not be copied to duplicated locomotives. This would result in those parameters producing the intended value only for the very first locomotive loaded, all other copies would use the default value.

I believe this PR covers all the missing copy commands in MSTSLocomotive.cs:

Player and trail loco variables: (These affect the operation of both the player locomotive and other locomotives in their train. As I found out, it can impact gameplay if these are not copied properly.)
- BrakePipeChargingRatePSIorInHgpS
- BrakePipeQuickChargingRatePSIpS
- EngineBrakeApplyRatePSIpS
- EngineBrakeReleaseRatePSIpS
- DPSyncTrainApplication
- DPSyncTrainRelease
- DPSyncEmergency
- DPSyncIndependent

Player loco only variables: (These only affect the player loco, so usually it would be harmless if these initialized to defaults, unless the player decided to change cabs. Less visible, but still added to Copy() for robustness.)
- BrakePipeTimeFactorS
- BrakeServiceTimeFactorPSIpS
- BrakeEmergencyTimeFactorPSIpS
- DoesVacuumBrakeCutPower
- DoesBrakeCutPower
- BrakeCutsPowerAtBrakeCylinderPressurePSI
- BrakeCutsPowerAtBrakePipePressurePSI
- BrakeRestoresPowerAtBrakePipePressurePSI
- EngineOperatingProcedures
- VigilanceMonitor (I don't actually know if this does anything)
- OnLineCabRadio
- OnLineCabRadioURL

I can only advise others and myself to ensure the Copy() initializer is **updated with every new user input added**, and to remember that the Parse() initializer is skipped entirely for duplicate rail vehicles.

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)