### PR TITLE
Superelevation Follow Up Fixes

### DIFF
--- a/Source/Orts.Formats.Msts/TrackSectionsFile.cs
+++ b/Source/Orts.Formats.Msts/TrackSectionsFile.cs
@@ -182,8 +182,18 @@ namespace Orts.Formats.Msts
                     STFException.TraceWarning(stf, "Invalid track section " + token);
 			}
 			stf.SkipRestOfBlock();
-		}
-		public uint NoSections;
+        }
+        public SectionIdx(TrackPath path)
+        {
+            X = 0;
+            Y = 0;
+            Z = 0;
+            A = 0;
+            NoSections = path.NoSections;
+            TrackSections = path.TrackSections;
+        }
+
+        public uint NoSections;
 		public double X,Y,Z;  // Offset
 		public double A;  // Angular offset 
 		public uint[] TrackSections;

--- a/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AITrain.cs
@@ -375,10 +375,8 @@ namespace Orts.Simulation.AIs
                 float initialThrottlepercent = InitialThrottlepercent;
                 MUDynamicBrakePercent = -1;
                 AITrainBrakePercent = 0;
-                // Percent slope = rise / run -> the Y position of the forward vector gives us the 'rise'
-                // Derive the 'run' by assuming a hypotenuse length of 1, so run = sqrt(1 - rise^2)
-                float rise = FirstCar.WorldPosition.XNAMatrix.M32;
-                FirstCar.CurrentElevationPercent = 100f * (rise / (float)Math.Sqrt(1 - rise * rise));
+                // Force calculate gradient at the front of the train
+                FirstCar.UpdateGravity();
                 // Give it a bit more gas if it is uphill
                 if (FirstCar.CurrentElevationPercent < -2.0) initialThrottlepercent = 40f;
                 // Better block gas if it is downhill

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -1861,18 +1861,8 @@ namespace Orts.Simulation.Physics
                 MSTSLocomotive lead = (MSTSLocomotive)Cars[LeadLocomotiveIndex];
                 if (lead is MSTSSteamLocomotive) MUReverserPercent = 25;
 
-                // Percent slope = rise / run -> the Y position of the forward vector gives us the 'rise'
-                // Derive the 'run' by assuming a hypotenuse length of 1, so run = sqrt(1 - rise^2)
-                float rise = lead.WorldPosition.XNAMatrix.M32;
-                lead.CurrentElevationPercent = 100f * (rise / (float)Math.Sqrt(1 - rise * rise));
-
-                //TODO: next if block has been inserted to flip trainset physics in order to get viewing direction coincident with loco direction when using rear cab.
-                // To achieve the same result with other means, without flipping trainset physics, the block should be deleted
-                //         
-                if (lead.IsDriveable && (lead as MSTSLocomotive).UsingRearCab)
-                {
-                    lead.CurrentElevationPercent = -lead.CurrentElevationPercent;
-                }
+                // Force calculate gradient at the lead locomotive
+                lead.UpdateGravity();
                 // give it a bit more gas if it is uphill
                 if (lead.CurrentElevationPercent < -2.0) initialThrottlepercent = 40f;
                 // better block gas if it is downhill
@@ -4532,9 +4522,7 @@ namespace Orts.Simulation.Physics
                     car.WorldPosition.XNAMatrix *= Simulator.XNAMatrixFromMSTSCoordinates(traveller.X, traveller.Y, traveller.Z, x, y, z);
 
                     // Update gravity force when position is updated, but before any secondary motion is added
-                    Vector3 fwd = car.WorldPosition.XNAMatrix.Backward;
-                    car.GravityForceN = car.MassKG * TrainCar.GravitationalAccelerationMpS2 * fwd.Y;
-                    car.CurrentElevationPercent = 100f * (fwd.Y / (float)Math.Sqrt(1 - fwd.Y * fwd.Y));
+                    car.UpdateGravity();
 
                     // Apply superelevation to car
                     car.WorldPosition.XNAMatrix = Matrix.CreateRotationZ((car.Flipped ? -1.0f : 1.0f) * roll) * car.WorldPosition.XNAMatrix;
@@ -4653,9 +4641,7 @@ namespace Orts.Simulation.Physics
                     car.WorldPosition.XNAMatrix *= Simulator.XNAMatrixFromMSTSCoordinates(traveller.X, traveller.Y, traveller.Z, x, y, z);
 
                     // Update gravity force when position is updated, but before any secondary motion is added
-                    Vector3 fwd = car.WorldPosition.XNAMatrix.Backward;
-                    car.GravityForceN = car.MassKG * TrainCar.GravitationalAccelerationMpS2 * fwd.Y;
-                    car.CurrentElevationPercent = 100f * (fwd.Y / (float)Math.Sqrt(1 - fwd.Y * fwd.Y));
+                    car.UpdateGravity();
 
                     // Apply superelevation to car
                     car.WorldPosition.XNAMatrix = Matrix.CreateRotationZ((car.Flipped ? -1.0f : 1.0f) * roll) * car.WorldPosition.XNAMatrix;
@@ -4734,9 +4720,7 @@ namespace Orts.Simulation.Physics
                 car.WorldPosition.XNAMatrix *= Simulator.XNAMatrixFromMSTSCoordinates(traveller.X, traveller.Y, traveller.Z, x, y, z);
 
                 // Update gravity force when position is updated, but before any secondary motion is added
-                Vector3 fwd = car.WorldPosition.XNAMatrix.Backward;
-                car.GravityForceN = car.MassKG * TrainCar.GravitationalAccelerationMpS2 * fwd.Y;
-                car.CurrentElevationPercent = 100f * (fwd.Y / (float)Math.Sqrt(1 - fwd.Y * fwd.Y));
+                car.UpdateGravity();
 
                 // Apply superelevation to car
                 car.WorldPosition.XNAMatrix = Matrix.CreateRotationZ((car.Flipped ? -1.0f : 1.0f) * roll) * car.WorldPosition.XNAMatrix;

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -4512,9 +4512,9 @@ namespace Orts.Simulation.Physics
 
                     // Update car's curve radius and superelevation based on bogie position and move traveller to front bogie
                     // Also determine roll angle for superelevation by averaging both bogies
-                    float roll = traveller.GetVisualElevation();
+                    float roll = traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation);
                     car.UpdateCurvePhys(traveller, new[] { 0, car.CarBogieCentreLengthM });
-                    roll = (roll + traveller.GetVisualElevation()) / 2.0f;
+                    roll = (roll + traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation)) / 2.0f;
 
                     // Normalize across tile boundaries
                     x += 2048 * (tileX - traveller.TileX);
@@ -4633,9 +4633,9 @@ namespace Orts.Simulation.Physics
 
                     // Update car's curve radius and superelevation based on bogie position and move traveller to front bogie
                     // Outputs rotation angle for superelevation, used below
-                    float roll = traveller.GetVisualElevation();
+                    float roll = traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation);
                     car.UpdateCurvePhys(traveller, new[] { 0, car.CarBogieCentreLengthM });
-                    roll = (roll + traveller.GetVisualElevation()) / 2.0f;
+                    roll = (roll + traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation)) / 2.0f;
 
                     // Normalize across tile boundaries
                     x += 2048 * (tileX - traveller.TileX);
@@ -4714,9 +4714,9 @@ namespace Orts.Simulation.Physics
 
                 // Update car's curve radius and superelevation based on bogie position and move traveller to front bogie
                 // Outputs rotation angle for superelevation, used below
-                float roll = traveller.GetVisualElevation();
+                float roll = traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation);
                 car.UpdateCurvePhys(traveller, new[] { 0, car.CarBogieCentreLengthM });
-                roll = (roll + traveller.GetVisualElevation()) / 2.0f;
+                roll = (roll + traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation)) / 2.0f;
 
                 // Normalize across tile boundaries
                 x += 2048 * (tileX - traveller.TileX);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -974,15 +974,6 @@ namespace Orts.Simulation.RollingStocks
 
             AbsSpeedMpS = Math.Abs(_SpeedMpS);
 
-            //TODO: next if block has been inserted to flip trainset physics in order to get viewing direction coincident with loco direction when using rear cab.
-            // To achieve the same result with other means, without flipping trainset physics, the block should be deleted
-            //      
-            if (IsDriveable && Train != null & Train.IsPlayerDriven && (this as MSTSLocomotive).UsingRearCab)
-            {
-                GravityForceN = -GravityForceN;
-                CurrentElevationPercent = -CurrentElevationPercent;
-            }
-
             UpdateCurveSpeedLimit(elapsedClockSeconds);
             UpdateCurveForce(elapsedClockSeconds);
             UpdateTunnelForce();
@@ -2824,8 +2815,7 @@ namespace Orts.Simulation.RollingStocks
             m.Backward = fwd;
 
             // Update gravity force when position is updated, but before any secondary motion is added
-            GravityForceN = MassKG * GravitationalAccelerationMpS2 * fwd.Y;
-            CurrentElevationPercent = 100f * (fwd.Y / (float)Math.Sqrt(1 - fwd.Y * fwd.Y));
+            UpdateGravity(m);
 
             // Consider body roll from superelevation and from tilting.
             UpdateTilting(traveler, elapsedTimeS, speed, direction);
@@ -3527,6 +3517,36 @@ namespace Orts.Simulation.RollingStocks
             }
 
             return new LatLonDirection(latLon, directionDeg); ;
+        }
+
+        /// <summary>
+        /// Update the gravity force and % gradient of this train car at the current position
+        /// </summary>
+        public void UpdateGravity()
+        {
+            UpdateGravity(WorldPosition.XNAMatrix);
+        }
+
+        /// <summary>
+        /// Update the gravity force and % gradient of this train car at an arbitrary position
+        /// </summary>
+        /// <param name="orientation">Matrix giving the train car orientation used to determine gravity.</param>
+        public void UpdateGravity(Matrix orientation)
+        {
+            // Percent slope = 100 * rise / run -> the Y component of the forward vector gives us the 'rise'
+            // Derive the 'run' by assuming a hypotenuse length of 1, so per Pythagoras run = sqrt(1 - rise^2)
+            float rise = orientation.Backward.Y;
+
+            GravityForceN = MassKG * GravitationalAccelerationMpS2 * rise;
+            CurrentElevationPercent = 100f * (rise / (float)Math.Sqrt(1 - rise * rise));
+
+            // Reverse gravity force and % gradient on locomotives operated from the rear cab
+            // FUTURE: Change rear cabs to not require such forbidden manipulations of physics
+            if (IsDriveable && Train != null & Train.IsPlayerDriven && (this as MSTSLocomotive).UsingRearCab)
+            {
+                GravityForceN = -GravityForceN;
+                CurrentElevationPercent = -CurrentElevationPercent;
+            }
         }
     }
 

--- a/Source/RunActivity/Viewer3D/DynamicTrack.cs
+++ b/Source/RunActivity/Viewer3D/DynamicTrack.cs
@@ -1508,6 +1508,9 @@ namespace Orts.Viewer3D
                     }
                     break;
             }
+            // Limit the number of sections to prevent overflowing the number of triangles
+            if (NumSections > 250)
+                NumSections = 250;
             // Ensure an even number of sections
             if (NumSections % 2 == 1)
                 NumSections++;

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSWagonViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSWagonViewer.cs
@@ -882,7 +882,7 @@ namespace Orts.Viewer3D.RollingStock
 
 #endif
 
-            // truck angle animation
+            // Bogie angle animation
             Matrix inverseLocation = Matrix.Invert(Car.WorldPosition.XNAMatrix);
 
             foreach (var p in Car.Parts)
@@ -890,25 +890,30 @@ namespace Orts.Viewer3D.RollingStock
                 if (p.iMatrix <= 0)
                     continue;
 
-                // Determine orientation of bogie in absolute space
                 Matrix m = Matrix.Identity;
-                Vector3 fwd = new Vector3(p.Dir[0], p.Dir[1], -p.Dir[2]);
-                // Only do this calculation if the bogie position has been calculated
-                if (!(fwd.X == 0 && fwd.Y == 0 && fwd.Z == 0))
+
+                // Bogie rotation calculation doesn't work on turntables
+                // Assume bogies aren't rotated when on a turntable
+                if (Car.Train?.ControlMode != Train.TRAIN_CONTROL.TURNTABLE)
                 {
-                    fwd.Normalize();
-                    Vector3 side = Vector3.Cross(Vector3.Up, fwd);
-                    if (!(side.X == 0 && side.Y == 0 && side.Z == 0))
-                        side.Normalize();
-                    Vector3 up = Vector3.Cross(fwd, side);
-                    m.Right = side;
-                    m.Up = up;
-                    m.Backward = fwd;
+                    // Determine orientation of bogie in absolute space
+                    Vector3 fwd = new Vector3(p.Dir[0], p.Dir[1], -p.Dir[2]);
+                    // Only do this calculation if the bogie position has been calculated
+                    if (!(fwd.X == 0 && fwd.Y == 0 && fwd.Z == 0))
+                    {
+                        fwd.Normalize();
+                        Vector3 side = Vector3.Cross(Vector3.Up, fwd);
+                        if (!(side.X == 0 && side.Y == 0 && side.Z == 0))
+                            side.Normalize();
+                        Vector3 up = Vector3.Cross(fwd, side);
+                        m.Right = side;
+                        m.Up = up;
+                        m.Backward = fwd;
 
-                    // Convert absolute rotation into rotation relative to train car
-                    m = Matrix.CreateRotationZ(p.Roll) * m * inverseLocation;
+                        // Convert absolute rotation into rotation relative to train car
+                        m = Matrix.CreateRotationZ(p.Roll) * m * inverseLocation;
+                    }
                 }
-
                 // Insert correct translation (previous step likely introduced garbage data)
                 m.Translation = TrainCarShape.SharedShape.Matrices[p.iMatrix].Translation;
 

--- a/Source/RunActivity/Viewer3D/SuperElevation.cs
+++ b/Source/RunActivity/Viewer3D/SuperElevation.cs
@@ -838,6 +838,9 @@ namespace Orts.Viewer3D
                 // Very short length track, use minimum of two sections
                 if (NumSections == 0)
                     NumSections = 2;
+                // Limit the number of sections to prevent overflowing the number of triangles
+                else if (NumSections > 250)
+                    NumSections = 250;
                 // Ensure an even number of sections
                 if (NumSections % 2 == 1)
                     NumSections++;


### PR DESCRIPTION
Follow up to #954 

One lacking point of the superelevation rewrite that a few [users noticed](https://www.elvastower.com/forums/index.php?/topic/38114-multiple-track-profiles/page__view__findpost__p__313415) was the [lack of support for DynaTrax](https://www.trainsim.com/forums/forum/open-rails/open-rails-modeling-and-physics/2315220-dbtracks-with-superelevation?p=2315452#post2315452). Due to the unusual way DynaTrax is handled, the system would interpret a DynaTrax object as a missing section of track, resulting in no superelevation when some should be present. Dedicated detection for this edge case has been added, which will attempt a second method of checking the TSection if the usual method fails to find a match, which should catch a lot of DynaTrax and other custom track sections.

No changes should be required from the content side, though track profiles might not correctly match to DynaTrax sections if "IncludedShapes" or "ExcludedShapes" are used in the track profile as DynaTrax shapes tend to have very different naming schemes than typical track shapes.

Except in niche situations (eg: you want dynamic track with different appearances in different places, as opposed to the current dynamic track system which always produces the same appearance), regular old dynamic track plus TrProfile(s) will be more reliable and easier to work with than DynaTrax.


Also includes other small bugfixes

- [Rigid frame rolling stock will correctly have superelevation disabled when superelevation is disabled globally](https://www.elvastower.com/forums/index.php?/topic/38542-problem-with-superelevation-and-two-axle-rolling-stock/)
- [Dynamic track segments are now limited to 250 sections in order to lower risk of excessively complicated 3D models](https://www.elvastower.com/forums/index.php?/topic/38586-crash-with-track-profile/)
- [Bogie rotation calculations are now disabled while on a turntable as the superelevation method used doesn't work with turntables](https://bugs.launchpad.net/or/+bug/2101066)
- [Some unusual track sections are now accounted for, fixing some cases of missing superelevation](https://www.elvastower.com/forums/index.php?/topic/38699-super-elevation-anomoly/page__gopid__317131#entry317131)
- [Gravity calculations tweaked again to ensure the expected gradient is shown when in a rear cab](https://www.elvastower.com/forums/index.php?/topic/38497-incorrect-gradient-display-on-track-monitor/)