### PR TITLE
Fix .ace Textures Not Being Used as Fallback for Missing .dds

### DIFF
--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -79,7 +79,7 @@ namespace Orts.Viewer3D
                             if (File.Exists(aceTexture))
                             {
                                 texture = Orts.Formats.Msts.AceFile.Texture2DFromFile(GraphicsDevice, aceTexture);
-                                Trace.TraceWarning("Required texture {1} not existing; using existing texture {2}", path, aceTexture);
+                                Trace.TraceWarning("Required texture {0} not existing; using existing texture {1}", path, aceTexture);
                             }
                             else return defaultTexture;
                         }


### PR DESCRIPTION
Five years ago, PR #63 added support for .ace textures to replace missing .dds textures, so long as the .ace texture had the same name as the .dds texture. As I'm sure [many in the community have discovered](https://www.trainsim.com/forums/forum/open-rails/open-rails-discussion/2303777-first-time-install-of-wp3-has-no-track-or-roadbed) first hand, this simply does not happen in any current builds of OR. A shape looking for .dds textures will show the default texture even when a suitable .ace is present.

This is because of PR #64, which was supposed to add a warning message to show when a .dds was replaced with a .ace, but instead broke this process because the string formatting was set up incorrectly (used 1-indexing when string format uses 0-indexing). The resulting index out of bounds exception is caught, so no crash happens, but the catch statement for this part of the code causes the default texture to be used and a missing texture error to be added to the log (ie: the same behavior as if neither pull request existed).

Getting on my soapbox for a moment here, I am baffled that, **A**: nobody noticed the syntax error in #64 before merging it, **B**: nobody acted on the fact that #63 stopped functioning as intended after #64 was merged, and **C**: after _years_ of community members reporting frustration with missing textures (that ultimately were because the shape files were looking for .dds and refused to use the .ace of the same name) nobody re-investigated the issue until I got curious enough to check what was going on. This series of mistakes would be much harder now considering the regular updates to the unstable version and the eagle-eyed community noticing when there's even the slightest regression between adjacent unstable builds (as long as there is a discussion going on telling the community what should be happening).

This PR finally fixes that basic mistake, so no more grey track textures unless the user is actually missing the textures they need.