### PR TITLE
Bugfix refocus to the main window when opening  the map window

### DIFF
--- a/Source/RunActivity/Viewer3D/Map/MapForm.cs
+++ b/Source/RunActivity/Viewer3D/Map/MapForm.cs
@@ -1375,10 +1375,10 @@ namespace Orts.Viewer3D.Debugging
             int gameY1 = GameForm.Size.Height;
 
             return
-                ((mapX0 >= gameX0) && (mapX0 <= gameX1)) && ((mapY0 >= gameY0) && (mapY0 <= gameY1)) ||
-                ((mapX0 >= gameX0) && (mapX0 <= gameX1)) && ((mapY1 >= gameY0) && (mapY1 <= gameY1)) ||
-                ((mapX1 >= gameX0) && (mapX1 <= gameX1)) && ((mapY0 >= gameY0) && (mapY0 <= gameY1)) ||
-                ((mapX1 >= gameX0) && (mapX1 <= gameX1)) && ((mapY1 >= gameY0) && (mapY1 <= gameY1));
+                (((mapX0 >= gameX0) && (mapX0 <= gameX1)) && ((mapY0 >= gameY0) && (mapY0 <= gameY1))) ||
+                (((mapX0 >= gameX0) && (mapX0 <= gameX1)) && ((mapY1 >= gameY0) && (mapY1 <= gameY1))) ||
+                (((mapX1 >= gameX0) && (mapX1 <= gameX1)) && ((mapY0 >= gameY0) && (mapY0 <= gameY1))) ||
+                (((mapX1 >= gameX0) && (mapX1 <= gameX1)) && ((mapY1 >= gameY0) && (mapY1 <= gameY1)));
         }
 
         private void allowJoiningCheckbox_CheckedChanged(object sender, EventArgs e)

--- a/Source/RunActivity/Viewer3D/Map/MapForm.cs
+++ b/Source/RunActivity/Viewer3D/Map/MapForm.cs
@@ -1345,7 +1345,12 @@ namespace Orts.Viewer3D.Debugging
             if (Viewer.MapViewerEnabledSetToTrue)
             {
                 GenerateView();
-                GameForm.Focus();
+                if (!mapBehindGameForm())
+                {
+                    // do not return focus to the main OR game window
+                    // when map is (partially) overlapping the game window
+                    GameForm.Focus();
+                }
                 Viewer.MapViewerEnabledSetToTrue = false;
             }
 
@@ -1355,6 +1360,25 @@ namespace Orts.Viewer3D.Debugging
             lastUpdateTime = Program.Simulator.GameTime;
 
             GenerateView();
+        }
+
+        private bool mapBehindGameForm()
+        {        
+            int mapX0 = Bounds.X;
+            int mapY0 = Bounds.Y;
+            int mapX1 = mapX0 + Size.Width;
+            int mapY1 = mapY0 + Size.Height;
+
+            int gameX0 = GameForm.Bounds.X;
+            int gameY0 = GameForm.Bounds.Y;
+            int gameX1 = GameForm.Size.Width;
+            int gameY1 = GameForm.Size.Height;
+
+            return
+                ((mapX0 >= gameX0) && (mapX0 <= gameX1)) && ((mapY0 >= gameY0) && (mapY0 <= gameY1)) ||
+                ((mapX0 >= gameX0) && (mapX0 <= gameX1)) && ((mapY1 >= gameY0) && (mapY1 <= gameY1)) ||
+                ((mapX1 >= gameX0) && (mapX1 <= gameX1)) && ((mapY0 >= gameY0) && (mapY0 <= gameY1)) ||
+                ((mapX1 >= gameX0) && (mapX1 <= gameX1)) && ((mapY1 >= gameY0) && (mapY1 <= gameY1));
         }
 
         private void allowJoiningCheckbox_CheckedChanged(object sender, EventArgs e)

--- a/Source/RunActivity/Viewer3D/Map/MapForm.cs
+++ b/Source/RunActivity/Viewer3D/Map/MapForm.cs
@@ -1371,14 +1371,14 @@ namespace Orts.Viewer3D.Debugging
 
             int gameX0 = GameForm.Bounds.X;
             int gameY0 = GameForm.Bounds.Y;
-            int gameX1 = GameForm.Size.Width;
-            int gameY1 = GameForm.Size.Height;
+            int gameX1 = gameX0 + GameForm.Size.Width;
+            int gameY1 = gameY0 + GameForm.Size.Height;
 
             return
-                (((mapX0 >= gameX0) && (mapX0 <= gameX1)) && ((mapY0 >= gameY0) && (mapY0 <= gameY1))) ||
-                (((mapX0 >= gameX0) && (mapX0 <= gameX1)) && ((mapY1 >= gameY0) && (mapY1 <= gameY1))) ||
-                (((mapX1 >= gameX0) && (mapX1 <= gameX1)) && ((mapY0 >= gameY0) && (mapY0 <= gameY1))) ||
-                (((mapX1 >= gameX0) && (mapX1 <= gameX1)) && ((mapY1 >= gameY0) && (mapY1 <= gameY1)));
+                (((mapX0 > gameX0) && (mapX0 < gameX1)) && ((mapY0 > gameY0) && (mapY0 < gameY1))) ||
+                (((mapX0 > gameX0) && (mapX0 < gameX1)) && ((mapY1 > gameY0) && (mapY1 < gameY1))) ||
+                (((mapX1 > gameX0) && (mapX1 < gameX1)) && ((mapY0 > gameY0) && (mapY0 < gameY1))) ||
+                (((mapX1 > gameX0) && (mapX1 < gameX1)) && ((mapY1 > gameY0) && (mapY1 < gameY1)));
         }
 
         private void allowJoiningCheckbox_CheckedChanged(object sender, EventArgs e)

--- a/Source/RunActivity/Viewer3D/Map/MapForm.cs
+++ b/Source/RunActivity/Viewer3D/Map/MapForm.cs
@@ -364,7 +364,11 @@ namespace Orts.Viewer3D.Debugging
             var maxsize = maxX - minX > maxY - minY ? maxX - minX : maxY - minY;
             // Take up to next 500
             maxsize = (int)((maxsize / 100) + 1) * 500;
-            mapResolutionUpDown.Maximum = (decimal)maxsize;
+            if ((decimal)maxsize < mapResolutionUpDown.Maximum)
+            {
+                // do not make maximum larger then the maximum defined in the Designer
+                mapResolutionUpDown.Maximum = (decimal)maxsize;
+            }
             Inited = true;
 
             if (simulator.TDB == null || simulator.TDB.TrackDB == null || simulator.TDB.TrackDB.TrItemTable == null)


### PR DESCRIPTION
When opening the map window focus is returned to the main OR game window. This can cause confusion when running in full screen mode. In that case the map window will be hidden behind the game window. Therefore this bug fix does not refocus when (part) of the map window is overlapping the game window.

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)