### PR TITLE
On Map window color changed switch or signal is not changed

### DIFF
--- a/Source/RunActivity/Viewer3D/Map/MapForm.cs
+++ b/Source/RunActivity/Viewer3D/Map/MapForm.cs
@@ -1596,6 +1596,7 @@ namespace Orts.Viewer3D.Debugging
                     break;
             }
 
+            mapCanvas.Invalidate(); // Triggers a re-paint
             UnHandleItemPick();
         }
 
@@ -1640,6 +1641,7 @@ namespace Orts.Viewer3D.Debugging
                         break;
                 }
             }
+            mapCanvas.Invalidate(); // Triggers a re-paint
             UnHandleItemPick();
         }
 


### PR DESCRIPTION
When status of a switch or signal is changed color of that switch or signal is not changed to reflect the status (probably when train is not moving, not tested)