### PR TITLE
Dynamic Brakes Behavior & Display Improvements

### DIFF
--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -1007,6 +1007,7 @@ namespace Orts.Formats.Msts
         public bool MouseControl;
         public int Orientation;
         public int Direction;
+        public bool Reversed { get; protected set; } = false;
 
         public List<double> Values 
         {
@@ -1022,8 +1023,8 @@ namespace Orts.Formats.Msts
         public List<int> Positions = new List<int>();
 
         private int _ValuesRead;
-        private int numPositions;
-        private bool canFill = true;
+        private int NumPositions;
+        private bool CanFill = true;
 
         public struct NewScreenData
         {
@@ -1076,7 +1077,7 @@ namespace Orts.Formats.Msts
                         stf.MustMatch("(");
                         // If Positions are not filled before by Values
                         bool shouldFill = (Positions.Count == 0);
-                        numPositions = stf.ReadInt(null); // Number of Positions
+                        NumPositions = stf.ReadInt(null); // Number of Positions
 
                         var minPosition = 0;
                         var positionsRead = 0;
@@ -1117,20 +1118,20 @@ namespace Orts.Formats.Msts
 
                         // Check if eligible for filling
 
-                        if (Positions.Count > 1 && Positions[0] != 0) canFill = false;
+                        if (Positions.Count > 1 && Positions[0] != 0) CanFill = false;
                         else 
                         { 
                             for (var iPos = 1; iPos <= Positions.Count - 1; iPos++)
                             {
                                 if (Positions[iPos] > Positions[iPos-1]) continue;
-                                canFill = false;
+                                CanFill = false;
                                 break;
                             }
                         }
 
                         // This is a protection against GP40 locomotives that erroneously have positions pointing beyond frame count limit.
 
-                        if (Positions.Count > 1 && canFill && Positions.Count < FramesCount && Positions[Positions.Count-1] >= FramesCount && Positions[0] == 0)
+                        if (Positions.Count > 1 && CanFill && Positions.Count < FramesCount && Positions[Positions.Count-1] >= FramesCount && Positions[0] == 0)
                         {
                             STFException.TraceInformation(stf, "Some NumPositions entries refer to non-exisiting frames, trying to renumber");
                             Positions[Positions.Count - 1] = FramesCount - 1;
@@ -1155,7 +1156,7 @@ namespace Orts.Formats.Msts
                             }
                             // Avoid later repositioning, put every value to its Position
                             // But before resize Values if needed
-                            if (numValues != numPositions)
+                            if (numValues != NumPositions)
                             { 
                                 while (Values.Count <= Positions[_ValuesRead])
                                 {
@@ -1214,7 +1215,7 @@ namespace Orts.Formats.Msts
 
                     // Only shuffle data in following cases
 
-                    if (Values.Count != Positions.Count || (Values.Count < FramesCount & canFill)|| ( Values.Count > 0 && Values[0] == Values[Values.Count - 1] && Values[0] == 0))
+                    if (Values.Count != Positions.Count || (Values.Count < FramesCount & CanFill)|| ( Values.Count > 0 && Values[0] == Values[Values.Count - 1] && Values[0] == 0))
                     {
 
                         // Fixup Positions and Values collections first
@@ -1257,7 +1258,11 @@ namespace Orts.Formats.Msts
                             // Fill empty Values
                             for (int i = 0; i < (FramesCount - 1); i++)
                                 Values.Add(0);
-                            Values[0] = MinValue;
+                            // Some dummy controls will have only one frame
+                            if (Values.Count > 0)
+                                Values[0] = MinValue;
+                            else
+                                Values.Add(MinValue);
 
                             // Add maximum value to the end
                             Values.Add(MaxValue);
@@ -1353,13 +1358,21 @@ namespace Orts.Formats.Msts
                         break;
                 }
             }
-//            catch (Exception error)
-//            {
-//                if (error is STFException) // Parsing error, so pass it on
-//                    throw;
-//                else                       // Unexpected error, so provide a hint
-//                    throw new STFException(stf, "Problem with NumPositions/NumValues/NumFrames/ScaleRange");
-//            } // End of Need check the Values collection for validity
+            //            catch (Exception error)
+            //            {
+            //                if (error is STFException) // Parsing error, so pass it on
+            //                    throw;
+            //                else                       // Unexpected error, so provide a hint
+            //                    throw new STFException(stf, "Problem with NumPositions/NumValues/NumFrames/ScaleRange");
+            //            } // End of Need check the Values collection for validity
+
+            // Ensure resulting set of values has the correct format (sorted least to greatest) and resort
+            // Assume values have been entered in reverse order if final value is less than initial value
+            if (Values.Count > 0 && Values[0] > Values[Values.Count - 1])
+                Reversed = true;
+            // Force sort values from least to greatest
+            Values.Sort();
+
         } // End of Constructor
 
         protected void ParseNewScreen(STFReader stf)
@@ -1407,7 +1420,7 @@ namespace Orts.Formats.Msts
                             stf.ParseBlock( new STFReader.TokenProcessor[] {
                                 new STFReader.TokenProcessor("style", ()=>{ MSStyles.Add(ParseNumStyle(stf));
                                 }),
-                                new STFReader.TokenProcessor("switchval", ()=>{ Values.Add(stf.ReadFloatBlock(STFReader.UNITS.None, null))
+                                new STFReader.TokenProcessor("switchval", ()=>{ Values.Add(stf.ReadDoubleBlock(null))
                                 ; }),
                         });}),
                     });
@@ -1419,6 +1432,13 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
             });
+
+            // Ensure resulting set of values has the correct format (sorted least to greatest) and resort
+            // Assume values have been entered in reverse order if final value is less than initial value
+            if (Values.Count > 0 && Values[0] > Values[Values.Count - 1])
+                Reversed = true;
+            // Force sort values from least to greatest
+            Values.Sort();
         }
         protected int ParseNumStyle(STFReader stf)
         {
@@ -1457,7 +1477,7 @@ namespace Orts.Formats.Msts
                             stf.ParseBlock( new STFReader.TokenProcessor[] {
                                 new STFReader.TokenProcessor("style", ()=>{ MSStyles.Add(ParseNumStyle(stf));
                                 }),
-                                new STFReader.TokenProcessor("switchval", ()=>{ Values.Add(stf.ReadFloatBlock(STFReader.UNITS.None, null))
+                                new STFReader.TokenProcessor("switchval", ()=>{ Values.Add(stf.ReadDoubleBlock(null))
                                 ; }),
                         });}),
                     });
@@ -1469,6 +1489,13 @@ namespace Orts.Formats.Msts
                 new STFReader.TokenProcessor("ortsscreenpage", () => {ParseScreen(stf); }),
                 new STFReader.TokenProcessor("ortscabviewpoint", ()=>{ParseCabViewpoint(stf); }),
             });
+
+            // Ensure resulting set of values has the correct format (sorted least to greatest) and resort
+            // Assume values have been entered in reverse order if final value is less than initial value
+            if (Values.Count > 0 && Values[0] > Values[Values.Count - 1])
+                Reversed = true;
+            // Force sort values from least to greatest
+            Values.Sort();
         }
         protected int ParseNumStyle(STFReader stf)
         {

--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -1252,13 +1252,14 @@ namespace Orts.Formats.Msts
                             Positions.Add(0);
                             // We will need the FramesCount later!
                             // We use Positions only here
-                            Positions.Add(FramesCount);
+                            Positions.Add(FramesCount - 1);
 
                             // Fill empty Values
-                            for (int i = 0; i < FramesCount; i++)
+                            for (int i = 0; i < (FramesCount - 1); i++)
                                 Values.Add(0);
                             Values[0] = MinValue;
 
+                            // Add maximum value to the end
                             Values.Add(MaxValue);
                         }
                         else if (Values.Count == 2 && Values[0] == 0 && Values[1] < MaxValue && Positions[0] == 0 && Positions[1] == 1 && Values.Count < FramesCount)
@@ -1271,13 +1272,13 @@ namespace Orts.Formats.Msts
 			                //Orientation ( 0 )
 			                //DirIncrease ( 0 )
 			                //ScaleRange ( 0 1 )
-                            Positions.Add(FramesCount);
+                            Positions.Add(FramesCount - 1);
                             // Fill empty Values
-                            for (int i = Values.Count; i < FramesCount; i++)
+                            for (int i = Values.Count; i < (FramesCount - 1); i++)
                                 Values.Add(Values[1]);
+                            // Add maximum value to the end
                             Values.Add(MaxValue);                            
                         }
-
                         else
                         {
                             //This if clause covers among others following cases:
@@ -1303,11 +1304,6 @@ namespace Orts.Formats.Msts
                                 }
                                 iValues++;
                             }
-
-                            // Add the maximums to the end, the Value will be removed
-                            // We use Positions only here
-                            if (Values.Count > 0 && Values[0] <= Values[Values.Count - 1]) Values.Add(MaxValue);
-                            else if (Values.Count > 0 && Values[0] > Values[Values.Count - 1]) Values.Add(MinValue);
                         }
 
                         // OK, we have a valid size of Positions and Values
@@ -1333,9 +1329,6 @@ namespace Orts.Formats.Msts
                                 p = Positions[i];
                             }
                         }
-
-                        // Don't need the MaxValue added before, remove it
-                        Values.RemoveAt(Values.Count - 1);
                     }
                 }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -4731,7 +4731,7 @@ namespace Orts.Simulation.RollingStocks
                 return;
 
             // Only allow increasing dynamic brake if dynamic braking is off, there's no setup lock, or dynamic braking is already active
-            if (DynamicBrake || !DynamicBrakeControllerSetupLock || DynamicBrakeController.CurrentValue <= 0)
+            if (DynamicBrakeController != null && (DynamicBrake || !DynamicBrakeControllerSetupLock || DynamicBrakeController.CurrentValue <= 0))
             {
                 float prevValue = DynamicBrakeController.CurrentValue;
 
@@ -4767,7 +4767,7 @@ namespace Orts.Simulation.RollingStocks
         {
             // Only allow decreasing dynamic brake if dynamic brake isn't off
             // Note: For safety, this will allow decreasing the dynamic brake even if a mechanical interlock should have locked dynamic brake in off position
-            if (DynamicBrakeController.CurrentValue > 0)
+            if (DynamicBrakeController?.CurrentValue > 0)
             {
                 DynamicBrakeController.StartDecrease(target);
 
@@ -4878,7 +4878,7 @@ namespace Orts.Simulation.RollingStocks
         public bool CheckDisableDynamicBrake()
         {
             // Only disable the dynamic brake if the lever is in the off position and the controller isn't trying to increase
-            if (DynamicBrakeController.CurrentValue <= 0 && DynamicBrakeController.UpdateValue <= 0)
+            if (DynamicBrakeController?.CurrentValue <= 0 && DynamicBrakeController?.UpdateValue <= 0)
             {
                 StopDynamicBrakeDecrease();
                 Simulator.Confirmer.Confirm(CabControl.DynamicBrake, CabSetting.Off);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -478,6 +478,9 @@ namespace Orts.Simulation.RollingStocks
         public float ThrottleIntervention = -1;
         public float DynamicBrakeIntervention = -1;
 
+        // Has dynamic brake movement been paused to give user a chance to react?
+        private bool DynamicBrakePause = false;
+
         public enum TractionMotorTypes
         {
             DC,
@@ -1388,7 +1391,6 @@ namespace Orts.Simulation.RollingStocks
             outf.Write(PreviousGearBoxNotch);
             outf.Write(previousChangedGearBoxNotch);
             outf.Write(DynamicBrake);
-            outf.Write(DynamicBrakeIntervention);
             outf.Write(CurrentTrackSandBoxCapacityM3);
             outf.Write(CurrentTrackSanderSandConsumptionM3pS);
             outf.Write(CurrentTrackSanderAirConsumptionM3pS);
@@ -1448,7 +1450,6 @@ namespace Orts.Simulation.RollingStocks
             previousChangedGearBoxNotch = inf.ReadInt32();
 
             DynamicBrake = inf.ReadBoolean();
-            DynamicBrakeIntervention = inf.ReadSingle();
             CurrentTrackSandBoxCapacityM3 = inf.ReadSingle();
             CurrentTrackSanderSandConsumptionM3pS = inf.ReadSingle();
             CurrentTrackSanderAirConsumptionM3pS = inf.ReadSingle();
@@ -2105,10 +2106,10 @@ namespace Orts.Simulation.RollingStocks
                     if (DynamicBrakeCommandStartTime + DynamicBrakeDelayS < Simulator.ClockTime)
                     {
                         DynamicBrake = true; // Engage
-                        if (IsLeadLocomotive() && DynamicBrakeIntervention >= 0)
+                        if (IsLeadLocomotive() && DynamicBrakeController.CurrentValue > 0)
                             Simulator.Confirmer.ConfirmWithPerCent(CabControl.DynamicBrake, DynamicBrakeController.CurrentValue * 100);
                     }
-                    else if (IsLeadLocomotive() && DynamicBrakeIntervention >= 0)
+                    else if (IsLeadLocomotive() && DynamicBrakeController.CurrentValue > 0)
                         Simulator.Confirmer.Confirm(CabControl.DynamicBrake, CabSetting.On); // Keeping status string on screen so user knows what's happening
                 }
             }
@@ -2189,10 +2190,12 @@ namespace Orts.Simulation.RollingStocks
                     }
                     if (DynamicBrakeController != null && DynamicBrakeController.UpdateValue != 0.0 && (DynamicBrake || !DynamicBrakeControllerSetupLock))
                     {
-                        Simulator.Confirmer.UpdateWithPerCent(
-                            CabControl.DynamicBrake,
-                            DynamicBrakeController.UpdateValue > 0 ? CabSetting.Increase : CabSetting.Decrease,
-                            DynamicBrakeController.CurrentValue * 100);
+                        // Check if dynamic brake needs to be disabled before displaying control confirmation
+                        if (!CheckDisableDynamicBrake())
+                            Simulator.Confirmer.UpdateWithPerCent(
+                                CabControl.DynamicBrake,
+                                DynamicBrakeController.UpdateValue > 0 ? CabSetting.Increase : CabSetting.Decrease,
+                                DynamicBrakeController.CurrentValue * 100);
                     }
 
                     // SimpleControlPhysics and if locomotive is a control car advanced adhesion will be "disabled".
@@ -2391,18 +2394,27 @@ namespace Orts.Simulation.RollingStocks
             {
                 LocalDynamicBrakePercent = TrainBrakeController.TrainDynamicBrakeIntervention * 100;
             }
-            if (DynamicBrakeController != null && DynamicBrakeIntervention >= 0)
+            if (DynamicBrakeController != null && DynamicBrakeController.CurrentValue > 0)
             {
+                float prevValue = DynamicBrakeController.CurrentValue;
                 if (DynamicBrake || !DynamicBrakeControllerSetupLock)
-                {
                     DynamicBrakeController.Update(elapsedClockSeconds);
-                    DynamicBrakeIntervention = DynamicBrakeController.CurrentValue;
-                }
-                else
+                // Dynamic brake is about to be disabled, pause motion of controller to prevent accidental shut-off
+                if (DynamicBrakeController.CurrentValue <= 0)
                 {
-                    DynamicBrakeIntervention = 0;
+                    if (!DynamicBrakePause)
+                    {
+                        DynamicBrakePause = true;
+                        StopDynamicBrakeDecrease();
+                        DynamicBrakeController.CurrentValue = prevValue;
+                    }
+                    else
+                        DynamicBrakePause = false;
                 }
-                LocalDynamicBrakePercent = Math.Max(DynamicBrakeIntervention * 100, LocalDynamicBrakePercent);
+                else if (DynamicBrakeController.CurrentValue > prevValue)
+                    DynamicBrakePause = false;
+
+                LocalDynamicBrakePercent = Math.Max(DynamicBrakeController.CurrentValue * 100, LocalDynamicBrakePercent);
             }
             if (IsLeadLocomotive()) DynamicBrakePercent = LocalDynamicBrakePercent;
 
@@ -3593,7 +3605,7 @@ namespace Orts.Simulation.RollingStocks
                     checkBraking = false;
                 }
             }
-            if (DynamicBrakeController != null && DynamicBrakeIntervention >= 0 && checkBraking)
+            if (DynamicBrakeController != null && DynamicBrakeController.CurrentValue > 0 && checkBraking)
             {
                 if (!(CombinedControlType == CombinedControl.ThrottleDynamic
                     || CombinedControlType == CombinedControl.ThrottleAir && TrainBrakeController.CurrentValue > 0))
@@ -3603,7 +3615,7 @@ namespace Orts.Simulation.RollingStocks
                 }
             }
 
-            if (CombinedControlType == CombinedControl.ThrottleDynamic && DynamicBrakeIntervention >= 0)
+            if (CombinedControlType == CombinedControl.ThrottleDynamic && DynamicBrakeController.CurrentValue > 0)
                 StartDynamicBrakeDecrease(null);
             else if (CombinedControlType == CombinedControl.ThrottleAir && TrainBrakeController.CurrentValue > 0)
                 StartTrainBrakeDecrease(null);
@@ -4059,33 +4071,42 @@ namespace Orts.Simulation.RollingStocks
         /// </summary>
         public void SetCombinedHandleValue(float value)
         {
-            bool ccUseCombinedControl = CruiseControl != null && (CruiseControl.UseThrottleAsForceSelector || CruiseControl.UseThrottleAsSpeedSelector ) && CruiseControl.UseThrottleInCombinedControl; 
-            if (CombinedControlType == CombinedControl.ThrottleDynamic && DynamicBrakeIntervention >= 0 &&
+            bool ccUseCombinedControl = CruiseControl != null && (CruiseControl.UseThrottleAsForceSelector || CruiseControl.UseThrottleAsSpeedSelector ) && CruiseControl.UseThrottleInCombinedControl;
+            bool canBrake = ThrottleController.CurrentValue == 0;
+            if (ccUseCombinedControl && CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto)
+                canBrake = (CruiseControl.UseThrottleAsForceSelector && CruiseControl.SelectedMaxAccelerationPercent == 0) || (CruiseControl.UseThrottleAsSpeedSelector && CruiseControl.SelectedSpeedMpS == 0);
+
+            // Check if currently braking, update brake controllers accordingly
+            if (CombinedControlType == CombinedControl.ThrottleDynamic && DynamicBrakeController.CurrentValue > 0 &&
                 !(ccUseCombinedControl && !CruiseControl.DynamicBrakePriority && CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto))
             {
-                if (DynamicBrakeController.CurrentValue == 0 && value < CombinedControlSplitPosition)
-                    DynamicBrakeChangeActiveState(false);
-                else if (DynamicBrakeIntervention > -1)
-                    SetDynamicBrakeValue((MathHelper.Clamp(value, CombinedControlSplitPosition, 1) - CombinedControlSplitPosition) / (1 - CombinedControlSplitPosition));
+                SetDynamicBrakeValue((MathHelper.Clamp(value, CombinedControlSplitPosition, 1) - CombinedControlSplitPosition) / (1 - CombinedControlSplitPosition));
             }
             else if (CombinedControlType == CombinedControl.ThrottleAir && TrainBrakeController.CurrentValue > 0)
             {
                 SetTrainBrakeValue((MathHelper.Clamp(value, CombinedControlSplitPosition, 1) - CombinedControlSplitPosition) / (1 - CombinedControlSplitPosition));
             }
-            else
+            // Currently not braking, check if we need to start braking
+            else if (canBrake && value > CombinedControlSplitPosition)
             {
-                bool canBrake = ThrottleController.CurrentValue == 0;
-                if (ccUseCombinedControl && CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto) canBrake = (CruiseControl.UseThrottleAsForceSelector && CruiseControl.SelectedMaxAccelerationPercent == 0) || (CruiseControl.UseThrottleAsSpeedSelector && CruiseControl.SelectedSpeedMpS == 0);
-                if (CombinedControlType == CombinedControl.ThrottleDynamic && canBrake && value > CombinedControlSplitPosition)
-                {
-                    DynamicBrakeChangeActiveState(true);
-                    if (CruiseControl != null && CruiseControl.DynamicBrakeCommandHasPriorityOverCruiseControl) CruiseControl.DynamicBrakePriority = true;
-                }
-                else if (CombinedControlType == CombinedControl.ThrottleAir && canBrake && value > CombinedControlSplitPosition)
+                if (CombinedControlType == CombinedControl.ThrottleDynamic)
+                    SetDynamicBrakeValue((MathHelper.Clamp(value, CombinedControlSplitPosition, 1) - CombinedControlSplitPosition) / (1 - CombinedControlSplitPosition));
+                else if (CombinedControlType == CombinedControl.ThrottleAir)
                     SetTrainBrakeValue((MathHelper.Clamp(value, CombinedControlSplitPosition, 1) - CombinedControlSplitPosition) / (1 - CombinedControlSplitPosition));
-                else if (DynamicBrakeIntervention < 0 ||
-                    (CruiseControl != null && !CruiseControl.DynamicBrakePriority && CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto))
-                    SetThrottleValue(1 - MathHelper.Clamp(value, 0, CombinedControlSplitPosition) / CombinedControlSplitPosition);
+
+                // Set throttle intermediate value to 0 to remove any garbage data left over
+                ThrottleController.IntermediateValue = 0;
+            }
+            // Return to throttling
+            else if ((DynamicBrakeController.CurrentValue <= 0 && value < CombinedControlSplitPosition) ||
+                (CruiseControl != null && !CruiseControl.DynamicBrakePriority && CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto))
+            {
+                SetThrottleValue(1 - MathHelper.Clamp(value, 0, CombinedControlSplitPosition) / CombinedControlSplitPosition);
+
+                if (CombinedControlType == CombinedControl.ThrottleAir)
+                    TrainBrakeController.IntermediateValue = 0;
+                else if (CombinedControlType == CombinedControl.ThrottleDynamic)
+                    DynamicBrakeController.IntermediateValue = 0;
             }
         }
 
@@ -4097,6 +4118,10 @@ namespace Orts.Simulation.RollingStocks
         /// <returns>Combined position into 0-1 range, where arrangement is [[1--throttle--0]split[0--dynamic|airbrake--1]]</returns>
         public float GetCombinedHandleValue(bool intermediateValue)
         {
+            float throttleValue = intermediateValue ? ThrottleController.IntermediateValue : ThrottleController.CurrentValue;
+            float dynamicsValue = intermediateValue ? DynamicBrakeController.IntermediateValue : DynamicBrakeController.CurrentValue;
+            float brakesValue = intermediateValue ? TrainBrakeController.IntermediateValue : TrainBrakeController.CurrentValue;
+
             if (CruiseControl?.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto)
             {
                 if (CruiseControl.SelectedMaxAccelerationPercent != 0 && CruiseControl.HasIndependentThrottleDynamicBrakeLever)
@@ -4112,30 +4137,19 @@ namespace Orts.Simulation.RollingStocks
                 }
             }
 
-            if (CombinedControlType == CombinedControl.ThrottleDynamic && DynamicBrakeIntervention >= 0)
+            if (CombinedControlType == CombinedControl.ThrottleDynamic && throttleValue <= 0 && dynamicsValue > 0)
             {
-                if (CruiseControl != null)
-                {
-                    if (CruiseControl.SkipThrottleDisplay && !CruiseControl.DynamicBrakeCommandHasPriorityOverCruiseControl)
-                    {
-                        return CombinedControlSplitPosition;
-                    }
-                    else
-                    {
-                        return CombinedControlSplitPosition + (1 - CombinedControlSplitPosition) * (intermediateValue ? DynamicBrakeController.IntermediateValue : DynamicBrakeController.CurrentValue);
-                    }
-                }
+                if (CruiseControl != null && CruiseControl.SkipThrottleDisplay && !CruiseControl.DynamicBrakeCommandHasPriorityOverCruiseControl)
+                    return CombinedControlSplitPosition;
                 else
-                {
-                    return CombinedControlSplitPosition + (1 - CombinedControlSplitPosition) * (intermediateValue ? DynamicBrakeController.IntermediateValue : DynamicBrakeController.CurrentValue);
-                }
+                    return CombinedControlSplitPosition + (1 - CombinedControlSplitPosition) * dynamicsValue;
             }
-            else if (CombinedControlType == CombinedControl.ThrottleAir && TrainBrakeController.CurrentValue > 0)
-                return CombinedControlSplitPosition + (1 - CombinedControlSplitPosition) * (intermediateValue ? TrainBrakeController.IntermediateValue : TrainBrakeController.CurrentValue);
+            else if (CombinedControlType == CombinedControl.ThrottleAir && throttleValue <= 0 && brakesValue > 0)
+                return CombinedControlSplitPosition + (1 - CombinedControlSplitPosition) * brakesValue;
             else if (CruiseControl == null)
-                return CombinedControlSplitPosition * (1 - (intermediateValue ? ThrottleController.IntermediateValue : ThrottleController.CurrentValue));
+                return CombinedControlSplitPosition * (1 - throttleValue);
             else if (CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Manual)
-                return CombinedControlSplitPosition * (1 - (intermediateValue ? ThrottleController.IntermediateValue : ThrottleController.CurrentValue));
+                return CombinedControlSplitPosition * (1 - throttleValue);
             else if (CruiseControl.UseThrottleAsSpeedSelector)
                 return CombinedControlSplitPosition * (1 - (CruiseControl.SelectedSpeedMpS / MaxSpeedMpS));
             else if (CruiseControl.UseThrottleAsForceSelector && CruiseControl.UseThrottleInCombinedControl)
@@ -4700,7 +4714,6 @@ namespace Orts.Simulation.RollingStocks
                 Simulator.Confirmer.Warning(CabControl.DynamicBrake, CabSetting.Warn1);
                 return;
             }
-            AlerterReset(TCSEvent.DynamicBrakeChanged);
             if (CruiseControl != null && CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto && (CruiseControl.DynamicBrakeCommandHasPriorityOverCruiseControl ||
                 (CruiseControl.DisableCruiseControlOnThrottleAndZeroForce && CruiseControl.SelectedMaxAccelerationPercent == 0)))
             {
@@ -4710,14 +4723,13 @@ namespace Orts.Simulation.RollingStocks
             if (!CanUseDynamicBrake())
                 return;
 
-            if (DynamicBrakeIntervention < 0)
+            // Only allow increasing dynamic brake if dynamic braking is off, there's no setup lock, or dynamic braking is already active
+            if (DynamicBrake || !DynamicBrakeControllerSetupLock || DynamicBrakeController.CurrentValue <= 0)
             {
-                DynamicBrakeChangeActiveState(true);
-            }
-            else if (DynamicBrake || !DynamicBrakeControllerSetupLock)
-            {
-                SignalEvent(Event.DynamicBrakeChange);
                 DynamicBrakeController.StartIncrease(target);
+
+                AlerterReset(TCSEvent.DynamicBrakeChanged);
+                SignalEvent(Event.DynamicBrakeChange);
                 if (!HasSmoothStruc)
                 {
                     StopDynamicBrakeIncrease();
@@ -4738,29 +4750,23 @@ namespace Orts.Simulation.RollingStocks
 
         public void StartDynamicBrakeDecrease(float? target)
         {
-            if (Direction == Direction.N)
+            // Only allow decreasing dynamic brake if dynamic brake isn't off
+            // Note: For safety, this will allow decreasing the dynamic brake even if a mechanical interlock should have locked dynamic brake in off position
+            if (DynamicBrakeController.CurrentValue > 0)
             {
-                Simulator.Confirmer.Warning(CabControl.DynamicBrake, CabSetting.Warn1);
-                return;
-            }
-            AlerterReset(TCSEvent.DynamicBrakeChanged);
-            if (!CanUseDynamicBrake())
-                return;
-
-            if (DynamicBrakeIntervention <= 0)
-            {
-                DynamicBrakeChangeActiveState(false);
-            }
-            else if (DynamicBrake || !DynamicBrakeControllerSetupLock)
-            {
-                SignalEvent(Event.DynamicBrakeChange);
                 DynamicBrakeController.StartDecrease(target);
+
+                AlerterReset(TCSEvent.DynamicBrakeChanged);
+                SignalEvent(Event.DynamicBrakeChange);
                 if (!HasSmoothStruc)
                 {
                     StopDynamicBrakeDecrease();
-                    Simulator.Confirmer.ConfirmWithPerCent(CabControl.DynamicBrake, DynamicBrakeController.CurrentValue * 100);
+                    if (!CheckDisableDynamicBrake())
+                        Simulator.Confirmer.ConfirmWithPerCent(CabControl.DynamicBrake, DynamicBrakeController.CurrentValue * 100);
+                    return;
                 }
             }
+            CheckDisableDynamicBrake();
         }
 
         public void StopDynamicBrakeDecrease()
@@ -4793,33 +4799,38 @@ namespace Orts.Simulation.RollingStocks
 
         public void SetDynamicBrakeValue(float value)
         {
-            if (DynamicBrakeIntervention < 0 && ThrottleController.CurrentValue == 0 && value > 0.05f)
+            // Always allow dynamic brake decrease, but only allow dynamic brake increase with specific conditions
+            if (value > DynamicBrakeController.CurrentValue)
             {
-                DynamicBrakeChangeActiveState(true);
-                if (CruiseControl != null && CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto && CruiseControl.DynamicBrakeCommandHasPriorityOverCruiseControl)
+                if (Direction == Direction.N)
                 {
-                    CruiseControl.DynamicBrakePriority = true;
+                    Simulator.Confirmer.Warning(CabControl.DynamicBrake, CabSetting.Warn1);
+                    return;
                 }
+                if (!CanUseDynamicBrake())
+                    return;
+                if (!DynamicBrake && DynamicBrakeControllerSetupLock && DynamicBrakeController.CurrentValue > 0)
+                    return;
+                if (CruiseControl != null && CruiseControl.UseThrottleAsForceSelector && !CruiseControl.DynamicBrakePriority && !CruiseControl.UseThrottleInCombinedControl)
+                    return;
             }
-            if (DynamicBrakeIntervention >= 0 && DynamicBrakeController.CurrentValue == 0 && value < -0.05f)
-            {
-                DynamicBrakeChangeActiveState(false);
-                return;
-            }
-            if ((!DynamicBrake && DynamicBrakeControllerSetupLock) || CruiseControl != null && CruiseControl.UseThrottleAsForceSelector && !CruiseControl.DynamicBrakePriority && !CruiseControl.UseThrottleInCombinedControl)
-                return;
 
-            var controller = DynamicBrakeController;
-            var oldValue = controller.IntermediateValue;
-            var change = controller.SetValue(value);
+            var oldValue = DynamicBrakeController.IntermediateValue;
+            var change = DynamicBrakeController.SetValue(value);
             if (change != 0)
             {
-                new DynamicBrakeCommand(Simulator.Log, change > 0, controller.CurrentValue, Simulator.ClockTime);
+                new DynamicBrakeCommand(Simulator.Log, change > 0, DynamicBrakeController.CurrentValue, Simulator.ClockTime);
                 SignalEvent(Event.DynamicBrakeChange);
                 AlerterReset(TCSEvent.DynamicBrakeChanged);
             }
-            if (oldValue != controller.IntermediateValue)
-                Simulator.Confirmer.UpdateWithPerCent(CabControl.DynamicBrake, oldValue < controller.IntermediateValue ? CabSetting.Increase : CabSetting.Decrease, DynamicBrakeController.CurrentValue * 100);
+            if (oldValue != DynamicBrakeController.IntermediateValue && !CheckDisableDynamicBrake())
+                Simulator.Confirmer.UpdateWithPerCent(CabControl.DynamicBrake, oldValue < DynamicBrakeController.IntermediateValue ? CabSetting.Increase : CabSetting.Decrease, DynamicBrakeController.CurrentValue * 100);
+
+            if (ThrottleController.CurrentValue <= 0 && DynamicBrakeController.CurrentValue > 0)
+            {
+                if (CruiseControl != null && CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto && CruiseControl.DynamicBrakeCommandHasPriorityOverCruiseControl)
+                    CruiseControl.DynamicBrakePriority = true;
+            }
         }
 
         public void SetDynamicBrakePercent(float percent)
@@ -4832,7 +4843,6 @@ namespace Orts.Simulation.RollingStocks
             if (!CanUseDynamicBrake())
                 return;
             DynamicBrakeController.SetPercent(percent);
-            DynamicBrakeChangeActiveState(percent >= 0);
         }
 
         public void SetDynamicBrakePercentWithSound(float percent)
@@ -4850,22 +4860,16 @@ namespace Orts.Simulation.RollingStocks
                 SignalEvent(Event.DynamicBrakeChange);
         }
 
-        public void DynamicBrakeChangeActiveState(bool toState)
+        public bool CheckDisableDynamicBrake()
         {
-            if (toState && DynamicBrakeIntervention < 0)
+            if (DynamicBrakeController.CurrentValue <= 0)
             {
-                DynamicBrakeIntervention = 0;
-                DynamicBrakeController.CommandStartTime = Simulator.ClockTime;
-                StopDynamicBrakeIncrease();
-            }
-            else if (!toState && DynamicBrakeIntervention > -1)
-            {
-                DynamicBrakeIntervention = -1;
-                DynamicBrakeController.CommandStartTime = Simulator.ClockTime;
-                StopDynamicBrakeIncrease();
+                StopDynamicBrakeDecrease();
                 Simulator.Confirmer.Confirm(CabControl.DynamicBrake, CabSetting.Off);
                 SignalEvent(Event.DynamicBrakeOff);
+                return true;
             }
+            return false;
         }
 
         protected bool CanUseDynamicBrake()

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/CruiseControl.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/CruiseControl.cs
@@ -1034,8 +1034,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 // return back to manual, clear all we have controlled before and let the driver to set up new stuff
                 SpeedRegMode = SpeedRegulatorMode.Manual;
                 //                Locomotive.ThrottleController.SetPercent(0);
-                //                Locomotive.SetDynamicBrakePercent(0);
-                Locomotive.DynamicBrakeChangeActiveState(false);
+                Locomotive.SetDynamicBrakePercent(0);
             }
             if (SelectedSpeedMpS == 0)
             {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -426,7 +426,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.SetDynamicBrakeController = (value) =>
                 {
                 if (Locomotive.DynamicBrakeController == null) return;
-                Locomotive.DynamicBrakeChangeActiveState(value > 0);
                 Locomotive.DynamicBrakeController.SetValue(value);
                 };
                 Script.SetPantographsDown = () =>

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2147,10 +2147,8 @@ namespace Orts.Viewer3D.RollingStock
                         {
                             if (Locomotive.CruiseControl != null)
                             {
-                                if ((Locomotive.CruiseControl.SpeedRegMode == Simulation.RollingStocks.SubSystems.CruiseControl.SpeedRegulatorMode.Auto && !Locomotive.CruiseControl.DynamicBrakePriority) || Locomotive.DynamicBrakeIntervention > 0)
-                                {
+                                if (Locomotive.CruiseControl.SpeedRegMode == Simulation.RollingStocks.SubSystems.CruiseControl.SpeedRegulatorMode.Auto && !Locomotive.CruiseControl.DynamicBrakePriority)
                                     index = 0;
-                                }
                                 else
                                     index = PercentToIndex(dynBrakePercent);
                             }

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2130,7 +2130,8 @@ namespace Orts.Viewer3D.RollingStock
                     break;
                 case CABViewControlTypes.DYNAMIC_BRAKE:
                 case CABViewControlTypes.DYNAMIC_BRAKE_DISPLAY:
-                    var dynBrakePercent = Locomotive.DynamicBrakeController.CurrentValue;
+                    var dynBrakePercent = Locomotive.Train.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING ?
+                        Locomotive.DynamicBrakePercent : Locomotive.LocalDynamicBrakePercent;
                     if (Locomotive.DynamicBrakeController != null)
                     {
                         if (dynBrakePercent <= 0)

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2134,13 +2134,18 @@ namespace Orts.Viewer3D.RollingStock
                         Locomotive.DynamicBrakePercent : Locomotive.LocalDynamicBrakePercent;
                     if (dynBrakePercent <= 0)
                         index = 0;
-                    else if (!Locomotive.HasSmoothStruc && Locomotive.DynamicBrakeController != null)
-                        index = Locomotive.DynamicBrakeController.CurrentNotch;
+                    else if (Locomotive.DynamicBrakeController != null)
+                    {
+                        if (!Locomotive.HasSmoothStruc)
+                            index = Locomotive.DynamicBrakeController.CurrentNotch;
+                        else
+                            index = PercentToIndex(Locomotive.DynamicBrakeController.CurrentValue);
+                    }
                     else
                         index = PercentToIndex(dynBrakePercent);
                     break;
                 case CABViewControlTypes.CPH_DISPLAY:
-                    if (Locomotive.CombinedControlType == MSTSLocomotive.CombinedControl.ThrottleDynamic && Locomotive.DynamicBrakePercent >= 0)
+                    if (Locomotive.CombinedControlType == MSTSLocomotive.CombinedControl.ThrottleDynamic && Locomotive.DynamicBrakeController?.CurrentValue > 0)
                         // TODO <CSComment> This is a sort of hack to allow MSTS-compliant operation of Dynamic brake indications in the standard USA case with 8 steps (e.g. Dash9)
                         // This hack returns to code of previous OR versions (e.g. release 1.0).
                         // The clean solution for MSTS compliance would be not to increment the percentage of the dynamic brake at first dynamic brake key pression, so that
@@ -2150,8 +2155,8 @@ namespace Orts.Viewer3D.RollingStock
                         index = PercentToIndex(Locomotive.GetCombinedHandleValue(false));
                     break;
                 case CABViewControlTypes.CP_HANDLE:
-                    if (Locomotive.CombinedControlType == MSTSLocomotive.CombinedControl.ThrottleDynamic && Locomotive.DynamicBrakePercent >= 0
-                            || Locomotive.CombinedControlType == MSTSLocomotive.CombinedControl.ThrottleAir && Locomotive.TrainBrakeController.CurrentValue > 0)
+                    if (Locomotive.CombinedControlType == MSTSLocomotive.CombinedControl.ThrottleDynamic && Locomotive.DynamicBrakeController?.CurrentValue > 0
+                            || Locomotive.CombinedControlType == MSTSLocomotive.CombinedControl.ThrottleAir && Locomotive.TrainBrakeController?.CurrentValue > 0)
                             index = PercentToIndex(Locomotive.GetCombinedHandleValue(false));
                         else
                             index = PercentToIndex(Locomotive.GetCombinedHandleValue(false));

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2041,8 +2041,18 @@ namespace Orts.Viewer3D.RollingStock
                     break;
                 default: ChangedValue = (value) => value + NormalizedMouseMovement(); break;
             }
-            // The cab view control index shown when combined control is at the split position
-            SplitIndex = PercentToIndex(Locomotive.CombinedControlSplitPosition);
+            // Determine the cab view control index shown when combined control is at the split position
+            // Find the index of the next value LARGER than the split value
+            int splitIndex = ControlDiscrete.Values.BinarySearch(Locomotive.CombinedControlSplitPosition);
+            // Account for any edge cases
+            if (splitIndex < 0)
+                splitIndex = ~splitIndex;
+            if (splitIndex > ControlDiscrete.Values.Count - 1)
+                splitIndex = ControlDiscrete.Values.Count - 1;
+            if (ControlDiscrete.Reversed)
+                splitIndex = (ControlDiscrete.Values.Count - 1) - splitIndex;
+
+            SplitIndex = splitIndex;
         }
 
         public override void PrepareFrame(RenderFrame frame, ElapsedTime elapsedTime)
@@ -2151,13 +2161,14 @@ namespace Orts.Viewer3D.RollingStock
                 case CABViewControlTypes.CP_HANDLE:
                     var combinedHandlePosition = Locomotive.GetCombinedHandleValue(false);
                     index = PercentToIndex(combinedHandlePosition);
-                    // Make sure power indications are not shown when locomotive is in braking range
-                    if (combinedHandlePosition > Locomotive.CombinedControlSplitPosition)
+                    // Make sure any deviation from the split position gives a different index
+                    int handleRelativePos = combinedHandlePosition.CompareTo(Locomotive.CombinedControlSplitPosition);
+                    if (handleRelativePos != 0)
                     {
-                        if (ControlDiscrete.Reversed)
-                            index = Math.Min(index, SplitIndex - 1);
-                        else
+                        if (handleRelativePos == (ControlDiscrete.Reversed ? - 1 : 1))
                             index = Math.Max(index, SplitIndex + 1);
+                        else
+                            index = Math.Min(index, SplitIndex - 1);
                     }
                     break;
                 case CABViewControlTypes.ORTS_SELECTED_SPEED_DISPLAY:

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -118,7 +118,7 @@ namespace Orts.Viewer3D.RollingStock
         {
             if (Locomotive.Direction != Direction.Forward
             && (Locomotive.ThrottlePercent >= 1
-            || Math.Abs(Locomotive.SpeedMpS) > 1 || Locomotive.DynamicBrakeIntervention >= 0))
+            || Math.Abs(Locomotive.SpeedMpS) > 1 || Locomotive.DynamicBrakeController.CurrentValue > 0))
             {
                 Viewer.Simulator.Confirmer.Warning(CabControl.Reverser, CabSetting.Warn1);
                 return;
@@ -130,7 +130,7 @@ namespace Orts.Viewer3D.RollingStock
         {
             if (Locomotive.Direction != Direction.Reverse
             && (Locomotive.ThrottlePercent >= 1
-            || Math.Abs(Locomotive.SpeedMpS) > 1 || Locomotive.DynamicBrakeIntervention >= 0))
+            || Math.Abs(Locomotive.SpeedMpS) > 1 || Locomotive.DynamicBrakeController.CurrentValue > 0))
             {
                 Viewer.Simulator.Confirmer.Warning(CabControl.Reverser, CabSetting.Warn1);
                 return;
@@ -2130,31 +2130,18 @@ namespace Orts.Viewer3D.RollingStock
                     break;
                 case CABViewControlTypes.DYNAMIC_BRAKE:
                 case CABViewControlTypes.DYNAMIC_BRAKE_DISPLAY:
-                    var dynBrakePercent = Locomotive.Train.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING ?
-                        Locomotive.DynamicBrakePercent : Locomotive.LocalDynamicBrakePercent;
+                    var dynBrakePercent = Locomotive.DynamicBrakeController.CurrentValue;
                     if (Locomotive.DynamicBrakeController != null)
                     {
-                        if (dynBrakePercent == -1)
+                        if (dynBrakePercent <= 0)
                         {
                             index = 0;
                             break;
                         }
                         if (!Locomotive.HasSmoothStruc)
-                        {
                             index = Locomotive.DynamicBrakeController != null ? Locomotive.DynamicBrakeController.CurrentNotch : 0;
-                        }
                         else
-                        {
-                            if (Locomotive.CruiseControl != null)
-                            {
-                                if (Locomotive.CruiseControl.SpeedRegMode == Simulation.RollingStocks.SubSystems.CruiseControl.SpeedRegulatorMode.Auto && !Locomotive.CruiseControl.DynamicBrakePriority)
-                                    index = 0;
-                                else
-                                    index = PercentToIndex(dynBrakePercent);
-                            }
-                            else
-                                index = PercentToIndex(dynBrakePercent);
-                        }
+                            index = PercentToIndex(dynBrakePercent);
                     }
                     else
                     {

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -118,7 +118,7 @@ namespace Orts.Viewer3D.RollingStock
         {
             if (Locomotive.Direction != Direction.Forward
             && (Locomotive.ThrottlePercent >= 1
-            || Math.Abs(Locomotive.SpeedMpS) > 1 || Locomotive.DynamicBrakeController.CurrentValue > 0))
+            || Math.Abs(Locomotive.SpeedMpS) > 1 || Locomotive.DynamicBrakeController?.CurrentValue > 0))
             {
                 Viewer.Simulator.Confirmer.Warning(CabControl.Reverser, CabSetting.Warn1);
                 return;
@@ -130,7 +130,7 @@ namespace Orts.Viewer3D.RollingStock
         {
             if (Locomotive.Direction != Direction.Reverse
             && (Locomotive.ThrottlePercent >= 1
-            || Math.Abs(Locomotive.SpeedMpS) > 1 || Locomotive.DynamicBrakeController.CurrentValue > 0))
+            || Math.Abs(Locomotive.SpeedMpS) > 1 || Locomotive.DynamicBrakeController?.CurrentValue > 0))
             {
                 Viewer.Simulator.Confirmer.Warning(CabControl.Reverser, CabSetting.Warn1);
                 return;
@@ -2132,22 +2132,12 @@ namespace Orts.Viewer3D.RollingStock
                 case CABViewControlTypes.DYNAMIC_BRAKE_DISPLAY:
                     var dynBrakePercent = Locomotive.Train.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING ?
                         Locomotive.DynamicBrakePercent : Locomotive.LocalDynamicBrakePercent;
-                    if (Locomotive.DynamicBrakeController != null)
-                    {
-                        if (dynBrakePercent <= 0)
-                        {
-                            index = 0;
-                            break;
-                        }
-                        if (!Locomotive.HasSmoothStruc)
-                            index = Locomotive.DynamicBrakeController != null ? Locomotive.DynamicBrakeController.CurrentNotch : 0;
-                        else
-                            index = PercentToIndex(dynBrakePercent);
-                    }
+                    if (dynBrakePercent <= 0)
+                        index = 0;
+                    else if (!Locomotive.HasSmoothStruc && Locomotive.DynamicBrakeController != null)
+                        index = Locomotive.DynamicBrakeController.CurrentNotch;
                     else
-                    {
                         index = PercentToIndex(dynBrakePercent);
-                    }
                     break;
                 case CABViewControlTypes.CPH_DISPLAY:
                     if (Locomotive.CombinedControlType == MSTSLocomotive.CombinedControl.ThrottleDynamic && Locomotive.DynamicBrakePercent >= 0)

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2160,16 +2160,17 @@ namespace Orts.Viewer3D.RollingStock
                 case CABViewControlTypes.CPH_DISPLAY:
                 case CABViewControlTypes.CP_HANDLE:
                     var combinedHandlePosition = Locomotive.GetCombinedHandleValue(false);
-                    index = PercentToIndex(combinedHandlePosition);
                     // Make sure any deviation from the split position gives a different index
                     int handleRelativePos = combinedHandlePosition.CompareTo(Locomotive.CombinedControlSplitPosition);
                     if (handleRelativePos != 0)
                     {
                         if (handleRelativePos == (ControlDiscrete.Reversed ? - 1 : 1))
-                            index = Math.Max(index, SplitIndex + 1);
+                            index = Math.Max(PercentToIndex(combinedHandlePosition), SplitIndex + 1);
                         else
-                            index = Math.Min(index, SplitIndex - 1);
+                            index = Math.Min(PercentToIndex(combinedHandlePosition), SplitIndex - 1);
                     }
+                    else
+                        index = SplitIndex;
                     break;
                 case CABViewControlTypes.ORTS_SELECTED_SPEED_DISPLAY:
                     if (Locomotive.CruiseControl == null)

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -2153,7 +2153,12 @@ namespace Orts.Viewer3D.RollingStock
                     index = PercentToIndex(combinedHandlePosition);
                     // Make sure power indications are not shown when locomotive is in braking range
                     if (combinedHandlePosition > Locomotive.CombinedControlSplitPosition)
-                        index = Math.Max(index, SplitIndex + 1);
+                    {
+                        if (ControlDiscrete.Reversed)
+                            index = Math.Min(index, SplitIndex - 1);
+                        else
+                            index = Math.Max(index, SplitIndex + 1);
+                    }
                     break;
                 case CABViewControlTypes.ORTS_SELECTED_SPEED_DISPLAY:
                     if (Locomotive.CruiseControl == null)
@@ -2811,33 +2816,25 @@ namespace Orts.Viewer3D.RollingStock
                 try
                 {
                     // Binary search process to find the control value closest to percent
-                    List<double> vals = ControlDiscrete.Values;
-                    // Check if control values were defined in reverse, reverse them back for this calculation
-                    // This is less efficient, so creators should be encouraged to not do this
-                    bool reversed = ControlDiscrete.Values[0] > ControlDiscrete.Values[ControlDiscrete.Values.Count - 1];
-                    if (reversed)
-                        vals.Reverse();
-
-                    // Returns index of first val larger than percent, or bitwise compliment of this index if percent isn't in the list
-                    int checkIndex = vals.BinarySearch(percent);
+                    // Returns index of first val LARGER than percent, or bitwise compliment of this index if percent isn't in the list
+                    int checkIndex = ControlDiscrete.Values.BinarySearch(percent);
 
                     if (checkIndex < 0)
                         checkIndex = ~checkIndex;
-                    if (checkIndex > vals.Count - 1)
-                        checkIndex = vals.Count - 1;
+                    if (checkIndex > ControlDiscrete.Values.Count - 1)
+                        checkIndex = ControlDiscrete.Values.Count - 1;
                     // Choose lower index if it is closer to percent
-                    if (checkIndex > 0 && Math.Abs(vals[checkIndex - 1] - percent) < Math.Abs(vals[checkIndex] - percent))
+                    if (checkIndex > 0 && Math.Abs(ControlDiscrete.Values[checkIndex - 1] - percent) < Math.Abs(ControlDiscrete.Values[checkIndex] - percent))
                         checkIndex--;
-                    // Re-reverse the index as needed
-                    if (reversed)
-                        checkIndex = (vals.Count - 1) - checkIndex;
+                    // If values were originally defined in reverse, correct index to account for the reversing
+                    if (ControlDiscrete.Reversed)
+                        checkIndex = (ControlDiscrete.Values.Count - 1) - checkIndex;
 
                     index = checkIndex;
                 }
                 catch
                 {
-                    var val = ControlDiscrete.Values.Min();
-                    index = ControlDiscrete.Values.IndexOf(val);
+                    index = ControlDiscrete.Reversed ? ControlDiscrete.Values.Count - 1 : 0;
                 }
             }
             else if (ControlDiscrete.MaxValue != ControlDiscrete.MinValue)


### PR DESCRIPTION
Due to some relatively recent improvements in dynamic brake behavior, particularly PR #874, parts of the dynamic brake control and display code have become bloated with workarounds that are no longer needed, which are resulting in some unrealistic and unintended behaviors when combined with the updated behaviors. This PR reworks much of the dynamic brake handling and cab view display to closer match reality, simplify the code, and provide more robust handling of user input.

- Dynamic brakes are enabled if the dynamic brake lever is set above 0%, disabled if the lever is at 0%; it is no longer possible to enter the confusing state where the dynamic brake lever is set to off but the dynamic brakes remain active
- Side effect: Except in some edge cases, it will no longer be possible to have the dynamic brakes enabled and producing no braking force-this is per reality
- Tracking of whether or not the dynamic brakes should be enabled or disabled is now done directly based on the position of the dynamic brake handle
- Removed significant redundant code, variables, and functions related to determining whether or not the dynamic brake is enabled or disabled
- Reworked some of the combined handle code to more reliably handle transition between power and braking, especially in mouse controls
- Removed now-unneeded checks related to cruise control in the dynamic brake cab view code (this was preventing dynamic brake displays from working correctly)
- Improved consistency of dynamic brake interlocking (with reverser and with throttle) in all control styles (combined and split) and control modes (keyboard, mouse...unsure of raildriver since that behaves differently); should be much harder to produce a situation where the throttle and dynamic brakes are applied simultaneously
- Refactored how control animation frames are selected to improve tolerance to user errors, especially when control values are entered in the wrong order, (including some errors in original MSTS cab views) and more reliably produce the indications expected for the situation at hand (specifically combined controls)

https://bugs.launchpad.net/or/+bug/2066456