### PR TITLE
Fix Missing Initializations From Copy in MSTSWagon.cs

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1601,6 +1601,7 @@ namespace Orts.Simulation.RollingStocks
             TenderWagonMaxCoalMassKG = copy.TenderWagonMaxCoalMassKG;
             TenderWagonMaxWaterMassKG = copy.TenderWagonMaxWaterMassKG;
             InitWagonNumAxles = copy.InitWagonNumAxles;
+            WagonNumAxles = copy.WagonNumAxles;
             DerailmentCoefficientEnabled = copy.DerailmentCoefficientEnabled;
             WagonNumBogies = copy.WagonNumBogies;
             MSTSWagonNumWheels = copy.MSTSWagonNumWheels;
@@ -1672,6 +1673,7 @@ namespace Orts.Simulation.RollingStocks
             AxleInertiaKgm2 = copy.AxleInertiaKgm2;
             SlipWarningThresholdPercent = copy.SlipWarningThresholdPercent;
             Lights = copy.Lights;
+            HasInsideView = copy.HasInsideView;
             ExternalSoundPassThruPercent = copy.ExternalSoundPassThruPercent;
             TrackSoundPassThruPercent = copy.TrackSoundPassThruPercent;
             foreach (PassengerViewPoint passengerViewPoint in copy.PassengerViewpoints)
@@ -1830,18 +1832,12 @@ namespace Orts.Simulation.RollingStocks
             outf.Write(Variable1_2);
             outf.Write(Variable1_3);
             outf.Write(Variable1_4);
-            outf.Write(IsDavisFriction);
-            outf.Write(IsRollerBearing);
-            outf.Write(IsLowTorqueRollerBearing);
-            outf.Write(IsFrictionBearing);
             outf.Write(Friction0N);
             outf.Write(DavisAN);
             outf.Write(DavisBNSpM);
             outf.Write(DavisCNSSpMM);
-            outf.Write(StandstillFrictionN);
             outf.Write(MergeSpeedFrictionN);
             outf.Write(IsBelowMergeSpeed);
-            outf.Write(MergeSpeedMpS);
             outf.Write(MassKG);
             outf.Write(MaxBrakeForceN);
             outf.Write(MaxHandbrakeForceN);
@@ -1895,18 +1891,12 @@ namespace Orts.Simulation.RollingStocks
             Variable1_2 = inf.ReadSingle();
             Variable1_3 = inf.ReadSingle();
             Variable1_4 = inf.ReadSingle();
-            IsDavisFriction = inf.ReadBoolean();
-            IsRollerBearing = inf.ReadBoolean();
-            IsLowTorqueRollerBearing = inf.ReadBoolean();
-            IsFrictionBearing = inf.ReadBoolean();
             Friction0N = inf.ReadSingle();
             DavisAN = inf.ReadSingle();
             DavisBNSpM = inf.ReadSingle();
             DavisCNSSpMM = inf.ReadSingle();
-            StandstillFrictionN = inf.ReadSingle();
             MergeSpeedFrictionN = inf.ReadSingle();
             IsBelowMergeSpeed = inf.ReadBoolean();
-            MergeSpeedMpS = inf.ReadSingle();
             MassKG = inf.ReadSingle();
             MaxBrakeForceN = inf.ReadSingle();
             MaxHandbrakeForceN = inf.ReadSingle();


### PR DESCRIPTION
Follow up to PR #928, similar process but for MSTSWagon.cs. Again while testing, I noticed that the first instance of a given wagon had different standstill friction than any other instances of the wagon, indicating to me that something was missing when initializing from a copy.

Luckily it seems most things are set correctly, I only noticed missing initialization from copy for:
- WagonNumAxles (this is what was causing the discrepancy in friction calculations)
- HasInsideView (unsure if this was actually causing problems, but it might help for trains with lots of passenger/3D cabviews)

I also checked the save and restore functions, some variables were being saved even though it was impossible for them to change during runtime:
- IsDavisFriction
- IsRollerBearing
- IsLowTorqueRollerBearing
- IsFrictionBearing
- StandstillFrictionN
- MergeSpeedMpS

As always, make sure any variables calculated during initialization are copied, and don't bother to save/restore a variable unless that variable changes during gameplay.

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)