### PR TITLE
Fix AI Lights After Reversing Points

### DIFF
--- a/Source/RunActivity/Viewer3D/Lights.cs
+++ b/Source/RunActivity/Viewer3D/Lights.cs
@@ -278,9 +278,7 @@ namespace Orts.Viewer3D
 
 			Debug.Assert(Viewer.PlayerTrain.LeadLocomotive == Viewer.PlayerLocomotive ||Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.AI_PLAYERHOSTING ||
                 Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.REMOTE || Viewer.PlayerTrain.TrainType == Train.TRAINTYPE.STATIC, "PlayerTrain.LeadLocomotive must be PlayerLocomotive.");
-			var leadLocomotiveCar = Car.Train?.LeadLocomotive;
-            if (leadLocomotiveCar == null && Car.Train?.Cars[0] is MSTSLocomotive) // AI trains have no lead locomotive
-                leadLocomotiveCar = Car.Train.Cars[0];
+			var leadLocomotiveCar = Car.Train?.LeadLocomotive; // Note: Will return null for AI trains, this is intended behavior
 			var leadLocomotive = leadLocomotiveCar as MSTSLocomotive;
 
             // There are a lot of conditions now! IgnoredConditions[] stores which conditions are ignored, allowing shortcutting of many of these calculations


### PR DESCRIPTION
Bug fix for [this bug on Elvas Tower](https://www.elvastower.com/forums/index.php?/topic/38120-ai-train-lights-dont-commute-from-front-to-rear-and-vice-versa-at-reversal-points/)

When a train trips a reverse point, the order of the train cars is reversed and every train car is flipped. For AI trains, this should result in the lights treating the train as if the front is now the rear and the rear is now the front (ie: any red tail lights move to the opposite end of the train). However, the check to determine which locomotive in the AI train is the lead locomotive also gets reversed, thus cancelling out the reversing point and causing the lights not to respond to the reversing point.

Previous versions of lights simply ignored the lead locomotive of AI trains so we are going back to that behavior to maintain consistency with old versions.