### PR TITLE
Fix Lights Crash on Corrupt Shapes

### DIFF
--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -277,9 +277,20 @@ namespace Orts.Viewer3D
         public PoseableShape(Viewer viewer, string path, WorldPosition initialPosition, ShapeFlags flags)
             : base(viewer, path, initialPosition, flags)
         {
-            XNAMatrices = new Matrix[SharedShape.Matrices.Length];
-            for (int iMatrix = 0; iMatrix < SharedShape.Matrices.Length; ++iMatrix)
-                XNAMatrices[iMatrix] = SharedShape.Matrices[iMatrix];
+            // In some cases, a corrupt shape file can prevent matrices from loading
+            if (SharedShape.Matrices.Length > 0)
+            {
+                XNAMatrices = new Matrix[SharedShape.Matrices.Length];
+                for (int iMatrix = 0; iMatrix < SharedShape.Matrices.Length; ++iMatrix)
+                    XNAMatrices[iMatrix] = SharedShape.Matrices[iMatrix];
+            }
+            else
+            {
+                Trace.TraceWarning("Could not determine matrices for shape file {0} file may be corrupt", SharedShape.FilePath);
+                // The 0th matrix should always be the identity matrix, add this to avoid crashes elsewhere
+                XNAMatrices = new Matrix[1];
+                XNAMatrices[0] = Matrix.Identity;
+            }
 
             if (SharedShape.LodControls.Length > 0 && SharedShape.LodControls[0].DistanceLevels.Length > 0 && SharedShape.LodControls[0].DistanceLevels[0].SubObjects.Length > 0 && SharedShape.LodControls[0].DistanceLevels[0].SubObjects[0].ShapePrimitives.Length > 0)
                 Hierarchy = SharedShape.LodControls[0].DistanceLevels[0].SubObjects[0].ShapePrimitives[0].Hierarchy;

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -277,17 +277,23 @@ namespace Orts.Viewer3D
         public PoseableShape(Viewer viewer, string path, WorldPosition initialPosition, ShapeFlags flags)
             : base(viewer, path, initialPosition, flags)
         {
-            // In some cases, a corrupt shape file can prevent matrices from loading
             if (SharedShape.Matrices.Length > 0)
             {
                 XNAMatrices = new Matrix[SharedShape.Matrices.Length];
                 for (int iMatrix = 0; iMatrix < SharedShape.Matrices.Length; ++iMatrix)
                     XNAMatrices[iMatrix] = SharedShape.Matrices[iMatrix];
             }
-            else
+            else // If the shape file is missing or fails to load, we need some default data to prevent crashes
             {
-                Trace.TraceWarning("Could not determine matrices for shape file {0} file may be corrupt", SharedShape.FilePath);
-                // The 0th matrix should always be the identity matrix, add this to avoid crashes elsewhere
+                if (path != null && path != "Empty")
+                {
+                    string location = path;
+                    if (path != null && path.Contains('\0'))
+                        location = path.Split('\0')[0];
+
+                    Trace.TraceWarning("Couldn't load shape {0} file may be corrupt", location);
+                }
+                // The 0th matrix should always be the identity matrix
                 XNAMatrices = new Matrix[1];
                 XNAMatrices[0] = Matrix.Identity;
             }


### PR DESCRIPTION
Bug report: https://www.elvastower.com/forums/index.php?/topic/38103-crash-in-lightscs-code-with-unstable-release/

Changes in lights from PR #917 have resulted in lights being pickier about engine/wagon shape files. A corrupt shape file would previously have no impact on lighting specifically, but now lights need to know where Indvidual parts of the shape file are to allow for attaching lights to the various shape components. This may not be possible if a shape file is corrupted in a particular way.

To solve this, when a poseable shape (includes engines and wagons but also other animated shapes too) is generated, if the XNAMatrices requires by the lights code are missing, a warning is produced and a default matrix is used. This should prevent crashes in lights and help users find more broken shape files.