### PR TITLE
Brake cuts power unification

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -5249,12 +5249,16 @@ the tables below.
 .. index::
    single: DoesBrakeCutPower
    single: BrakeCutsPowerAtBrakeCylinderPressure
+   single: ORTSBrakeCutsPowerAtBrakePipePressure
+   single: ORTSBrakeRestoresPowerAtBrakePipePressure
 
-Two other parameters in the Engine section of the ENG file are used by the TCS:
+Other parameters in the Engine section of the ENG file are used by the braking system to request traction cut-off to the TCS:
 
-- ``DoesBrakeCutPower( x )`` sets whether applying brake on the locomotive cuts the traction (1 for enabled, 0 for disabled)
+- ``DoesBrakeCutPower( x )`` sets whether applying brake on the locomotive cuts the traction for air brake system (1 for enabled, 0 for disabled)
+- ``ORTSDoesVacuumBrakeCutPower( x )`` sets whether applying brake on the locomotive cuts the traction for vacuum brake system (1 for enabled, 0 for disabled)
 - ``BrakeCutsPowerAtBrakeCylinderPressure( x )`` sets the minimum pressure in the brake cylinder that cuts the traction (by default 4 PSI)
-
+- ``ORTSBrakeCutsPowerAtBrakePipePressure( x )`` sets the maximum pressure in the brake pipe that cuts the traction
+- ``ORTSBrakeRestoresPowerAtBrakePipePressure( x )`` sets the minimum pressure in the brake pipe that restores the traction
 
 Train Derailment
 ----------------

--- a/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Common/Scripting/TrainControlSystem.cs
@@ -261,9 +261,14 @@ namespace ORTS.Scripting.Api
         /// </summary>
         public Func<bool> DoesBrakeCutPower;
         /// <summary>
-        /// Train brake pressure value which triggers the power cut-off.
+        /// Deprecated. Returns positive infinity if traction cutoff is requested by the brake system, and negative infinity if it is not requested
         /// </summary>
-        public Func<float> BrakeCutsPowerAtBrakeCylinderPressureBar;
+        [Obsolete("BrakeCutsPowerAtBrakeCylinderPressureBar() is deprecated, use BrakeSystemTractionAuthorization instead")]
+        public float BrakeCutsPowerAtBrakeCylinderPressureBar()
+        {
+            return BrakeSystemTractionAuthorization ? float.PositiveInfinity : float.NegativeInfinity;
+        }
+        public bool BrakeSystemTractionAuthorization => Host.BrakeSystemTractionAuthorization;
         /// <summary>
         /// State of the train brake controller.
         /// </summary>

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -296,7 +296,6 @@ namespace Orts.Simulation.RollingStocks
         public float LargeEjectorBrakePipeChargingRatePSIorInHgpS;
         public float ExhausterHighSBPChargingRatePSIorInHgpS;  // Rate for Exhauster in high speed mode
         public float ExhausterLowSBPChargingRatePSIorInHgpS;  // Rate for Exhauster in high speed mode
-        public bool VacuumBrakeCutoffActivated = false;
         public bool BrakeFlagDecrease = false;
         public bool BrakeFlagIncrease = false;
 
@@ -1799,17 +1798,17 @@ namespace Orts.Simulation.RollingStocks
 
             }
 
-            if (DoesBrakeCutPower && BrakeCutsPowerAtBrakePipePressurePSI > BrakeRestoresPowerAtBrakePipePressurePSI)
+            if ((DoesBrakeCutPower || DoesVacuumBrakeCutPower) && BrakeCutsPowerAtBrakePipePressurePSI > BrakeRestoresPowerAtBrakePipePressurePSI)
             {
                 BrakeCutsPowerAtBrakePipePressurePSI = BrakeRestoresPowerAtBrakePipePressurePSI - 1.0f;
 
                 if (Simulator.Settings.VerboseConfigurationMessages)
                 {
-                    Trace.TraceInformation("BrakeCutsPowerAtBrakePipePressure is greater then BrakeRestoresPowerAtBrakePipePressurePSI, and has been set to value of {0} InHg", Bar.ToInHg(Bar.FromPSI(BrakeCutsPowerAtBrakePipePressurePSI)));
+                    Trace.TraceInformation("BrakeCutsPowerAtBrakePipePressure is greater then BrakeRestoresPowerAtBrakePipePressure, and has been set to value of {0}", FormatStrings.FormatPressure(BrakeCutsPowerAtBrakePipePressurePSI, PressureUnit.PSI, BrakeSystemPressureUnits[BrakeSystemComponent.BrakePipe], true));
                 }
             }
 
-            if (DoesBrakeCutPower && (BrakeSystem is VacuumSinglePipe) && (BrakeRestoresPowerAtBrakePipePressurePSI == 0 || BrakeRestoresPowerAtBrakePipePressurePSI > OneAtmospherePSI))
+            if (DoesVacuumBrakeCutPower && BrakeSystem is VacuumSinglePipe && (BrakeRestoresPowerAtBrakePipePressurePSI == 0 || BrakeRestoresPowerAtBrakePipePressurePSI > OneAtmospherePSI))
             {
                 BrakeRestoresPowerAtBrakePipePressurePSI = Bar.ToPSI(Bar.FromInHg(15.0f)); // Power can be restored once brake pipe rises above 15 InHg
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -1160,6 +1160,18 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             }
         }
 
+        public virtual void UpdateTractionCutoff()
+        {
+            var locomotive = Car as MSTSLocomotive;
+            if (!locomotive.DoesBrakeCutPower) return;
+            if (locomotive.BrakeCutsPowerAtBrakePipePressurePSI > 0)
+            {
+                if (BrakeLine1PressurePSI < locomotive.BrakeCutsPowerAtBrakePipePressurePSI) locomotive.TrainControlSystem.BrakeSystemTractionAuthorization = false;
+                else if (BrakeLine1PressurePSI >= locomotive.BrakeRestoresPowerAtBrakePipePressurePSI) locomotive.TrainControlSystem.BrakeSystemTractionAuthorization = true;
+            }
+            else locomotive.TrainControlSystem.BrakeSystemTractionAuthorization = CylPressurePSI <= locomotive.BrakeCutsPowerAtBrakeCylinderPressurePSI;
+        }
+
         public override void Update(float elapsedClockSeconds)
         {
             var valveType = BrakeValve;
@@ -1926,6 +1938,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 }
 
             }
+
+            if (Car is MSTSLocomotive) UpdateTractionCutoff();
                        
             // Record HUD display values for brake cylinders depending upon whether they are wagons or locomotives/tenders (which are subject to their own engine brakes)   
             if (Car.WagonType == MSTSWagon.WagonTypes.Engine || Car.WagonType == MSTSWagon.WagonTypes.Tender)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs
@@ -453,25 +453,19 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                 float BrakeCutoffPressurePSI = OneAtmospherePSI - lead.BrakeCutsPowerAtBrakePipePressurePSI;
                 float BrakeRestorePressurePSI = OneAtmospherePSI - lead.BrakeRestoresPowerAtBrakePipePressurePSI;
 
-                if (lead.DoesVacuumBrakeCutPower)
+                if (Car is MSTSLocomotive locomotive && locomotive.DoesVacuumBrakeCutPower)
                 {
-
                     // There are three zones of operation - (note logic reversed - O InHg = 14.73psi, and eg 21 InHg = 4.189psi)
                     // Cutoff - exceeds set value, eg 12.5InHg (= 8.5psi)
                     // Between cutoff and restore levels - only if cutoff has triggerd
                     // Restore - when value exceeds set value, eg 17InHg (= 6.36 psi) - resets throttle
                     if (BrakeLine1PressurePSI < BrakeRestorePressurePSI)
                     {
-                        lead.VacuumBrakeCutoffActivated = false;
+                        locomotive.TrainControlSystem.BrakeSystemTractionAuthorization = true;
                     }
                     else if (BrakeLine1PressurePSI > BrakeCutoffPressurePSI)
                     {
-                        lead.MotiveForceN = 0.0f;  // ToDO - This is not a good way to do it, better to be added to MotiveForce Update in MSTSLocomotive(s) when PRs Added
-                        lead.VacuumBrakeCutoffActivated = true;
-                    }
-                    else if (lead.VacuumBrakeCutoffActivated)
-                    {
-                        lead.MotiveForceN = 0.0f; // ToDO - This is not a good way to do it, better to be added to MotiveForce Update in MSTSLocomotive(s) when PRs Added
+                        locomotive.TrainControlSystem.BrakeSystemTractionAuthorization = false;
                     }
                 }
             }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -152,6 +152,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
         public bool TractionAuthorization { get; private set; }
         public float MaxThrottlePercent { get; private set; } = 100f;
         public bool FullDynamicBrakingOrder { get; private set; }
+        public bool BrakeSystemTractionAuthorization = true;
 
         public Dictionary<int, float> CabDisplayControls = new Dictionary<int, float>();
 
@@ -365,8 +366,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 Script.TractionAuthorization = () => TractionAuthorization;
                 Script.BrakePipePressureBar = () => Locomotive.BrakeSystem != null ? Bar.FromPSI(Locomotive.BrakeSystem.BrakeLine1PressurePSI) : float.MaxValue;
                 Script.LocomotiveBrakeCylinderPressureBar = () => Locomotive.BrakeSystem != null ? Bar.FromPSI(Locomotive.BrakeSystem.GetCylPressurePSI()) : float.MaxValue;
-                Script.DoesBrakeCutPower = () => Locomotive.DoesBrakeCutPower;
-                Script.BrakeCutsPowerAtBrakeCylinderPressureBar = () => Bar.FromPSI(Locomotive.BrakeCutsPowerAtBrakeCylinderPressurePSI);
+                Script.DoesBrakeCutPower = () => Locomotive.DoesBrakeCutPower || Locomotive.DoesVacuumBrakeCutPower;
                 Script.TrainBrakeControllerState = () => Locomotive.TrainBrakeController.TrainBrakeControllerState;
                 Script.AccelerationMpSS = () => Locomotive.AccelerationMpSS;
                 Script.AltitudeM = () => Locomotive.WorldPosition.Location.Y;
@@ -1189,7 +1189,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                         PowerCut |= ExternalEmergency;
                 }
 
-                SetTractionAuthorization(!DoesBrakeCutPower() || LocomotiveBrakeCylinderPressureBar() < BrakeCutsPowerAtBrakeCylinderPressureBar());
+                SetTractionAuthorization(BrakeSystemTractionAuthorization);
 
                 SetEmergencyBrake(EmergencyBrake);
                 SetFullBrake(FullBrake);


### PR DESCRIPTION
This is a proposed solution to overcome the original compatibility issues with #527

It moves the DoesBrakeCutPower handling to the brake system, but the ultimate responsible of cutting power is the TCS (e.g. to restore traction only after pressing a button, setting throttle to 0, etc.).

Compatibility is preserved by taking into account that scripts are using

`DoesBrakeCutPower() && BrakeCutsPowerAtBrakeCylinderPressureBar() < LocomotiveBrakeCylinderPressureBar()`

I deprecated BrakeCutsPowerAtBrakeCylinderPressureBar, and now it is returning either -infinity or +infinity depending on whether traction cut-off is requested by the brake system.

https://blueprints.launchpad.net/or/+spec/brake-cuts-power-parameters

Context:
https://www.elvastower.com/forums/index.php?/topic/35678-ortsdoesvacuumbrakecutpower-is-no-longer-working/
https://www.elvastower.com/forums/index.php?/topic/38757-brakepipetokens-not-working-anymore-twinpipe/