### PR TITLE
Fix: TrainDrivingInfo crashes if engineBrakeStatus is null.

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
@@ -1009,28 +1009,31 @@ namespace Orts.Viewer3D.Popups
                 });
             }
 
-            if (engineBrakeStatus.Contains(Viewer.Catalog.GetString("BC")))
+            if (engineBrakeStatus != null)
             {
-                AddLabel(new ListLabel
+                if (engineBrakeStatus.Contains(Viewer.Catalog.GetString("BC")))
                 {
-                    FirstCol = Viewer.Catalog.GetString("Engine brake"),
-                    LastCol = engineBrakeStatus.Substring(0, engineBrakeStatus.IndexOf("BC")) + ColorCode[Color.Cyan],
-                });
-                index = engineBrakeStatus.IndexOf(Viewer.Catalog.GetString("BC"));
-                brakeInfoValue = engineBrakeStatus.Substring(index, engineBrakeStatus.Length - index).TrimEnd();
-                AddLabel(new ListLabel
+                    AddLabel(new ListLabel
+                    {
+                        FirstCol = Viewer.Catalog.GetString("Engine brake"),
+                        LastCol = engineBrakeStatus.Substring(0, engineBrakeStatus.IndexOf("BC")) + ColorCode[Color.Cyan],
+                    });
+                    index = engineBrakeStatus.IndexOf(Viewer.Catalog.GetString("BC"));
+                    brakeInfoValue = engineBrakeStatus.Substring(index, engineBrakeStatus.Length - index).TrimEnd();
+                    AddLabel(new ListLabel
+                    {
+                        FirstCol = Viewer.Catalog.GetString(""),
+                        LastCol = $"{brakeInfoValue}{ColorCode[Color.White]}",
+                    });
+                }
+                else
                 {
-                    FirstCol = Viewer.Catalog.GetString(""),
-                    LastCol = $"{brakeInfoValue}{ColorCode[Color.White]}",
-                });
-            }
-            else
-            {
-                AddLabel(new ListLabel
-                {
-                    FirstCol = Viewer.Catalog.GetString("Engine brake"),
-                    LastCol = $"{engineBrakeStatus}{ColorCode[Color.Cyan]}",
-                });
+                    AddLabel(new ListLabel
+                    {
+                        FirstCol = Viewer.Catalog.GetString("Engine brake"),
+                        LastCol = $"{engineBrakeStatus}{ColorCode[Color.Cyan]}",
+                    });
+                }
             }
 
             if (dynamicBrakeStatus != null && locomotive.IsLeadLocomotive())


### PR DESCRIPTION
More info here:
[Bug #2096450](https://bugs.launchpad.net/or/+bug/2096450)