### PR TITLE
Fix: TrainCarOperations-crashes-locales

### DIFF
--- a/Source/Locales/RunActivity/cs.po
+++ b/Source/Locales/RunActivity/cs.po
@@ -3217,3 +3217,28 @@ msgstr "Naběrač vody je poškozen, nelze ji doplnit"
 #~ msgctxt "Labels"
 #~ msgid "none"
 #~ msgstr "není"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Engine"
+msgstr "Lokomotiva"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "On"
+msgstr "Zap"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "Power"
+msgstr "Výkon"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Running"
+msgstr "Motor běží"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Stopped"
+msgstr "Motor zastaven"

--- a/Source/Locales/RunActivity/cs.po
+++ b/Source/Locales/RunActivity/cs.po
@@ -133,12 +133,6 @@ msgctxt "PowerSupply"
 msgid "On ongoing"
 msgstr "Běží"
 
-#. Context: PowerSupply
-#: ../../RunActivity/Common/Scripting/PowerSupply/AbstractPowerSupply.cs:81
-msgctxt "PowerSupply"
-msgid "On"
-msgstr "Zap"
-
 #. Context: Pantograph
 #: ../../RunActivity/Common/Scripting/PowerSupply/AbstractPowerSupply.cs:86
 msgctxt "Pantograph"
@@ -583,12 +577,6 @@ msgstr "Strojvedoucí"
 #: ../../RunActivity/RollingStock/MSTSElectricLocomotive.cs:334
 msgid "Auxiliary power"
 msgstr "Pomocný výkon"
-
-#. Context: PowerSupply
-#: ../../RunActivity/RollingStock/MSTSElectricLocomotive.cs:322
-msgctxt "PowerSupply"
-msgid "Power"
-msgstr "Výkon"
 
 #: ../../RunActivity/RollingStock/MSTSSteamLocomotive.cs:1573
 #: ../../RunActivity/Viewer3D/RollingStock/MSTSSteamLocomotiveViewer.cs:203

--- a/Source/Locales/RunActivity/da.po
+++ b/Source/Locales/RunActivity/da.po
@@ -2886,3 +2886,28 @@ msgstr[1] "{0} meter"
 #~ msgctxt "Labels"
 #~ msgid "none"
 #~ msgstr "ingen"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Engine"
+msgstr "Motor"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "On"
+msgstr "Til"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "Power"
+msgstr "Effekt"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Running"
+msgstr "Kører"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Stopped"
+msgstr "Stoppet"

--- a/Source/Locales/RunActivity/da.po
+++ b/Source/Locales/RunActivity/da.po
@@ -96,12 +96,6 @@ msgctxt "PowerSupply"
 msgid "On ongoing"
 msgstr "Starter op"
 
-#. Context: PowerSupply
-#: ../../RunActivity/Common/Scripting/PowerSupply/AbstractPowerSupply.cs:81
-msgctxt "PowerSupply"
-msgid "On"
-msgstr "Til"
-
 #. Context: Pantograph
 #: ../../RunActivity/Common/Scripting/PowerSupply/AbstractPowerSupply.cs:86
 msgctxt "Pantograph"
@@ -548,12 +542,6 @@ msgstr "Fører"
 #: ../../RunActivity/RollingStock/MSTSElectricLocomotive.cs:334
 msgid "Auxiliary power"
 msgstr "Ekstra effekt"
-
-#. Context: PowerSupply
-#: ../../RunActivity/RollingStock/MSTSElectricLocomotive.cs:322
-msgctxt "PowerSupply"
-msgid "Power"
-msgstr "Effekt"
 
 #: ../../RunActivity/RollingStock/MSTSSteamLocomotive.cs:1366
 msgid "Tender coal supply is empty. Your loco will fail."

--- a/Source/Locales/RunActivity/de.po
+++ b/Source/Locales/RunActivity/de.po
@@ -4108,3 +4108,28 @@ msgstr ""
 #~ msgctxt "Switch"
 #~ msgid "change"
 #~ msgstr "stellen"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Engine"
+msgstr "Motor"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "On"
+msgstr "An"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "Power"
+msgstr "Strom"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Running"
+msgstr "An"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Stopped"
+msgstr "Aus"

--- a/Source/Locales/RunActivity/fr.po
+++ b/Source/Locales/RunActivity/fr.po
@@ -3215,3 +3215,28 @@ msgstr "Dist"
 #, csharp-format
 #~ msgid "filtered by {0:F0}"
 #~ msgstr "filtré par {0:F0}"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Engine"
+msgstr "Moteur"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "On"
+msgstr "Actif"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "Power"
+msgstr "Puissance"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Running"
+msgstr "En marche"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Stopped"
+msgstr "Arrêté"

--- a/Source/Locales/RunActivity/hu.po
+++ b/Source/Locales/RunActivity/hu.po
@@ -4983,3 +4983,28 @@ msgstr "csatl."
 
 #~ msgid "Coupler overloaded"
 #~ msgstr "Vonókészülék túlterhelve"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Engine"
+msgstr "Gép"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "On"
+msgstr "Van"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "Power"
+msgstr "Feszültség"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Running"
+msgstr "Üzemben"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Stopped"
+msgstr "Leállítva"

--- a/Source/Locales/RunActivity/it.po
+++ b/Source/Locales/RunActivity/it.po
@@ -3973,3 +3973,28 @@ msgstr ""
 #~ msgctxt "Labels"
 #~ msgid "none"
 #~ msgstr "nessuno"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Engine"
+msgstr "Motore"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "On"
+msgstr "Accesa"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "Power"
+msgstr "Alimentazione"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Running"
+msgstr "In funzione"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Stopped"
+msgstr "Spento"

--- a/Source/Locales/RunActivity/pt-BR.po
+++ b/Source/Locales/RunActivity/pt-BR.po
@@ -1496,3 +1496,23 @@ msgstr "O furo está quebrado, não é possível reabastecer"
 #: ../../RunActivity/Viewer3D/RollingStock/MSTSSteamLocomotiveViewer.cs:230
 msgid "Scoop broken because activated outside through"
 msgstr "Scoop quebrado porque ativado do lado de fora"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Engine"
+msgstr "Motor"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "On"
+msgstr "Ligada"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Running"
+msgstr "Trabalhando"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Stopped"
+msgstr "Parado"

--- a/Source/Locales/RunActivity/ru.po
+++ b/Source/Locales/RunActivity/ru.po
@@ -3799,3 +3799,28 @@ msgstr "Соединено"
 #~ msgctxt "Coupler"
 #~ msgid "Push"
 #~ msgstr "Растян"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Engine"
+msgstr "ДВС"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "Power"
+msgstr "Напряж"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "On"
+msgstr "Вкл"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Running"
+msgstr "Работает"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Stopped"
+msgstr "Заглушен"

--- a/Source/Locales/RunActivity/zh-CN.po
+++ b/Source/Locales/RunActivity/zh-CN.po
@@ -2826,3 +2826,28 @@ msgstr[1] "{0}米"
 
 #~ msgid "successfully"
 #~ msgstr "成功"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Engine"
+msgstr "柴油机"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "On"
+msgstr "打开"
+
+#. Context: PowerSupply
+msgctxt "PowerSupply"
+msgid "Power"
+msgstr "电力"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Running"
+msgstr "运行"
+
+#. Context: DieselEngine
+msgctxt "DieselEngine"
+msgid "Stopped"
+msgstr "停机"

--- a/Source/Locales/RunActivity/zh-CN.po
+++ b/Source/Locales/RunActivity/zh-CN.po
@@ -97,12 +97,6 @@ msgctxt "PowerSupply"
 msgid "On ongoing"
 msgstr "正在进行"
 
-#. Context: PowerSupply
-#: ../../RunActivity/Common/Scripting/PowerSupply/AbstractPowerSupply.cs:81
-msgctxt "PowerSupply"
-msgid "On"
-msgstr "打开"
-
 #. Context: Pantograph
 #: ../../RunActivity/Common/Scripting/PowerSupply/AbstractPowerSupply.cs:86
 msgctxt "Pantograph"
@@ -545,12 +539,6 @@ msgstr "司机"
 #: ../../RunActivity/RollingStock/MSTSElectricLocomotive.cs:334
 msgid "Auxiliary power"
 msgstr "辅助动力"
-
-#. Context: PowerSupply
-#: ../../RunActivity/RollingStock/MSTSElectricLocomotive.cs:322
-msgctxt "PowerSupply"
-msgid "Power"
-msgstr "电力"
 
 #: ../../RunActivity/RollingStock/MSTSSteamLocomotive.cs:1411
 msgid "Tender coal supply is empty. Your loco will fail."

--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
@@ -1091,11 +1091,11 @@ namespace Orts.Viewer3D.Popups
                     string[] parts = data.Split(new string[] { " = " }, 2, StringSplitOptions.None);
                     string keyPart = parts[0];
                     string valuePart = parts?[1];
-                    if (keyPart.Contains(Viewer.Catalog.GetString("Engine")))
+                    if (keyPart.Contains(Viewer.Catalog.GetParticularString("DieselEngine","Engine")))
                     {
                         TrainCarViewer.PowerSupplyStatus = locomotiveStatus;
-                        Texture = valuePart.Contains(Viewer.Catalog.GetString("Running")) ? PowerOn
-                           : valuePart.Contains(Viewer.Catalog.GetString("Stopped")) ? PowerOff
+                        Texture = valuePart.Contains(Viewer.Catalog.GetParticularString("DieselEngine", "Running")) ? PowerOn
+                           : valuePart.Contains(Viewer.Catalog.GetParticularString("DieselEngine", "Stopped")) ? PowerOff
                            : PowerChanging;
                         break;
                     }

--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
@@ -1029,12 +1029,12 @@ namespace Orts.Viewer3D.Popups
                 string[] parts = data.Split(new string[] { " = " }, 2, StringSplitOptions.None);
                 string keyPart = parts[0];
                 string valuePart = parts?[1];
-                if (keyPart.Contains(Viewer.Catalog.GetString("Engine")))
+                if (Viewer.PlayerTrain.Cars[CarPosition] is MSTSDieselLocomotive && keyPart.Contains(Viewer.Catalog.GetParticularString("DieselEngine", "Engine")))
                 {
                     TrainCarOperations.PowerSupplyStatus = locomotiveStatus;
 
-                    Texture = valuePart.Contains(Viewer.Catalog.GetString("Running")) ? PowerOn
-                       : valuePart.Contains(Viewer.Catalog.GetString("Stopped")) ? PowerOff
+                    Texture = valuePart.Contains(Viewer.Catalog.GetParticularString("DieselEngine", "Running")) ? PowerOn
+                       : valuePart.Contains(Viewer.Catalog.GetParticularString("DieselEngine", "Stopped")) ? PowerOff
                        : PowerChanging;
 
                     if (CarPosition == TrainCarViewer.CarPosition)
@@ -1043,10 +1043,10 @@ namespace Orts.Viewer3D.Popups
                     }
                     break;
                 }
-                else if (keyPart.Contains(Viewer.Catalog.GetString("Power")))
+                else if (keyPart.Contains(Viewer.Catalog.GetParticularString("PowerSupply", "Power")))
                 {
                     TrainCarViewer.PowerSupplyStatus = locomotiveStatus;
-                    var powerStatus = valuePart.Contains(Viewer.Catalog.GetString("On"));
+                    var powerStatus = valuePart.Contains(Viewer.Catalog.GetParticularString("PowerSupply", "On"));
                     Texture = powerStatus ? PowerOn : PowerOff;
                     if (CarPosition == TrainCarViewer.CarPosition)
                         TrainCarOperations.SupplyStatusChanged = TrainCarOperations.MainPowerSupplyOn != powerStatus;


### PR DESCRIPTION
TrainCarOperations (F9) crashes in some languages.
Bug [#2084162](https://bugs.launchpad.net/or/+bug/2084162)

More info[ here](https://www.elvastower.com/forums/index.php?/topic/37062-proposal-f9-train-operations/page__view__findpost__p__311324).

