### PR TITLE
adds cache for SD files

### DIFF
--- a/Source/Orts.Formats.Msts/ShapeDescriptorFile.cs
+++ b/Source/Orts.Formats.Msts/ShapeDescriptorFile.cs
@@ -16,6 +16,8 @@
 // along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
+
 using Orts.Parsers.Msts;
 
 namespace Orts.Formats.Msts
@@ -29,16 +31,26 @@ namespace Orts.Formats.Msts
             shape = new SDShape();
         }
 
+        public static Dictionary<string, SDShape> Cache = new Dictionary<string, SDShape>();
+
         public ShapeDescriptorFile(string filename)
         {
-            using (STFReader stf = new STFReader(filename, false))
+            var shapeDescriptorPath = filename.ToLowerInvariant();
+            if (Cache.ContainsKey(shapeDescriptorPath))
             {
-                stf.ParseFile(new STFReader.TokenProcessor[] {
-                    new STFReader.TokenProcessor("shape", ()=>{ shape = new SDShape(stf); }),
-                });
-                //TODO This should be changed to STFException.TraceError() with defaults values created
-                if (shape == null)
-                    throw new STFException(stf, "Missing shape statement");
+                shape = Cache[shapeDescriptorPath];
+            }
+            else
+            {
+                using (STFReader stf = new STFReader(filename, false))
+                {
+                    stf.ParseFile(new STFReader.TokenProcessor[] {
+                        new STFReader.TokenProcessor("shape", ()=>{ shape = new SDShape(stf); }),
+                    });
+                    //TODO This should be changed to STFException.TraceError() with defaults values created
+                    if (shape == null) throw new STFException(stf, "Missing shape statement");
+                }
+                Cache.Add(shapeDescriptorPath, shape);
             }
         }
 

--- a/Source/Orts.Formats.Msts/ShapeDescriptorFile.cs
+++ b/Source/Orts.Formats.Msts/ShapeDescriptorFile.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Collections.Generic;
-
 using Orts.Parsers.Msts;
 
 namespace Orts.Formats.Msts
@@ -36,12 +35,19 @@ namespace Orts.Formats.Msts
         public ShapeDescriptorFile(string filename)
         {
             var shapeDescriptorPath = filename.ToLowerInvariant();
+
             if (Cache.ContainsKey(shapeDescriptorPath))
             {
                 shape = Cache[shapeDescriptorPath];
             }
             else
             {
+                if (!System.IO.File.Exists(filename)) // If not found, skip
+                {
+                    shape = null;
+                    return;
+                }
+
                 using (STFReader stf = new STFReader(filename, false))
                 {
                     stf.ParseFile(new STFReader.TokenProcessor[] {

--- a/Source/RunActivity/Viewer3D/Scenery.cs
+++ b/Source/RunActivity/Viewer3D/Scenery.cs
@@ -341,19 +341,23 @@ namespace Orts.Viewer3D
                     }
                 }
 
-                if (shapeFilePath != null && File.Exists(shapeFilePath + "d"))
+                var shapeDescriptorPath = shapeFilePath + "d";
+                if (shapeFilePath != null)
                 {
-                    var shape = new ShapeDescriptorFile(shapeFilePath + "d");
-                    if (shape.shape.ESD_Bounding_Box != null)
+                    var shape = new ShapeDescriptorFile(shapeDescriptorPath);
+                    if (shape != null)
                     {
-                        var min = shape.shape.ESD_Bounding_Box.Min;
-                        var max = shape.shape.ESD_Bounding_Box.Max;
-                        var transform = Matrix.Invert(worldMatrix.XNAMatrix);
-                        // Not sure if this is needed, but it is to correct for center-of-gravity being not the center of the box.
-                        //transform.M41 += (max.X + min.X) / 2;
-                        //transform.M42 += (max.Y + min.Y) / 2;
-                        //transform.M43 += (max.Z + min.Z) / 2;
-                        BoundingBoxes.Add(new BoundingBox(transform, new Vector3((max.X - min.X) / 2, (max.Y - min.Y) / 2, (max.Z - min.Z) / 2), worldMatrix.XNAMatrix.Translation.Y));
+                        if (shape.shape.ESD_Bounding_Box != null)
+                        {
+                            var min = shape.shape.ESD_Bounding_Box.Min;
+                            var max = shape.shape.ESD_Bounding_Box.Max;
+                            var transform = Matrix.Invert(worldMatrix.XNAMatrix);
+                            // Not sure if this is needed, but it is to correct for center-of-gravity being not the center of the box.
+                            //transform.M41 += (max.X + min.X) / 2;
+                            //transform.M42 += (max.Y + min.Y) / 2;
+                            //transform.M43 += (max.Z + min.Z) / 2;
+                            BoundingBoxes.Add(new BoundingBox(transform, new Vector3((max.X - min.X) / 2, (max.Y - min.Y) / 2, (max.Z - min.Z) / 2), worldMatrix.XNAMatrix.Translation.Y));
+                        }
                     }
                 }
 

--- a/Source/RunActivity/Viewer3D/Scenery.cs
+++ b/Source/RunActivity/Viewer3D/Scenery.cs
@@ -345,19 +345,16 @@ namespace Orts.Viewer3D
                 if (shapeFilePath != null)
                 {
                     var shape = new ShapeDescriptorFile(shapeDescriptorPath);
-                    if (shape != null)
+                    if (shape.shape?.ESD_Bounding_Box != null)
                     {
-                        if (shape.shape.ESD_Bounding_Box != null)
-                        {
-                            var min = shape.shape.ESD_Bounding_Box.Min;
-                            var max = shape.shape.ESD_Bounding_Box.Max;
-                            var transform = Matrix.Invert(worldMatrix.XNAMatrix);
-                            // Not sure if this is needed, but it is to correct for center-of-gravity being not the center of the box.
-                            //transform.M41 += (max.X + min.X) / 2;
-                            //transform.M42 += (max.Y + min.Y) / 2;
-                            //transform.M43 += (max.Z + min.Z) / 2;
-                            BoundingBoxes.Add(new BoundingBox(transform, new Vector3((max.X - min.X) / 2, (max.Y - min.Y) / 2, (max.Z - min.Z) / 2), worldMatrix.XNAMatrix.Translation.Y));
-                        }
+                        var min = shape.shape.ESD_Bounding_Box.Min;
+                        var max = shape.shape.ESD_Bounding_Box.Max;
+                        var transform = Matrix.Invert(worldMatrix.XNAMatrix);
+                        // Not sure if this is needed, but it is to correct for center-of-gravity being not the center of the box.
+                        //transform.M41 += (max.X + min.X) / 2;
+                        //transform.M42 += (max.Y + min.Y) / 2;
+                        //transform.M43 += (max.Z + min.Z) / 2;
+                        BoundingBoxes.Add(new BoundingBox(transform, new Vector3((max.X - min.X) / 2, (max.Y - min.Y) / 2, (max.Z - min.Z) / 2), worldMatrix.XNAMatrix.Translation.Y));
                     }
                 }
 


### PR DESCRIPTION
SD files are short and simple, but the overhead of testing for them and reading them more than once is excessive. More than half of the file accesses at start are due to SD files for:
- 2176/4178  Demo Model 1 - Queens Street
- 1481/1844  BNSF Scenic Sub - Eastbound
- 2345/2873  Portugal 79 - Linha do Algarve

This PR adds a simple cache.

See [https://trello.com/c/8hcG5645/595-cache-sd-files-for-faster-loading](https://trello.com/c/8hcG5645/595-cache-sd-files-for-faster-loading)