### PR TITLE
Disable independent brake syncing by default

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -2415,9 +2415,9 @@ present for simplicity.
    single: ORTSDPBrakeSynchronization
 
 By default, Open Rails will treat remote groups as manned helpers who typically
-would not assist in train brake operations, so only independent brakes will synchronize.
-To enable train brake synchronization, the token ``engine(ORTSDPBrakeSynchronization(``
-should be used. The valid settings for ``ORTSDPBrakeSynchronization`` are as follows:
+would not assist in train brake operations. To enable brake synchronization,
+the token ``engine(ORTSDPBrakeSynchronization(`` should be used.
+The valid settings for ``ORTSDPBrakeSynchronization`` are as follows:
 
 - ``"Apply"``: DP units will reduce the brake pipe pressure locally to match the
   equalizing reservoir pressure of the controlling locomotive. (The controlling
@@ -2432,10 +2432,6 @@ should be used. The valid settings for ``ORTSDPBrakeSynchronization`` are as fol
   controlling locomotive, and will automatically bail-off automatic brake
   applications if needed. (The controlling locomotive must also have the
   ``"Independent"`` setting.)
-                - NOTE: Although ``"Independent"`` is enabled by default,
-                  if ``ORTSDPBrakeSynchronization`` is present in the .eng
-                  file but ``"Independent"`` is not specified as an option,
-                  independent brakes will NOT be synchronized.
 
 All settings can be combined as needed, simply place a comma between each setting
 in the string: ``ORTSDPBrakeSynchronization("Apply, Release, Emergency, Independent")``

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -448,7 +448,7 @@ namespace Orts.Simulation.RollingStocks
         public bool DPSyncTrainApplication { get; private set; }
         public bool DPSyncTrainRelease { get; private set; }
         public bool DPSyncEmergency { get; private set; }
-        public bool DPSyncIndependent { get; private set; } = true;
+        public bool DPSyncIndependent { get; private set; }
 
         protected const float DefaultCompressorRestartToMaxSysPressureDiff = 35;    // Used to check if difference between these two .eng parameters is correct, and to correct it
         protected const float DefaultMaxMainResToCompressorRestartPressureDiff = 10; // Used to check if difference between these two .eng parameters is correct, and to correct it
@@ -1160,8 +1160,6 @@ namespace Orts.Simulation.RollingStocks
                         DPSyncEmergency = true;
                     if (dpSyncModes.Contains("independent"))
                         DPSyncIndependent = true;
-                    else // Independent synchronization is assumed to be enabled unless explicitly not enabled
-                        DPSyncIndependent = false;
                     break;
                 case "engine(ortsdynamicblendingoverride": DynamicBrakeBlendingOverride = stf.ReadBoolBlock(false); break;
                 case "engine(ortsdynamicblendingforcematch": DynamicBrakeBlendingForceMatch = stf.ReadBoolBlock(false); break;


### PR DESCRIPTION
Activating it by default breaks the behaviour of almost all UIC locomotives