### PR TITLE
Content Manager: Add axle count, and lowest derail force

### DIFF
--- a/Source/Contrib/ContentManager/ContentInfo.cs
+++ b/Source/Contrib/ContentManager/ContentInfo.cs
@@ -195,8 +195,13 @@ namespace ORTS.ContentManager
                     details.AppendFormat("Power:\t{1}{0}", Environment.NewLine, FormatStrings.FormatPower(data.MaxPowerW, IsMetric, IsImperialBHP, IsImperialBTUpS));
                     details.AppendFormat("MaxTE:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxTractiveForceN, IsMetric));
                     details.AppendFormat("MaxDynBrk:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxDynamicBrakeForceN, IsMetric));
-                    if (!IsMetric && !IsUK) { details.AppendFormat("HPT:\t{1}{0}", Environment.NewLine, FormatHPT(data.MaxPowerW, data.MassKG)); }
-                    if (!IsMetric && !IsUK) { details.AppendFormat("TpOB:\t{1}{0}", Environment.NewLine, FormatTPOB(data.MassKG, data.NumOperativeBrakes)); }
+                    if (!IsMetric && !IsUK)
+                    {
+                        details.AppendFormat("HPT:\t{1}{0}", Environment.NewLine, FormatHPT(data.MaxPowerW, data.MassKG));
+                        details.AppendFormat("TpOB:\t{1}{0}", Environment.NewLine, FormatTPOB(data.MassKG, data.NumOperativeBrakes));
+                        details.AppendFormat("TpEPA:\t{1}{0}", Environment.NewLine, FormatTonsPerEPA(data.MassKG, data.MaxTractiveForceN));
+                        details.AppendFormat("TpEDBA:\t{1}{0}", Environment.NewLine, FormatTonsPerEDBA(data.MassKG, data.MaxDynamicBrakeForceN));
+                    }
                     details.AppendFormat("MinCouplerStrength:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinCouplerStrengthN, IsMetric));
                     details.AppendFormat("MinDerailForce:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinDerailForceN, IsMetric));
                     details.AppendLine();
@@ -273,9 +278,6 @@ namespace ORTS.ContentManager
         /// <summary>
         /// Calculate and format horsepower per ton for consist, rounded to one decimal.
         /// </summary>
-        /// <param name="consistPowerW"></param>
-        /// <param name="consistMassKG"></param>
-        /// <returns>horsepower-per-ton formated to one decimal.</returns>
         //TODO: implement UK and metric version
         static string FormatHPT(float consistPowerW, float consistMassKG)
         {
@@ -286,14 +288,33 @@ namespace ORTS.ContentManager
         /// <summary>
         /// Calculate and format tons per operative brake for consist, rounded to an integer.
         /// </summary>
-        /// <param name="consistMassKG"></param>
-        /// <param name="consistNumOpBrakes"></param>
-        /// <returns>tons-per-operative-brake formated to an integer.</returns>
         //TODO: implement UK and metric version
         static string FormatTPOB(float consistMassKG, float consistNumOpBrakes)
         {
             var tpob = consistNumOpBrakes > 0 ? Kg.ToTUS(consistMassKG) / consistNumOpBrakes : 0;
             return string.Format("{0:0}", tpob);
+        }
+
+        /// <summary>
+        /// Calculate and format tons per equivalent powered axle, rounded to an integer.
+        /// Based on UP convention, of 10k lbf counting as one axle.
+        /// Strictly, EPA should be defined in the eng file. May be done in future.
+        /// </summary>
+        static string FormatTonsPerEPA(float consistMassKG, float consistMaxTractiveEffortN)
+        {
+            var tpepa = consistMaxTractiveEffortN > 0 ? Kg.ToTUS(consistMassKG) / (N.ToLbf(consistMaxTractiveEffortN) / 10000f) : 0;
+            return string.Format("{0:0}", tpepa);
+        }
+
+        /// <summary>
+        /// Calculate and format tons per equivalent dynamic brake axle, rounded to an integer.
+        /// Based on UP convention, of 10k lbf counting as one axle.
+        /// Strictly, EDBA should be defined in the eng file. May be done in future.
+        /// </summary>
+        static string FormatTonsPerEDBA(float consistMassKG, float consistMaxDynamicBrakeForceN)
+        {
+            var tpedba = consistMaxDynamicBrakeForceN > 0 ? Kg.ToTUS(consistMassKG) / (N.ToLbf(consistMaxDynamicBrakeForceN) / 10000f) : 0;
+            return string.Format("{0:0}", tpedba);
         }
     }
 }

--- a/Source/Contrib/ContentManager/ContentInfo.cs
+++ b/Source/Contrib/ContentManager/ContentInfo.cs
@@ -188,14 +188,16 @@ namespace ORTS.ContentManager
                     details.AppendFormat("Name:\t{1}{0}", Environment.NewLine, data.Name);
                     details.AppendFormat("NumEngines:\t{1}{0}", Environment.NewLine, data.NumEngines);
                     details.AppendFormat("NumCars:\t{1}{0}", Environment.NewLine, data.NumCars);
+                    details.AppendFormat("Axles:\t{1}{0}", Environment.NewLine, data.NumAxles);
                     details.AppendFormat("MaxSpeed:\t{1}{0}", Environment.NewLine, FormatStrings.FormatSpeedLimit(data.MaxSpeedMps, IsMetric));
                     details.AppendFormat("Weight:\t{1}{0}", Environment.NewLine, FormatStrings.FormatLargeMass(data.MassKG, IsMetric, IsUK));
                     details.AppendFormat("Length:\t{1}{0}", Environment.NewLine, FormatStrings.FormatShortDistanceDisplay(data.LengthM, IsMetric));
                     details.AppendFormat("Power:\t{1}{0}", Environment.NewLine, FormatStrings.FormatPower(data.MaxPowerW, IsMetric, IsImperialBHP, IsImperialBTUpS));
                     details.AppendFormat("MaxTE:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxTractiveForceN, IsMetric));
-                    details.AppendFormat("MinCouplerStrength:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinCouplerStrengthN, IsMetric));
                     if (!IsMetric && !IsUK) { details.AppendFormat("HPT:\t{1}{0}", Environment.NewLine, FormatHPT(data.MaxPowerW, data.MassKG)); }
                     if (!IsMetric && !IsUK) { details.AppendFormat("TPOB:\t{1}{0}", Environment.NewLine, FormatTPOB(data.MassKG, data.NumOperativeBrakes)); }
+                    details.AppendFormat("MinCouplerStrength:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinCouplerStrengthN, IsMetric));
+                    details.AppendFormat("MinDerailForce:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinDerailForceN, IsMetric));
                     details.AppendLine();
                     details.AppendFormat("Car ID:\tDirection:\tWeight:\tName:\t{0}", Environment.NewLine);
                     foreach (var car in data.Cars)
@@ -210,14 +212,20 @@ namespace ORTS.ContentManager
                     details.AppendFormat("Name:\t{1}{0}", Environment.NewLine, data.Name);
                     details.AppendFormat("Weight:\t{1} ({2}){0}", Environment.NewLine, FormatStrings.FormatMass(data.MassKG, IsMetric), FormatStrings.FormatLargeMass(data.MassKG, IsMetric, IsUK));
                     details.AppendFormat("Length:\t{1}{0}", Environment.NewLine, FormatStrings.FormatShortDistanceDisplay(data.LengthM, IsMetric));
-                    if (data.Type == CarType.Engine)
+                    if (data.Type != CarType.Engine)
                     {
+                        details.AppendFormat("Axles:\t{1}{0}", Environment.NewLine, data.NumAllAxles);
+                    }
+                    else
+                    {
+                        details.AppendFormat("Axles:\t{1}+{2}{0}", Environment.NewLine, data.NumDriveAxles, data.NumAllAxles - data.NumDriveAxles);
                         details.AppendFormat("MaxPowerW:\t{1}{0}", Environment.NewLine, FormatStrings.FormatPower(data.MaxPowerW, IsMetric, IsImperialBHP, IsImperialBTUpS));
                         details.AppendFormat("MaxForce:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxForceN, IsMetric));
                         details.AppendFormat("MaxSpeed:\t{1}{0}", Environment.NewLine, FormatStrings.FormatSpeedLimit(data.MaxSpeedMps, IsMetric));
                     }
-                    details.AppendFormat("MaxBrakeF:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxBarkeForceN, IsMetric));
+                    details.AppendFormat("MaxBrakeF:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxBrakeForceN, IsMetric));
                     details.AppendFormat("MinCouplerStrength:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinCouplerStrengthN, IsMetric));
+                    details.AppendFormat("MinDerailForce:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinDerailForceN, IsMetric));
                     details.AppendLine();
                     details.AppendFormat("Description:\t{0}{0}{1}{0}{0}", Environment.NewLine, data.Description);
                 }

--- a/Source/Contrib/ContentManager/ContentInfo.cs
+++ b/Source/Contrib/ContentManager/ContentInfo.cs
@@ -194,8 +194,9 @@ namespace ORTS.ContentManager
                     details.AppendFormat("Length:\t{1}{0}", Environment.NewLine, FormatStrings.FormatShortDistanceDisplay(data.LengthM, IsMetric));
                     details.AppendFormat("Power:\t{1}{0}", Environment.NewLine, FormatStrings.FormatPower(data.MaxPowerW, IsMetric, IsImperialBHP, IsImperialBTUpS));
                     details.AppendFormat("MaxTE:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxTractiveForceN, IsMetric));
+                    details.AppendFormat("MaxDynBrk:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxDynamicBrakeForceN, IsMetric));
                     if (!IsMetric && !IsUK) { details.AppendFormat("HPT:\t{1}{0}", Environment.NewLine, FormatHPT(data.MaxPowerW, data.MassKG)); }
-                    if (!IsMetric && !IsUK) { details.AppendFormat("TPOB:\t{1}{0}", Environment.NewLine, FormatTPOB(data.MassKG, data.NumOperativeBrakes)); }
+                    if (!IsMetric && !IsUK) { details.AppendFormat("TpOB:\t{1}{0}", Environment.NewLine, FormatTPOB(data.MassKG, data.NumOperativeBrakes)); }
                     details.AppendFormat("MinCouplerStrength:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinCouplerStrengthN, IsMetric));
                     details.AppendFormat("MinDerailForce:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinDerailForceN, IsMetric));
                     details.AppendLine();

--- a/Source/Contrib/ContentManager/ContentInfo.cs
+++ b/Source/Contrib/ContentManager/ContentInfo.cs
@@ -189,19 +189,21 @@ namespace ORTS.ContentManager
                     details.AppendFormat("NumEngines:\t{1}{0}", Environment.NewLine, data.NumEngines);
                     details.AppendFormat("NumCars:\t{1}{0}", Environment.NewLine, data.NumCars);
                     details.AppendFormat("Axles:\t{1}{0}", Environment.NewLine, data.NumAxles);
-                    details.AppendFormat("MaxSpeed:\t{1}{0}", Environment.NewLine, FormatStrings.FormatSpeedLimit(data.MaxSpeedMps, IsMetric));
-                    details.AppendFormat("Weight:\t{1}{0}", Environment.NewLine, FormatStrings.FormatLargeMass(data.MassKG, IsMetric, IsUK));
+                    details.AppendFormat("Weight:\t{1}  (trailing: {2}){0}", Environment.NewLine, FormatStrings.FormatLargeMass(data.MassKG, IsMetric, IsUK),
+                        FormatStrings.FormatLargeMass(data.TrailingMassKG, IsMetric, IsUK));
                     details.AppendFormat("Length:\t{1}{0}", Environment.NewLine, FormatStrings.FormatShortDistanceDisplay(data.LengthM, IsMetric));
-                    details.AppendFormat("Power:\t{1}{0}", Environment.NewLine, FormatStrings.FormatPower(data.MaxPowerW, IsMetric, IsImperialBHP, IsImperialBTUpS));
+                    details.AppendFormat("MaxPower:\t{1}{0}", Environment.NewLine, FormatStrings.FormatPower(data.MaxPowerW, IsMetric, IsImperialBHP, IsImperialBTUpS));
                     details.AppendFormat("MaxTE:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxTractiveForceN, IsMetric));
+                    details.AppendFormat("MaxContTE:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxContinuousTractiveForceN, IsMetric));
                     details.AppendFormat("MaxDynBrk:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxDynamicBrakeForceN, IsMetric));
                     if (!IsMetric && !IsUK)
                     {
-                        details.AppendFormat("HPT:\t{1}{0}", Environment.NewLine, FormatHPT(data.MaxPowerW, data.MassKG));
+                        details.AppendFormat("HPT:\t{1}{0}", Environment.NewLine, FormatHPT(data.MaxPowerW, data.TrailingMassKG));
                         details.AppendFormat("TpOB:\t{1}{0}", Environment.NewLine, FormatTPOB(data.TrailingMassKG, data.NumOperativeBrakes));
-                        details.AppendFormat("TpEPA:\t{1}{0}", Environment.NewLine, FormatTonsPerEPA(data.MassKG, data.MaxTractiveForceN));
-                        details.AppendFormat("TpEDBA:\t{1}{0}", Environment.NewLine, FormatTonsPerEDBA(data.MassKG, data.MaxDynamicBrakeForceN));
+                        details.AppendFormat("TpEPA:\t{1}{0}", Environment.NewLine, FormatTonsPerEPA(data.TrailingMassKG, data.MaxContinuousTractiveForceN));
+                        details.AppendFormat("TpEDBA:\t{1}{0}", Environment.NewLine, FormatTonsPerEDBA(data.TrailingMassKG, data.MaxDynamicBrakeForceN));
                     }
+                    details.AppendFormat("MaxSpeed:\t{1}{0}", Environment.NewLine, FormatStrings.FormatSpeedLimit(data.MaxSpeedMps, IsMetric));
                     details.AppendFormat("MinCouplerStrength:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinCouplerStrengthN, IsMetric));
                     details.AppendFormat("MinDerailForce:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinDerailForceN, IsMetric));
                     details.AppendLine();
@@ -216,7 +218,7 @@ namespace ORTS.ContentManager
                     details.AppendFormat("Type:\t{1}{0}", Environment.NewLine, data.Type);
                     details.AppendFormat("SubType:\t{1}{0}", Environment.NewLine, data.SubType);
                     details.AppendFormat("Name:\t{1}{0}", Environment.NewLine, data.Name);
-                    details.AppendFormat("Weight:\t{1} ({2}){0}", Environment.NewLine, FormatStrings.FormatMass(data.MassKG, IsMetric), FormatStrings.FormatLargeMass(data.MassKG, IsMetric, IsUK));
+                    details.AppendFormat("Weight:\t{1}  ({2}){0}", Environment.NewLine, FormatStrings.FormatMass(data.MassKG, IsMetric), FormatStrings.FormatLargeMass(data.MassKG, IsMetric, IsUK));
                     details.AppendFormat("Length:\t{1}{0}", Environment.NewLine, FormatStrings.FormatShortDistanceDisplay(data.LengthM, IsMetric));
                     if (data.Type != CarType.Engine)
                     {
@@ -225,11 +227,13 @@ namespace ORTS.ContentManager
                     else
                     {
                         details.AppendFormat("Axles:\t{1}+{2}{0}", Environment.NewLine, data.NumDriveAxles, data.NumAllAxles - data.NumDriveAxles);
-                        details.AppendFormat("MaxPowerW:\t{1}{0}", Environment.NewLine, FormatStrings.FormatPower(data.MaxPowerW, IsMetric, IsImperialBHP, IsImperialBTUpS));
-                        details.AppendFormat("MaxForce:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxForceN, IsMetric));
-                        details.AppendFormat("MaxSpeed:\t{1}{0}", Environment.NewLine, FormatStrings.FormatSpeedLimit(data.MaxSpeedMps, IsMetric));
+                        details.AppendFormat("MaxPower:\t{1}{0}", Environment.NewLine, FormatStrings.FormatPower(data.MaxPowerW, IsMetric, IsImperialBHP, IsImperialBTUpS));
+                        details.AppendFormat("MaxTE:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxForceN, IsMetric));
+                        details.AppendFormat("MaxContTE:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxContinuousForceN, IsMetric));
+                        details.AppendFormat("MaxDynBrk:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxDynamicBrakeForceN, IsMetric));
                     }
                     details.AppendFormat("MaxBrakeF:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MaxBrakeForceN, IsMetric));
+                    if (data.MaxSpeedMps > 0f) { details.AppendFormat("MaxSpeed:\t{1}{0}", Environment.NewLine, FormatStrings.FormatSpeedLimit(data.MaxSpeedMps, IsMetric)); }
                     details.AppendFormat("MinCouplerStrength:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinCouplerStrengthN, IsMetric));
                     details.AppendFormat("MinDerailForce:\t{1}{0}", Environment.NewLine, FormatStrings.FormatForce(data.MinDerailForceN, IsMetric));
                     details.AppendLine();

--- a/Source/Contrib/ContentManager/ContentInfo.cs
+++ b/Source/Contrib/ContentManager/ContentInfo.cs
@@ -198,7 +198,7 @@ namespace ORTS.ContentManager
                     if (!IsMetric && !IsUK)
                     {
                         details.AppendFormat("HPT:\t{1}{0}", Environment.NewLine, FormatHPT(data.MaxPowerW, data.MassKG));
-                        details.AppendFormat("TpOB:\t{1}{0}", Environment.NewLine, FormatTPOB(data.MassKG, data.NumOperativeBrakes));
+                        details.AppendFormat("TpOB:\t{1}{0}", Environment.NewLine, FormatTPOB(data.TrailingMassKG, data.NumOperativeBrakes));
                         details.AppendFormat("TpEPA:\t{1}{0}", Environment.NewLine, FormatTonsPerEPA(data.MassKG, data.MaxTractiveForceN));
                         details.AppendFormat("TpEDBA:\t{1}{0}", Environment.NewLine, FormatTonsPerEDBA(data.MassKG, data.MaxDynamicBrakeForceN));
                     }

--- a/Source/Contrib/ContentManager/ContentMSTS.cs
+++ b/Source/Contrib/ContentManager/ContentMSTS.cs
@@ -127,6 +127,13 @@ namespace ORTS.ContentManager
                     foreach (var item in Enumerable.Concat(Directory.GetFiles(pathOR, "*.timetable_or"), Directory.GetFiles(pathOR, "*.timetable-or")))
                         yield return new ContentORTimetableActivity(this, Path.Combine(pathOR, item));
             }
+            else if (type == ContentType.Path)
+            {
+                var path = Path.Combine(PathName, "Paths");
+                if (Directory.Exists(path))
+                    foreach (var item in Directory.GetFiles(path, "*.pat"))
+                        yield return new ContentMSTSPath(this, Path.Combine(path, item));
+            }
         }
 
         public override Content Get(string name, ContentType type)

--- a/Source/Contrib/ContentManager/Models/Car.cs
+++ b/Source/Contrib/ContentManager/Models/Car.cs
@@ -57,6 +57,8 @@ namespace ORTS.ContentManager.Models
 
             const float GravitationalAccelerationMpS2 = 9.80665f;
 
+            int ortsEngAxles = -1;  // not present
+
             // .eng files also have a wagon block
             var wagFile = new WagonFile(content.PathName);
             Type = CarType.Wagon;
@@ -77,15 +79,18 @@ namespace ORTS.ContentManager.Models
                 MaxForceN = engFile.MaxForceN;
                 MaxSpeedMps = engFile.MaxSpeedMps;
                 Description = engFile.Description;
+
                 // see MSTSLocomotive.Initialize()
-                if (engFile.NumDriveAxles > 0) { NumDriveAxles = engFile.NumDriveAxles; }
+                ortsEngAxles = engFile.NumDriveAxles;
+                if (ortsEngAxles >= 0) { NumDriveAxles = ortsEngAxles; }
                 else if (engFile.NumEngWheels >= 7f) { NumDriveAxles = (int)(engFile.NumEngWheels / 2f); }
                 else if (engFile.NumEngWheels > 0f) { NumDriveAxles = (int)engFile.NumEngWheels; }
                 else { NumDriveAxles = 4; }
             }
 
             // see MSTSWagon.LoadFromWagFile()
-            if (wagFile.NumWagAxles > 0) { NumAllAxles = wagFile.NumWagAxles + NumDriveAxles; }
+            if (ortsEngAxles >= 0 && wagFile.NumWagAxles >= 0) { NumAllAxles = ortsEngAxles + wagFile.NumWagAxles; }
+            else if (wagFile.NumWagAxles >= 0) { NumAllAxles = wagFile.NumWagAxles; }
             else if (wagFile.NumWagWheels >= 7f) { NumAllAxles = (int)(wagFile.NumWagWheels / 2f); }
             else if (wagFile.NumWagWheels > 0f) { NumAllAxles = (int)wagFile.NumWagWheels; }
             else { NumAllAxles = 4; }

--- a/Source/Contrib/ContentManager/Models/Car.cs
+++ b/Source/Contrib/ContentManager/Models/Car.cs
@@ -48,6 +48,8 @@ namespace ORTS.ContentManager.Models
         public readonly float MaxBrakeForceN;
         public readonly float MaxPowerW;
         public readonly float MaxForceN;
+        public readonly float MaxContinuousForceN;
+        public readonly float MaxDynamicBrakeForceN;
         public readonly float MaxSpeedMps;
         public readonly float MinCouplerStrengthN;
         public readonly float MinDerailForceN;
@@ -76,6 +78,8 @@ namespace ORTS.ContentManager.Models
                 Name = engFile.Name;
                 MaxPowerW = engFile.MaxPowerW;
                 MaxForceN = engFile.MaxForceN;
+                MaxContinuousForceN = engFile.MaxContinuousForceN;
+                MaxDynamicBrakeForceN = engFile.MaxDynamicBrakeForceN;
                 MaxSpeedMps = engFile.MaxSpeedMps;
                 Description = engFile.Description;
 

--- a/Source/Contrib/ContentManager/Models/Car.cs
+++ b/Source/Contrib/ContentManager/Models/Car.cs
@@ -43,6 +43,7 @@ namespace ORTS.ContentManager.Models
         public readonly float MassKG;
         public readonly float LengthM;
         public readonly int NumDriveAxles;
+        public readonly int NumIdleAxles;
         public readonly int NumAllAxles;
         public readonly float MaxBrakeForceN;
         public readonly float MaxPowerW;
@@ -56,8 +57,6 @@ namespace ORTS.ContentManager.Models
             Debug.Assert(content.Type == ContentType.Car);
 
             const float GravitationalAccelerationMpS2 = 9.80665f;
-
-            int ortsEngAxles = -1;  // not present
 
             // .eng files also have a wagon block
             var wagFile = new WagonFile(content.PathName);
@@ -81,20 +80,27 @@ namespace ORTS.ContentManager.Models
                 Description = engFile.Description;
 
                 // see MSTSLocomotive.Initialize()
-                ortsEngAxles = engFile.NumDriveAxles;
-                if (ortsEngAxles >= 0) { NumDriveAxles = ortsEngAxles; }
-                else if (engFile.NumEngWheels >= 7f) { NumDriveAxles = (int)(engFile.NumEngWheels / 2f); }
-                else if (engFile.NumEngWheels > 0f) { NumDriveAxles = (int)engFile.NumEngWheels; }
-                else { NumDriveAxles = 4; }
+                NumDriveAxles = engFile.NumDriveAxles;
+                if (NumDriveAxles == 0)
+                {
+                    if (engFile.NumEngWheels != 0 && engFile.NumEngWheels < 7) { NumDriveAxles = (int)engFile.NumEngWheels; }
+                    else { NumDriveAxles = 4; }
+                }
             }
 
             // see MSTSWagon.LoadFromWagFile()
-            if (ortsEngAxles >= 0 && wagFile.NumWagAxles >= 0) { NumAllAxles = ortsEngAxles + wagFile.NumWagAxles; }
-            else if (wagFile.NumWagAxles >= 0) { NumAllAxles = wagFile.NumWagAxles; }
-            else if (wagFile.NumWagWheels >= 7f) { NumAllAxles = (int)(wagFile.NumWagWheels / 2f); }
-            else if (wagFile.NumWagWheels > 0f) { NumAllAxles = (int)wagFile.NumWagWheels; }
-            else { NumAllAxles = 4; }
-            if (NumDriveAxles > NumAllAxles) { NumAllAxles = NumDriveAxles; }
+            NumIdleAxles = wagFile.NumWagAxles;
+            if ((NumIdleAxles == 0) && Type != CarType.Engine)
+            {
+                if (wagFile.NumWagWheels != 0 && wagFile.NumWagWheels < 6) { NumIdleAxles = (int)wagFile.NumWagWheels; }
+                else { NumIdleAxles = 4; }
+            }
+
+            // correction for steam engines; see TrainCar.Update()
+            // this is not always correct as TrainCar uses the WheelAxles array for the count; that is too complex to do here
+            if (SubType.Equals("Steam") && NumDriveAxles >= (NumDriveAxles + NumIdleAxles)) { NumDriveAxles /= 2; }
+
+            NumAllAxles = NumDriveAxles + NumIdleAxles;
 
             // see TrainCar.UpdateTrainDerailmentRisk()
             var numWheels = NumAllAxles * 2;

--- a/Source/Contrib/ContentManager/Models/Car.cs
+++ b/Source/Contrib/ContentManager/Models/Car.cs
@@ -100,6 +100,7 @@ namespace ORTS.ContentManager.Models
             // this is not always correct as TrainCar uses the WheelAxles array for the count; that is too complex to do here
             if (SubType.Equals("Steam") && NumDriveAxles >= (NumDriveAxles + NumIdleAxles)) { NumDriveAxles /= 2; }
 
+            // see TrainCar.UpdateTrainDerailmentRisk(), ~ line 1609
             NumAllAxles = NumDriveAxles + NumIdleAxles;
 
             // see TrainCar.UpdateTrainDerailmentRisk()

--- a/Source/Contrib/ContentManager/Models/Consist.cs
+++ b/Source/Contrib/ContentManager/Models/Consist.cs
@@ -114,6 +114,7 @@ namespace ORTS.ContentManager.Models
                         // this is not always correct as TrainCar uses the WheelAxles array for the count; that is too complex to do here
                         if (subType.Equals("Steam") && numDriveAxles >= (numDriveAxles + numIdleAxles)) { numDriveAxles /= 2; }
 
+                        // see TrainCar.UpdateTrainDerailmentRisk(), ~ line 1609
                         numAllAxles = numDriveAxles + numIdleAxles;
 
                         // exclude legacy EOT from total axle count

--- a/Source/Contrib/ContentManager/Models/Consist.cs
+++ b/Source/Contrib/ContentManager/Models/Consist.cs
@@ -34,6 +34,7 @@ namespace ORTS.ContentManager.Models
         public readonly float MassKG = 0F;
         public readonly float MaxPowerW = 0F;
         public readonly float MaxTractiveForceN = 0F;
+        public readonly float MaxDynamicBrakeForceN = 0F;
         public readonly float MaxBrakeForce = 0F;
         public readonly int NumOperativeBrakes = 0;
         public readonly float MinCouplerStrengthN = 9.999e8f;  // impossible high force
@@ -88,6 +89,7 @@ namespace ORTS.ContentManager.Models
                                 EngCount++;
                                 MaxPowerW += engFile.MaxPowerW;
                                 MaxTractiveForceN += engFile.MaxForceN;
+                                MaxDynamicBrakeForceN += engFile.MaxDynamicBrakeForceN;
                             }
                             else { WagCount++; }
                         }

--- a/Source/Contrib/ContentManager/Models/Consist.cs
+++ b/Source/Contrib/ContentManager/Models/Consist.cs
@@ -32,6 +32,7 @@ namespace ORTS.ContentManager.Models
         public readonly float LengthM = 0F;
         public readonly int NumAxles = 0;
         public readonly float MassKG = 0F;
+        public readonly float TrailingMassKG = 0F;
         public readonly float MaxPowerW = 0F;
         public readonly float MaxTractiveForceN = 0F;
         public readonly float MaxDynamicBrakeForceN = 0F;
@@ -74,7 +75,6 @@ namespace ORTS.ContentManager.Models
                         MaxBrakeForce += wagonFile.MaxBrakeForceN;
                         MinCouplerStrengthN = Math.Min(MinCouplerStrengthN, wagonFile.MinCouplerStrengthN);
                         var subType = wagonFile.WagonType;
-                        if (wagonFile.MaxBrakeForceN > 0) { NumOperativeBrakes++; }
 
                         if (engFile != null)
                         {
@@ -100,6 +100,12 @@ namespace ORTS.ContentManager.Models
                         else if (!wag.IsEOT && wagonFile.WagonSize.LengthM > 1.1) // exclude legacy EOT
                         {
                             WagCount++;
+                            TrailingMassKG += wagonFile.MassKG;
+                            if (wagonFile.MaxBrakeForceN > 0 && wagonFile.BrakeSystemType != null && !wagonFile.BrakeSystemType.Contains("manual_braking") &&
+                                !wagonFile.BrakeSystemType.Contains("air_piped") && !wagonFile.BrakeSystemType.Contains("vacuum_piped"))
+                            {
+                                NumOperativeBrakes++;
+                            }
                         }
 
                         // see MSTSWagon.LoadFromWagFile()

--- a/Source/Contrib/ContentManager/Models/Consist.cs
+++ b/Source/Contrib/ContentManager/Models/Consist.cs
@@ -60,7 +60,7 @@ namespace ORTS.ContentManager.Models
                 var CarList = new List<Car>();
                 foreach (Wagon wag in file.Train.TrainCfg.WagonList)
                 {
-                    float wagonMassKG = 0; int ortsEngAxles = -1; int numDriveAxles = 0; int numAllAxles = 0;
+                    float wagonMassKG = 0; int numDriveAxles = 0; int numIdleAxles = 0; int numAllAxles = 0;
                     try
                     {
                         var fileType = wag.IsEngine ? ".eng" : ".wag";
@@ -73,16 +73,20 @@ namespace ORTS.ContentManager.Models
                         wagonMassKG = wagonFile.MassKG;
                         MaxBrakeForce += wagonFile.MaxBrakeForceN;
                         MinCouplerStrengthN = Math.Min(MinCouplerStrengthN, wagonFile.MinCouplerStrengthN);
+                        var subType = wagonFile.WagonType;
                         if (wagonFile.MaxBrakeForceN > 0) { NumOperativeBrakes++; }
 
-                        if (wag.IsEngine)
+                        if (engFile != null)
                         {
+                            subType = engFile.EngineType;
+
                             // see MSTSLocomotive.Initialize()
-                            ortsEngAxles = engFile.NumDriveAxles;
-                            if (ortsEngAxles >= 0) { numDriveAxles = ortsEngAxles; }
-                            else if (engFile.NumEngWheels > 7f) { numDriveAxles = (int)(engFile.NumEngWheels / 2f); }
-                            else if (engFile.NumEngWheels > 0) { numDriveAxles = (int)engFile.NumEngWheels; }
-                            else { numDriveAxles = 4; }
+                            numDriveAxles = engFile.NumDriveAxles;
+                            if (numDriveAxles == 0)
+                            {
+                                if (engFile.NumEngWheels != 0 && engFile.NumEngWheels < 7) { numDriveAxles = (int)engFile.NumEngWheels; }
+                                else { numDriveAxles = 4; }
+                            }
 
                             if (engFile.MaxForceN > 25000)  // exclude legacy driving trailers / cab-cars
                             {
@@ -99,12 +103,18 @@ namespace ORTS.ContentManager.Models
                         }
 
                         // see MSTSWagon.LoadFromWagFile()
-                        if (ortsEngAxles >= 0 && wagonFile.NumWagAxles >= 0) { numAllAxles = ortsEngAxles + wagonFile.NumWagAxles; }
-                        else if (wagonFile.NumWagAxles >= 0) { numAllAxles =  wagonFile.NumWagAxles; }
-                        else if (wagonFile.NumWagWheels >= 7f) { numAllAxles = (int)(wagonFile.NumWagWheels / 2f); }
-                        else if (wagonFile.NumWagWheels >= 0f) { numAllAxles = (int)wagonFile.NumWagWheels; }
-                        else { numAllAxles = 4; }
-                        if (numDriveAxles > numAllAxles) { numAllAxles = numDriveAxles; }
+                        numIdleAxles = wagonFile.NumWagAxles;
+                        if (numIdleAxles == 0 && !wag.IsEngine)
+                        {
+                            if (wagonFile.NumWagWheels != 0 && wagonFile.NumWagWheels < 6) { numIdleAxles = (int)wagonFile.NumWagWheels; }
+                            else { numIdleAxles = 4; }
+                        }
+
+                        // correction for steam engines; see TrainCar.Update()
+                        // this is not always correct as TrainCar uses the WheelAxles array for the count; that is too complex to do here
+                        if (subType.Equals("Steam") && numDriveAxles >= (numDriveAxles + numIdleAxles)) { numDriveAxles /= 2; }
+
+                        numAllAxles = numDriveAxles + numIdleAxles;
 
                         // exclude legacy EOT from total axle count
                         if (!wag.IsEOT && wagonFile.WagonSize.LengthM > 1.1)

--- a/Source/Contrib/ContentManager/Models/Consist.cs
+++ b/Source/Contrib/ContentManager/Models/Consist.cs
@@ -35,6 +35,7 @@ namespace ORTS.ContentManager.Models
         public readonly float TrailingMassKG = 0F;
         public readonly float MaxPowerW = 0F;
         public readonly float MaxTractiveForceN = 0F;
+        public readonly float MaxContinuousTractiveForceN = 0F;
         public readonly float MaxDynamicBrakeForceN = 0F;
         public readonly float MaxBrakeForce = 0F;
         public readonly int NumOperativeBrakes = 0;
@@ -93,6 +94,7 @@ namespace ORTS.ContentManager.Models
                                 EngCount++;
                                 MaxPowerW += engFile.MaxPowerW;
                                 MaxTractiveForceN += engFile.MaxForceN;
+                                MaxContinuousTractiveForceN += engFile.MaxContinuousForceN > 0f ? engFile.MaxContinuousForceN : engFile.MaxForceN;
                                 MaxDynamicBrakeForceN += engFile.MaxDynamicBrakeForceN;
                             }
                             else { WagCount++; }

--- a/Source/Contrib/SettingsExporter/Properties/launchSettings.json
+++ b/Source/Contrib/SettingsExporter/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "SettingsExporter": {
+      "commandName": "Project",
+      "commandLineArgs": "REG INI"
+    }
+  }
+}

--- a/Source/Contrib/SettingsExporter/Properties/launchSettings.json
+++ b/Source/Contrib/SettingsExporter/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "SettingsExporter": {
-      "commandName": "Project",
-      "commandLineArgs": "REG INI"
-    }
-  }
-}

--- a/Source/Orts.Formats.Msts/EngineFile.cs
+++ b/Source/Orts.Formats.Msts/EngineFile.cs
@@ -31,6 +31,7 @@ namespace Orts.Formats.Msts
         public string EngineType;
         public float MaxPowerW;
         public float MaxForceN;
+        public float MaxContinuousForceN;
         public float MaxDynamicBrakeForceN;
         public float MaxSpeedMps;
         public int NumDriveAxles;  // ORTS
@@ -51,6 +52,7 @@ namespace Orts.Formats.Msts
                             new STFReader.TokenProcessor("type", ()=>{ EngineType = stf.ReadStringBlock(null); }),
                             new STFReader.TokenProcessor("maxpower", ()=>{ MaxPowerW = stf.ReadFloatBlock( STFReader.UNITS.Power, null); }),
                             new STFReader.TokenProcessor("maxforce", ()=>{ MaxForceN = stf.ReadFloatBlock( STFReader.UNITS.Force, null); }),
+                            new STFReader.TokenProcessor("maxcontinuousforce", ()=>{ MaxContinuousForceN = stf.ReadFloatBlock( STFReader.UNITS.Force, null); }),
                             new STFReader.TokenProcessor("dynamicbrakesmaximumforce", ()=>{ MaxDynamicBrakeForceN = stf.ReadFloatBlock( STFReader.UNITS.Force, null); }),
                             new STFReader.TokenProcessor("maxvelocity", ()=>{ MaxSpeedMps = stf.ReadFloatBlock( STFReader.UNITS.Speed, null); }),
                             new STFReader.TokenProcessor("ortsnumberdriveaxles", ()=>{ NumDriveAxles = stf.ReadIntBlock(null); }),

--- a/Source/Orts.Formats.Msts/EngineFile.cs
+++ b/Source/Orts.Formats.Msts/EngineFile.cs
@@ -32,7 +32,7 @@ namespace Orts.Formats.Msts
         public float MaxPowerW;
         public float MaxForceN;
         public float MaxSpeedMps;
-        public int NumDriveAxles;  // ORTS
+        public int NumDriveAxles = -1;  // ORTS; -1 indicates absent
         public float NumEngWheels;  // MSTS
         public string Description;
         public string CabViewFile;
@@ -51,8 +51,8 @@ namespace Orts.Formats.Msts
                             new STFReader.TokenProcessor("maxpower", ()=>{ MaxPowerW = stf.ReadFloatBlock( STFReader.UNITS.Power, null); }),
                             new STFReader.TokenProcessor("maxforce", ()=>{ MaxForceN = stf.ReadFloatBlock( STFReader.UNITS.Force, null); }),
                             new STFReader.TokenProcessor("maxvelocity", ()=>{ MaxSpeedMps = stf.ReadFloatBlock( STFReader.UNITS.Speed, null); }),
-                            new STFReader.TokenProcessor("ortsnumberdriveaxles", ()=>{ NumDriveAxles = stf.ReadIntBlock( 0); }),
-                            new STFReader.TokenProcessor("numwheels", ()=>{ NumEngWheels = stf.ReadFloatBlock( STFReader.UNITS.None, 0f); }),
+                            new STFReader.TokenProcessor("ortsnumberdriveaxles", ()=>{ NumDriveAxles = stf.ReadIntBlock(null); }),
+                            new STFReader.TokenProcessor("numwheels", ()=>{ NumEngWheels = stf.ReadFloatBlock( STFReader.UNITS.None, null); }),
                             new STFReader.TokenProcessor("description", ()=>{ Description = stf.ReadStringBlock(null); }),
                             new STFReader.TokenProcessor("cabview", ()=>{ CabViewFile = stf.ReadStringBlock(null); }),
                         });

--- a/Source/Orts.Formats.Msts/EngineFile.cs
+++ b/Source/Orts.Formats.Msts/EngineFile.cs
@@ -32,6 +32,8 @@ namespace Orts.Formats.Msts
         public float MaxPowerW;
         public float MaxForceN;
         public float MaxSpeedMps;
+        public int NumDriveAxles;  // ORTS
+        public float NumEngWheels;  // MSTS
         public string Description;
         public string CabViewFile;
 
@@ -39,6 +41,7 @@ namespace Orts.Formats.Msts
         {
             Name = Path.GetFileNameWithoutExtension(filePath);
             using (var stf = new STFReader(filePath, false))
+            {
                 stf.ParseFile(new STFReader.TokenProcessor[] {
                     new STFReader.TokenProcessor("engine", ()=>{
                         stf.ReadString();
@@ -48,11 +51,14 @@ namespace Orts.Formats.Msts
                             new STFReader.TokenProcessor("maxpower", ()=>{ MaxPowerW = stf.ReadFloatBlock( STFReader.UNITS.Power, null); }),
                             new STFReader.TokenProcessor("maxforce", ()=>{ MaxForceN = stf.ReadFloatBlock( STFReader.UNITS.Force, null); }),
                             new STFReader.TokenProcessor("maxvelocity", ()=>{ MaxSpeedMps = stf.ReadFloatBlock( STFReader.UNITS.Speed, null); }),
+                            new STFReader.TokenProcessor("ortsnumberdriveaxles", ()=>{ NumDriveAxles = stf.ReadIntBlock( 0); }),
+                            new STFReader.TokenProcessor("numwheels", ()=>{ NumEngWheels = stf.ReadFloatBlock( STFReader.UNITS.None, 0f); }),
                             new STFReader.TokenProcessor("description", ()=>{ Description = stf.ReadStringBlock(null); }),
                             new STFReader.TokenProcessor("cabview", ()=>{ CabViewFile = stf.ReadStringBlock(null); }),
                         });
                     }),
                 });
+            }
         }
 
         public override string ToString()

--- a/Source/Orts.Formats.Msts/EngineFile.cs
+++ b/Source/Orts.Formats.Msts/EngineFile.cs
@@ -31,6 +31,7 @@ namespace Orts.Formats.Msts
         public string EngineType;
         public float MaxPowerW;
         public float MaxForceN;
+        public float MaxDynamicBrakeForceN;
         public float MaxSpeedMps;
         public int NumDriveAxles = -1;  // ORTS; -1 indicates absent
         public float NumEngWheels;  // MSTS
@@ -50,6 +51,7 @@ namespace Orts.Formats.Msts
                             new STFReader.TokenProcessor("type", ()=>{ EngineType = stf.ReadStringBlock(null); }),
                             new STFReader.TokenProcessor("maxpower", ()=>{ MaxPowerW = stf.ReadFloatBlock( STFReader.UNITS.Power, null); }),
                             new STFReader.TokenProcessor("maxforce", ()=>{ MaxForceN = stf.ReadFloatBlock( STFReader.UNITS.Force, null); }),
+                            new STFReader.TokenProcessor("dynamicbrakesmaximumforce", ()=>{ MaxDynamicBrakeForceN = stf.ReadFloatBlock( STFReader.UNITS.Force, null); }),
                             new STFReader.TokenProcessor("maxvelocity", ()=>{ MaxSpeedMps = stf.ReadFloatBlock( STFReader.UNITS.Speed, null); }),
                             new STFReader.TokenProcessor("ortsnumberdriveaxles", ()=>{ NumDriveAxles = stf.ReadIntBlock(null); }),
                             new STFReader.TokenProcessor("numwheels", ()=>{ NumEngWheels = stf.ReadFloatBlock( STFReader.UNITS.None, null); }),

--- a/Source/Orts.Formats.Msts/EngineFile.cs
+++ b/Source/Orts.Formats.Msts/EngineFile.cs
@@ -33,7 +33,7 @@ namespace Orts.Formats.Msts
         public float MaxForceN;
         public float MaxDynamicBrakeForceN;
         public float MaxSpeedMps;
-        public int NumDriveAxles = -1;  // ORTS; -1 indicates absent
+        public int NumDriveAxles;  // ORTS
         public float NumEngWheels;  // MSTS
         public string Description;
         public string CabViewFile;

--- a/Source/Orts.Formats.Msts/WagonFile.cs
+++ b/Source/Orts.Formats.Msts/WagonFile.cs
@@ -34,6 +34,8 @@ namespace Orts.Formats.Msts
         public CarSize WagonSize;
         public int NumWagAxles;  // ORTS
         public float NumWagWheels;  // MSTS
+        public string BrakeSystemType;
+        public string BrakeEquipmentType;
         public float MaxBrakeForceN;
         public float MinCouplerStrengthN = ImpossiblyHighForceN;
 
@@ -111,6 +113,8 @@ namespace Orts.Formats.Msts
                             new STFReader.TokenProcessor("size", ()=>{ WagonSize = new CarSize( stf); }),
                             new STFReader.TokenProcessor("ortsnumberaxles", ()=>{ NumWagAxles = stf.ReadIntBlock(null); }),
                             new STFReader.TokenProcessor("numwheels", ()=>{ NumWagWheels = stf.ReadFloatBlock( STFReader.UNITS.None, null); }),
+                            new STFReader.TokenProcessor("brakesystemtype", ()=>{ BrakeSystemType = stf.ReadStringBlock(null).ToLower(); }),
+                            new STFReader.TokenProcessor("brakeequipmenttype", ()=>{ BrakeEquipmentType = stf.ReadStringBlock(null).ToLower(); }),
                             new STFReader.TokenProcessor("maxbrakeforce", ()=>{ MaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); }),
                             new STFReader.TokenProcessor("coupling", ()=>{ new CouplingSpring( ref MinCouplerStrengthN, stf); })
                         });

--- a/Source/Orts.Formats.Msts/WagonFile.cs
+++ b/Source/Orts.Formats.Msts/WagonFile.cs
@@ -32,6 +32,8 @@ namespace Orts.Formats.Msts
         public string WagonType;
         public float MassKG;
         public CarSize WagonSize;
+        public int NumWagAxles;  // ORTS
+        public float NumWagWheels;  // MSTS
         public float MaxBrakeForceN;
         public float MinCouplerStrengthN = ImpossiblyHighForceN;
 
@@ -107,6 +109,8 @@ namespace Orts.Formats.Msts
                             new STFReader.TokenProcessor("type", ()=>{ WagonType = stf.ReadStringBlock(null); }),
                             new STFReader.TokenProcessor("mass", ()=>{ MassKG = stf.ReadFloatBlock(STFReader.UNITS.Mass, null); }),
                             new STFReader.TokenProcessor("size", ()=>{ WagonSize = new CarSize( stf); }),
+                            new STFReader.TokenProcessor("ortsnumberaxles", ()=>{ NumWagAxles = stf.ReadIntBlock( 0); }),
+                            new STFReader.TokenProcessor("numwheels", ()=>{ NumWagWheels = stf.ReadFloatBlock( STFReader.UNITS.None, 0f); }),
                             new STFReader.TokenProcessor("maxbrakeforce", ()=>{ MaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); }),
                             new STFReader.TokenProcessor("coupling", ()=>{ new CouplingSpring( ref MinCouplerStrengthN, stf); })
                         });

--- a/Source/Orts.Formats.Msts/WagonFile.cs
+++ b/Source/Orts.Formats.Msts/WagonFile.cs
@@ -32,7 +32,7 @@ namespace Orts.Formats.Msts
         public string WagonType;
         public float MassKG;
         public CarSize WagonSize;
-        public int NumWagAxles = -1;  // ORTS; -1 indicates absent
+        public int NumWagAxles;  // ORTS
         public float NumWagWheels;  // MSTS
         public float MaxBrakeForceN;
         public float MinCouplerStrengthN = ImpossiblyHighForceN;

--- a/Source/Orts.Formats.Msts/WagonFile.cs
+++ b/Source/Orts.Formats.Msts/WagonFile.cs
@@ -32,7 +32,7 @@ namespace Orts.Formats.Msts
         public string WagonType;
         public float MassKG;
         public CarSize WagonSize;
-        public int NumWagAxles;  // ORTS
+        public int NumWagAxles = -1;  // ORTS; -1 indicates absent
         public float NumWagWheels;  // MSTS
         public float MaxBrakeForceN;
         public float MinCouplerStrengthN = ImpossiblyHighForceN;
@@ -109,8 +109,8 @@ namespace Orts.Formats.Msts
                             new STFReader.TokenProcessor("type", ()=>{ WagonType = stf.ReadStringBlock(null); }),
                             new STFReader.TokenProcessor("mass", ()=>{ MassKG = stf.ReadFloatBlock(STFReader.UNITS.Mass, null); }),
                             new STFReader.TokenProcessor("size", ()=>{ WagonSize = new CarSize( stf); }),
-                            new STFReader.TokenProcessor("ortsnumberaxles", ()=>{ NumWagAxles = stf.ReadIntBlock( 0); }),
-                            new STFReader.TokenProcessor("numwheels", ()=>{ NumWagWheels = stf.ReadFloatBlock( STFReader.UNITS.None, 0f); }),
+                            new STFReader.TokenProcessor("ortsnumberaxles", ()=>{ NumWagAxles = stf.ReadIntBlock(null); }),
+                            new STFReader.TokenProcessor("numwheels", ()=>{ NumWagWheels = stf.ReadFloatBlock( STFReader.UNITS.None, null); }),
                             new STFReader.TokenProcessor("maxbrakeforce", ()=>{ MaxBrakeForceN = stf.ReadFloatBlock(STFReader.UNITS.Force, null); }),
                             new STFReader.TokenProcessor("coupling", ()=>{ new CouplingSpring( ref MinCouplerStrengthN, stf); })
                         });


### PR DESCRIPTION
Adding the axle count for the consist, as mentioned in this thread:

Feature request: https://www.elvastower.com/forums/index.php?/topic/38493-consist-data-in-content-manager/page__view__findpost__p__314665

Also adding the minimal derail force. There are some issues with cars derailing in the BNSF Starter Route (Scenic Sub) See [here ](https://www.trainsim.com/forums/forum/open-rails/open-rails-discussion/2316088-problems-with-trainsimulations-bnsf-scenic-subdivision-demo-route?p=2317033#post2317033)(TrainSIm.com). This helps identify trains at risk (and needing some fixing).

BTW, some rolling stock has incorrect axles/wheels config. Most are because of legacy-MSTS issues. But some also mix ORTS Axles and MSTS Wheels. That usually explains unexpected Axle counts.

**Update**: Added one more enhancement to this PR: Showing the path under the route category (after activities). 
I often run RunActivity directly, and this makes it easy to find a suitable path. Previously one had to mavigate through each service to view a path.

**Update 2**: Also  added TpEPA and TpEDBA, when units are imperial.
TpEPA = Tons per Equivalent Powered Axles.
TpEDBA = Tons per Equivalent Dynamic Brake Axles.

These metrics are more accurate than HP per Ton, as they are based on
tractive effort.

The calculations are based on Union Pacific practices. UP uses a
standard axle of 10'000 lbf tractive effort or dynamic brake force.
For example a GP40-2 is 5.0 EPA, an SD40-2 is 7.1 EPA. Both have the
same HP (and thus result in the same HP-per-Ton).

**Example of Path list**:

![image](https://github.com/user-attachments/assets/5c69a0ea-0c89-4063-bd1e-8178902e2552)

**Example of Consist info (before second update)**:

![image](https://github.com/user-attachments/assets/83730612-59c2-417f-b8ff-6c478f48a63a)
