### PR TITLE
Menu contents route name clash

### DIFF
--- a/Source/Menu/ContentForm.Designer.cs
+++ b/Source/Menu/ContentForm.Designer.cs
@@ -344,6 +344,7 @@ namespace Menu
             this.textBoxManualInstallRoute.Size = new System.Drawing.Size(453, 20);
             this.textBoxManualInstallRoute.TabIndex = 4;
             this.textBoxManualInstallRoute.TextChanged += new System.EventHandler(this.textBoxManualInstallRoute_TextChanged);
+            this.textBoxManualInstallRoute.Leave += new System.EventHandler(this.textBoxManualInstallRoute_Leave);
             // 
             // buttonManualInstallAdd
             // 

--- a/Source/Menu/ContentForm.Designer.cs
+++ b/Source/Menu/ContentForm.Designer.cs
@@ -398,7 +398,7 @@ namespace Menu
             // 
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(544, 442);
+            this.buttonCancel.Location = new System.Drawing.Point(463, 442);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
             this.buttonCancel.TabIndex = 12;
@@ -408,7 +408,7 @@ namespace Menu
             // buttonOK
             // 
             this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOK.Location = new System.Drawing.Point(463, 442);
+            this.buttonOK.Location = new System.Drawing.Point(544, 442);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
             this.buttonOK.TabIndex = 11;

--- a/Source/Menu/ContentForm.Designer.cs
+++ b/Source/Menu/ContentForm.Designer.cs
@@ -404,6 +404,7 @@ namespace Menu
             this.buttonCancel.TabIndex = 12;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
+            this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
             // 
             // buttonOK
             // 

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -113,6 +113,10 @@ namespace Menu
             // set focus to datagridview so that arrow keys can be used to scroll thru the list
             dataGridViewAutoInstall.Select();
 
+            // tab "Auto Installed" does not contain a Cancel button
+            // it's too difficult and not logical to rollback an "Auto Installed" route
+            buttonCancel.Hide();
+
             //
             // "Manually Installed" tab
             //
@@ -138,9 +142,11 @@ namespace Menu
             {
                 case "tabPageAutoInstall":
                     dataGridViewAutoInstall.Select();
+                    buttonCancel.Hide();
                     break;
                 case "tabPageManuallyInstall":
                     dataGridViewManualInstall.Select();
+                    buttonCancel.Show();
                     break;
             }
         }

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -1598,6 +1598,17 @@ namespace Menu
             return false;
         }
 
+        private void buttonCancel_Click(object sender, EventArgs e)
+        {
+            string message = Catalog.GetString("Cancel: changes made in the 'Manually Installed' tab will not be saved, are you sure?");
+            if (MessageBox.Show(message, Catalog.GetString("Attention"), MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
+            {
+                // not sure, cancel the cancel
+                ManualInstallChangesMade = false;
+                this.DialogResult = DialogResult.None;
+            }
+        }
+
         private void buttonOK_Click(object sender, EventArgs e)
         {
             // save "Manually Installed" tab changes into the registry/ini file via Settings.Folders.Folders
@@ -1651,6 +1662,8 @@ namespace Menu
 
             Settings.Save();
 
+            ManualInstallChangesMade = false;
+
             this.Close();
         }
 
@@ -1682,6 +1695,17 @@ namespace Menu
 
         private void DownloadContentForm_FormClosing(object sender, FormClosingEventArgs formClosingEventArgs)
         {
+            if (ManualInstallChangesMade)
+            {
+                string message = Catalog.GetString("Cancel: changes made in the 'Manually Installed' tab will not be saved, are you sure?");
+                if (MessageBox.Show(message, Catalog.GetString("Attention"), MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
+                {
+                    // not sure, cancel the cancel
+                    formClosingEventArgs.Cancel = true;
+                    return;
+                }
+            }
+
             if (AutoInstallClosingBlocked)
             {
                 // cancelled event, so continue

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -141,6 +141,8 @@ namespace Menu
 
             ManualInstallBrouwseDir = determineBrowseDir();
             buttonCancel.Enabled = false;
+
+            setTextBoxesManualInstall();
         }
 
         void changeManualInstallRoute(string Route)
@@ -1563,6 +1565,7 @@ namespace Menu
                 }
                 else
                 {
+                    // route automatically installed
                     textBoxManualInstallRoute.Text = "";
                     textBoxManualInstallPath.Text = "";
                     textBoxManualInstallRoute.Enabled = false;
@@ -1571,25 +1574,46 @@ namespace Menu
                     buttonManualInstallDelete.Enabled = false;
                 }
             }
+            else
+            {
+                // empty form, like after installing OR
+                textBoxManualInstallRoute.Text = "";
+                textBoxManualInstallPath.Text = "";
+                textBoxManualInstallRoute.Enabled = false;
+                textBoxManualInstallPath.Enabled = false;
+                buttonManualInstallBrowse.Enabled = false;
+                buttonManualInstallDelete.Enabled = false;
+            }
         }
 
         string determineUniqueRoute(string Route)
         {
             string route = Route;
             long seqNr = 0;
-            bool found = false;
+            bool foundUniqueRoute = false;
 
-            while (!found)
+            if (AutoInstallRoutes.ContainsKey(route))
             {
-                found = true;
+                // route already exists in the AutoInstall routes
+                seqNr = 1;
+                route = Route + " (" + seqNr + ")";
+            }
+
+            while (!foundUniqueRoute)
+            {
+                bool found = false;
                 for (int i = 0; i < dataGridViewManualInstall.Rows.Count; i++)
                 {
-                    if (((!dataGridViewManualInstall.Rows[i].Selected)) && (dataGridViewManualInstall.Rows[i].Cells[0].Value.ToString() == route) ||
-                            (AutoInstallRoutes.ContainsKey(route))) {
+                    if ((!dataGridViewManualInstall.Rows[i].Selected) && (dataGridViewManualInstall.Rows[i].Cells[0].Value.ToString() == route))
+                    {
                         seqNr++;
                         route = Route + " (" + seqNr + ")";
-                        found = false;
+                        found = true;
                     }
+                }
+                if (!found)
+                {
+                    foundUniqueRoute = true;
                 }
             }
 

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -1544,8 +1544,8 @@ namespace Menu
                 found = true;
                 for (int i = 0; i < dataGridViewManualInstall.Rows.Count - 1; i++)
                 {
-                    if ((dataGridViewManualInstall.Rows[i].Cells[0].Value.ToString() == route) && (!dataGridViewManualInstall.Rows[i].Selected))
-                    {
+                    if (((dataGridViewManualInstall.Rows[i].Cells[0].Value.ToString() == route) && (!dataGridViewManualInstall.Rows[i].Selected)) ||
+                            (AutoInstallRoutes.ContainsKey(route))) {
                         seqNr++;
                         route = Route + " (" + seqNr + ")";
                         found = false;

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -1406,6 +1406,18 @@ namespace Menu
             {
                 // only update the grid when user is filling/changing the route in the textbox
                 dataGridViewManualInstall.CurrentRow.Cells[0].Value = textBoxManualInstallRoute.Text;
+                ManualInstallChangesMade = true;
+                buttonCancel.Enabled = true;
+            }
+        }
+
+        private void textBoxManualInstallRoute_Leave(object sender, EventArgs e)
+        {
+            string route = textBoxManualInstallRoute.Text;
+            textBoxManualInstallRoute.Text = determineUniqueRoute(route);
+            if (textBoxManualInstallRoute.Text != route)
+            {
+                dataGridViewManualInstall.CurrentRow.Cells[0].Value = textBoxManualInstallRoute.Text;
             }
         }
 
@@ -1524,7 +1536,7 @@ namespace Menu
         string determineUniqueRoute(string Route)
         {
             string route = Route;
-
+            long seqNr = 0;
             bool found = false;
 
             while (!found)
@@ -1532,9 +1544,10 @@ namespace Menu
                 found = true;
                 for (int i = 0; i < dataGridViewManualInstall.Rows.Count - 1; i++)
                 {
-                    if (dataGridViewManualInstall.Rows[i].Cells[0].Value.ToString() == route)
+                    if ((dataGridViewManualInstall.Rows[i].Cells[0].Value.ToString() == route) && (!dataGridViewManualInstall.Rows[i].Selected))
                     {
-                        route += " copy";
+                        seqNr++;
+                        route = Route + " (" + seqNr + ")";
                         found = false;
                     }
                 }

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -1061,7 +1061,6 @@ namespace Menu
             buttonAutoInstallUpdate.Enabled = false;
             buttonAutoInstallDelete.Enabled = false;
             buttonOK.Enabled = false;
-            buttonCancel.Enabled = false;
         }
 
         private void setCursorToWaitCursor()
@@ -1083,7 +1082,6 @@ namespace Menu
             buttonAutoInstallUpdate.Enabled = route.Installed && (route.getDownloadType() == ContentRouteSettings.DownloadType.github);
             buttonAutoInstallDelete.Enabled = route.Installed;
             buttonOK.Enabled = true;
-            buttonCancel.Enabled = true;
 
             setCursorToDefaultCursor();
         }

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -61,6 +61,8 @@ namespace Menu
         private bool In_dataGridViewManualInstall_SelectionChanged = false;
         private bool In_buttonManualInstallAdd_Click = false;
 
+        private bool ManualInstallChangesMade = false;
+
         public ContentForm(UserSettings settings, string baseDocumentationUrl)
         {
             InitializeComponent();
@@ -134,6 +136,7 @@ namespace Menu
             dataGridViewManualInstall.Sort(dataGridViewManualInstall.Columns[0], ListSortDirection.Ascending);
 
             ManualInstallBrouwseDir = determineBrowseDir();
+            buttonCancel.Enabled = false;
         }
 
         private void tabControlContent_Selecting(object sender, TabControlCancelEventArgs e)
@@ -147,6 +150,7 @@ namespace Menu
                 case "tabPageManuallyInstall":
                     dataGridViewManualInstall.Select();
                     buttonCancel.Show();
+                    buttonCancel.Enabled = ManualInstallChangesMade;
                     break;
             }
         }
@@ -1483,6 +1487,8 @@ namespace Menu
             if (dataGridViewManualInstall.CurrentRow != null)
             {
                 dataGridViewManualInstall.Rows.Remove(dataGridViewManualInstall.CurrentRow);
+                ManualInstallChangesMade = true;
+                buttonCancel.Enabled = ManualInstallChangesMade;
             }
         }
 

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -1582,9 +1582,9 @@ namespace Menu
             while (!found)
             {
                 found = true;
-                for (int i = 0; i < dataGridViewManualInstall.Rows.Count - 1; i++)
+                for (int i = 0; i < dataGridViewManualInstall.Rows.Count; i++)
                 {
-                    if (((dataGridViewManualInstall.Rows[i].Cells[0].Value.ToString() == route) && (!dataGridViewManualInstall.Rows[i].Selected)) ||
+                    if (((!dataGridViewManualInstall.Rows[i].Selected)) && (dataGridViewManualInstall.Rows[i].Cells[0].Value.ToString() == route) ||
                             (AutoInstallRoutes.ContainsKey(route))) {
                         seqNr++;
                         route = Route + " (" + seqNr + ")";

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -1453,7 +1453,7 @@ namespace Menu
 
         private void textBoxManualInstallRoute_Leave(object sender, EventArgs e)
         {
-            string route = textBoxManualInstallRoute.Text;
+            string route = textBoxManualInstallRoute.Text.Trim();
             textBoxManualInstallRoute.Text = determineUniqueRoute(route);
             if (textBoxManualInstallRoute.Text != route)
             {

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -95,6 +95,10 @@ namespace Menu
                     route.Installed ? route.DateInstalled.ToString(CultureInfo.CurrentCulture.DateTimeFormat) : "",
                     route.Url });
                 dataGridViewAutoInstall.Rows[indexAdded].Cells[2].ToolTipText = route.Url;
+                if (!route.Installed)
+                {
+                    changeManualInstallRoute(routeName);
+                }
             }
 
             dataGridViewAutoInstall.Sort(dataGridViewAutoInstall.Columns[0], ListSortDirection.Ascending);
@@ -137,6 +141,42 @@ namespace Menu
 
             ManualInstallBrouwseDir = determineBrowseDir();
             buttonCancel.Enabled = false;
+        }
+
+        void changeManualInstallRoute(string Route)
+        {
+            bool found = false;
+
+            foreach (var folder in Settings.Folders.Folders)
+            {
+                if (folder.Key == Route)
+                {
+                    // Route found in folder settings
+                    found = true;
+                }
+            }
+
+            if (found)
+            {
+                // search for the next route (1), (2) etc. not found in folder settings
+                int seqNr = 1;
+                string route = Route + " (" + seqNr + ")";
+                while (found)
+                {
+                    found = false;
+                    foreach (var folder in Settings.Folders.Folders)
+                    {
+                        if (folder.Key == route)
+                        {
+                            found = true;
+                            seqNr++;
+                            route = Route + " (" + seqNr + ")";
+                        }
+                    }
+                }
+                Settings.Folders.Folders[route] = Settings.Folders.Folders[Route];
+                Settings.Folders.Folders.Remove(Route);
+            }
         }
 
         private void tabControlContent_Selecting(object sender, TabControlCancelEventArgs e)

--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -1460,6 +1460,8 @@ namespace Menu
                     string route = determineUniqueRoute(Path.GetFileName(folderBrowser.SelectedPath));
                     dataGridViewManualInstall.CurrentRow.Cells[0].Value = route;
                     dataGridViewManualInstall.CurrentRow.Cells[1].Value = folderBrowser.SelectedPath;
+                    ManualInstallChangesMade = true;
+                    buttonCancel.Enabled = ManualInstallChangesMade;
                 }
                 else
                 {
@@ -1604,8 +1606,12 @@ namespace Menu
             if (MessageBox.Show(message, Catalog.GetString("Attention"), MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
             {
                 // not sure, cancel the cancel
-                ManualInstallChangesMade = false;
                 this.DialogResult = DialogResult.None;
+            }
+            else 
+            {
+                // sure to cancel the changes
+                ManualInstallChangesMade = false;
             }
         }
 


### PR DESCRIPTION
Whenever route names clashes occur, the route is renamed by appending (1), (2) etc.

Pressing cancel button issues a warning.

See commit comments for details.

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)