### PR TITLE
refactor: TrainCar junction detection

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1,4 +1,4 @@
-﻿// COPYRIGHT 2009, 2010, 2011, 2012, 2013 by the Open Rails project.
+// COPYRIGHT 2009, 2010, 2011, 2012, 2013 by the Open Rails project.
 // 
 // This file is part of Open Rails.
 // 
@@ -3108,7 +3108,7 @@ namespace Orts.Simulation.RollingStocks
                     Simulator.Confirmer.Message(ConfirmLevel.Error, Simulator.Catalog.GetString("Scoop is broken, can't refill"));
                     RefillingFromTrough = false;
                 }
-                else if (IsOverJunction())
+                else if (IsOverJunction)
                 {
                     if (!ScoopIsBroken) // Only display message first time scoop is broken
                     {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -3108,7 +3108,7 @@ namespace Orts.Simulation.RollingStocks
                     Simulator.Confirmer.Message(ConfirmLevel.Error, Simulator.Catalog.GetString("Scoop is broken, can't refill"));
                     RefillingFromTrough = false;
                 }
-                else if (IsOverJunction)
+                else if (IsOverSwitch || IsOverCrossover)
                 {
                     if (!ScoopIsBroken) // Only display message first time scoop is broken
                     {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1,4 +1,4 @@
-// COPYRIGHT 2009, 2010, 2011, 2012, 2013 by the Open Rails project.
+﻿// COPYRIGHT 2009, 2010, 2011, 2012, 2013 by the Open Rails project.
 // 
 // This file is part of Open Rails.
 // 
@@ -3118,7 +3118,7 @@ namespace Orts.Simulation.RollingStocks
                     RefillingFromTrough = false;
                     SignalEvent(Event.WaterScoopBroken);
                 }
-                else if (!IsOverTrough())
+                else if (!IsOverTrough)
                 {
                     if (!WaterScoopOverTroughFlag)
                     {
@@ -3163,7 +3163,7 @@ namespace Orts.Simulation.RollingStocks
                 }
 
             }
-            else if (HasWaterScoop && MSTSWagon.RefillProcess.OkToRefill == true && IsOverTrough())// water scoop has been raised, stop water filling
+            else if (HasWaterScoop && MSTSWagon.RefillProcess.OkToRefill == true && IsOverTrough)// water scoop has been raised, stop water filling
             {
                 MSTSWagon.RefillProcess.OkToRefill = false;
                 MSTSWagon.RefillProcess.ActivePickupObjectUID = 0;
@@ -3234,7 +3234,7 @@ namespace Orts.Simulation.RollingStocks
                 WaterScoopInputAmountL = 0;
                 WaterScoopVelocityMpS = 0;
 
-                if (!IsOverTrough()) // Only reset once train moves off the trough
+                if (!IsOverTrough) // Only reset once train moves off the trough
                 {
                     WaterScoopTotalWaterL = 0.0f; // Reset amount of water picked up by water sccop.
                 }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -3525,7 +3525,7 @@ namespace Orts.Simulation.RollingStocks
                     }
 
                     // Water scoop spray effects control - always on when scoop over trough, regardless of whether above minimum speed or not
-                    if (ProcessWaterEffects && LocomotiveParameters.IsWaterScoopDown && IsOverTrough() && AbsSpeedMpS > 0.1)
+                    if (ProcessWaterEffects && LocomotiveParameters.IsWaterScoopDown && IsOverTrough && AbsSpeedMpS > 0.1)
                     {
                         float SpeedRatio = AbsSpeedMpS / MpS.FromMpH(100); // Ratio to reduce water disturbance with speed - an arbitary value of 100mph has been chosen as the reference
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -3093,7 +3093,8 @@ namespace Orts.Simulation.RollingStocks
         }
         #endregion
 
-        public bool IsOverJunction { get; private set; }
+        public bool IsOverSwitch { get; private set; }
+        public bool IsOverCrossover { get; private set; }
         public bool IsOverTrough { get; private set; }
 
         void UpdatePositionFlags()
@@ -3107,7 +3108,8 @@ namespace Orts.Simulation.RollingStocks
                 rearOffsetM += Train.Cars[i - 1].CouplerSlackM + Train.Cars[i - 1].GetCouplerZeroLengthM() + Train.Cars[i].CarLengthM;
             var frontOffsetM = rearOffsetM + CarLengthM;
 
-            var isOverJunction = false;
+            var isOverSwitch = false;
+            var isOverCrossover = false;
             var isOverTrough = false;
 
             // Scan through the track sections forwards from the REAR of the train (`Train.PresentPosition[1]`),
@@ -3122,7 +3124,8 @@ namespace Orts.Simulation.RollingStocks
                 // Does this car overlap this track section?
                 if (checkedM <= frontOffsetM && rearOffsetM <= checkedM + section.Length)
                 {
-                    if (section.CircuitType == TrackCircuitSection.TrackCircuitType.Junction || section.CircuitType == TrackCircuitSection.TrackCircuitType.Crossover) isOverJunction = true;
+                    if (section.CircuitType == TrackCircuitSection.TrackCircuitType.Junction) isOverSwitch = true;
+                    if (section.CircuitType == TrackCircuitSection.TrackCircuitType.Crossover) isOverCrossover = true;
                     if (section.TroughInfo != null)
                     {
                         foreach (var troughs in section.TroughInfo)
@@ -3139,7 +3142,8 @@ namespace Orts.Simulation.RollingStocks
                 currentPin = nextPin;
             }
 
-            IsOverJunction = isOverJunction;
+            IsOverSwitch = isOverSwitch;
+            IsOverCrossover = isOverCrossover;
             IsOverTrough = isOverTrough;
         }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -3131,7 +3131,10 @@ namespace Orts.Simulation.RollingStocks
                         foreach (var troughs in section.TroughInfo)
                         {
                             var trough = troughs[currentPin.Direction];
-                            if (checkedM + trough.TroughStart <= frontOffsetM && rearOffsetM <= checkedM + trough.TroughEnd) isOverTrough = true;
+                            // Start and end are -1 if the trough extends beyond this section
+                            var troughStart = trough.TroughStart < 0 ? 0 : trough.TroughStart;
+                            var troughEnd = trough.TroughEnd < 0 ? section.Length : trough.TroughEnd;
+                            if (checkedM + troughStart <= frontOffsetM && rearOffsetM <= checkedM + troughEnd) isOverTrough = true;
                         }
                     }
                 }

--- a/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
@@ -1187,7 +1187,7 @@ namespace Orts.Viewer3D.Popups
                 }
                 else if (locomotive.IsWaterScoopDown && !locomotive.ScoopIsBroken)
                 {
-                    waterScoopIndicator = Viewer.Catalog.GetString("Down") + (locomotive.IsOverTrough() ? ColorCode[Color.Cyan] : ColorCode[Color.Orange]);
+                    waterScoopIndicator = Viewer.Catalog.GetString("Down") + (locomotive.IsOverTrough ? ColorCode[Color.Cyan] : ColorCode[Color.Orange]);
                     waterScoopKey = Symbols.ArrowToRight + ColorCode[Color.Yellow];
                 }
                 else

--- a/Source/RunActivity/Viewer3D/Sound.cs
+++ b/Source/RunActivity/Viewer3D/Sound.cs
@@ -395,32 +395,8 @@ namespace Orts.Viewer3D
 
                     var CarBehind = Car.Train.Cars[CarNo + CarIncr];
                     var carPreviouslyOnSwitch = CarOnSwitch;
-                    CarOnSwitch = false;
-                    if (Car.Train.PresentPosition[0].TCSectionIndex != Car.Train.PresentPosition[1].TCSectionIndex)
-                    {
-                        try
-                        {
-                            var copyOccupiedTrack = Car.Train.OccupiedTrack.ToArray();
-                            foreach (var thisSection in copyOccupiedTrack)
-                            {
-                                if (thisSection.CircuitType == TrackCircuitSection.TrackCircuitType.Junction || thisSection.CircuitType == TrackCircuitSection.TrackCircuitType.Crossover)
-                                {
-                                    // train is on a switch; let's see if car is on a switch too
-                                    WorldLocation switchLocation = UidLocation(Viewer.Simulator.TDB.TrackDB.TrackNodes[thisSection.OriginalIndex].UiD);
-                                    var distanceFromSwitch = WorldLocation.GetDistanceSquared(Car.WorldPosition.WorldLocation, switchLocation);
-                                    if (distanceFromSwitch < Car.CarLengthM * Car.CarLengthM + Math.Min(Car.SpeedMpS * 3, 150))
-                                    {
-                                        CarOnSwitch = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        catch
-                        {
+                    CarOnSwitch = Car.IsOverJunction;
 
-                        }
-                    }
                     // here check for curve
                     var carPreviouslyOnCurve = CarOnCurve;
                     CarOnCurve = false;

--- a/Source/RunActivity/Viewer3D/Sound.cs
+++ b/Source/RunActivity/Viewer3D/Sound.cs
@@ -395,7 +395,7 @@ namespace Orts.Viewer3D
 
                     var CarBehind = Car.Train.Cars[CarNo + CarIncr];
                     var carPreviouslyOnSwitch = CarOnSwitch;
-                    CarOnSwitch = Car.IsOverJunction;
+                    CarOnSwitch = Car.IsOverSwitch || Car.IsOverCrossover;
 
                     // here check for curve
                     var carPreviouslyOnCurve = CarOnCurve;

--- a/Source/RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs
@@ -729,7 +729,7 @@ namespace Orts.Viewer3D.WebServices
                 }
                 else if (locomotive.WaterScoopDown && !locomotive.ScoopIsBroken)
                 {
-                    waterScoopIndicator = Viewer.Catalog.GetString("Down") + (locomotive.IsOverTrough() ? ColorCode[Color.Cyan] : ColorCode[Color.Orange]);
+                    waterScoopIndicator = Viewer.Catalog.GetString("Down") + (locomotive.IsOverTrough ? ColorCode[Color.Cyan] : ColorCode[Color.Orange]);
                     waterScoopKey = Symbols.ArrowToRight + ColorCode[Color.Yellow];
                 }
                 else


### PR DESCRIPTION
Before:

- TrainCar is-over-junction did not work at all
- Sound is-over-junction worked for switches but not crossovers

After:

- New is-over-junction works for switches and crossovers
- TrainCar and Sound both use same flag
- Is-over-water-trough check also migrated to new code for simplicity