### PR TITLE
Fix: TrainDrivingInfo window width not stable.

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
@@ -227,6 +227,7 @@ namespace Orts.Viewer3D.Popups
 
         public bool normalTextMode = true;// Standard text
         public bool TrainDrivingUpdating = false;
+        public int CurrentWidth = 0;
         public static bool MonoFont;
         public static bool FontChanged;
         public static bool FontToBold;
@@ -488,6 +489,15 @@ namespace Orts.Viewer3D.Popups
 
                 var newHeight = (int)MathHelper.Clamp(desiredHeight, (normalTextMode ? WindowHeightMin : 100), WindowHeightMax);
                 var newWidth = (int)MathHelper.Clamp(desiredWidth, (normalTextMode ? WindowWidthMin : 100), WindowWidthMax);
+
+                // Stable window width
+                if (normalTextMode) CurrentWidth = 0;// Reset CurrentWidth value
+                if (!normalTextMode && newWidth != CurrentWidth)
+                {
+                    var newWidthHigher = newWidth > CurrentWidth;
+                    newWidth = newWidthHigher ? newWidth : CurrentWidth;
+                    CurrentWidth = newWidthHigher ? newWidth : CurrentWidth;
+                }
 
                 // Move the dialog up if we're expanding it, or down if not; this keeps the center in the same place.
                 var newTop = Location.Y + (Location.Height - newHeight) / 2;


### PR DESCRIPTION
When using automatic mode, the width of the TrainDrivingInfo window may change frequently due to the data being displayed. This can be visually disturbing.
[Bug #2090962](https://bugs.launchpad.net/or/+bug/2090962).