### PR TITLE
Fix: TrainCarOperations doesn't work as expected after resume.

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
@@ -273,6 +273,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             outf.Write(CylPressurePSIA);
             outf.Write(VacResPressurePSIA);
             outf.Write(FrontBrakeHoseConnected);
+            outf.Write(RearBrakeHoseConnected);
             outf.Write(AngleCockAOpen);
             outf.Write(AngleCockBOpen);
             outf.Write(BleedOffValveOpen);
@@ -286,6 +287,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             CylPressurePSIA = inf.ReadSingle();
             VacResPressurePSIA = inf.ReadSingle();
             FrontBrakeHoseConnected = inf.ReadBoolean();
+            RearBrakeHoseConnected = inf.ReadBoolean();
             AngleCockAOpen = inf.ReadBoolean();
             AngleCockBOpen = inf.ReadBoolean();
             BleedOffValveOpen = inf.ReadBoolean();

--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
@@ -164,6 +164,7 @@ namespace Orts.Viewer3D.Popups
             outf.Write(Location.Height);
 
             outf.Write(SelectedCarPosition);
+            outf.Write(Owner.Viewer.FrontCamera.IsCameraFront);
         }
         protected internal override void Restore(BinaryReader inf)
         {
@@ -175,6 +176,7 @@ namespace Orts.Viewer3D.Popups
             LocationRestore.Height = inf.ReadInt32();
 
             SelectedCarPosition = inf.ReadInt32();
+            Owner.Viewer.FrontCamera.IsCameraFront = inf.ReadBoolean();
 
             // Display window
             SizeTo(LocationRestore.Width, LocationRestore.Height);
@@ -581,7 +583,7 @@ namespace Orts.Viewer3D.Popups
                 var trainCarWebpage = Owner.Viewer.TrainCarOperationsWebpage;
 
                 // Allows interaction with <Alt>+<PageDown> and <Alt>+<PageUP>.
-                if (Owner.Viewer.Camera.AttachedCar != null && !(Owner.Viewer.Camera is CabCamera) && Owner.Viewer.Camera != Owner.Viewer.ThreeDimCabCamera && (trainCarViewer.Visible || Visible))
+                if (CarPositionChanged && Owner.Viewer.Camera.AttachedCar != null && !(Owner.Viewer.Camera is CabCamera) && Owner.Viewer.Camera != Owner.Viewer.ThreeDimCabCamera && (trainCarViewer.Visible || Visible))
                 {
                     var currentCameraCarID = Owner.Viewer.Camera.AttachedCar.CarID;
                     if (PlayerTrain != null && (currentCameraCarID != trainCarViewer.CurrentCarID || CarPosition != trainCarViewer.CarPosition))


### PR DESCRIPTION
The TrainCarOperations windows is not working as expected after resume.
More info here, [Bug #2090952](https://bugs.launchpad.net/or/+bug/2090952).