### PR TITLE
Bug fix for https://bugs.launchpad.net/or/+bug/2092489 Containers not appearing in timetable mode

### DIFF
--- a/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
@@ -2430,6 +2430,7 @@ namespace Orts.Simulation.Timetables
                     car = RollingStock.Load(simulator, TTTrain, wagonFilePath);
                     car.UiD = wagon.UiD;
                     car.Flipped = consistDetails.reversed ? !wagon.Flip : wagon.Flip;
+                    car.FreightAnimations?.Load(wagon.LoadDataList);
                     car.CarID = string.Concat(TTTrain.Number.ToString("0###"), "_", carId.ToString("0##"));
                     carId++;
                     car.OrgConsist = consistDetails.consistFile.ToLower();


### PR DESCRIPTION
See https://www.elvastower.com/forums/index.php?/topic/38462-container-freight-shapes-not-appearing-in-timetable-mode/