### PR TITLE
Fix: The TrainCarOperations window does not resize correctly.

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
@@ -495,6 +495,10 @@ namespace Orts.Viewer3D.Popups
                     Client = ControlLayoutScrollboxVertical.NewClient;
                     RowsCount = Client.Controls.Where(c => c is ControlLayoutHorizontal).Count();
                     SeparatorCount = Client.Controls.Where(c => c is Separator).Count();
+
+                    // Allows to resize the window according to the carPosition value.
+                    if (RowsCount > carPosition) RowsCount = carPosition;
+                    if (SeparatorCount > carPosition -1) SeparatorCount = carPosition - 1;
                 }
             }
             return Vbox;


### PR DESCRIPTION
The TrainCarOperation window doesn't resize when the number of cars changes.

https://bugs.launchpad.net/or/+bug/2083270
