### PR TITLE
Bugfix: Empty Start Time for Explore, and other issues loading from Menu Selection and Content Routes

### DIFF
--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -1335,6 +1335,8 @@ namespace Menu
 
         void UpdateFromMenuSelection<T>(ComboBox comboBox, UserSettings.Menu_SelectionIndex index, Func<T, string> map, T defaultValue)
         {
+            // if folder field, or the selected folder matches the menu selection setting
+            // and there is a value in the menu selection setting
             if (((index == UserSettings.Menu_SelectionIndex.Folder) ||
                  ((comboBoxFolder.Items.Count > 0) && (SelectedFolder != null) &&
                   (Settings.Menu_Selection.Count() > 0) &&
@@ -1353,6 +1355,7 @@ namespace Menu
             }
             else
             {
+                // if selected folder is in the content routes setting and has a start route
                 var routes = Settings.Content.ContentRouteSettings.Routes;
                 if ((SelectedFolder != null) &&
                     routes.ContainsKey(SelectedFolder.Name) &&
@@ -1390,30 +1393,37 @@ namespace Menu
                         default:
                             break;
                     }
-                    bool found = false;
-                    if ((index != UserSettings.Menu_SelectionIndex.Path) ||
-                        (SelectedActivity == null) || (!(SelectedActivity is ExploreActivity)))
+                    if (string.IsNullOrEmpty(valueComboboxToSetTo))
                     {
-                        if (comboBox.DropDownStyle == ComboBoxStyle.DropDown)
-                        {
-                            comboBox.Text = valueComboboxToSetTo;
-                            found = true;
-                        } 
-                        else
-                        {
-                            found = searchInComboBox(comboBox,  valueComboboxToSetTo);
-                        }
+                        SetToDefault(comboBox, index, map, defaultValue);
                     }
                     else
                     {
-                        found = searchInComboBox(comboBoxStartAt, valueComboboxToSetTo);
-                        found = searchInComboBox(comboBoxHeadTo, valueComboboxToSetTo);
-                    }
-                    if (!found)
-                    {
-                        if (comboBox.Items.Count > 0)
+                        bool found = false;
+                        if ((index != UserSettings.Menu_SelectionIndex.Path) ||
+                            (SelectedActivity == null) || (!(SelectedActivity is ExploreActivity)))
                         {
-                            comboBox.SelectedIndex = 0;
+                            if (comboBox.DropDownStyle == ComboBoxStyle.DropDown)
+                            {
+                                comboBox.Text = valueComboboxToSetTo;
+                                found = true;
+                            }
+                            else
+                            {
+                                found = searchInComboBox(comboBox, valueComboboxToSetTo);
+                            }
+                        }
+                        else
+                        {
+                            found = searchInComboBox(comboBoxStartAt, valueComboboxToSetTo);
+                            found = searchInComboBox(comboBoxHeadTo, valueComboboxToSetTo);
+                        }
+                        if (!found)
+                        {
+                            if (comboBox.Items.Count > 0)
+                            {
+                                comboBox.SelectedIndex = 0;
+                            }
                         }
                     }
                 }

--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -1343,12 +1343,14 @@ namespace Menu
             string value = GetValueFromMenuSelection(index);
             if (!string.IsNullOrEmpty(value))
             {
-                if (comboBox.DropDownStyle == ComboBoxStyle.DropDown) { comboBox.Text = value; }
-                else { SelectComboBoxItem<T>(comboBox, item => map(item) == value); }
+                if (comboBox.DropDownStyle == ComboBoxStyle.DropDown)
+                    comboBox.Text = value;
+                else
+                    SelectComboBoxItem<T>(comboBox, item => map(item) == value);
             }
             else
             {
-                // when explore in activit mode, try the content route info
+                // when explore-in-activity mode, try the content route info
                 var routes = Settings.Content.ContentRouteSettings.Routes;
                 if ((SelectedActivity != null && SelectedActivity is ExploreThroughActivity) &&
                     (SelectedFolder != null && routes.ContainsKey(SelectedFolder.Name) && routes[SelectedFolder.Name].Installed) &&

--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -1356,11 +1356,13 @@ namespace Menu
             else
             {
                 // if selected folder is in the content routes setting and has a start route
+                // and the selected activity is explore in activit mode
                 var routes = Settings.Content.ContentRouteSettings.Routes;
                 if ((SelectedFolder != null) &&
                     routes.ContainsKey(SelectedFolder.Name) &&
                     routes[SelectedFolder.Name].Installed &&
-                    !string.IsNullOrEmpty(routes[SelectedFolder.Name].Start.Route))
+                    !string.IsNullOrEmpty(routes[SelectedFolder.Name].Start.Route) &&
+                    SelectedActivity != null && SelectedActivity is ExploreThroughActivity)
                 {
                     var route = routes[SelectedFolder.Name];
                     string valueComboboxToSetTo = "";

--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -1397,33 +1397,21 @@ namespace Menu
                     {
                         SetToDefault(comboBox, index, map, defaultValue);
                     }
+                    else if (index == UserSettings.Menu_SelectionIndex.Path && SelectedActivity != null && SelectedActivity is ExploreActivity)
+                    {
+                        // Is this ever called? Theoretically from ShowHeadToList(), but breakpoint was never hit.
+                        searchInComboBoxAndSet(comboBoxStartAt, valueComboboxToSetTo);
+                        searchInComboBoxAndSet(comboBoxHeadTo, valueComboboxToSetTo);
+                    }
                     else
                     {
-                        bool found = false;
-                        if ((index != UserSettings.Menu_SelectionIndex.Path) ||
-                            (SelectedActivity == null) || (!(SelectedActivity is ExploreActivity)))
+                        if (comboBox.DropDownStyle == ComboBoxStyle.DropDown)
                         {
-                            if (comboBox.DropDownStyle == ComboBoxStyle.DropDown)
-                            {
-                                comboBox.Text = valueComboboxToSetTo;
-                                found = true;
-                            }
-                            else
-                            {
-                                found = searchInComboBox(comboBox, valueComboboxToSetTo);
-                            }
+                            comboBox.Text = valueComboboxToSetTo;
                         }
                         else
                         {
-                            found = searchInComboBox(comboBoxStartAt, valueComboboxToSetTo);
-                            found = searchInComboBox(comboBoxHeadTo, valueComboboxToSetTo);
-                        }
-                        if (!found)
-                        {
-                            if (comboBox.Items.Count > 0)
-                            {
-                                comboBox.SelectedIndex = 0;
-                            }
+                            searchInComboBoxAndSet(comboBox, valueComboboxToSetTo);
                         }
                     }
                 }
@@ -1434,17 +1422,25 @@ namespace Menu
             }
         }
 
-        bool searchInComboBox(ComboBox comboBox, string valueComboboxToSetTo)
+        /// <summary>
+        /// Search the combobox for the specified value. When found, set the combobox to the value.
+        /// When not found, set it to the first defined value.
+        /// Leave empty when there are no defined values.
+        /// </summary>
+        void searchInComboBoxAndSet(ComboBox comboBox, string valueComboboxToSetTo)
         {
             for (var i = 0; i < comboBox.Items.Count; i++)
             {
                 if ((string)comboBox.Items[i].ToString() == valueComboboxToSetTo)
                 {
                     comboBox.SelectedIndex = i;
-                    return true;
+                    return;
                 }
             }
-            return false;
+            if (comboBox.Items.Count > 0)
+            {
+                comboBox.SelectedIndex = 0;
+            }
         }
 
         void SetToDefault<T>(ComboBox comboBox, UserSettings.Menu_SelectionIndex index, Func<T, string> map, T defaultValue)

--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -1333,39 +1333,30 @@ namespace Menu
             UpdateFromMenuSelection<T>(comboBox, index, map, default(T));
         }
 
+        /// <summary>
+        /// Update the combobox with the selection stored in the menu selection settings (from the previous run).
+        /// If the menu selection settings do not match the current selection use the default; except for 
+        /// "Explore in Activity Mode" also try the content route settings (for the route).
+        /// </summary>
         void UpdateFromMenuSelection<T>(ComboBox comboBox, UserSettings.Menu_SelectionIndex index, Func<T, string> map, T defaultValue)
         {
-            // if folder field, or the selected folder matches the menu selection setting
-            // and there is a value in the menu selection setting
-            if (((index == UserSettings.Menu_SelectionIndex.Folder) ||
-                 ((comboBoxFolder.Items.Count > 0) && (SelectedFolder != null) &&
-                  (Settings.Menu_Selection.Count() > 0) &&
-                  (SelectedFolder.Path == Settings.Menu_Selection[(int)UserSettings.Menu_SelectionIndex.Folder]))) &&
-                (Settings.Menu_Selection.Length > (int)index) && 
-                (Settings.Menu_Selection[(int)index] != ""))
+            string value = GetValueFromMenuSelection(index);
+            if (!string.IsNullOrEmpty(value))
             {
-                if (comboBox.DropDownStyle == ComboBoxStyle.DropDown)
-                {
-                    comboBox.Text = Settings.Menu_Selection[(int)index];
-                }
-                else
-                {
-                    SelectComboBoxItem<T>(comboBox, item => map(item) == Settings.Menu_Selection[(int)index]);
-                }
+                if (comboBox.DropDownStyle == ComboBoxStyle.DropDown) { comboBox.Text = value; }
+                else { SelectComboBoxItem<T>(comboBox, item => map(item) == value); }
             }
             else
             {
-                // if selected folder is in the content routes setting and has a start route
-                // and the selected activity is explore in activit mode
+                // when explore in activit mode, try the content route info
                 var routes = Settings.Content.ContentRouteSettings.Routes;
-                if ((SelectedFolder != null) &&
-                    routes.ContainsKey(SelectedFolder.Name) &&
-                    routes[SelectedFolder.Name].Installed &&
-                    !string.IsNullOrEmpty(routes[SelectedFolder.Name].Start.Route) &&
-                    SelectedActivity != null && SelectedActivity is ExploreThroughActivity)
+                if ((SelectedActivity != null && SelectedActivity is ExploreThroughActivity) &&
+                    (SelectedFolder != null && routes.ContainsKey(SelectedFolder.Name) && routes[SelectedFolder.Name].Installed) &&
+                    (!string.IsNullOrEmpty(routes[SelectedFolder.Name].Start.Route)))
                 {
                     var route = routes[SelectedFolder.Name];
                     string valueComboboxToSetTo = "";
+                    string conditionalSecondValue = "";
                     switch (index)
                     {
                         case UserSettings.Menu_SelectionIndex.Route:
@@ -1382,6 +1373,7 @@ namespace Menu
                             break;
                         case UserSettings.Menu_SelectionIndex.Path:
                             valueComboboxToSetTo = route.Start.StartingAt;
+                            conditionalSecondValue = route.Start.HeadingTo;
                             break;
                         case UserSettings.Menu_SelectionIndex.Time:
                             valueComboboxToSetTo = route.Start.Time;
@@ -1395,26 +1387,29 @@ namespace Menu
                         default:
                             break;
                     }
-                    if (string.IsNullOrEmpty(valueComboboxToSetTo))
+
+                    if (index == UserSettings.Menu_SelectionIndex.Path)
                     {
-                        SetToDefault(comboBox, index, map, defaultValue);
+                        if (!string.IsNullOrEmpty(valueComboboxToSetTo))
+                            searchInComboBoxAndSet(comboBoxStartAt, valueComboboxToSetTo);
+                        else
+                            SetToDefault(comboBoxStartAt, index, map, defaultValue);
+
+                        if (!string.IsNullOrEmpty(conditionalSecondValue))
+                            searchInComboBoxAndSet(comboBoxHeadTo, conditionalSecondValue);
+                        else
+                            SetToDefault(comboBoxHeadTo, index, map, defaultValue);
                     }
-                    else if (index == UserSettings.Menu_SelectionIndex.Path && SelectedActivity != null && SelectedActivity is ExploreActivity)
+                    else if (!string.IsNullOrEmpty(valueComboboxToSetTo))
                     {
-                        // Is this ever called? Theoretically from ShowHeadToList(), but breakpoint was never hit.
-                        searchInComboBoxAndSet(comboBoxStartAt, valueComboboxToSetTo);
-                        searchInComboBoxAndSet(comboBoxHeadTo, valueComboboxToSetTo);
+                        if (comboBox.DropDownStyle == ComboBoxStyle.DropDown) 
+                            comboBox.Text = valueComboboxToSetTo;
+                        else
+                            searchInComboBoxAndSet(comboBox, valueComboboxToSetTo);
                     }
                     else
                     {
-                        if (comboBox.DropDownStyle == ComboBoxStyle.DropDown)
-                        {
-                            comboBox.Text = valueComboboxToSetTo;
-                        }
-                        else
-                        {
-                            searchInComboBoxAndSet(comboBox, valueComboboxToSetTo);
-                        }
+                        SetToDefault(comboBox, index, map, defaultValue);
                     }
                 }
                 else
@@ -1425,9 +1420,56 @@ namespace Menu
         }
 
         /// <summary>
-        /// Search the combobox for the specified value. When found, set the combobox to the value.
-        /// When not found, set it to the first defined value.
-        /// Leave empty when there are no defined values.
+        /// Get the combobox's value from the menu selection in the settings. 
+        /// Checks that folder, route and activity/timetable-set match.
+        /// Returns the value from the settings, or an empty string.
+        /// </summary>
+        string GetValueFromMenuSelection(UserSettings.Menu_SelectionIndex index)
+        {
+            if (Settings.Menu_Selection.Length <= (int)index)
+                return ""; // not in menu selection settings
+
+            else if (index == UserSettings.Menu_SelectionIndex.Folder)
+                return Settings.Menu_Selection[(int)index];
+
+            else if (SelectedFolder == null)
+                return ""; // no current folder to match to
+
+            else if (SelectedFolder.Path != Settings.Menu_Selection[(int)UserSettings.Menu_SelectionIndex.Folder])
+                return ""; // current folder and menu selection settings folder don't match
+
+            else if (index == UserSettings.Menu_SelectionIndex.Route)
+                return Settings.Menu_Selection[(int)index];
+
+            else if (SelectedRoute == null)
+                return ""; // no current route to match to
+
+            else if (SelectedRoute.Path != Settings.Menu_Selection[(int)UserSettings.Menu_SelectionIndex.Route])
+                return ""; // current route and menu selection settings route don't match
+
+            else if (index == UserSettings.Menu_SelectionIndex.Activity || index == UserSettings.Menu_SelectionIndex.TimetableSet)
+                return Settings.Menu_Selection[(int)index];
+
+            else if (radioButtonModeActivity.Checked && SelectedActivity == null)
+                return ""; // no current activity to match to
+
+            else if (radioButtonModeTimetable.Checked && SelectedTimetableSet == null)
+                return ""; // no current timetable set to match to
+
+            else if (radioButtonModeActivity.Checked && SelectedActivity.Name != Settings.Menu_Selection[(int)UserSettings.Menu_SelectionIndex.Activity])
+                return ""; // current activity and menu selection settings activity don't match
+
+            else if (radioButtonModeTimetable.Checked && SelectedTimetableSet.fileName != Settings.Menu_Selection[(int)UserSettings.Menu_SelectionIndex.TimetableSet])
+                return ""; // current timetable set is different from timetable set in menu selection setting
+
+            else
+                return Settings.Menu_Selection[(int)index];
+        }
+
+        /// <summary>
+        /// Search the DropDown combobox (editable) for the specified string value.
+        /// When found, set the combobox to the value, otherwise to the first defined value.
+        /// Leave unselected when there are no defined values.
         /// </summary>
         void searchInComboBoxAndSet(ComboBox comboBox, string valueComboboxToSetTo)
         {
@@ -1445,6 +1487,9 @@ namespace Menu
             }
         }
 
+        /// <summary>
+        /// Set the combobox to the specified default (item).
+        /// </summary>
         void SetToDefault<T>(ComboBox comboBox, UserSettings.Menu_SelectionIndex index, Func<T, string> map, T defaultValue)
         {
             if (comboBox.DropDownStyle == ComboBoxStyle.DropDown)
@@ -1467,6 +1512,11 @@ namespace Menu
             }
         }
 
+        /// <summary>
+        /// Select  the the specified item in the combobox (not editable).
+        /// When not found, set it to the first item.
+        /// Leave unselected when there are no defined items.
+        /// </summary>
         void SelectComboBoxItem<T>(ComboBox comboBox, Func<T, bool> predicate)
         {
             if (comboBox.Items.Count == 0)


### PR DESCRIPTION
Bug: [2097690](https://bugs.launchpad.net/or/+bug/2097690)
Discussion: [purpose-of-start-element-in-contentroutes-setting](https://www.elvastower.com/forums/index.php?/topic/38617-purpose-of-start-element-in-contentroutes-setting/)

This started with a simple issue: The Start Time was empty (unset) for Explore activities of (many) automatically installed routes. That caused RunActivity to fail. 

As I tried to understand the code, I discovered other issues where values from the settings (Menu Selection or Content Routes) were not handled correctly. For example:
- Some fields were loaded from the Menu Selection settings even thought the settings were from a different activity.
- When loading from the Content Route settings, the StartAt and HeadingTo fields were set to the same.

Eventually I decided to refactor some of the code, to make it easier to understand.
