### PR TITLE
Make change of odometer count direction apply immediately.

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -5094,7 +5094,12 @@ namespace Orts.Simulation.RollingStocks
             if (Train == null)
                 return;
 
+            // change the up/down flag for the reset logic (above)
+            // change the forward/reverse flag for OdometerM calculation (see OdometerM get() function)
+            // change the reference point to match the up/down flag
             OdometerCountingUp = !OdometerCountingUp;
+            OdometerCountingForwards = !OdometerCountingForwards;
+            OdometerResetPositionM = OdometerCountingUp ? OdometerResetPositionM - Train.Length : OdometerResetPositionM + Train.Length;
 
             Simulator.Confirmer.Confirm(CabControl.Odometer, OdometerCountingUp ? CabSetting.Increase : CabSetting.Decrease);
         }


### PR DESCRIPTION
Previously the change in count direction (Shift-Ctrl-Z) would not apply until a reset (Ctrl-Z) is done.

Now, the odometer will change immediately when its count direction is changed. 

For example, you pass a switch and reset (Ctrl-Z) the odometer. Then you notice it counts up. Now, when you hit toggle-direction (Shift-Ctrl-Z), the counter will jump to the length of the train minus the distance already traveled between when the reset was done and when the count-direction was changed. When the counter reaches zero, your train has passed the switch.

Feature request: https://www.elvastower.com/forums/index.php?/topic/38587-odometer-count-updown-not-taking-effect-until-reset/

I ended up doing some refactoring, as I had a hard time understanding the logic. Part of the complexity is that the odometer behaves different from a typical odometer. When doing a reverse move, the odometer can be used to count the distance as if it were a normal move.

Hence, the reset logic depends on the position of the reverser at the time of the reset. The reverser position at reset is preserved in the OdometerDirectionForward flag.