### PR TITLE
Bugfix: Content Form exception when there is manually installed content in a top level directory.

### DIFF
--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -1536,7 +1536,9 @@ namespace ORTS
             Dictionary<string, int> subDirs = new Dictionary<string, int>();
             foreach (var folder in Settings.Folders.Folders)
             {
-                string subDir = Directory.GetParent(folder.Value).ToString();
+                var parentDir = Directory.GetParent(folder.Value);
+                if (parentDir == null) { continue; }  // ignore content in top-level dir
+                string subDir = parentDir.ToString();
                 if (subDirs.ContainsKey(subDir))
                 {
                     subDirs[subDir] += 1;
@@ -1556,16 +1558,16 @@ namespace ORTS
                 }
             }
 
-            string brouwseDir = "";
+            string browseDir = "";
             foreach (var subDir in subDirs)
             {
                 if (subDir.Value == max)
                 {
-                    brouwseDir = subDir.Key;
+                    browseDir = subDir.Key;
                 }
             }
 
-            return brouwseDir;
+            return browseDir;
         }
 
         #endregion


### PR DESCRIPTION
When manually installed content has a path of only a top level directory, eg. "H:\", then the Content form of the main Menu (Content button) will crash with an exception. The problem is in the code that attempts to find the most used content directory.

The fix is to ignore content that is installed in a directory without a parent directory.

The commit also includes fixing a simple typo in a variable name.

See also:
https://bugs.launchpad.net/or/+bug/2089801
https://www.elvastower.com/forums/index.php?/topic/38414-crash-with-content-manager/page__view__findpost__p__313090
