### PR TITLE
Fix: Adds guard for missing notifications

### DIFF
--- a/Source/Menu/Notifications/NotificationManager.cs
+++ b/Source/Menu/Notifications/NotificationManager.cs
@@ -218,9 +218,10 @@ namespace ORTS
         /// </summary>
         public void PopulatePage()
         {
-            Page = new NotificationPage(MainForm, Panel, this); 
+            Page = new NotificationPage(MainForm, Panel, this);
+            var list = Notifications?.NotificationList;
 
-            if (UpdateManager.LastCheckError != null || Error != null)
+            if (UpdateManager.LastCheckError != null || Error != null || list == null)
             {
                 PopulateRetryPage();
             }
@@ -229,7 +230,6 @@ namespace ORTS
                 Settings.LastViewNotificationDate = $"{DateTime.Today:yyyy-MM-dd}";
                 Settings.Save("LastViewNotificationDate");  // Saves the date on any viewing of notifications
 
-                var list = Notifications.NotificationList;
                 var n = list[CurrentPageIndex];
                 LogNotification(n);
 


### PR DESCRIPTION
DRAFT as don't understand yet why this is needed.
MainForm_shown() is not being called, so Notifications are not being populated.
Thorough fix is needed, but this will prevent an exception and then mark the Notifications as "not available".