### PR TITLE
fix: Restore assembly info which allows platform compatibility checks

### DIFF
--- a/Source/ORTS.Settings/ORTS.Settings.csproj
+++ b/Source/ORTS.Settings/ORTS.Settings.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net472</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPublishable>False</IsPublishable>


### PR DESCRIPTION
This was the only project with this set, and I cannot see any reason for it. Having this set also causes a load of incorrect "CA1416: This call site is reachable on all platforms" warnings in the .NET 6 build.