### PR TITLE
Improve warning message for signal location mismatch.

### DIFF
--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -444,23 +444,26 @@ namespace Orts.Simulation.Signalling
 
                         //check if signalheads are on same or adjacent tile as signal itself - otherwise there is an invalid match
                         uint? BadSignal = null;
+                        string badSignalMsg = "";
                         foreach (var si in thisWorldObject.SignalUnits.Units)
                         {
                             if (this.trackDB.TrItemTable == null || si.TrItem >= this.trackDB.TrItemTable.Count())
                             {
                                 BadSignal = si.TrItem;
+                                badSignalMsg = "not present in .tdb file";
                                 break;
                             }
                             var item = this.trackDB.TrItemTable[si.TrItem];
                             if (Math.Abs(item.TileX - WFile.TileX) > 1 || Math.Abs(item.TileZ - WFile.TileZ) > 1)
                             {
                                 BadSignal = si.TrItem;
+                                badSignalMsg = String.Format("not matching .tdb tile location {0} {1}", item.TileX, item.TileZ);
                                 break;
                             }
                         }
                         if (BadSignal.HasValue)
                         {
-                            Trace.TraceWarning("Signal referenced in .w file {0} {1} as TrItem {2} not present in .tdb file ", WFile.TileX, WFile.TileZ, BadSignal.Value);
+                            Trace.TraceWarning("Signal referenced in .w file {0} {1} as TrItem {2} {3} ", WFile.TileX, WFile.TileZ, BadSignal.Value, badSignalMsg);
                             continue;
                         }
 


### PR DESCRIPTION
This is a warning logged for the BNSF starter route. 

There are two different error conditions, and the log now identifies which it is.

Message for the second condition (the one for the first condition remains unchanged):
```
Warning: Signal referenced in .w file -12819 14715 as TrItem 146 not matching .tdb tile location -12849 14731 
```
