### PR TITLE
Correct bug created in diesel electric locomotive

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -2156,10 +2156,13 @@ namespace Orts.Simulation.RollingStocks
 
                                 // if train is a geared locomotive then set it to automatic operation as AI driver can't operate manual gearboxes
                                 if (de.GearBox != null)
+                                {
                                     de.GearBox.GearBoxOperation = GearBoxOperation.Automatic;
 
-                                // Set gear to "low gear" at start.
-                                de.GearBox.currentGearIndex = de.GearBox.NumOfGears - 1;
+                                    // Set gear to at start.
+                                    de.GearBox.currentGearIndex = de.GearBox.NumOfGears - 1;
+                                }
+                            
                             }
                         }
                     }


### PR DESCRIPTION
Correct bug identified in this Bug Report

https://bugs.launchpad.net/or/+bug/2061047

Subsequent bug reported - 

Appears this change is causing a new crash on diesel electric locomotives https://www.elvastower.com/forums/index.php?/topic/37993-940-stable-build-autopilot-immediate-ctd/

This line should probably be added underneath the if statement in line 2158 so that it doesn't try to set low gear if there is no gearbox.

