### PR TITLE
Better Missing Track Section Error Message

### DIFF
--- a/Source/Orts.Simulation/Simulation/Traveller.cs
+++ b/Source/Orts.Simulation/Simulation/Traveller.cs
@@ -261,7 +261,7 @@ namespace Orts.Simulation
                     throw new InvalidDataException(String.Format("Track node {0} could not be found in the track database.", startTrackNode.UiD));
                 else
                 {
-                    throw new MissingTrackNodeException();
+                    throw new MissingTrackNodeException(tvs.ShapeIndex);
                 }
 
             }
@@ -295,7 +295,7 @@ namespace Orts.Simulation
                         throw new InvalidDataException(String.Format("Track node {0} could not be found in the track database.", startTrackNode.UiD));
                     else
                     {
-                        throw new MissingTrackNodeException();
+                        throw new MissingTrackNodeException(tvs.ShapeIndex);
                     }
                     
                 }
@@ -1358,9 +1358,12 @@ namespace Orts.Simulation
 
         public sealed class MissingTrackNodeException : Exception
         {
-            public MissingTrackNodeException()
+            public readonly uint Index;
+
+            public MissingTrackNodeException(uint index)
                 : base("")
             {
+                Index = index;
             }
         }
     }

--- a/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
+++ b/Source/RunActivity/Viewer3D/Processes/GameStateRunActivity.cs
@@ -1,4 +1,4 @@
-// COPYRIGHT 2021 by the Open Rails project.
+﻿// COPYRIGHT 2021 by the Open Rails project.
 // 
 // This file is part of Open Rails.
 // 
@@ -281,8 +281,10 @@ namespace Orts.Viewer3D.Processes
                                 String.Join("\n", data.Select(d => "\u2022 " + d).ToArray())),
                                 Application.ProductName + " " + VersionInfo.VersionOrBuild, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         else if (error is Traveller.MissingTrackNodeException)
-                            MessageBox.Show(String.Format("Open Rails detected a track section which is not present in tsection.dat and cannot continue.\n\n" +
-                                "Most likely you don't have the XTracks or Ytracks version needed for this route."));
+                            MessageBox.Show(String.Format("Open Rails detected a track shape index {0} which is not present in tsection.dat and cannot continue.\n\n" +
+                                "The version of standard tsection.dat may be out of date, or this route requires a custom tsection.dat.\n" +
+                                "Please check the route installation instructions to verify the required tsection.dat.",
+                                ((Traveller.MissingTrackNodeException)error).Index));
                         else if (error is FileNotFoundException)
                         {
                             MessageBox.Show(String.Format(


### PR DESCRIPTION
Feature request: https://www.elvastower.com/forums/index.php?/topic/38643-change-an-error-message/

This changes the error message displayed when a route needs a track shape missing from tsection.dat.

- Error message now declares which shape index couldn't be found (only the _first_ missing shape can be detected, as the program will stop before additional track sections are processed) which should make it vastly easier to determine what's missing.
- The error no longer mentions any specific track systems, as it is misleading to imply this error is related to any specific track system.
- Probable cause is now stated to be the wrong version of the standard tsection.dat or the route requiring a non-standard tsection.dat, as this is what will actually produce the error.