### PR TITLE
Add support for common circuit breaker variants

### DIFF
--- a/Source/Documentation/Manual/features-rollingstock.rst
+++ b/Source/Documentation/Manual/features-rollingstock.rst
@@ -1912,8 +1912,18 @@ Use the following .eng parameter to load a circuit breaker script::
   )
 
 ``ORTSCircuitBreaker`` refers to the circuit breaker script in the engine's ``Script`` 
-subfolder. For this field, the .cs extension is optional. "Automatic" and "Manual" load the generic OR 
-circuit breaker implementation, so do `not` use these names for your own script.
+subfolder. For this field, the .cs extension is optional. Alternatively, there are several
+built-in OR circuit breaker implementations:
+
+- "Automatic": no driver intervention required, circuit breaker is closed when conditions are met.
+- "Manual": a circuit breaker switch with open and closed positions.
+- "PushButtons": a circuit breaker with dedicated open and close buttons.
+- "TwoStage": circuit breaker closing is authorized by a switch. If the switch is off, 
+  the circuit breaker is kept open. Once the switch is activated, it is required to use
+  a second button to order the closing.
+
+Please do `not` use these names for your own script, since the generic implementation will
+be loaded instead.
 
 ``ORTSCircuitBreakerClosingDelay`` refers to the delay between the closing command of the circuit breaker
 and the effective closing of the circuit breaker.

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricPowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/ElectricPowerSupply.cs
@@ -205,7 +205,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                             if (QuickPowerOn)
                             {
                                 QuickPowerOn = false;
-                                SignalEventToCircuitBreaker(PowerSupplyEvent.CloseCircuitBreaker);
+                                SignalEventToCircuitBreaker(PowerSupplyEvent.QuickPowerOn);
                             }
 
                             if (PowerOnTimer.Started)
@@ -277,7 +277,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 case PowerSupplyEvent.QuickPowerOff:
                     QuickPowerOn = false;
                     SignalEventToElectricTrainSupplySwitch(PowerSupplyEvent.SwitchOffElectricTrainSupply);
-                    SignalEventToCircuitBreaker(PowerSupplyEvent.OpenCircuitBreaker);
+                    SignalEventToCircuitBreaker(PowerSupplyEvent.QuickPowerOff);
                     SignalEventToPantographs(PowerSupplyEvent.LowerPantograph);
                     SignalEventToOtherTrainVehicles(PowerSupplyEvent.LowerPantograph);
                     SignalEventToMasterKey(PowerSupplyEvent.TurnOffMasterKey);


### PR DESCRIPTION
There are some common circuit breaker variants which are widely used in different stock. Including them into the OR source allows to easily include new features into them, without user intervention.

The following variants are added:
- PushButtons: dedicated buttons for opening and closing. Behaviour is similar to the Italian script. This variant is the most common in modern vehicles.
- TwoStage: one switch for driver closing authorization, and one button for driver closing order. Behaviour is similar to the French script. This variant is used in TGV trains, as well as in older electric locomotives.

Partly implements https://trello.com/c/xShE5iVJ/583-built-in-scripts-for-common-systems
Discussion: https://www.elvastower.com/forums/index.php?/topic/28645-circuit-breaker-for-electric-locomotives/page__view__findpost__p__307197