### PR TITLE
Add KM/HOUR/MIN to Cabview Units + Custom Units

### DIFF
--- a/Source/Documentation/Manual/cabs.rst
+++ b/Source/Documentation/Manual/cabs.rst
@@ -791,15 +791,22 @@ Custom Display Units
 
 Due to the wide variety of railroad equipment across the world, Open Rails may not
 provide the units of measure needed for a cabview control. In this case, the tokens
-`ORTSUnitsScaleFactor` and `ORTSUnitsOffset` can be added to the control block in
-the .cvf file to create the units of measure required for the cab view.
+`ORTSUnitsExponent`, `ORTSUnitsScaleFactor`, and `ORTSUnitsOffset` can be added
+to the control block in the .cvf file to create the units of measure required for
+the cab view.
 
-- ORTSUnitsScaleFactor ( x ): Multiplies the value shown by the cab view control
-  by a factor of x, allowing for arbitrary conversion of units of measure. For
-  example, a cab view control displaying MILES_PER_HOUR with ORTSUnitsScaleFactor ( 1.467 )
-  would instead display a value equivalent to feet per second.
-- ORTSUnitsOffset ( x ): After applying the scale factor, adds x to the value shown
-  by the cab view control. To subtract from the shown value, set x to a negative number.
+- ORTSUnitsExponent ( x ): Raises the value shown by the cab view control to the
+  power of x, which may be used to calibrate nonlinear gauges or complete nonlinear
+  conversions. Fractional and negative values are allowed. For example, an accelerometer
+  gauge with ORTSUnitsExponent ( 0.5 ) would change the accelerometer to be more sensitive
+  to small accelerations, but less sensitive to large acceleration. (However, the values
+  shown would not be in any meaningful units.)
+- ORTSUnitsScaleFactor ( y ): After accounting for any exponent, multiplies the value
+  shown by the cab view control by a factor of y, allowing for arbitrary conversion of
+  units of measure. For example, a cab view control displaying MILES_PER_HOUR with
+  ORTSUnitsScaleFactor ( 1.467 ) would instead display a value equivalent to feet per second.
+- ORTSUnitsOffset ( z ): After applying the scale factor, adds z to the value shown
+  by the cab view control. To subtract from the shown value, set z to a negative number.
   For example, a cab view control with units of BAR and ORTSUnitsOffset ( 0.987 ) would show
   pressure as absolute pressure, rather than gauge pressure.
 

--- a/Source/Documentation/Manual/cabs.rst
+++ b/Source/Documentation/Manual/cabs.rst
@@ -785,6 +785,26 @@ can be customized with following line, to be added within the control block in t
 .cvf file::
 
    ORTSLabel ( "string" )
+
+Custom Display Units
+--------------------
+
+Due to the wide variety of railroad equipment across the world, Open Rails may not
+provide the units of measure needed for a cabview control. In this case, the tokens
+`ORTSUnitsScaleFactor` and `ORTSUnitsOffset` can be added to the control block in
+the .cvf file to create the units of measure required for the cab view.
+
+- ORTSUnitsScaleFactor ( x ): Multiplies the value shown by the cab view control
+  by a factor of x, allowing for arbitrary conversion of units of measure. For
+  example, a cab view control displaying MILES_PER_HOUR with ORTSUnitsScaleFactor ( 1.467 )
+  would instead display a value equivalent to feet per second.
+- ORTSUnitsOffset ( x ): After applying the scale factor, adds x to the value shown
+  by the cab view control. To subtract from the shown value, set x to a negative number.
+  For example, a cab view control with units of BAR and ORTSUnitsOffset ( 0.987 ) would show
+  pressure as absolute pressure, rather than gauge pressure.
+
+Note that while these tokens can be used to convert between many units, it is recommended
+to use built in Open Rails units wherever suitable.
    
 Multiple screen pages on displays
 ---------------------------------

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -470,6 +470,9 @@ namespace Orts.Formats.Msts
         public CABViewControlStyles ControlStyle = CABViewControlStyles.NONE;
         public CABViewControlUnits Units = CABViewControlUnits.NONE;
 
+        public float UnitsScale = 1.0f;
+        public float UnitsOffset;
+
         public bool DisabledIfLowVoltagePowerSupplyOff { get; private set; } = false;
         public bool DisabledIfCabPowerSupplyOff { get; private set; } = false;
         public bool HideIfDisabled { get; private set; } = true;
@@ -687,6 +690,8 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
+                new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
         }
     }
@@ -783,6 +788,8 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
+                new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
         }
     }
@@ -925,6 +932,8 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
+                new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
         }
 
@@ -1181,6 +1190,8 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsnewscreenpage", () => {ParseNewScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
                 new STFReader.TokenProcessor("ortsparameter1", ()=>{ Parameter1 = stf.ReadFloatBlock(STFReader.UNITS.Any, 0); }),
+                new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
+                new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 });
 
                 // If no ACE, just don't need any fixup
@@ -1427,6 +1438,8 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
+                new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
         }
         protected int ParseNumStyle(STFReader stf)
@@ -1477,6 +1490,8 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
+                new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
         }
         protected int ParseNumStyle(STFReader stf)
@@ -1518,6 +1533,8 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
+                new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
         }
         protected void ParseCustomParameters(STFReader stf)

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -322,6 +322,8 @@ namespace Orts.Formats.Msts
         METRES_SEC_SEC,
         KMµHOURµHOUR,
         KM_HOUR_HOUR,
+        KMµHOURµMIN,
+        KM_HOUR_MIN,
         KMµHOURµSEC,
         KM_HOUR_SEC,
         METRESµSECµHOUR,

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -470,6 +470,7 @@ namespace Orts.Formats.Msts
         public CABViewControlStyles ControlStyle = CABViewControlStyles.NONE;
         public CABViewControlUnits Units = CABViewControlUnits.NONE;
 
+        public double UnitsExponent = 1.0f;
         public float UnitsScale = 1.0f;
         public float UnitsOffset;
 
@@ -690,6 +691,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsexponent", ()=>{ UnitsExponent = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
@@ -788,6 +790,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsexponent", ()=>{ UnitsExponent = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
@@ -932,6 +935,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsexponent", ()=>{ UnitsExponent = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
@@ -1190,6 +1194,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsnewscreenpage", () => {ParseNewScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
                 new STFReader.TokenProcessor("ortsparameter1", ()=>{ Parameter1 = stf.ReadFloatBlock(STFReader.UNITS.Any, 0); }),
+                new STFReader.TokenProcessor("ortsunitsexponent", ()=>{ UnitsExponent = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 });
@@ -1438,6 +1443,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsexponent", ()=>{ UnitsExponent = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
@@ -1490,6 +1496,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsexponent", ()=>{ UnitsExponent = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });
@@ -1533,6 +1540,7 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsdisplay", ()=>{ParseDisplay(stf); }),
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
+                new STFReader.TokenProcessor("ortsunitsexponent", ()=>{ UnitsExponent = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsscalefactor", ()=>{ UnitsScale = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
                 new STFReader.TokenProcessor("ortsunitsoffset", ()=>{ UnitsOffset = stf.ReadFloatBlock(STFReader.UNITS.None, null); }),
             });

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -6133,7 +6133,10 @@ namespace Orts.Simulation.RollingStocks
                         data = Train.EOT.GetDataOf(cvc);
                     break;
             }
-
+            // Don't waste time calculating exponents if one isn't set
+            // To avoid potential imaginary numbers, use data's absolute value
+            if (cvc.UnitsExponent != 1.0f)
+                data = Math.Sign(data)*(float)Math.Pow(Math.Abs(data), cvc.UnitsExponent);
             data = cvc.UnitsOffset + (data * cvc.UnitsScale);
 
             return data;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -5195,6 +5195,10 @@ namespace Orts.Simulation.RollingStocks
                                 data = this.AccelerationMpSS * 3.6f;
                                 break;
 
+                            case CABViewControlUnits.KM_HOUR_MIN:
+                                data = this.AccelerationMpSS * 3.6f * 60.0f;
+                                break;
+
                             case CABViewControlUnits.KM_HOUR_HOUR:
                                 data = this.AccelerationMpSS * 3.6f * 3600.0f;
                                 break;
@@ -5216,7 +5220,7 @@ namespace Orts.Simulation.RollingStocks
                         break;
                     }
 
-                 case CABViewControlTypes.ORTS_WATER_SCOOP:
+                case CABViewControlTypes.ORTS_WATER_SCOOP:
                     data = WaterScoopDown ? 1 : 0;
                     break;
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -6133,6 +6133,9 @@ namespace Orts.Simulation.RollingStocks
                         data = Train.EOT.GetDataOf(cvc);
                     break;
             }
+
+            data = cvc.UnitsOffset + (data * cvc.UnitsScale);
+
             return data;
         }
 

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2147,7 +2147,7 @@ namespace Orts.Viewer3D.RollingStock
                         {
                             if (Locomotive.CruiseControl != null)
                             {
-                                if ((Locomotive.CruiseControl.SpeedRegMode == Simulation.RollingStocks.SubSystems.CruiseControl.SpeedRegulatorMode.Auto && !Locomotive.CruiseControl.DynamicBrakePriority) || Locomotive.DynamicBrakeIntervention > 0)
+                                if (Locomotive.CruiseControl.SpeedRegMode == Simulation.RollingStocks.SubSystems.CruiseControl.SpeedRegulatorMode.Auto && !Locomotive.CruiseControl.DynamicBrakePriority)
                                 {
                                     index = 0;
                                 }

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2147,7 +2147,7 @@ namespace Orts.Viewer3D.RollingStock
                         {
                             if (Locomotive.CruiseControl != null)
                             {
-                                if (Locomotive.CruiseControl.SpeedRegMode == Simulation.RollingStocks.SubSystems.CruiseControl.SpeedRegulatorMode.Auto && !Locomotive.CruiseControl.DynamicBrakePriority)
+                                if ((Locomotive.CruiseControl.SpeedRegMode == Simulation.RollingStocks.SubSystems.CruiseControl.SpeedRegulatorMode.Auto && !Locomotive.CruiseControl.DynamicBrakePriority) || Locomotive.DynamicBrakeIntervention > 0)
                                 {
                                     index = 0;
                                 }


### PR DESCRIPTION
At the request of multiple people, kilometers per hour per minute has been added as a cabview unit. This seems to be common on American built locomotives sent internationally as a metric replacement for the usual mph/min display.

[Trello Card](https://trello.com/c/pOk3XiFK)
[Elvas Tower Discussion](https://www.elvastower.com/forums/index.php?/topic/24040-3d-cabs/page__st__790__p__308227#entry308227)

Realizing it is entirely impractical to make a code change for every single unit people want to add, I also added some tokens which can be added to the control block in the .cvf file to allow for custom units.
- `ORTSUnitsExponent ( x )` - Raises the value shown by the cab view control to the power `x`. There aren't many cases where this is useful for units conversion, but it is useful for the various types of nonlinear gauges present in locomotives. Can be set to any decimal number (negative exponents to invert the relationship, fractional exponents to do square roots, 0...all should work). If not specified, the exponent is 1 (ie: no change).
- `ORTSUnitsScaleFactor ( y )` - After the exponent, multiplies the value shown by the cab view control by a factor of `y`. For example, a cab view control with units of MILES_PER_HOUR can be converted to feet per second (a unit ORTS does not support) using ORTSUnitsScaleFactor ( 1.467 ). Can be any decimal number (negative, fractional, 0...all should work). If not specified, the factor is 1 (ie: no change).
- `ORTSUnitsOffset ( z )` - After the scale factor is applied, adds `z` to the value shown by the cab view control. For example, a cab view control with units of BAR actually shows gauge pressure specifically. This can be converted to absolute pressure in BAR with ORTSUnitsOffset ( 0.987 ). This can also be any decimal number, but negative numbers will reduce the value shown by the cab view control. If not specified, the offset is 0 (ie: no change).