### PR TITLE
Add null check to avoid crash on corrupt signal files

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -673,6 +673,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                     foreach (var head in trainSignal.SignalObject.SignalHeads)
                         if (head.Function == function)
                             functionHead = head;
+                    if (functionHead != null)
+                        goto Exit;
                     signalTypeName = functionHead.SignalTypeName;
                     foreach (var key in functionHead.signalType.DrawStates.Keys)
                     {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/TrainControlSystem.cs
@@ -673,7 +673,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                     foreach (var head in trainSignal.SignalObject.SignalHeads)
                         if (head.Function == function)
                             functionHead = head;
-                    if (functionHead != null)
+                    if (functionHead == null)
                         goto Exit;
                     signalTypeName = functionHead.SignalTypeName;
                     foreach (var key in functionHead.signalType.DrawStates.Keys)


### PR DESCRIPTION
Follow-up for #1070

If the signalling is corrupted, it is possible to get a signal added to the NORMAL signal list without actually having a NORMAL head, causing a null pointer exception.