### PR TITLE
AI Penalty Lights Fix

### DIFF
--- a/Source/RunActivity/Viewer3D/Lights.cs
+++ b/Source/RunActivity/Viewer3D/Lights.cs
@@ -295,11 +295,13 @@ namespace Orts.Viewer3D
             bool newCarIsFirst = !Car.Lights.IgnoredConditions[1] && (locomotiveFlipped ^ locomotiveReverseCab ? Car.Train?.LastCar : Car.Train?.FirstCar) == Car;
             bool newCarIsLast = !Car.Lights.IgnoredConditions[1] && (locomotiveFlipped ^ locomotiveReverseCab ? Car.Train?.FirstCar : Car.Train?.LastCar) == Car;
             // Penalty
-			bool newPenalty = !Car.Lights.IgnoredConditions[2] && leadLocomotive != null && leadLocomotive.TrainBrakeController.EmergencyBraking;
+			bool newPenalty = !Car.Lights.IgnoredConditions[2] && Car.Train.TrainType != Train.TRAINTYPE.AI
+                && leadLocomotive != null && leadLocomotive.TrainBrakeController.EmergencyBraking;
             // Control
             bool newCarIsPlayer = !Car.Lights.IgnoredConditions[3] && Car.Train != null && (Car.Train == Viewer.PlayerTrain || Car.Train.TrainType == Train.TRAINTYPE.REMOTE);
             // Service - if a player or AI train, then will considered to be in servie, loose consists will not be considered to be in service.
-            bool newCarInService = !Car.Lights.IgnoredConditions[4] && Car.Train != null && (Car.Train == Viewer.PlayerTrain || Car.Train.TrainType == Train.TRAINTYPE.REMOTE || Car.Train.TrainType == Train.TRAINTYPE.AI);
+            bool newCarInService = !Car.Lights.IgnoredConditions[4] && Car.Train != null
+                && (Car.Train == Viewer.PlayerTrain || Car.Train.TrainType == Train.TRAINTYPE.REMOTE || Car.Train.TrainType == Train.TRAINTYPE.AI);
             // Time of day
             bool newIsDay = false;
             if (!Car.Lights.IgnoredConditions[5])


### PR DESCRIPTION
Fix for [this bug](https://www.elvastower.com/forums/index.php?/topic/32640-or-newyear-mg/page__view__findpost__p__308409). The AI train brake simulation is not detailed enough to correctly determine if an AI train should be showing emergency lights or not. In this case, the SNCF Z 50000 unit spawns in with the brake handle in emergency, which triggers the emergency lights on every AI train even if they are not braking.

Since AI trains should never use the emergency brake anyway, we are reverting to the old behavior which simply ignores the emergency lights on AI trains.