### PR TITLE
Correct bug with steam locomotive chuffing sound

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -3505,14 +3505,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
 
                 if (((Train.TrainType == Train.TRAINTYPE.PLAYER && !Train.Autopilot) || Train.TrainType == Train.TRAINTYPE.AI_PLAYERDRIVEN) && (Simulator.UseAdvancedAdhesion && !Simulator.Settings.SimpleControlPhysics))
                 {
-                    if (SteamEngines[i].AttachedAxle.IsWheelSlip)
-                    {
-                        variable[i] = Math.Abs(SteamEngines[i].AttachedAxle.SlipSpeedMpS / SteamEngines[i].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
-                    }
-                    else
-                    {
                         variable[i] = Math.Abs((float)SteamEngines[i].AttachedAxle.AxleSpeedMpS / SteamEngines[i].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
-                    }
                 }
                 else 
                 // Axle code is not executed if it is an AI train, on Autopilot, or Simple adhesion or simple physics is selected. Hence must use wheelspeed in these instances

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -3503,13 +3503,26 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                 // Variable is proportional to angular speed, value of 10 means 1 rotation/second.
                 // If wheel is not slipping then use normal wheel speed, this reduces oscillations in variable1 which causes issues with sounds.
 
-                if (SteamEngines[i].AttachedAxle.IsWheelSlip)
+                if (((Train.TrainType == Train.TRAINTYPE.PLAYER && !Train.Autopilot) || Train.TrainType == Train.TRAINTYPE.AI_PLAYERDRIVEN) && (Simulator.UseAdvancedAdhesion && !Simulator.Settings.SimpleControlPhysics))
                 {
-                    variable[i] = Math.Abs(SteamEngines[i].AttachedAxle.SlipSpeedMpS / SteamEngines[i].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
+                    if (SteamEngines[i].AttachedAxle.IsWheelSlip)
+                    {
+                        variable[i] = Math.Abs(SteamEngines[i].AttachedAxle.SlipSpeedMpS / SteamEngines[i].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
+                    }
+                    else
+                    {
+                        variable[i] = Math.Abs((float)SteamEngines[i].AttachedAxle.AxleSpeedMpS / SteamEngines[i].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
+                    }
                 }
-                else
+                else 
+                // Axle code is not executed if it is an AI train, on Autopilot, or Simple adhesion or simple physics is selected. Hence must use wheelspeed in these instances
                 {
-                    variable[i] = Math.Abs((float)SteamEngines[i].AttachedAxle.AxleSpeedMpS / SteamEngines[i].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
+                    if (WheelSlip)
+                        variable[i] = Math.Abs(WheelSpeedSlipMpS / SteamEngines[0].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
+                    else
+                    {
+                        variable[i] = Math.Abs(WheelSpeedMpS / SteamEngines[0].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
+                    }
                 }
 
                 variable[i] = ThrottlePercent == 0 ? 0 : variable[i];


### PR DESCRIPTION
Corrects a bug identified with no sound occurring for steam locomotive chuffing when advanced adhesion is not used by a train.

https://www.elvastower.com/forums/index.php?/topic/38284-no-chuffing-from-steam-locos/

https://bugs.launchpad.net/or/+bug/2080599