### PR TITLE
Fix bug 1944070: ContentManager search exception.

### DIFF
--- a/Source/Contrib/ContentManager/ContentManagerGUI.cs
+++ b/Source/Contrib/ContentManager/ContentManagerGUI.cs
@@ -270,7 +270,8 @@ namespace ORTS.ContentManager
                     var content = pending[path];
                     pending.Remove(path);
 
-                    if (content.Name.ToLowerInvariant().Contains(search))
+                    // do not add root element to search results, see bug 1944070
+                    if (content.Type != ContentType.Root && content.Name.ToLowerInvariant().Contains(search))
                         finds.Add(new SearchResult(content, path));
 
                     foreach (var child in ((ContentType[])Enum.GetValues(typeof(ContentType))).SelectMany(ct => content.Get(ct)))


### PR DESCRIPTION
ContentManager search crashed when one of the following letters was typed into the search box: A,C,E,G,M,N,O,R,T. These are the letters in "ContentManager", the name of the root element in the content tree. The root element was being added to the search results, which then searches the element for a directory separator (/), and caused an System.ArgumentOutOfRangeException.

See https://bugs.launchpad.net/or/+bug/1944070.

The fix is to not compare the element name tothe search string when the element is the root.