### PR TITLE
Browser HUD column alignment improvements

### DIFF
--- a/Source/RunActivity/Viewer3D/WebServices/Web/HUD/index.js
+++ b/Source/RunActivity/Viewer3D/WebServices/Web/HUD/index.js
@@ -86,8 +86,9 @@ function ApiHeadUpDisplay() {
 						DebugWidthTofix = ['primitives','Camera'],
 					// Force information
 						ForceColSpanTo15 = ['Wind Speed'],
-						ForceColSpanTo4 = ['(Simple adhesion model)','Dynamic brake'],
-						ForceColSpanTo3 = ['Axle out force','Loco Adhesion','Wagon Adhesion'],
+						ForceColSpanTo4 = ['(Advanced adhesion model)', '(Simple adhesion model)'],
+						ForceColSpanTo3 = ['Wheel slip (Thres)', 'Conditions', 'Axle drive force', 'Axle brake force', 'Number of substeps', 'Wheel Adh. (Max)',
+							'Axle out force', 'Comp Axle out force', 'Wheel speed (Slip)', 'Wheel ang. pos.', 'Loco Adhesion', 'Wagon Adhesion'],
 					// Brake information
 						BrakeColSpanTo2 = ['PlayerLoco','Brake Sys Vol'];
 
@@ -96,6 +97,7 @@ function ApiHeadUpDisplay() {
 						var colspanmax = false,
 							colspan10 = false,
 							colspan3 = false,
+							colspan2 = false,
 							fixwidth = false,
 							locomotivetype = false;
 						
@@ -126,6 +128,10 @@ function ApiHeadUpDisplay() {
 								locomotivetype = true;
 								Str += "<td colspan='2' >" + obj.extraTable.values[next] + "</td>";
 							}
+							else if (colspan2)
+							{
+								Str += "<td class='td_nowrap' colspan='2' >" + obj.extraTable.values[next] + "</td>";
+							}
 							else if (colspan3 || BrakeColSpanTo2.indexOf(obj.extraTable.values[next]) !== -1){
 								Str += "<td colspan='3' >" + obj.extraTable.values[next] + "</td>";
 							}
@@ -144,6 +150,7 @@ function ApiHeadUpDisplay() {
 							}
 							else if (ForceColSpanTo3.indexOf(obj.extraTable.values[next]) !== -1 ){
 								Str += "<td colspan='3' >" + obj.extraTable.values[next] + "</td>";
+								colspan2 = true; // data cells in these row span two columns
 							}
 							else {
 								// Apply colspan if required after first col


### PR DESCRIPTION
A limited effort to improve the alignment of columns in the browser-based head up display (HUD). The whole HUD could benefit from some refactoring to improve the presentation, but that is beyond my intent. Some challenges:
- The non-common part is represented by a single table (two-dimensional array of strings), but it contains data in multiple formats:
   - preformated data spanning the full row, eg "Wind speed" in the forces desplay;
   - keyword-value pairs;
   - sub-tables with the label in the first column;
   - sub-tables with the label in the first row.
- The browser auto-sizes the columns. When a value changes magnitude, the cell-size may change and the subsequent columns may shift.
- The table cells are left-aligned. The decimal separator shifts as the magnitude changes, or the value goes negative.
- The unit may change, possibly causing the cell-size (and thus column size) to change.

Unfortunately I got stuck after the first change, fixing general alignment problems with the Forces HUD. I was not able to fix the Brake and Loco HUD alignment (without putting too much semantic details into index.js). And trying to right-align cells quickly became complex and ugly, and would also affect the in-display presentation.

### Force Info

Only the browser presentation is changed, the in-display presentation is unaffected.

Before:
![image](https://github.com/openrails/openrails/assets/159661206/dc5dc64a-16ba-4afa-8b30-cccf26198b00)

After:
![image](https://github.com/openrails/openrails/assets/159661206/12817baa-5999-45c3-82c6-1e1e9d00fd51)

I verified that it also works with the first set of data reported for each axle, even though there does not seem to be any case where multiple axles are reported (I had to fake it).

### Brake Info

There is misalignment between the player locomotives and the rest of the locomotives.

![image](https://github.com/openrails/openrails/assets/159661206/03039ab6-561a-42ad-ba71-4622724c68dd)

Adjusting colspan did not fix it, or cause other problems.

Also , the following looks like a bug:

```
else if (colspan3 || BrakeColSpanTo2.indexOf(obj.extraTable.values[next]) !== -1){
    Str += "<td colspan='3' >" + obj.extraTable.values[next] + "</td>";
}
```

``BrakeColSpanTo2`` is different from ``colspan3``. But splitting this up into two blocks, one for colspan 2 and one for colspan 3, does not help. The "PlayerLoco" and "Loco" rows are still misaligned.

