### PR TITLE
Fix pantographs on unpowered cars

### DIFF
--- a/Source/Orts.Simulation/Common/Scripting/PowerSupply/PowerSupply.cs
+++ b/Source/Orts.Simulation/Common/Scripting/PowerSupply/PowerSupply.cs
@@ -95,6 +95,7 @@ namespace ORTS.Scripting.Api
         public virtual void HandleEventFromLeadLocomotive(PowerSupplyEvent evt)
         {
             // By default, send the event to every component
+            SignalEventToPantographs(evt);
             SignalEventToBatterySwitch(evt);
         }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1097,6 +1097,7 @@ namespace Orts.Simulation.RollingStocks
             }
             FreightAnimations?.Load(FreightAnimations.LoadDataList, true);
             InitializeLoadPhysics();
+            if (!(this is MSTSLocomotive) && Simulator.Settings.ElectricHotStart) Pantographs.HandleEvent(PowerSupplyEvent.RaisePantograph, 1);
         }
 
         public override void InitializeMoving()

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/LocomotivePowerSupply.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/LocomotivePowerSupply.cs
@@ -332,11 +332,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             AbstractScript.SignalEventToTcsWithMessage = (evt, message) => Locomotive.TrainControlSystem.HandleEvent(evt, message);
             AbstractScript.SignalEventToOtherLocomotives = (evt) =>
             {
-                if (Locomotive == Simulator.PlayerLocomotive)
+                if (Locomotive == Train.LeadLocomotive)
                 {
                     foreach (MSTSLocomotive locomotive in Locomotive.Train.Cars.OfType<MSTSLocomotive>())
                     {
-                        if (locomotive != Locomotive && locomotive != Locomotive.Train.LeadLocomotive && locomotive.RemoteControlGroup != -1)
+                        if (locomotive != Locomotive && locomotive.RemoteControlGroup != -1)
                         {
                             locomotive.LocomotivePowerSupply.HandleEventFromLeadLocomotive(evt);
                         }
@@ -345,11 +345,11 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             };
             AbstractScript.SignalEventToOtherLocomotivesWithId = (evt, id) =>
             {
-                if (Locomotive == Simulator.PlayerLocomotive)
+                if (Locomotive == Train.LeadLocomotive)
                 {
                     foreach (MSTSLocomotive locomotive in Locomotive.Train.Cars.OfType<MSTSLocomotive>())
                     {
-                        if (locomotive != Locomotive && locomotive != Locomotive.Train.LeadLocomotive && locomotive.RemoteControlGroup != -1)
+                        if (locomotive != Locomotive && locomotive.RemoteControlGroup != -1)
                         {
                             locomotive.LocomotivePowerSupply.HandleEventFromLeadLocomotive(evt, id);
                         }
@@ -358,26 +358,40 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             };
             AbstractScript.SignalEventToOtherTrainVehicles = (evt) =>
             {
-                if (Locomotive == Simulator.PlayerLocomotive)
+                if (Locomotive == Train.LeadLocomotive)
                 {
                     foreach (TrainCar car in Locomotive.Train.Cars)
                     {
-                        if (car != Locomotive && car != Locomotive.Train.LeadLocomotive && car.RemoteControlGroup != -1)
+                        if (car != Locomotive && car.RemoteControlGroup != -1)
                         {
-                            car.PowerSupply?.HandleEventFromLeadLocomotive(evt);
+                            if (car.PowerSupply != null)
+                            {
+                                car.PowerSupply.HandleEventFromLeadLocomotive(evt);
+                            }
+                            else if (car is MSTSWagon wagon)
+                            {
+                                wagon.Pantographs.HandleEvent(evt);
+                            }
                         }
                     }
                 }
             };
             AbstractScript.SignalEventToOtherTrainVehiclesWithId = (evt, id) =>
             {
-                if (Locomotive == Simulator.PlayerLocomotive)
+                if (Locomotive == Train.LeadLocomotive)
                 {
                     foreach (TrainCar car in Locomotive.Train.Cars)
                     {
-                        if (car != Locomotive && car != Locomotive.Train.LeadLocomotive && car.RemoteControlGroup != -1)
+                        if (car != Locomotive && car.RemoteControlGroup != -1)
                         {
-                            car.PowerSupply?.HandleEventFromLeadLocomotive(evt, id);
+                            if (car.PowerSupply != null)
+                            {
+                                car.PowerSupply.HandleEventFromLeadLocomotive(evt, id);
+                            }
+                            else if (car is MSTSWagon wagon)
+                            {
+                                wagon.Pantographs.HandleEvent(evt, id);
+                            }
                         }
                     }
                 }
@@ -388,7 +402,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
 
                 foreach (MSTSDieselLocomotive locomotive in Train.Cars.OfType<MSTSDieselLocomotive>().Where((MSTSLocomotive locomotive) => { return locomotive.RemoteControlGroup != -1; }))
                 {
-                    if (locomotive == Simulator.PlayerLocomotive)
+                    if (locomotive == Train.LeadLocomotive)
                     {
                         // Engine number 1 or above are helper engines
                         for (int i = 1; i < locomotive.DieselEngines.Count; i++)


### PR DESCRIPTION
Raise and lower pantograph events are not sent to pantographs if car doesn't have a power supply

https://www.elvastower.com/forums/index.php?/topic/32640-or-newyear-mg/page__view__findpost__p__309746

https://bugs.launchpad.net/or/+bug/2071495