### PR TITLE
Fix Emergency Brake Pressure Being Overridden

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -1308,7 +1308,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         AutoCylPressurePSI += dp;
                     }
 
-                    if (EmergencyDumpValveTimerS == 0)
+                    if (EmergencyDumpValveTimerS == 0 && EmergencyDumpStartTime != null)
                     {
                         if (BrakeLine1PressurePSI < 1) EmergencyDumpStartTime = null;
                     }
@@ -1395,8 +1395,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                     AutoCylPressurePSI -= dp;
             }
             // Special cases for equipment which bypasses triple valve
-            else if ((TwoStageLowSpeedActive && AutoCylPressurePSI > TwoStageLowPressurePSI) ||
-                (!TwoStageLowSpeedActive && AutoCylPressurePSI > ServiceMaxCylPressurePSI)) // Two stage braking
+            else if (TwoStageSpeedDownMpS > 0 && (TwoStageLowSpeedActive && AutoCylPressurePSI > TwoStageLowPressurePSI) ||
+                (TripleValveState != ValveState.Emergency && !TwoStageLowSpeedActive && AutoCylPressurePSI > ServiceMaxCylPressurePSI)) // Two stage braking
             {
                 float target = TwoStageLowSpeedActive ? TwoStageLowPressurePSI : ServiceMaxCylPressurePSI;
                 float dp = elapsedClockSeconds * ReleaseRatePSIpS;


### PR DESCRIPTION
[Bug on Elvas Tower](https://www.elvastower.com/forums/index.php?/topic/38608-ortsmaxservicecylinderpressure/)

A small oversight in the implementation of the service cylinder pressure limit was causing emergency applications to be vented down to the service cylinder pressure all the time. While the service pressure limit was correctly disabled for the actual level of application, the venting is handled separately and needed an additional check to be disabled for emergency applications.