### PR TITLE
 Increased center of gravity range

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1260,9 +1260,9 @@ namespace Orts.Simulation.RollingStocks
                     InitialCentreOfGravityM.X = stf.ReadFloat(STFReader.UNITS.Distance, null);
                     InitialCentreOfGravityM.Y = stf.ReadFloat(STFReader.UNITS.Distance, null);
                     InitialCentreOfGravityM.Z = stf.ReadFloat(STFReader.UNITS.Distance, null);
-                    if (Math.Abs(InitialCentreOfGravityM.Z) > 1)
+                    if (Math.Abs(InitialCentreOfGravityM.Z) > 2)
                     {
-                        STFException.TraceWarning(stf, string.Format("Ignored CentreOfGravity Z value {0} outside range -1 to +1", InitialCentreOfGravityM.Z));
+                        STFException.TraceWarning(stf, string.Format("CentreOfGravity Z set to zero because value {0} outside range -2 to +2", InitialCentreOfGravityM.Z));
                         InitialCentreOfGravityM.Z = 0;
                     }
                     stf.SkipRestOfBlock();


### PR DESCRIPTION
This range change is already implemented in the New Year version, but not in the other versions, which causes visual problems in some train compositions where the centre of gravity exceeds the +-1 range even if only by a little.