### PR TITLE
Fix TrackViewer crash on big zoom value

### DIFF
--- a/Source/Contrib/TrackViewer/Drawing/DrawTerrain.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawTerrain.cs
@@ -486,8 +486,14 @@ namespace ORTS.TrackViewer.Drawing
             float camHeight = width / device.Viewport.AspectRatio / 2;
             Vector3 cameraPosition = cameraTarget;
             cameraPosition.Y = -camHeight;
+            float nearPlaneDistance = camHeight / 2;
+            if (nearPlaneDistance <= 0)
+            {
+                // distance is too close for CreatePerspectiveFieldOfView
+                return;
+            }
             basicEffect.View = Matrix.CreateLookAt(cameraPosition, cameraTarget, new Vector3(0, 0, 1));
-            basicEffect.Projection = Matrix.CreatePerspectiveFieldOfView(MathHelper.PiOver2, device.Viewport.AspectRatio, camHeight / 2, camHeight * 2);
+            basicEffect.Projection = Matrix.CreatePerspectiveFieldOfView(MathHelper.PiOver2, device.Viewport.AspectRatio, nearPlaneDistance, camHeight * 2);
 
         }
         #endregion


### PR DESCRIPTION
Hi,

My son found a little bug in the TrackViewer program. With a really big value of zoom, the program crashes due to an unhandled ArgumentException

After investigating, I have found that with a really big zoom value, the width becomes 0.0, and the result of pass zero for the value of nearPlaneDistance parameter of the  Matrix.CreatePerspectiveFieldOfView method.

This PR proposed to solve this issue by returning without updating the camera when the nearPlaneDistance computed value is less or equals to zero.

