### PR TITLE
Clean up logging during loading #or-std-log

### DIFF
--- a/Source/Orts.Common/FatalException.cs
+++ b/Source/Orts.Common/FatalException.cs
@@ -1,0 +1,31 @@
+﻿// COPYRIGHT 2009 - 2024 by the Open Rails project.
+//
+// This file is part of Open Rails.
+//
+// Open Rails is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Open Rails is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Diagnostics;
+
+namespace ORTS.Common
+{
+    public sealed class FatalException : Exception
+    {
+        public FatalException(Exception innerException)
+            : base("A fatal error has occurred", innerException)
+        {
+            Debug.Assert(innerException != null, "The inner exception of a FatalException must not be null.");
+        }
+    }
+}

--- a/Source/Orts.Common/FileTeeLogger.cs
+++ b/Source/Orts.Common/FileTeeLogger.cs
@@ -23,12 +23,12 @@ namespace ORTS.Common
 {
     public class FileTeeLogger : TextWriter
     {
-        public readonly string FileName;
+        public readonly TextWriter LogFile;
         public readonly TextWriter Console;
 
         public FileTeeLogger(string fileName, TextWriter console)
         {
-            FileName = fileName;
+            LogFile = new StreamWriter(fileName, true, Encoding);
             Console = console;
         }
 
@@ -54,15 +54,13 @@ namespace ORTS.Common
         public override void Write(string value)
         {
             Console.Write(value);
-            using (var writer = new StreamWriter(FileName, true, Encoding))
-            {
-                writer.Write(value);
-            }
+            LogFile.Write(value);
+            LogFile.Flush();
         }
 
         public override void Write(char[] buffer, int index, int count)
         {
-            Write(new String(buffer, index, count));
+            Write(new string(buffer, index, count));
         }
     }
 }

--- a/Source/Orts.Common/FileTeeLogger.cs
+++ b/Source/Orts.Common/FileTeeLogger.cs
@@ -1,0 +1,68 @@
+﻿// COPYRIGHT 2009 - 2024 by the Open Rails project.
+//
+// This file is part of Open Rails.
+//
+// Open Rails is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Open Rails is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+using System.Text;
+
+namespace ORTS.Common
+{
+    public class FileTeeLogger : TextWriter
+    {
+        public readonly string FileName;
+        public readonly TextWriter Console;
+
+        public FileTeeLogger(string fileName, TextWriter console)
+        {
+            FileName = fileName;
+            Console = console;
+        }
+
+        public override Encoding Encoding
+        {
+            get
+            {
+                return Encoding.UTF8;
+            }
+        }
+
+        public override void Write(char value)
+        {
+            // Everything in TextWriter boils down to Write(char), but
+            // actually implementing just this would be horribly inefficient
+            // since we open and close the file every time. Instead, we
+            // implement Write(string) and Write(char[], int, int) which
+            // should mean we only end up here if called directly by user
+            // code. Which we won't support unless necessary.
+            throw new NotImplementedException();
+        }
+
+        public override void Write(string value)
+        {
+            Console.Write(value);
+            using (var writer = new StreamWriter(FileName, true, Encoding))
+            {
+                writer.Write(value);
+            }
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            Write(new String(buffer, index, count));
+        }
+    }
+}

--- a/Source/Orts.Common/NullLogger.cs
+++ b/Source/Orts.Common/NullLogger.cs
@@ -1,0 +1,41 @@
+﻿// COPYRIGHT 2009 - 2024 by the Open Rails project.
+//
+// This file is part of Open Rails.
+//
+// Open Rails is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Open Rails is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.IO;
+using System.Text;
+
+namespace ORTS.Common
+{
+    public class NullLogger : TextWriter
+    {
+        public NullLogger()
+        {
+        }
+
+        public override Encoding Encoding
+        {
+            get
+            {
+                return Encoding.UTF8;
+            }
+        }
+
+        public override void Write(char value)
+        {
+        }
+    }
+}

--- a/Source/Orts.Common/ORTraceListener.cs
+++ b/Source/Orts.Common/ORTraceListener.cs
@@ -1,17 +1,17 @@
-﻿// COPYRIGHT 2009, 2010, 2011, 2012, 2013 by the Open Rails project.
-// 
+﻿// COPYRIGHT 2009 - 2024 by the Open Rails project.
+//
 // This file is part of Open Rails.
-// 
+//
 // Open Rails is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // Open Rails is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -20,72 +20,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 
-namespace Orts.Common
+namespace ORTS.Common
 {
-    public class NullLogger : TextWriter
-    {
-        public NullLogger()
-        {
-        }
-
-        public override Encoding Encoding
-        {
-            get
-            {
-                return Encoding.UTF8;
-            }
-        }
-
-        public override void Write(char value)
-        {
-        }
-    }
-
-    public class FileTeeLogger : TextWriter
-    {
-        public readonly string FileName;
-        public readonly TextWriter Console;
-
-        public FileTeeLogger(string fileName, TextWriter console)
-        {
-            FileName = fileName;
-            Console = console;
-        }
-
-        public override Encoding Encoding
-        {
-            get
-            {
-                return Encoding.UTF8;
-            }
-        }
-
-        public override void Write(char value)
-        {
-            // Everything in TextWriter boils down to Write(char), but
-            // actually implementing just this would be horribly inefficient
-            // since we open and close the file every time. Instead, we
-            // implement Write(string) and Write(char[], int, int) which
-            // should mean we only end up here if called directly by user
-            // code. Which we won't support unless necessary.
-            throw new NotImplementedException();
-        }
-
-        public override void Write(string value)
-        {
-            Console.Write(value);
-            using (var writer = new StreamWriter(FileName, true, Encoding))
-            {
-                writer.Write(value);
-            }
-        }
-
-        public override void Write(char[] buffer, int index, int count)
-        {
-            Write(new String(buffer, index, count));
-        }
-    }
-
     public class ORTraceListener : TraceListener
     {
         public readonly TextWriter Writer;
@@ -128,7 +64,7 @@ namespace Orts.Common
             var errorLevel = (int)Math.Round(Math.Log((int)eventType) / Math.Log(2));
             if (errorLevel < Counts.Length)
                 Counts[errorLevel]++;
-            
+
             // Event is less important than error (and critical) and we're logging only errors... bail.
             if (eventType > TraceEventType.Error && OnlyErrors)
                 return;
@@ -214,15 +150,6 @@ namespace Orts.Common
 
         class LogicalOperation
         {
-        }
-    }
-
-    public sealed class FatalException : Exception
-    {
-        public FatalException(Exception innerException)
-            : base("A fatal error has occurred", innerException)
-        {
-            Debug.Assert(innerException != null, "The inner exception of a FatalException must not be null.");
         }
     }
 }

--- a/Source/Orts.Common/ORTraceListener.cs
+++ b/Source/Orts.Common/ORTraceListener.cs
@@ -27,7 +27,7 @@ namespace ORTS.Common
         public readonly TextWriter Writer;
         public readonly bool OnlyErrors;
         public readonly int[] Counts = new int[5];
-        bool LastWrittenFormatted;
+        int LinesNeeded;
 
         public ORTraceListener(TextWriter writer)
             : this(writer, false)
@@ -70,11 +70,7 @@ namespace ORTS.Common
                 return;
 
             var output = new StringBuilder();
-            if (!LastWrittenFormatted)
-            {
-                output.AppendLine();
-                output.AppendLine();
-            }
+            while (LinesNeeded-- > 0) output.AppendLine();
             output.Append(eventType);
             output.Append(": ");
             if (args.Length == 0)
@@ -107,7 +103,7 @@ namespace ORTS.Common
 
             output.AppendLine();
             Writer.Write(output);
-            LastWrittenFormatted = true;
+            LinesNeeded = 0;
         }
 
         public override void Write(string message)
@@ -115,7 +111,7 @@ namespace ORTS.Common
             if (!OnlyErrors)
             {
                 Writer.Write(message);
-                LastWrittenFormatted = false;
+                LinesNeeded = 2;
             }
         }
 
@@ -124,7 +120,7 @@ namespace ORTS.Common
             if (!OnlyErrors)
             {
                 Writer.WriteLine(message);
-                LastWrittenFormatted = false;
+                LinesNeeded = 1;
             }
         }
 
@@ -142,7 +138,6 @@ namespace ORTS.Common
             else if (!OnlyErrors)
             {
                 base.WriteLine(o);
-                LastWrittenFormatted = false;
             }
         }
 

--- a/Source/Orts.Formats.Msts/SignalScripts.cs
+++ b/Source/Orts.Formats.Msts/SignalScripts.cs
@@ -391,11 +391,6 @@ namespace Orts.Formats.Msts
                     {
                         readInfo.Scriptname = scriptname;
                         ScriptLines.Add(readInfo);
-
-                        if (readInfo.Linenumber % 1000 == 1)
-                        {
-                            Trace.Write("s");
-                        }
                     }
                 }
             }

--- a/Source/Orts.Formats.Msts/WorldSoundFile.cs
+++ b/Source/Orts.Formats.Msts/WorldSoundFile.cs
@@ -35,7 +35,6 @@ namespace Orts.Formats.Msts
         {
             if (File.Exists(wsfilename))
             {
-                Trace.Write("$");
                 using (STFReader stf = new STFReader(wsfilename, false))
                 {
                     stf.ParseFile(new STFReader.TokenProcessor[] {

--- a/Source/Orts.Formats.OR/AESignals.cs
+++ b/Source/Orts.Formats.OR/AESignals.cs
@@ -89,7 +89,6 @@ namespace Orts.Formats.OR
 
             // read SIGSCR files
 
-            Trace.Write(" SIGSCR ");
             //scrfile = new SIGSCRfile(data.RoutePath, sigcfg.ScriptFiles, sigcfg.SignalTypes);
 
             // build list of signal world file information
@@ -286,7 +285,6 @@ namespace Orts.Formats.OR
 
                 // read w-file, get SignalObjects only
 
-                Trace.Write("W");
                 WorldFile WFile;
                 try
                 {

--- a/Source/Orts.Simulation/Simulation/AIs/AI.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AI.cs
@@ -327,8 +327,6 @@ namespace Orts.Simulation.AIs
             float firstAITime = StartList.GetNextTime();
             if (firstAITime > 0 && firstAITime < Simulator.ClockTime)
             {
-                Trace.Write("\n Run AI : " + StartList.Count.ToString() + " ");
-
                 // Perform update for AI trains upto actual start time
                 clockTime = firstAITime - 1.0f;
                 localTime = true;
@@ -336,9 +334,6 @@ namespace Orts.Simulation.AIs
 
                 for (double runTime = firstAITime; runTime < Simulator.ClockTime; runTime += 5.0) // Update with 5 secs interval
                 {
-                    int fullsec = Convert.ToInt32(runTime);
-                    if (fullsec % 3600 == 0) Trace.Write(" " + (fullsec / 3600).ToString("00") + ":00 ");
-
                     AIUpdate((float)(runTime - clockTime), Simulator.PreUpdate);
                     Simulator.Signals.Update(true);
                     clockTime = runTime;
@@ -355,8 +350,6 @@ namespace Orts.Simulation.AIs
             float firstAITime = StartList.GetNextTime();
             if (firstAITime > 0 && firstAITime < Simulator.ClockTime)
             {
-                Trace.Write("\n Run AI : " + StartList.Count.ToString() + " ");
-
                 // Perform update for AI trains upto actual start time
                 clockTime = firstAITime - 1.0f;
                 localTime = true;
@@ -366,9 +359,6 @@ namespace Orts.Simulation.AIs
                 {
                     var loaderSpan = (float)TimetableInfo.PlayerTrainOriginalStartTime - firstAITime;
                     Simulator.TimetableLoadedFraction = ((float)runTime - firstAITime) / loaderSpan;
-
-                    int fullsec = Convert.ToInt32(runTime);
-                    if (fullsec % 3600 < 5) Trace.Write(" " + (fullsec / 3600).ToString("00") + ":00 ");
 
                     endPreRun = AITTUpdate((float)(runTime - clockTime), Simulator.PreUpdate, ref activeTrains);
 
@@ -539,9 +529,6 @@ namespace Orts.Simulation.AIs
                         if (cancellation.IsCancellationRequested) // Ping loader watchdog
                             return;
 
-                        int fullsec = Convert.ToInt32(runTime);
-                        if (fullsec % 3600 == 0) Trace.Write(" " + (fullsec / 3600).ToString("00") + ":00 ");
-
                         if (runTime >= 24 * 3600) // End of day reached
                         {
                             if (playerTrainOriginalTrain > 0)
@@ -614,7 +601,6 @@ namespace Orts.Simulation.AIs
                 clockTime = Simulator.ClockTime = playerTTTrain.StartTime.Value;
             }
 
-            Trace.Write("\n");
             Simulator.PreUpdate = false;
         }
 

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -101,7 +101,6 @@ namespace Orts.Simulation.Signalling
             tdbfile = Simulator.TDB;
 
             // read SIGSCR files
-            Trace.Write(" SIGSCR ");
             scrfile = new SIGSCRfile(new SignalScripts(sigcfg.ScriptPath, sigcfg.ScriptFiles, sigcfg.SignalTypes, sigcfg.SignalFunctions, sigcfg.ORTSNormalSubtypes));
             CsSignalScripts = new CsSignalScripts(Simulator);
 
@@ -423,7 +422,6 @@ namespace Orts.Simulation.Signalling
 
                 // read w-file, get SignalObjects only
 
-                Trace.Write("W");
                 WorldFile WFile;
                 try
                 {

--- a/Source/Orts.Simulation/Simulation/Simulator.cs
+++ b/Source/Orts.Simulation/Simulation/Simulator.cs
@@ -284,9 +284,6 @@ namespace Orts.Simulation
 
             string ORfilepath = System.IO.Path.Combine(RoutePath, "OpenRails");
 
-            Trace.Write("Loading ");
-
-            Trace.Write(" TRK");
             TRK = new RouteFile(MSTS.MSTSPath.GetTRKFileName(RoutePath));
             RouteName = TRK.Tr_RouteFile.Name;
             MilepostUnitsMetric = TRK.Tr_RouteFile.MilepostUnitsMetric;
@@ -307,21 +304,17 @@ namespace Orts.Simulation
             else if (TRK.Tr_RouteFile.SuperElevation.Count > 0 && !TRK.Tr_RouteFile.SuperElevation[0].DefaultStandard)
                 UseSuperElevation = true; // Custom superelevation standard entered, force enable superelevation
 
-            Trace.Write(" TDB");
             TDB = new TrackDatabaseFile(RoutePath + @"\" + TRK.Tr_RouteFile.FileName + ".tdb");
 
             if (File.Exists(ORfilepath + @"\sigcfg.dat"))
             {
-                Trace.Write(" SIGCFG_OR");
                 SIGCFG = new SignalConfigurationFile(ORfilepath + @"\sigcfg.dat", true);
             }
             else
             {
-                Trace.Write(" SIGCFG");
                 SIGCFG = new SignalConfigurationFile(RoutePath + @"\sigcfg.dat", false);
             }
 
-            Trace.Write(" DAT");
             if (Directory.Exists(RoutePath + @"\Openrails") && File.Exists(RoutePath + @"\Openrails\TSECTION.DAT"))
                 TSectionDat = new TrackSectionsFile(RoutePath + @"\Openrails\TSECTION.DAT");
             else if (Directory.Exists(RoutePath + @"\GLOBAL") && File.Exists(RoutePath + @"\GLOBAL\TSECTION.DAT"))
@@ -337,12 +330,9 @@ namespace Orts.Simulation
             orRouteConfig.SetTraveller(TSectionDat, TDB);
 #endif
 
-            Trace.Write(" ACT");
-
             var rdbFile = RoutePath + @"\" + TRK.Tr_RouteFile.FileName + ".rdb";
             if (File.Exists(rdbFile))
             {
-                Trace.Write(" RDB");
                 RDB = new RoadDatabaseFile(rdbFile);
             }
 
@@ -350,7 +340,6 @@ namespace Orts.Simulation
             if (File.Exists(carSpawnFile))
             {
                 CarSpawnerLists = new List<CarSpawnerList>();
-                Trace.Write(" CARSPAWN");
                 CarSpawnerFile = new CarSpawnerFile(RoutePath + @"\carspawn.dat", RoutePath + @"\shapes\", CarSpawnerLists);
             }
 
@@ -359,7 +348,6 @@ namespace Orts.Simulation
             if (File.Exists(extCarSpawnFile))
             {
                 if (CarSpawnerLists == null) CarSpawnerLists = new List<CarSpawnerList>();
-                Trace.Write(" EXTCARSPAWN");
                 ExtCarSpawnerFile = new ExtCarSpawnerFile(RoutePath + @"\openrails\carspawn.dat", RoutePath + @"\shapes\", CarSpawnerLists);
             }
 
@@ -367,14 +355,12 @@ namespace Orts.Simulation
             var clockFile = RoutePath + @"\animated.clocks-or";
             if (File.Exists(clockFile))
             {
-                Trace.Write(" CLOCKS");
                 new ClocksFile(clockFile, ClockShapeList, RoutePath + @"\shapes\");
             }
 
             // Generate a list of EOTs that may be used to attach at end of train
             if (Directory.Exists(EOTPath))
             {
-                Trace.Write(" EOT");
                 FullEOTPaths = new FullEOTPaths(EOTPath);
             }
 

--- a/Source/Orts.Simulation/Simulation/Timetables/PoolInfo.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/PoolInfo.cs
@@ -59,11 +59,9 @@ namespace Orts.Simulation.Timetables
             filenames = GetFilenames(arguments[0]);
 
             // Get file contents as strings
-            Trace.Write("\n");
             foreach (string filePath in filenames)
             {
                 // Get contents as strings
-                Trace.Write("Pool File : " + filePath + "\n");
                 var poolInfo = new TimetableReader(filePath);
 
                 // Read lines from input until 'Name' definition is found

--- a/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
@@ -112,11 +112,9 @@ namespace Orts.Simulation.Timetables
             filenames = GetFilenames(arguments[0]);
 
             // Get file contents as strings
-            Trace.Write("\n");
             foreach (string filePath in filenames)
             {
                 // Get contents as strings
-                Trace.Write("TT File : " + filePath + "\n");
                 var fileContents = new TimetableReader(filePath);
 
 #if DEBUG_TIMETABLE
@@ -128,9 +126,7 @@ namespace Orts.Simulation.Timetables
             }
 
             // Read and pre-process routes
-            Trace.Write(" TTROUTES:" + Paths.Count.ToString() + " ");
             loadPathNoFailure = PreProcessRoutes(cancellation);
-            Trace.Write(" TTTRAINS:" + trainInfoList.Count.ToString() + " ");
 
             // Get startinfo for player train
             playerTrain = GetPlayerTrain(ref trainInfoList, arguments);

--- a/Source/Orts.Simulation/Simulation/Timetables/TurntableInfo.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TurntableInfo.cs
@@ -56,11 +56,9 @@ namespace Orts.Simulation.Timetables
             filenames = GetTurntableFilenames(arguments[0]);
 
             // Get file contents as strings
-            Trace.Write("\n");
             foreach (string filePath in filenames)
             {
                 // Get contents as strings
-                Trace.Write("Turntable File : " + filePath + "\n");
                 var turntableInfo = new TimetableReader(filePath);
 
                 // Read lines from input until 'Name' definition is found

--- a/Source/Orts.Simulation/Simulation/Turntables.cs
+++ b/Source/Orts.Simulation/Simulation/Turntables.cs
@@ -46,8 +46,6 @@ namespace Orts.Simulation
                 return;
             }
 
-            Trace.Write(" TURNTBL");
-
             using (STFReader stf = new STFReader(filePath, false))
             {
                 var count = stf.ReadInt(null);

--- a/Source/RunActivity/Viewer3D/DynamicTrack.cs
+++ b/Source/RunActivity/Viewer3D/DynamicTrack.cs
@@ -420,14 +420,12 @@ namespace Orts.Viewer3D
             {
                 // No track profile provided, use default
                 TrackProfile = new TrProfile(viewer);
-                Trace.Write("(default)");
                 return;
             }
             FileInfo fileInfo = new FileInfo(filespec);
             if (!fileInfo.Exists)
             {
                 TrackProfile = new TrProfile(viewer); // Default profile if no file
-                Trace.Write("(default)");
             }
             else
             {
@@ -465,7 +463,6 @@ namespace Orts.Viewer3D
                                     }
                                 }
                         }
-                        Trace.Write("(.STF)");
                         break;
 
                     case ".XML": // XML-style
@@ -498,13 +495,11 @@ namespace Orts.Viewer3D
                         {
                             TrackProfile = new TrProfile(viewer, reader);
                         }
-                        Trace.Write("(.XML)");
                         break;
 
                     default:
                         // File extension not supported; create a default track profile
                         TrackProfile = new TrProfile(viewer);
-                        Trace.Write("(default)");
                         break;
                 }
             }

--- a/Source/RunActivity/Viewer3D/Scenery.cs
+++ b/Source/RunActivity/Viewer3D/Scenery.cs
@@ -210,7 +210,6 @@ namespace Orts.Viewer3D
 
         WorldFile LoadWorldFile(int tileX, int tileZ, bool visible)
         {
-            Trace.Write("W");
             try
             {
                 return new WorldFile(Viewer, tileX, tileZ, visible);

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2015,7 +2015,6 @@ namespace Orts.Viewer3D
         /// </summary>
         void LoadContent()
         {
-            Trace.Write("S");
             var filePath = FilePath;
             // commented lines allow reading the animation block from an additional file in an Openrails subfolder
 //           string dir = Path.GetDirectoryName(filePath);

--- a/Source/RunActivity/Viewer3D/Terrain.cs
+++ b/Source/RunActivity/Viewer3D/Terrain.cs
@@ -139,7 +139,6 @@ namespace Orts.Viewer3D
 
         public TerrainTile(Viewer viewer, TileManager tileManager, Tile tile)
         {
-            Trace.Write(tile.Size > 2 ? "L" : "T");
             TileX = tile.TileX;
             TileZ = tile.TileZ;
             Size = tile.Size;

--- a/Source/RunActivity/Viewer3D/Trains.cs
+++ b/Source/RunActivity/Viewer3D/Trains.cs
@@ -148,7 +148,6 @@ namespace Orts.Viewer3D
 
         TrainCarViewer LoadCar(TrainCar car)
         {
-            Trace.Write("C");
             TrainCarViewer carViewer =
                 car is MSTSDieselLocomotive ? new MSTSDieselLocomotiveViewer(Viewer, car as MSTSDieselLocomotive) :
                 car is MSTSElectricLocomotive ? new MSTSElectricLocomotiveViewer(Viewer, car as MSTSElectricLocomotive) :

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -330,22 +330,17 @@ namespace Orts.Viewer3D
 
             string ORfilepath = System.IO.Path.Combine(Simulator.RoutePath, "OpenRails");
             ContentPath = Game.ContentPath;
-            Trace.Write(" ENV");
             ENVFile = new EnvironmentFile(Simulator.RoutePath + @"\ENVFILES\" + Simulator.TRK.Tr_RouteFile.Environment.ENVFileName(Simulator.Season, Simulator.WeatherType));
 
-            Trace.Write(" SIGCFG");
             if (File.Exists(ORfilepath + @"\sigcfg.dat"))
             {
-                Trace.Write(" SIGCFG_OR");
                 SIGCFG = new SignalConfigurationFile(ORfilepath + @"\sigcfg.dat", true);
             }
             else
             {
-                Trace.Write(" SIGCFG");
                 SIGCFG = new SignalConfigurationFile(Simulator.RoutePath + @"\sigcfg.dat", false);
             }
 
-            Trace.Write(" TTYPE");
             TrackTypes = new TrackTypesFile(Simulator.RoutePath + @"\TTYPE.DAT");
 
             Tiles = new TileManager(Simulator.RoutePath + @"\TILES\", false);
@@ -373,7 +368,6 @@ namespace Orts.Viewer3D
                 var speedpostDatFile = Simulator.RoutePath + @"\speedpost.dat";
                 if (File.Exists(speedpostDatFile))
                 {
-                    Trace.Write(" SPEEDPOST");
                     SpeedpostDatFile = new SpeedpostDatFile(Simulator.RoutePath + @"\speedpost.dat", Simulator.RoutePath + @"\shapes\");
                 }
             }
@@ -533,7 +527,6 @@ namespace Orts.Viewer3D
             InfoDisplay = new InfoDisplay(this);
 
             // Load track profiles before considering the world/scenery
-            Trace.Write(" TRP");
             // Creates profile(s) and loads materials into SceneryMaterials
             if (TRPFile.CreateTrackProfile(this, Simulator.RoutePath, out TRPs))
             {

--- a/Source/RunActivity/Viewer3D/WebServices/SwitchPanel/SwitchOnPanelStatus.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/SwitchPanel/SwitchOnPanelStatus.cs
@@ -565,7 +565,7 @@ namespace Orts.Viewer3D.WebServices.SwitchPanel
                     // exception not yet logged
                     ExceptionForCommand.Add(userCommand);
 
-                    Trace.Write("Error in Switch Panel function \"getStatus\" getting status for " + userCommand + ":");
+                    Trace.WriteLine("Error in Switch Panel function \"getStatus\" getting status for " + userCommand + ":");
                     Trace.WriteLine(ex);
                 }
             }


### PR DESCRIPTION
Roadmap: https://trello.com/c/gf3Rcxob/600-scan-log-file-for-compatibility-issues-and-display-in-menu

This removes the clutter of the loading messages (e.g. "S", "W", "T") in preparation for log parsing and improved logging options.