### PR TITLE
Fix TrainCarOperations no interacts AltPgDn AltPgUp.

### DIFF
--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -1112,7 +1112,7 @@ namespace Orts.Viewer3D
                         SetCameraCar(GetCameraCars().Last());
                         oldCarPosition = 0;
                     }
-                    else if (isVisibleTrainCarViewerOrWebpage && carPosition >= 0)
+                    else if (carPosition < trainCars.Count && isVisibleTrainCarViewerOrWebpage && carPosition >= 0)
                     {
                         SetCameraCar(trainCars[carPosition]);
                         oldCarPosition = carPosition;

--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -987,6 +987,7 @@ namespace Orts.Viewer3D
         protected float LowWagonOffsetLimit;
         protected float HighWagonOffsetLimit;
         public int oldCarPosition;
+        public bool IsCameraFront;
         public override bool IsUnderground
         {
             get

--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
@@ -482,7 +482,11 @@ namespace Orts.Viewer3D.Popups
                     }
                     else if (OldCarPosition != CarPosition || (trainCarOperations.CarIdClicked && CarPosition == 0))
                     {
-                        Owner.Viewer.FrontCamera.Activate();
+                        if (Owner.Viewer.FrontCamera.AttachedCar != null && Owner.Viewer.FrontCamera.IsCameraFront)
+                            Owner.Viewer.FrontCamera.Activate();
+
+                        if (Owner.Viewer.BackCamera.AttachedCar != null && !Owner.Viewer.FrontCamera.IsCameraFront)
+                            Owner.Viewer.BackCamera.Activate();
                     }
                     OldCarPosition = CarPosition;
                     Layout();

--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
@@ -498,7 +498,7 @@ namespace Orts.Viewer3D.Popups
 
                 for (var position = 0 ; position < Owner.Viewer.PlayerTrain.Cars.Count; position++)
                 {
-                    if (trainCarOperations.WarningCarPosition[position])
+                    if (trainCarOperations.WarningCarPosition.Count > position && trainCarOperations.WarningCarPosition[position])
                     {
                         var carAngleCockAOpenAmount = Owner.Viewer.PlayerTrain.Cars[position].BrakeSystem.AngleCockAOpenAmount;
                         var carAngleCockBOpenAmount = Owner.Viewer.PlayerTrain.Cars[position].BrakeSystem.AngleCockBOpenAmount;

--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
@@ -92,6 +92,7 @@ namespace Orts.Viewer3D.Popups
         public int WindowHeightMax;
         public int WindowWidthMin;
         public int WindowWidthMax;
+        public bool SavedCabCamera;
         public int windowHeight { get; set; } //required by TrainCarWindow
         public int CarPosition
         {
@@ -159,6 +160,9 @@ namespace Orts.Viewer3D.Popups
 
             outf.Write(CarPosition);
             outf.Write(ResetAllSymbols);
+
+            var saveCabCamera = Owner.Viewer.Camera is CabCamera || Owner.Viewer.Camera == Owner.Viewer.ThreeDimCabCamera;
+            outf.Write(saveCabCamera);
         }
         protected internal override void Restore(BinaryReader inf)
         {
@@ -171,6 +175,7 @@ namespace Orts.Viewer3D.Popups
 
             CarPosition = inf.ReadInt32();
             ResetAllSymbols = inf.ReadBoolean();
+            SavedCabCamera = inf.ReadBoolean();
 
             // Display window
             SizeTo(LocationRestore.Width, LocationRestore.Height);
@@ -472,8 +477,12 @@ namespace Orts.Viewer3D.Popups
                 {
                     // Updates CarPosition
                     CarPosition = CouplerChanged ? NewCarPosition : CarPosition;
-                    
-                    if (OldCarPosition != CarPosition || (trainCarOperations.CarIdClicked && CarPosition == 0))
+
+                    if (SavedCabCamera)
+                    {
+                        SavedCabCamera = false;
+                    }
+                    else if (OldCarPosition != CarPosition || (trainCarOperations.CarIdClicked && CarPosition == 0))
                     {
                         Owner.Viewer.FrontCamera.Activate();
                     }

--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
@@ -92,7 +92,7 @@ namespace Orts.Viewer3D.Popups
         public int WindowHeightMax;
         public int WindowWidthMin;
         public int WindowWidthMax;
-        public bool SavedCabCamera;
+        public bool CabCameraEnabled;
         public int windowHeight { get; set; } //required by TrainCarWindow
         public int CarPosition
         {
@@ -160,9 +160,6 @@ namespace Orts.Viewer3D.Popups
 
             outf.Write(CarPosition);
             outf.Write(ResetAllSymbols);
-
-            var saveCabCamera = Owner.Viewer.Camera is CabCamera || Owner.Viewer.Camera == Owner.Viewer.ThreeDimCabCamera;
-            outf.Write(saveCabCamera);
         }
         protected internal override void Restore(BinaryReader inf)
         {
@@ -175,7 +172,8 @@ namespace Orts.Viewer3D.Popups
 
             CarPosition = inf.ReadInt32();
             ResetAllSymbols = inf.ReadBoolean();
-            SavedCabCamera = inf.ReadBoolean();
+
+            CabCameraEnabled = Owner.Viewer.Camera is CabCamera || Owner.Viewer.Camera == Owner.Viewer.ThreeDimCabCamera;
 
             // Display window
             SizeTo(LocationRestore.Width, LocationRestore.Height);
@@ -478,9 +476,9 @@ namespace Orts.Viewer3D.Popups
                     // Updates CarPosition
                     CarPosition = CouplerChanged ? NewCarPosition : CarPosition;
 
-                    if (SavedCabCamera)
+                    if (CabCameraEnabled)// Displays camera 1
                     {
-                        SavedCabCamera = false;
+                        CabCameraEnabled = false;
                     }
                     else if (OldCarPosition != CarPosition || (trainCarOperations.CarIdClicked && CarPosition == 0))
                     {

--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
@@ -571,6 +571,18 @@ namespace Orts.Viewer3D.Popups
                 var carOperations = Owner.Viewer.CarOperationsWindow;
                 var trainCarWebpage = Owner.Viewer.TrainCarOperationsWebpage;
 
+                // Allows interaction with <Alt>+<PageDown> and <Alt>+<PageUP>.
+                if (Owner.Viewer.Camera.AttachedCar != null && !(Owner.Viewer.Camera is CabCamera) && (trainCarViewer.Visible || Visible))
+                {
+                    var currentCameraCarID = Owner.Viewer.Camera.AttachedCar.CarID;
+                    if (PlayerTrain != null && (currentCameraCarID != trainCarViewer.CurrentCarID || CarPosition != trainCarViewer.CarPosition))
+                    {
+                        trainCarViewer.CurrentCarID = currentCameraCarID;
+                        trainCarViewer.CarPosition = CarPosition = PlayerTrain.Cars.TakeWhile(x => x.CarID != currentCameraCarID).Count();
+                        CarPositionChanged = true;
+                    }
+                }
+
                 trainCarViewer.TrainCarOperationsChanged = !trainCarViewer.Visible && trainCarViewer.TrainCarOperationsChanged ? false : trainCarViewer.TrainCarOperationsChanged;
 
                 CurrentDisplaySizeY = DisplaySizeY;

--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
@@ -572,7 +572,7 @@ namespace Orts.Viewer3D.Popups
                 var trainCarWebpage = Owner.Viewer.TrainCarOperationsWebpage;
 
                 // Allows interaction with <Alt>+<PageDown> and <Alt>+<PageUP>.
-                if (Owner.Viewer.Camera.AttachedCar != null && !(Owner.Viewer.Camera is CabCamera) && (trainCarViewer.Visible || Visible))
+                if (Owner.Viewer.Camera.AttachedCar != null && !(Owner.Viewer.Camera is CabCamera) && Owner.Viewer.Camera != Owner.Viewer.ThreeDimCabCamera && (trainCarViewer.Visible || Visible))
                 {
                     var currentCameraCarID = Owner.Viewer.Camera.AttachedCar.CarID;
                     if (PlayerTrain != null && (currentCameraCarID != trainCarViewer.CurrentCarID || CarPosition != trainCarViewer.CarPosition))

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -1087,11 +1087,13 @@ namespace Orts.Viewer3D
             }
             if (UserInput.IsPressed(UserCommand.CameraOutsideFront))
             {
+                FrontCamera.IsCameraFront = true;
                 CheckReplaying();
                 new UseFrontCameraCommand(Log);
             }
             if (UserInput.IsPressed(UserCommand.CameraOutsideRear))
             {
+                FrontCamera.IsCameraFront = false;
                 CheckReplaying();
                 new UseBackCameraCommand(Log);
             }

--- a/Source/RunActivity/Viewer3D/WebServices/TrainCarOperationsWebpage.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/TrainCarOperationsWebpage.cs
@@ -464,6 +464,19 @@ namespace Orts.Viewer3D.WebServices
                 TrainCarSelected = true;
                 TrainCarSelectedPosition = Viewer.TrainCarOperationsWindow.SelectedCarPosition;
             }
+            else
+            {
+                // select traincar on webpage when traincar operations window (F9) not visible
+                if (Viewer.Camera.AttachedCar != null && !(Viewer.Camera is CabCamera) && Viewer.Camera != Viewer.ThreeDimCabCamera)
+                {
+                    var currentCameraCarID = Viewer.Camera.AttachedCar.CarID;
+                    if (Viewer.PlayerTrain != null)
+                    {
+                        TrainCarSelected = true;
+                        TrainCarSelectedPosition = Viewer.PlayerTrain.Cars.TakeWhile(x => x.CarID != currentCameraCarID).Count();
+                    }
+                }
+            }
 
             if (TrainCarSelected && (carPosition == TrainCarSelectedPosition))
             {


### PR DESCRIPTION
The TrainCarOperations window (F9) does not interact with Alt+PageDown or Alt+PageUp.
Bug [#2084160](https://bugs.launchpad.net/or/+bug/2084160).