### PR TITLE
Fix Superelevation on Rigid Frame Rolling Stock Again

### DIFF
--- a/Source/Menu/Options.cs
+++ b/Source/Menu/Options.cs
@@ -266,7 +266,7 @@ namespace Menu
             numericPerformanceTunerTarget.Enabled = checkPerformanceTuner.Checked;
 
             // Experimental tab
-            checkUseSuperElevation.Checked = Settings.UseSuperElevation;
+            checkUseSuperElevation.Checked = Settings.LegacySuperElevation;
             numericSuperElevationGauge.Value = Settings.SuperElevationGauge;
             trackLODBias.Value = Settings.LODBias;
             trackLODBias_ValueChanged(null, null);
@@ -500,7 +500,7 @@ namespace Menu
             Settings.PerformanceTunerTarget = (int)numericPerformanceTunerTarget.Value;
 
             // Experimental tab
-            Settings.UseSuperElevation = checkUseSuperElevation.Checked;
+            Settings.LegacySuperElevation = checkUseSuperElevation.Checked;
             Settings.SuperElevationGauge = (int)numericSuperElevationGauge.Value;
             Settings.LODBias = trackLODBias.Value;
             Settings.SignalLightGlow = checkSignalLightGlow.Checked;

--- a/Source/Orts.Settings/UserSettings.cs
+++ b/Source/Orts.Settings/UserSettings.cs
@@ -263,7 +263,7 @@ namespace ORTS.Settings
 
         // Experimental settings:
         [Default(0)]
-        public bool UseSuperElevation { get; set; }
+        public bool LegacySuperElevation { get; set; }
         [Default(1435)]
         public int SuperElevationGauge { get; set; }
         [Default(0)]

--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -4490,25 +4490,27 @@ namespace Orts.Simulation.Physics
                     car.ComputePosition(traveller, false, 0, 0, SpeedMpS);
                 }
                 else
-                {
+                { 
                     // traveller is positioned at the front of the car
                     // advance to the first bogie 
                     traveller.Move((car.CarLengthM - car.CarBogieCentreLengthM) / 2.0f);
+                    Vector3 frontLoc = traveller.CalcElevationPositionOffset(0.0f, Simulator.UseSuperElevation, out float rearRoll);
+                    frontLoc += traveller.Location;
+
                     var tileX = traveller.TileX;
                     var tileZ = traveller.TileZ;
-                    var x = traveller.X;
-                    var y = traveller.Y;
-                    var z = traveller.Z;
 
                     // Update car's curve radius and superelevation based on bogie position and move traveller to front bogie
-                    // Also determine roll angle for superelevation by averaging both bogies
-                    float roll = traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation);
+                    // Outputs rotation angle for superelevation, used below
                     car.UpdateCurvePhys(traveller, new[] { 0, car.CarBogieCentreLengthM });
-                    roll = (roll + traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation)) / 2.0f;
+                    Vector3 rearLoc = traveller.CalcElevationPositionOffset(0.0f, Simulator.UseSuperElevation, out float frontRoll);
+                    rearLoc += traveller.Location;
+
+                    float roll = (rearRoll + frontRoll) / 2.0f;
 
                     // Normalize across tile boundaries
-                    x += 2048 * (tileX - traveller.TileX);
-                    z += 2048 * (tileZ - traveller.TileZ);
+                    frontLoc.X += 2048 * (tileX - traveller.TileX);
+                    frontLoc.Z += 2048 * (tileZ - traveller.TileZ);
 
                     car.WorldPosition.XNAMatrix = Matrix.Identity;
                     if (!car.Flipped)
@@ -4519,16 +4521,14 @@ namespace Orts.Simulation.Physics
                     }
 
                     // Position car based on position of the front and rear of the car
-                    car.WorldPosition.XNAMatrix *= Simulator.XNAMatrixFromMSTSCoordinates(traveller.X, traveller.Y, traveller.Z, x, y, z);
+                    car.WorldPosition.XNAMatrix *= Simulator.XNAMatrixFromMSTSCoordinates(rearLoc.X, rearLoc.Y, rearLoc.Z, frontLoc.X, frontLoc.Y, frontLoc.Z);
 
                     // Update gravity force when position is updated, but before any secondary motion is added
                     car.UpdateGravity();
 
                     // Apply superelevation to car
-                    car.WorldPosition.XNAMatrix = Matrix.CreateRotationZ((car.Flipped ? -1.0f : 1.0f) * roll) * car.WorldPosition.XNAMatrix;
-
-                    // note the railcar sits 0.275meters above the track database path  TODO - is this always consistent?
-                    car.WorldPosition.XNAMatrix.Translation += car.WorldPosition.XNAMatrix.Up * 0.275f;
+                    if (roll != 0)
+                        car.WorldPosition.XNAMatrix = Matrix.CreateRotationZ((car.Flipped ? -1.0f : 1.0f) * roll) * car.WorldPosition.XNAMatrix;
 
                     car.WorldPosition.TileX = traveller.TileX;
                     car.WorldPosition.TileZ = traveller.TileZ;
@@ -4613,21 +4613,23 @@ namespace Orts.Simulation.Physics
                     // traveller is positioned at the back of the car
                     // advance to the first bogie 
                     traveller.Move((car.CarLengthM - car.CarBogieCentreLengthM) / 2.0f);
+                    Vector3 rearLoc = traveller.CalcElevationPositionOffset(0.0f, Simulator.UseSuperElevation, out float rearRoll);
+                    rearLoc += traveller.Location;
+
                     var tileX = traveller.TileX;
                     var tileZ = traveller.TileZ;
-                    var x = traveller.X;
-                    var y = traveller.Y;
-                    var z = traveller.Z;
 
                     // Update car's curve radius and superelevation based on bogie position and move traveller to front bogie
                     // Outputs rotation angle for superelevation, used below
-                    float roll = traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation);
                     car.UpdateCurvePhys(traveller, new[] { 0, car.CarBogieCentreLengthM });
-                    roll = (roll + traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation)) / 2.0f;
+                    Vector3 frontLoc = traveller.CalcElevationPositionOffset(0.0f, Simulator.UseSuperElevation, out float frontRoll);
+                    frontLoc += traveller.Location;
+
+                    float roll = (rearRoll + frontRoll) / 2.0f;
 
                     // Normalize across tile boundaries
-                    x += 2048 * (tileX - traveller.TileX);
-                    z += 2048 * (tileZ - traveller.TileZ);
+                    rearLoc.X += 2048 * (tileX - traveller.TileX);
+                    rearLoc.Z += 2048 * (tileZ - traveller.TileZ);
 
                     car.WorldPosition.XNAMatrix = Matrix.Identity;
                     if (car.Flipped)
@@ -4638,16 +4640,14 @@ namespace Orts.Simulation.Physics
                     }
 
                     // Position car based on position of the front and rear of the car
-                    car.WorldPosition.XNAMatrix *= Simulator.XNAMatrixFromMSTSCoordinates(traveller.X, traveller.Y, traveller.Z, x, y, z);
+                    car.WorldPosition.XNAMatrix *= Simulator.XNAMatrixFromMSTSCoordinates(frontLoc.X, frontLoc.Y, frontLoc.Z, rearLoc.X, rearLoc.Y, rearLoc.Z);
 
                     // Update gravity force when position is updated, but before any secondary motion is added
                     car.UpdateGravity();
 
                     // Apply superelevation to car
-                    car.WorldPosition.XNAMatrix = Matrix.CreateRotationZ((car.Flipped ? -1.0f : 1.0f) * roll) * car.WorldPosition.XNAMatrix;
-
-                    // note the railcar sits 0.275meters above the track database path  TODO - is this always consistent?
-                    car.WorldPosition.XNAMatrix.Translation += car.WorldPosition.XNAMatrix.Up * 0.275f;
+                    if (roll != 0)
+                        car.WorldPosition.XNAMatrix = Matrix.CreateRotationZ((car.Flipped ? -1.0f : 1.0f) * roll) * car.WorldPosition.XNAMatrix;
 
                     car.WorldPosition.TileX = traveller.TileX;
                     car.WorldPosition.TileZ = traveller.TileZ;
@@ -4692,21 +4692,23 @@ namespace Orts.Simulation.Physics
                 // traveller is positioned at the back of the car
                 // advance to the first bogie 
                 traveller.Move((car.CarLengthM - car.CarBogieCentreLengthM) / 2.0f);
+                Vector3 rearLoc = traveller.CalcElevationPositionOffset(0.0f, Simulator.UseSuperElevation, out float rearRoll);
+                rearLoc += traveller.Location;
+
                 var tileX = traveller.TileX;
                 var tileZ = traveller.TileZ;
-                var x = traveller.X;
-                var y = traveller.Y;
-                var z = traveller.Z;
 
                 // Update car's curve radius and superelevation based on bogie position and move traveller to front bogie
                 // Outputs rotation angle for superelevation, used below
-                float roll = traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation);
                 car.UpdateCurvePhys(traveller, new[] { 0, car.CarBogieCentreLengthM });
-                roll = (roll + traveller.GetVisualElevation(Simulator.Settings.UseSuperElevation)) / 2.0f;
+                Vector3 frontLoc = traveller.CalcElevationPositionOffset(0.0f, Simulator.UseSuperElevation, out float frontRoll);
+                frontLoc += traveller.Location;
+
+                float roll = (rearRoll + frontRoll) / 2.0f;
 
                 // Normalize across tile boundaries
-                x += 2048 * (tileX - traveller.TileX);
-                z += 2048 * (tileZ - traveller.TileZ);
+                rearLoc.X += 2048 * (tileX - traveller.TileX);
+                rearLoc.Z += 2048 * (tileZ - traveller.TileZ);
 
                 car.WorldPosition.XNAMatrix = Matrix.Identity;
                 if (car.Flipped)
@@ -4717,16 +4719,14 @@ namespace Orts.Simulation.Physics
                 }
 
                 // Position car based on position of the front and rear of the car
-                car.WorldPosition.XNAMatrix *= Simulator.XNAMatrixFromMSTSCoordinates(traveller.X, traveller.Y, traveller.Z, x, y, z);
+                car.WorldPosition.XNAMatrix *= Simulator.XNAMatrixFromMSTSCoordinates(frontLoc.X, frontLoc.Y, frontLoc.Z, rearLoc.X, rearLoc.Y, rearLoc.Z);
 
                 // Update gravity force when position is updated, but before any secondary motion is added
                 car.UpdateGravity();
 
                 // Apply superelevation to car
-                car.WorldPosition.XNAMatrix = Matrix.CreateRotationZ((car.Flipped ? -1.0f : 1.0f) * roll) * car.WorldPosition.XNAMatrix;
-
-                // note the railcar sits 0.275meters above the track database path  TODO - is this always consistent?
-                car.WorldPosition.XNAMatrix.Translation += car.WorldPosition.XNAMatrix.Up * 0.275f;
+                if (roll != 0)
+                    car.WorldPosition.XNAMatrix = Matrix.CreateRotationZ((car.Flipped ? -1.0f : 1.0f) * roll) * car.WorldPosition.XNAMatrix;
 
                 car.WorldPosition.TileX = traveller.TileX;
                 car.WorldPosition.TileZ = traveller.TileZ;

--- a/Source/Orts.Simulation/Simulation/Simulator.cs
+++ b/Source/Orts.Simulation/Simulation/Simulator.cs
@@ -273,7 +273,7 @@ namespace Orts.Simulation
             UseAdvancedAdhesion = Settings.UseAdvancedAdhesion;
             BreakCouplers = Settings.BreakCouplers;
             CarVibrating = Settings.CarVibratingLevel; //0 no vib, 1-2 mid vib, 3 max vib
-            UseSuperElevation = Settings.UseSuperElevation;
+            UseSuperElevation = Settings.LegacySuperElevation;
             RouteTrackGaugeM = (float)Settings.SuperElevationGauge / 1000f; // Gauge in settings is given in mm, convert to m
             RoutePath = Path.GetDirectoryName(Path.GetDirectoryName(activityPath));
             if (useOpenRailsDirectory) RoutePath = Path.GetDirectoryName(RoutePath); // starting one level deeper!
@@ -297,8 +297,8 @@ namespace Orts.Simulation
                 Trace.TraceInformation("No route track gauge given in TRK, using default setting: {0}", FormatStrings.FormatVeryShortDistanceDisplay(RouteTrackGaugeM, MilepostUnitsMetric));
             if (TRK.Tr_RouteFile.SuperElevationMode >= 0)
             {
-                UseSuperElevation = TRK.Tr_RouteFile.SuperElevationMode == 1; // Perfer superelevation mode in TRK over the one in settings
-                if (UseSuperElevation != Settings.UseSuperElevation)
+                UseSuperElevation = TRK.Tr_RouteFile.SuperElevationMode == 1; // Prefer superelevation mode in TRK over the one in settings
+                if (UseSuperElevation != Settings.LegacySuperElevation)
                     Trace.TraceInformation("Superelevation graphics have been forced " + (UseSuperElevation ? "ENABLED" : "DISABLED") +
                         " by setting of ORTSForceSuperElevation in TRK file.");
             }


### PR DESCRIPTION
Follow up to #1029

Bug report: https://www.elvastower.com/forums/index.php?/topic/38542-problem-with-superelevation-and-two-axle-rolling-stock/page__view__findpost__p__318520

I previously fixed superelevation on two axle rolling stock, but a slight mistake meant it was only a partial fix. Also updated the method used to position two axle rolling stock during superelevation to solve instances of wheels sinking into rails on superelevated curves.