### PR TITLE
fix: Temporary workaround for building with NET 5+

### DIFF
--- a/Source/Menu/Notifications/NotificationManager.cs
+++ b/Source/Menu/Notifications/NotificationManager.cs
@@ -98,7 +98,12 @@ namespace ORTS
 
         public double GetScalingFactor()
         {
+#if NET5_0_OR_GREATER
+#warning GetScalingFactor() not implemented for NET5+
+            return 1;
+#else
             return Screen.PrimaryScreen.Bounds.Width / SystemParameters.PrimaryScreenWidth;
+#endif
         }
 
         public void CheckNotifications()


### PR DESCRIPTION
Roadmap: https://trello.com/c/TrIB2nUc/533-cross-platform-portability-support-for-linux-macos

`SystemParameters` (from WPF I think) isn't available here in .NET 5+ and I suspect we can implement this better in modern .NET anyway, so for the moment replacing the code with a build warning - only affects .NET 5+ builds, no change to .NET Framework builds