### PR TITLE
fix: revert namespace changes to restore Notifications

### DIFF
--- a/Source/Menu/ContentForm.Designer.cs
+++ b/Source/Menu/ContentForm.Designer.cs
@@ -17,7 +17,7 @@
 
 using System.Windows.Forms;
 
-namespace Menu
+namespace ORTS
 {
     partial class ContentForm : Form
     {
@@ -418,7 +418,7 @@ namespace Menu
             // 
             // pbContent
             // 
-            this.pbContent.Image = global::Menu.Properties.Resources.info_18_hover;
+            this.pbContent.Image = global::ORTS.Properties.Resources.info_18_hover;
             this.pbContent.Location = new System.Drawing.Point(598, 12);
             this.pbContent.Name = "pbContent";
             this.pbContent.Size = new System.Drawing.Size(18, 18);

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -33,7 +33,7 @@ using System.Drawing;
 using System.Threading.Tasks;
 using GNU.Gettext.WinForms;
 
-namespace Menu
+namespace ORTS
 {
     public partial class ContentForm : Form
     {
@@ -1120,25 +1120,25 @@ namespace Menu
                 switch (classOfItem)
                 {
                     case "Folder":
-                        comboboxName = ((ORTS.Menu.Folder)comboBox.Items[index]).Name;
+                        comboboxName = ((Menu.Folder)comboBox.Items[index]).Name;
                         break;
                     case "Route":
-                        comboboxName = ((ORTS.Menu.Route)comboBox.Items[index]).Name;
+                        comboboxName = ((Menu.Route)comboBox.Items[index]).Name;
                         break;
                     case "DefaultExploreActivity":
-                        comboboxName = ((ORTS.Menu.Activity)comboBox.Items[index]).Name;
+                        comboboxName = ((Menu.Activity)comboBox.Items[index]).Name;
                         break;
                     case "Locomotive":
-                        comboboxName = ((ORTS.Menu.Locomotive)comboBox.Items[index]).Name;
+                        comboboxName = ((Menu.Locomotive)comboBox.Items[index]).Name;
                         break;
                     case "Consist":
-                        comboboxName = ((ORTS.Menu.Consist)comboBox.Items[index]).Name;
+                        comboboxName = ((Menu.Consist)comboBox.Items[index]).Name;
                         break;
                     case "String":
                         comboboxName = (string)comboBox.Items[index];
                         break;
                     case "Path":
-                        comboboxName = ((ORTS.Menu.Path)comboBox.Items[index]).End;
+                        comboboxName = ((Menu.Path)comboBox.Items[index]).End;
                         break;
                     case "KeyedComboBoxItem":
                         comboboxName = ((MainForm.KeyedComboBoxItem)comboBox.Items[index]).Value;

--- a/Source/Menu/ImportExportSaveForm.Designer.cs
+++ b/Source/Menu/ImportExportSaveForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Menu {
+﻿namespace ORTS {
     partial class ImportExportSaveForm {
         /// <summary>
         /// Required designer variable.

--- a/Source/Menu/ImportExportSaveForm.cs
+++ b/Source/Menu/ImportExportSaveForm.cs
@@ -25,7 +25,7 @@ using GNU.Gettext;
 using GNU.Gettext.WinForms;
 using ORTS.Settings;
 
-namespace Menu
+namespace ORTS
 {
     public partial class ImportExportSaveForm : Form
     {

--- a/Source/Menu/KeyInputControl.Designer.cs
+++ b/Source/Menu/KeyInputControl.Designer.cs
@@ -1,6 +1,6 @@
 ﻿
 
-namespace Menu
+namespace ORTS
 {
     partial class KeyInputControl
     {

--- a/Source/Menu/KeyInputControl.cs
+++ b/Source/Menu/KeyInputControl.cs
@@ -20,7 +20,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using ORTS.Settings;
 
-namespace Menu
+namespace ORTS
 {
     /// <summary>
     /// A control for viewing and altering keyboard input settings, in combination with <see cref="KeyInputEditControl"/>.

--- a/Source/Menu/KeyInputEditControl.Designer.cs
+++ b/Source/Menu/KeyInputEditControl.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Menu
+﻿namespace ORTS
 {
     partial class KeyInputEditControl
     {

--- a/Source/Menu/KeyInputEditControl.cs
+++ b/Source/Menu/KeyInputEditControl.cs
@@ -23,7 +23,7 @@ using System.Windows.Forms;
 using ORTS.Settings;
 using Xna = Microsoft.Xna.Framework.Input;
 
-namespace Menu
+namespace ORTS
 {
     /// <summary>
     /// A form used to edit keyboard input settings, in combination with <see cref="KeyInputControl"/>.

--- a/Source/Menu/MainForm.Designer.cs
+++ b/Source/Menu/MainForm.Designer.cs
@@ -1,6 +1,6 @@
 ﻿// #define INCLUDE_TIMETABLE_INPUT
 
-namespace Menu
+namespace ORTS
 {
     partial class MainForm
     {
@@ -894,7 +894,7 @@ namespace Menu
             // pbNotificationsSome
             // 
             this.pbNotificationsSome.BackColor = System.Drawing.Color.Transparent;
-            this.pbNotificationsSome.Image = global::Menu.Properties.Resources.chat_icon_new_message_transparent;
+            this.pbNotificationsSome.Image = global::ORTS.Properties.Resources.chat_icon_new_message_transparent;
             this.pbNotificationsSome.Location = new System.Drawing.Point(805, 0);
             this.pbNotificationsSome.Name = "pbNotificationsSome";
             this.pbNotificationsSome.Size = new System.Drawing.Size(37, 31);
@@ -905,7 +905,7 @@ namespace Menu
             // 
             // pbNotificationsNone
             // 
-            this.pbNotificationsNone.Image = global::Menu.Properties.Resources.chat_icon_no_message_transparent;
+            this.pbNotificationsNone.Image = global::ORTS.Properties.Resources.chat_icon_no_message_transparent;
             this.pbNotificationsNone.InitialImage = ((System.Drawing.Image)(resources.GetObject("pbNotificationsNone.InitialImage")));
             this.pbNotificationsNone.Location = new System.Drawing.Point(805, 0);
             this.pbNotificationsNone.Name = "pbNotificationsNone";

--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -35,7 +35,7 @@ using ORTS.Updater;
 using Activity = ORTS.Menu.Activity;
 using Path = ORTS.Menu.Path;
 
-namespace Menu
+namespace ORTS
 {
     public partial class MainForm : Form
     {
@@ -69,7 +69,7 @@ namespace Menu
         Task<List<Path>> PathLoader;
         Task<List<TimetableInfo>> TimetableSetLoader;
         Task<List<WeatherFileInfo>> TimetableWeatherFileLoader;
-        readonly ResourceManager Resources = new ResourceManager("Menu.Properties.Resources", typeof(MainForm).Assembly);
+        readonly ResourceManager Resources = new ResourceManager("ORTS.Properties.Resources", typeof(MainForm).Assembly);
         readonly UpdateManager UpdateManager;
         readonly Image ElevationIcon;
         NotificationManager NotificationManager;

--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -27,7 +27,6 @@ using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using GNU.Gettext;
 using GNU.Gettext.WinForms;
-using Menu.Notifications;
 using Orts.Formats.OR;
 using ORTS.Common;
 using ORTS.Menu;

--- a/Source/Menu/Menu.csproj
+++ b/Source/Menu/Menu.csproj
@@ -3,6 +3,7 @@
     <TargetFramework Condition="'$(BuildDotNet)' == 'true'">net6-windows</TargetFramework>
     <TargetFramework Condition="'$(TargetFramework)' == ''">net472</TargetFramework>
     <OutputType>WinExe</OutputType>
+    <RootNamespace>ORTS</RootNamespace>
     <ApplicationIcon>..\ORTS.ico</ApplicationIcon>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>

--- a/Source/Menu/Notifications/NotificationManager.cs
+++ b/Source/Menu/Notifications/NotificationManager.cs
@@ -31,7 +31,7 @@ using ORTS.Common;
 using ORTS.Settings;
 using ORTS.Updater;
 using static ORTS.Common.SystemInfo;
-using static Menu.NotificationPage;
+using static ORTS.NotificationPage;
 
 // Behaviour
 // Notifications are read only once as a background task at start into Notifications.
@@ -40,7 +40,7 @@ using static Menu.NotificationPage;
 // the visibility of each notification in NotificationList is re-assessed. Also its date.
 // Every time the user selects a different notification page, the panel is re-loaded with items for that page.
 
-namespace Menu
+namespace ORTS
 {
     public class NotificationManager
     {

--- a/Source/Menu/Notifications/NotificationManager.cs
+++ b/Source/Menu/Notifications/NotificationManager.cs
@@ -31,7 +31,7 @@ using ORTS.Common;
 using ORTS.Settings;
 using ORTS.Updater;
 using static ORTS.Common.SystemInfo;
-using static Menu.Notifications.NotificationPage;
+using static Menu.NotificationPage;
 
 // Behaviour
 // Notifications are read only once as a background task at start into Notifications.
@@ -40,7 +40,7 @@ using static Menu.Notifications.NotificationPage;
 // the visibility of each notification in NotificationList is re-assessed. Also its date.
 // Every time the user selects a different notification page, the panel is re-loaded with items for that page.
 
-namespace Menu.Notifications
+namespace Menu
 {
     public class NotificationManager
     {

--- a/Source/Menu/Notifications/NotificationPage.cs
+++ b/Source/Menu/Notifications/NotificationPage.cs
@@ -24,7 +24,7 @@ using ORTS.Updater;
 using Button = System.Windows.Forms.Button;
 using Image = System.Drawing.Image;
 
-namespace Menu.Notifications
+namespace Menu
 {
     /// <summary>
     /// Holds presentation details of the current notification displayed on the panel.

--- a/Source/Menu/Notifications/NotificationPage.cs
+++ b/Source/Menu/Notifications/NotificationPage.cs
@@ -24,7 +24,7 @@ using ORTS.Updater;
 using Button = System.Windows.Forms.Button;
 using Image = System.Drawing.Image;
 
-namespace Menu
+namespace ORTS
 {
     /// <summary>
     /// Holds presentation details of the current notification displayed on the panel.

--- a/Source/Menu/Notifications/Notifications.cs
+++ b/Source/Menu/Notifications/Notifications.cs
@@ -18,7 +18,7 @@
 using System.Collections.Generic;
 
 
-namespace Menu
+namespace ORTS
 {
     public class Notifications
     {

--- a/Source/Menu/Notifications/Notifications.cs
+++ b/Source/Menu/Notifications/Notifications.cs
@@ -18,7 +18,7 @@
 using System.Collections.Generic;
 
 
-namespace Menu.Notifications
+namespace Menu
 {
     public class Notifications
     {

--- a/Source/Menu/Options.Designer.cs
+++ b/Source/Menu/Options.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Menu
+﻿namespace ORTS
 {
     partial class OptionsForm
     {
@@ -479,7 +479,7 @@
             // 
             // pbOverspeedMonitor
             // 
-            this.pbOverspeedMonitor.Image = global::Menu.Properties.Resources.info_18;
+            this.pbOverspeedMonitor.Image = global::ORTS.Properties.Resources.info_18;
             this.pbOverspeedMonitor.Location = new System.Drawing.Point(296, 7);
             this.pbOverspeedMonitor.Name = "pbOverspeedMonitor";
             this.pbOverspeedMonitor.Size = new System.Drawing.Size(18, 18);
@@ -491,7 +491,7 @@
             // 
             // pbEnableTcsScripts
             // 
-            this.pbEnableTcsScripts.Image = global::Menu.Properties.Resources.info_18;
+            this.pbEnableTcsScripts.Image = global::ORTS.Properties.Resources.info_18;
             this.pbEnableTcsScripts.Location = new System.Drawing.Point(6, 263);
             this.pbEnableTcsScripts.Name = "pbEnableTcsScripts";
             this.pbEnableTcsScripts.Size = new System.Drawing.Size(18, 18);
@@ -503,7 +503,7 @@
             // 
             // pbOtherUnits
             // 
-            this.pbOtherUnits.Image = global::Menu.Properties.Resources.info_18;
+            this.pbOtherUnits.Image = global::ORTS.Properties.Resources.info_18;
             this.pbOtherUnits.Location = new System.Drawing.Point(6, 234);
             this.pbOtherUnits.Name = "pbOtherUnits";
             this.pbOtherUnits.Size = new System.Drawing.Size(18, 18);
@@ -515,7 +515,7 @@
             // 
             // pbPressureUnit
             // 
-            this.pbPressureUnit.Image = global::Menu.Properties.Resources.info_18;
+            this.pbPressureUnit.Image = global::ORTS.Properties.Resources.info_18;
             this.pbPressureUnit.Location = new System.Drawing.Point(6, 207);
             this.pbPressureUnit.Name = "pbPressureUnit";
             this.pbPressureUnit.Size = new System.Drawing.Size(18, 18);
@@ -527,7 +527,7 @@
             // 
             // pbBrakePipeChargingRate
             // 
-            this.pbBrakePipeChargingRate.Image = global::Menu.Properties.Resources.info_18;
+            this.pbBrakePipeChargingRate.Image = global::ORTS.Properties.Resources.info_18;
             this.pbBrakePipeChargingRate.Location = new System.Drawing.Point(6, 145);
             this.pbBrakePipeChargingRate.Name = "pbBrakePipeChargingRate";
             this.pbBrakePipeChargingRate.Size = new System.Drawing.Size(18, 18);
@@ -539,7 +539,7 @@
             // 
             // pbGraduatedRelease
             // 
-            this.pbGraduatedRelease.Image = global::Menu.Properties.Resources.info_18;
+            this.pbGraduatedRelease.Image = global::ORTS.Properties.Resources.info_18;
             this.pbGraduatedRelease.Location = new System.Drawing.Point(6, 122);
             this.pbGraduatedRelease.Name = "pbGraduatedRelease";
             this.pbGraduatedRelease.Size = new System.Drawing.Size(18, 18);
@@ -551,7 +551,7 @@
             // 
             // pbRetainers
             // 
-            this.pbRetainers.Image = global::Menu.Properties.Resources.info_18;
+            this.pbRetainers.Image = global::ORTS.Properties.Resources.info_18;
             this.pbRetainers.Location = new System.Drawing.Point(6, 99);
             this.pbRetainers.Name = "pbRetainers";
             this.pbRetainers.Size = new System.Drawing.Size(18, 18);
@@ -563,7 +563,7 @@
             // 
             // pbAlerter
             // 
-            this.pbAlerter.Image = global::Menu.Properties.Resources.info_18;
+            this.pbAlerter.Image = global::ORTS.Properties.Resources.info_18;
             this.pbAlerter.Location = new System.Drawing.Point(6, 7);
             this.pbAlerter.Name = "pbAlerter";
             this.pbAlerter.Size = new System.Drawing.Size(18, 18);
@@ -683,7 +683,7 @@
             // 
             // pbExternalSoundPassThruPercent
             // 
-            this.pbExternalSoundPassThruPercent.Image = global::Menu.Properties.Resources.info_18;
+            this.pbExternalSoundPassThruPercent.Image = global::ORTS.Properties.Resources.info_18;
             this.pbExternalSoundPassThruPercent.Location = new System.Drawing.Point(11, 73);
             this.pbExternalSoundPassThruPercent.Name = "pbExternalSoundPassThruPercent";
             this.pbExternalSoundPassThruPercent.Size = new System.Drawing.Size(18, 18);
@@ -695,7 +695,7 @@
             // 
             // pbSoundDetailLevel
             // 
-            this.pbSoundDetailLevel.Image = global::Menu.Properties.Resources.info_18;
+            this.pbSoundDetailLevel.Image = global::ORTS.Properties.Resources.info_18;
             this.pbSoundDetailLevel.Location = new System.Drawing.Point(11, 41);
             this.pbSoundDetailLevel.Name = "pbSoundDetailLevel";
             this.pbSoundDetailLevel.Size = new System.Drawing.Size(18, 18);
@@ -707,7 +707,7 @@
             // 
             // pbSoundVolumePercent
             // 
-            this.pbSoundVolumePercent.Image = global::Menu.Properties.Resources.info_18;
+            this.pbSoundVolumePercent.Image = global::ORTS.Properties.Resources.info_18;
             this.pbSoundVolumePercent.Location = new System.Drawing.Point(11, 9);
             this.pbSoundVolumePercent.Name = "pbSoundVolumePercent";
             this.pbSoundVolumePercent.Size = new System.Drawing.Size(18, 18);
@@ -863,7 +863,7 @@
             // 
             // pbViewingFOV
             // 
-            this.pbViewingFOV.Image = global::Menu.Properties.Resources.info_18;
+            this.pbViewingFOV.Image = global::ORTS.Properties.Resources.info_18;
             this.pbViewingFOV.Location = new System.Drawing.Point(312, 233);
             this.pbViewingFOV.Name = "pbViewingFOV";
             this.pbViewingFOV.Size = new System.Drawing.Size(18, 18);
@@ -885,7 +885,7 @@
             // 
             // pbLODBias
             // 
-            this.pbLODBias.Image = global::Menu.Properties.Resources.info_18;
+            this.pbLODBias.Image = global::ORTS.Properties.Resources.info_18;
             this.pbLODBias.Location = new System.Drawing.Point(312, 169);
             this.pbLODBias.Name = "pbLODBias";
             this.pbLODBias.Size = new System.Drawing.Size(18, 18);
@@ -897,7 +897,7 @@
             // 
             // pbWorldObjectDensity
             // 
-            this.pbWorldObjectDensity.Image = global::Menu.Properties.Resources.info_18;
+            this.pbWorldObjectDensity.Image = global::ORTS.Properties.Resources.info_18;
             this.pbWorldObjectDensity.Location = new System.Drawing.Point(312, 137);
             this.pbWorldObjectDensity.Name = "pbWorldObjectDensity";
             this.pbWorldObjectDensity.Size = new System.Drawing.Size(18, 18);
@@ -909,7 +909,7 @@
             // 
             // pbAntiAliasing
             // 
-            this.pbAntiAliasing.Image = global::Menu.Properties.Resources.info_18;
+            this.pbAntiAliasing.Image = global::ORTS.Properties.Resources.info_18;
             this.pbAntiAliasing.Location = new System.Drawing.Point(312, 73);
             this.pbAntiAliasing.Name = "pbAntiAliasing";
             this.pbAntiAliasing.Size = new System.Drawing.Size(18, 18);
@@ -921,7 +921,7 @@
             // 
             // pbVerticalSync
             // 
-            this.pbVerticalSync.Image = global::Menu.Properties.Resources.info_18;
+            this.pbVerticalSync.Image = global::ORTS.Properties.Resources.info_18;
             this.pbVerticalSync.Location = new System.Drawing.Point(312, 41);
             this.pbVerticalSync.Name = "pbVerticalSync";
             this.pbVerticalSync.Size = new System.Drawing.Size(18, 18);
@@ -933,7 +933,7 @@
             // 
             // pbModelInstancing
             // 
-            this.pbModelInstancing.Image = global::Menu.Properties.Resources.info_18;
+            this.pbModelInstancing.Image = global::ORTS.Properties.Resources.info_18;
             this.pbModelInstancing.Location = new System.Drawing.Point(312, 9);
             this.pbModelInstancing.Name = "pbModelInstancing";
             this.pbModelInstancing.Size = new System.Drawing.Size(18, 18);
@@ -945,7 +945,7 @@
             // 
             // pbDayAmbientLight
             // 
-            this.pbDayAmbientLight.Image = global::Menu.Properties.Resources.info_18;
+            this.pbDayAmbientLight.Image = global::ORTS.Properties.Resources.info_18;
             this.pbDayAmbientLight.Location = new System.Drawing.Point(11, 297);
             this.pbDayAmbientLight.Name = "pbDayAmbientLight";
             this.pbDayAmbientLight.Size = new System.Drawing.Size(18, 18);
@@ -957,7 +957,7 @@
             // 
             // pbSignalLightGlow
             // 
-            this.pbSignalLightGlow.Image = global::Menu.Properties.Resources.info_18;
+            this.pbSignalLightGlow.Image = global::ORTS.Properties.Resources.info_18;
             this.pbSignalLightGlow.Location = new System.Drawing.Point(11, 265);
             this.pbSignalLightGlow.Name = "pbSignalLightGlow";
             this.pbSignalLightGlow.Size = new System.Drawing.Size(18, 18);
@@ -969,7 +969,7 @@
             // 
             // pbDoubleWire
             // 
-            this.pbDoubleWire.Image = global::Menu.Properties.Resources.info_18;
+            this.pbDoubleWire.Image = global::ORTS.Properties.Resources.info_18;
             this.pbDoubleWire.Location = new System.Drawing.Point(11, 233);
             this.pbDoubleWire.Name = "pbDoubleWire";
             this.pbDoubleWire.Size = new System.Drawing.Size(18, 18);
@@ -981,7 +981,7 @@
             // 
             // pbWire
             // 
-            this.pbWire.Image = global::Menu.Properties.Resources.info_18;
+            this.pbWire.Image = global::ORTS.Properties.Resources.info_18;
             this.pbWire.Location = new System.Drawing.Point(11, 201);
             this.pbWire.Name = "pbWire";
             this.pbWire.Size = new System.Drawing.Size(18, 18);
@@ -993,7 +993,7 @@
             // 
             // pbShadowAllShapes
             // 
-            this.pbShadowAllShapes.Image = global::Menu.Properties.Resources.info_18;
+            this.pbShadowAllShapes.Image = global::ORTS.Properties.Resources.info_18;
             this.pbShadowAllShapes.Location = new System.Drawing.Point(11, 169);
             this.pbShadowAllShapes.Name = "pbShadowAllShapes";
             this.pbShadowAllShapes.Size = new System.Drawing.Size(18, 18);
@@ -1005,7 +1005,7 @@
             // 
             // pbDynamicShadows
             // 
-            this.pbDynamicShadows.Image = global::Menu.Properties.Resources.info_18;
+            this.pbDynamicShadows.Image = global::ORTS.Properties.Resources.info_18;
             this.pbDynamicShadows.Location = new System.Drawing.Point(11, 137);
             this.pbDynamicShadows.Name = "pbDynamicShadows";
             this.pbDynamicShadows.Size = new System.Drawing.Size(18, 18);
@@ -1017,7 +1017,7 @@
             // 
             // pbLODViewingExtension
             // 
-            this.pbLODViewingExtension.Image = global::Menu.Properties.Resources.info_18;
+            this.pbLODViewingExtension.Image = global::ORTS.Properties.Resources.info_18;
             this.pbLODViewingExtension.Location = new System.Drawing.Point(11, 105);
             this.pbLODViewingExtension.Name = "pbLODViewingExtension";
             this.pbLODViewingExtension.Size = new System.Drawing.Size(18, 18);
@@ -1029,7 +1029,7 @@
             // 
             // pbDistantMountains
             // 
-            this.pbDistantMountains.Image = global::Menu.Properties.Resources.info_18;
+            this.pbDistantMountains.Image = global::ORTS.Properties.Resources.info_18;
             this.pbDistantMountains.Location = new System.Drawing.Point(11, 41);
             this.pbDistantMountains.Name = "pbDistantMountains";
             this.pbDistantMountains.Size = new System.Drawing.Size(18, 18);
@@ -1041,7 +1041,7 @@
             // 
             // pbViewingDistance
             // 
-            this.pbViewingDistance.Image = global::Menu.Properties.Resources.info_18;
+            this.pbViewingDistance.Image = global::ORTS.Properties.Resources.info_18;
             this.pbViewingDistance.Location = new System.Drawing.Point(11, 9);
             this.pbViewingDistance.Name = "pbViewingDistance";
             this.pbViewingDistance.Size = new System.Drawing.Size(18, 18);
@@ -1970,7 +1970,7 @@
             // 
             // pbPerformanceTuner
             // 
-            this.pbPerformanceTuner.Image = global::Menu.Properties.Resources.info_18;
+            this.pbPerformanceTuner.Image = global::ORTS.Properties.Resources.info_18;
             this.pbPerformanceTuner.Location = new System.Drawing.Point(11, 330);
             this.pbPerformanceTuner.Name = "pbPerformanceTuner";
             this.pbPerformanceTuner.Size = new System.Drawing.Size(18, 18);
@@ -2034,7 +2034,7 @@
             // 
             // pbWebServerPort
             // 
-            this.pbWebServerPort.Image = global::Menu.Properties.Resources.info_18;
+            this.pbWebServerPort.Image = global::ORTS.Properties.Resources.info_18;
             this.pbWebServerPort.Location = new System.Drawing.Point(11, 298);
             this.pbWebServerPort.Name = "pbWebServerPort";
             this.pbWebServerPort.Size = new System.Drawing.Size(18, 18);
@@ -2078,7 +2078,7 @@
             // 
             // pbControlConfirmations
             // 
-            this.pbControlConfirmations.Image = global::Menu.Properties.Resources.info_18;
+            this.pbControlConfirmations.Image = global::ORTS.Properties.Resources.info_18;
             this.pbControlConfirmations.Location = new System.Drawing.Point(11, 266);
             this.pbControlConfirmations.Name = "pbControlConfirmations";
             this.pbControlConfirmations.Size = new System.Drawing.Size(18, 18);
@@ -2112,7 +2112,7 @@
             // 
             // pbWindowGlass
             // 
-            this.pbWindowGlass.Image = global::Menu.Properties.Resources.info_18;
+            this.pbWindowGlass.Image = global::ORTS.Properties.Resources.info_18;
             this.pbWindowGlass.Location = new System.Drawing.Point(11, 234);
             this.pbWindowGlass.Name = "pbWindowGlass";
             this.pbWindowGlass.Size = new System.Drawing.Size(18, 18);
@@ -2172,7 +2172,7 @@
             // 
             // pbWindowed
             // 
-            this.pbWindowed.Image = global::Menu.Properties.Resources.info_18;
+            this.pbWindowed.Image = global::ORTS.Properties.Resources.info_18;
             this.pbWindowed.Location = new System.Drawing.Point(11, 169);
             this.pbWindowed.Name = "pbWindowed";
             this.pbWindowed.Size = new System.Drawing.Size(18, 18);
@@ -2195,7 +2195,7 @@
             // 
             // pbUpdateMode
             // 
-            this.pbUpdateMode.Image = global::Menu.Properties.Resources.info_18;
+            this.pbUpdateMode.Image = global::ORTS.Properties.Resources.info_18;
             this.pbUpdateMode.Location = new System.Drawing.Point(11, 52);
             this.pbUpdateMode.Name = "pbUpdateMode";
             this.pbUpdateMode.Size = new System.Drawing.Size(18, 18);
@@ -2207,7 +2207,7 @@
             // 
             // pbLanguage
             // 
-            this.pbLanguage.Image = global::Menu.Properties.Resources.info_18;
+            this.pbLanguage.Image = global::ORTS.Properties.Resources.info_18;
             this.pbLanguage.Location = new System.Drawing.Point(11, 9);
             this.pbLanguage.Name = "pbLanguage";
             this.pbLanguage.Size = new System.Drawing.Size(18, 18);
@@ -2614,7 +2614,7 @@
             // 
             // pbSuperElevation
             // 
-            this.pbSuperElevation.Image = global::Menu.Properties.Resources.info_18;
+            this.pbSuperElevation.Image = global::ORTS.Properties.Resources.info_18;
             this.pbSuperElevation.Location = new System.Drawing.Point(6, 23);
             this.pbSuperElevation.Name = "pbSuperElevation";
             this.pbSuperElevation.Size = new System.Drawing.Size(18, 18);
@@ -2626,7 +2626,7 @@
             // 
             // pbAutoSave
             // 
-            this.pbAutoSave.Image = global::Menu.Properties.Resources.info_18;
+            this.pbAutoSave.Image = global::ORTS.Properties.Resources.info_18;
             this.pbAutoSave.Location = new System.Drawing.Point(6, 299);
             this.pbAutoSave.Name = "pbAutoSave";
             this.pbAutoSave.Size = new System.Drawing.Size(18, 18);

--- a/Source/Menu/Options.cs
+++ b/Source/Menu/Options.cs
@@ -32,7 +32,7 @@ using ORTS.Common.Input;
 using ORTS.Settings;
 using ORTS.Updater;
 
-namespace Menu
+namespace ORTS
 {
     public partial class OptionsForm : Form
     {

--- a/Source/Menu/OptionsRailDriver.cs
+++ b/Source/Menu/OptionsRailDriver.cs
@@ -8,9 +8,10 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using ORTS.Common;
 using ORTS.Common.Input;
+using Orts.Menu;
 using ORTS.Settings;
 
-namespace Menu
+namespace ORTS
 {
     public partial class OptionsForm : Form
     {

--- a/Source/Menu/Program.cs
+++ b/Source/Menu/Program.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Windows.Forms;
 
-namespace Menu
+namespace ORTS
 {
     static class Program
     {

--- a/Source/Menu/Properties/Resources.Designer.cs
+++ b/Source/Menu/Properties/Resources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Menu.Properties {
+namespace ORTS.Properties {
     using System;
     
     
@@ -39,7 +39,7 @@ namespace Menu.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Menu.Properties.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ORTS.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/Source/Menu/RDButtonInputControl.Designer.cs
+++ b/Source/Menu/RDButtonInputControl.Designer.cs
@@ -1,6 +1,6 @@
 ﻿
 
-namespace Menu
+namespace Orts.Menu
 {
     partial class RDButtonInputControl
     {

--- a/Source/Menu/RDButtonInputControl.cs
+++ b/Source/Menu/RDButtonInputControl.cs
@@ -21,7 +21,7 @@ using System.Windows.Forms;
 
 using ORTS.Common.Input;
 
-namespace Menu
+namespace Orts.Menu
 {
     /// <summary>
     /// A control for viewing and altering keyboard input settings, in combination with <see cref="KeyInputEditControl"/>.

--- a/Source/Menu/ResumeForm.Designer.cs
+++ b/Source/Menu/ResumeForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Menu {
+﻿namespace ORTS {
     partial class ResumeForm {
         /// <summary>
         /// Required designer variable.
@@ -127,7 +127,7 @@
             // 
             // saveBindingSource
             // 
-            this.saveBindingSource.DataSource = typeof(Menu.ResumeForm.Save);
+            this.saveBindingSource.DataSource = typeof(ORTS.ResumeForm.Save);
             // 
             // buttonResume
             // 

--- a/Source/Menu/ResumeForm.cs
+++ b/Source/Menu/ResumeForm.cs
@@ -62,7 +62,7 @@ using ORTS.Menu;
 using ORTS.Settings;
 using Path = System.IO.Path;
 
-namespace Menu
+namespace ORTS
 {
     public partial class ResumeForm : Form
     {

--- a/Source/Menu/SortableBindingList.cs
+++ b/Source/Menu/SortableBindingList.cs
@@ -22,7 +22,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 
-namespace Menu
+namespace ORTS
 {
     public class SortableBindingList<T> : BindingList<T>
     {

--- a/Source/Menu/Task.cs
+++ b/Source/Menu/Task.cs
@@ -26,7 +26,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Windows.Forms;
 
-namespace Menu
+namespace ORTS
 {
     /// <summary>
     /// Allows work to be done as a background task so that the form remains responsive (e.g. to a cancel or close button).

--- a/Source/Menu/TestingForm.Designer.cs
+++ b/Source/Menu/TestingForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Menu {
+﻿namespace ORTS {
     partial class TestingForm {
         /// <summary>
         /// Required designer variable.
@@ -250,7 +250,7 @@
             // 
             // testBindingSource
             // 
-            this.testBindingSource.DataSource = typeof(Menu.TestingForm.TestActivity);
+            this.testBindingSource.DataSource = typeof(ORTS.TestingForm.TestActivity);
             // 
             // buttonDetails
             // 

--- a/Source/Menu/TestingForm.cs
+++ b/Source/Menu/TestingForm.cs
@@ -31,7 +31,7 @@ using ORTS.Settings;
 using Activity = ORTS.Menu.Activity;
 using Path = System.IO.Path;
 
-namespace Menu
+namespace ORTS
 {
     public partial class TestingForm : Form
     {


### PR DESCRIPTION
Don't yet know why these refactor commits broke the Notifications.
Until it gets figured out, these reverts will restore normal operation.