### PR TITLE
Fix F9 Web-page conflict.

### DIFF
--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -1083,6 +1083,9 @@ namespace Orts.Viewer3D
                 isVisibleTrainCarViewerOrWebpage = (Viewer.TrainCarOperationsWindow.Visible && !Viewer.TrainCarOperationsViewerWindow.Visible) || Viewer.TrainCarOperationsViewerWindow.Visible || (Viewer.TrainCarOperationsWebpage?.Connections > 0 && Viewer.TrainCarOperationsWebpage.TrainCarSelected);
             }
 
+            // Update the camera view
+            oldCarPosition = oldCarPosition == 0 && carPosition == 0 ? -1 : oldCarPosition;
+
             if (attachedCar == null || attachedCar.Train != Viewer.SelectedTrain || carPosition != oldCarPosition)
             {
                 if (Front)

--- a/Source/RunActivity/Viewer3D/WebServices/TrainCarOperationsWebpage.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/TrainCarOperationsWebpage.cs
@@ -282,8 +282,8 @@ namespace Orts.Viewer3D.WebServices
             // Makes this Webpage version, more autonoumus
             if (!Viewer.TrainCarOperationsWindow.Visible && !Viewer.TrainCarOperationsViewerWindow.Visible && Viewer.IsFormationReversed)
             {
-                _ = new FormationReversed(Viewer, Viewer.PlayerTrain);
                 Viewer.IsFormationReversed = false;
+                _ = new FormationReversed(Viewer, Viewer.PlayerTrain);
             }
 
             int carPosition = 0;


### PR DESCRIPTION
An internal conflict was detected that caused an internal loop when the TrainCarOperations web page version was opened and F9 was not visible.

More info here:
[Bug #2103422](https://bugs.launchpad.net/or/+bug/2103422) 