### PR TITLE
Fix menu notifications

### DIFF
--- a/Source/Menu/Notifications/NotificationManager.cs
+++ b/Source/Menu/Notifications/NotificationManager.cs
@@ -1,4 +1,4 @@
-﻿// COPYRIGHT 2009 - 2024 by the Open Rails project.
+// COPYRIGHT 2009 - 2024 by the Open Rails project.
 // 
 // This file is part of Open Rails.
 // 
@@ -126,7 +126,7 @@ namespace Menu.Notifications
                 Notifications.NotificationList = IncludeValid(Notifications.NotificationList);
                 Notifications.NotificationList = SortByDate(Notifications.NotificationList);
             }
-            catch (WebException ex)
+            catch (Exception ex)
             {
                 Error = ex;
             }


### PR DESCRIPTION
This addresses two related issues:
- Deserializing notification JSON is sensitive to namespaces
- Non-web exceptions (such as deserializing errors!) are not handled

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)