### PR TITLE
Investigation - Pulsing graphics

### DIFF
--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -567,10 +567,8 @@ namespace Orts.Simulation.Signalling
 
             if (foundSignals > 0)
             {
-                // loop through all signals
-```            // loop through all the signals, but only one batch of signals with every call to this method.
-                // update required part
-```             // update one batch of signals. Batch ends when time taken exceeds 1/20th of time for all signals.
+                // loop through all the signals, but only one batch of signals with every call to this method.
+                // update one batch of signals. Batch ends when time taken exceeds 1/20th of time for all signals.
                 // Processing 1/20th of signals in each batch gave a jerky result as processing time varies greatly.
                 // Smoother results now that equal time is given to each batch and let the batch size vary.
                 var updates = 0;

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -567,7 +567,7 @@ namespace Orts.Simulation.Signalling
                 // update required part
                 // in preupdate, process all
 
-                int totalSignal = SignalObjects.Length - 1;
+                int totalSignal = foundSignals;
 
                 int updatestep = (totalSignal / 20) + 1;
                 if (preUpdate)

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -585,7 +585,7 @@ namespace Orts.Simulation.Signalling
                 }
 
                 updatecount += updatestep;
-                updatecount = updatecount > totalSignal ? 0 : updatecount;
+                updatecount = updatecount >= totalSignal ? 0 : updatecount;
             }
         }
 

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -568,6 +568,7 @@ namespace Orts.Simulation.Signalling
             if (foundSignals > 0)
             {
                 // loop through all signals
+```            // loop through all the signals, but only one batch of signals with every call to this method.
                 // update required part
                 var updates = 0;
                 var updateStep = 0;

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -570,6 +570,9 @@ namespace Orts.Simulation.Signalling
                 // loop through all signals
 ```            // loop through all the signals, but only one batch of signals with every call to this method.
                 // update required part
+```             // update one batch of signals. Batch ends when time taken exceeds 1/20th of time for all signals.
+                // Processing 1/20th of signals in each batch gave a jerky result as processing time varies greatly.
+                // Smoother results now that equal time is given to each batch and let the batch size vary.
                 var updates = 0;
                 var updateStep = 0;
                 var targetTicks = Stopwatch.GetTimestamp() + UpdateTickTarget;


### PR DESCRIPTION
While a lot more has been figured out, and plenty more can be improved here, this is a really tiny change which means that - for content which generates them - we no longer have to scan through loads of null signals in the array. `foundSignals` tracks how many signals are actually allocated in the array.

This makes things better, but lots more to come.

Bug report: https://www.elvastower.com/forums/index.php?/topic/37592-lags-by-mg-with-route-24-gb/