### PR TITLE
Fix: TrainCarViewer overlaps when display size changed

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
@@ -86,11 +86,14 @@ namespace Orts.Viewer3D.Popups
         public int RowsCount;
         public int SpacerRowCount;
         public int SymbolsRowCount;
+        public int CurrentNewWidth;
         public bool BrakeHoseCarCoupling;
 
         const int SymbolWidth = 32;
         public static bool FontChanged;
         public static bool FontToBold;
+        public int DisplaySizeY;
+        public bool DisplayReSized = false;
         public int WindowHeightMin;
         public int WindowHeightMax;
         public int WindowWidthMin;
@@ -307,6 +310,7 @@ namespace Orts.Viewer3D.Popups
         {
             if (SymbolsRowCount > 0)
             {
+                DisplaySizeY = Owner.Viewer.DisplaySize.Y;
                 var desiredHeight = FontToBold ? Owner.TextFontDefaultBold.Height * RowsCount
                     : (Owner.TextFontDefault.Height * RowsCount) + SymbolWidth;
                 var desiredWidth = (SymbolsRowCount * SymbolWidth) + (SpacerRowCount * (SymbolWidth / 2)) + (LocoRowCount * (SymbolWidth * 2));
@@ -321,10 +325,12 @@ namespace Orts.Viewer3D.Popups
                 SizeTo(newWidth, newHeight);
                 var locationX = Location.X;
                 var locationY = newTop;
-                if (Owner.Viewer.TrainCarOperationsWindow.LayoutMoved)
+                if (Owner.Viewer.TrainCarOperationsWindow.LayoutMoved || newWidth != CurrentNewWidth || DisplayReSized)
                 {
                     CkeckCollision(newWidth, newHeight, ref locationX, ref locationY);
                     Owner.Viewer.TrainCarOperationsWindow.LayoutMoved = false;
+                    CurrentNewWidth = newWidth;
+                    DisplayReSized = false;
                 }
                 MoveTo(locationX, locationY);
             }
@@ -481,6 +487,12 @@ namespace Orts.Viewer3D.Popups
                     if (Owner.Viewer.PlayerLocomotive != null) LastPlayerLocomotiveFlippedState = Owner.Viewer.PlayerLocomotive.Flipped;
 
                     Layout();
+                    UpdateWindowSize();
+                }
+
+                if (DisplaySizeY != Owner.Viewer.DisplaySize.Y)
+                {
+                    DisplayReSized = true;
                     UpdateWindowSize();
                 }
 


### PR DESCRIPTION
The TrainCarViewer window has an overlap with the TrainCarOperations window when changing the screen size.
More info here, [Bug #2090960](https://bugs.launchpad.net/or/+bug/2090960).