### PR TITLE
Blended Braking Compatibility and Effectiveness Improvements

### DIFF
--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -3344,6 +3344,7 @@ the following parameters will adjust the behaviour of air brakes:
    single: DynamicBrakeHasAutoBailOff
    single: ORTSDynamicBrakesHasPartialBailOff
    single: ORTSDynamicBlendingRetainedPressure
+   single: ORTSDynamicBlendingMinimumSpeed
    single: ORTSTrainDynamicBlendingTable
    single: ORTSDynamicBrakeReplacementWithEngineBrake 
    single: ORTSDynamicBrakeReplacementWithEngineBrakeAtSpeed
@@ -3358,6 +3359,9 @@ the following parameters will adjust the behaviour of air brakes:
   pressure which, when used in combination with ORTSDynamicBrakesHasPartialBailOff,
   will remain applied regardless of the blended dynamic brake force. This
   pressure is also the minimum pressure at which the blended braking system will activate.
+- ``Engine(ORTSDynamicBlendingMinimumSpeed`` -- Below the specified speed
+  (default units mph, default value 5 mph / 8 kph), local dynamic brake blending
+  will be disabled, allowing locomotive brakes to hold the train while stopped.
   
 Sometimes the train brake controller is capable to apply the dynamic
 brakes for the whole consist, usually as a first step before air brakes

--- a/Source/Documentation/Manual/physics.rst
+++ b/Source/Documentation/Manual/physics.rst
@@ -3343,6 +3343,7 @@ the following parameters will adjust the behaviour of air brakes:
 .. index::
    single: DynamicBrakeHasAutoBailOff
    single: ORTSDynamicBrakesHasPartialBailOff
+   single: ORTSDynamicBlendingRetainedPressure
    single: ORTSTrainDynamicBlendingTable
    single: ORTSDynamicBrakeReplacementWithEngineBrake 
    single: ORTSDynamicBrakeReplacementWithEngineBrakeAtSpeed
@@ -3353,6 +3354,10 @@ the following parameters will adjust the behaviour of air brakes:
   air brakes are released while dynamic brakes satisfy the train brake demand.
   If dynamic braking is not sufficient, air brakes will be partially applied
   so the combination air+dynamic provides the required brake demand.
+- ``Engine(ORTSDynamicBlendingRetainedPressure`` -- Sets the brake cylinder
+  pressure which, when used in combination with ORTSDynamicBrakesHasPartialBailOff,
+  will remain applied regardless of the blended dynamic brake force. This
+  pressure is also the minimum pressure at which the blended braking system will activate.
   
 Sometimes the train brake controller is capable to apply the dynamic
 brakes for the whole consist, usually as a first step before air brakes

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -421,7 +421,7 @@ namespace Orts.Simulation.RollingStocks
         protected bool DynamicBrakeBlendingOverride; // true when DB lever >0% should always override the blending. When false, the bigger command is applied.
         protected bool DynamicBrakeBlendingForceMatch = true; // if true, dynamic brake blending tries to achieve the same braking force as the airbrake would have.
         public float DynamicBrakeBlendingRetainedPressurePSI { get; private set; } = -1.0f; // the amount of pressure that will always be retained in the brake cylinders during blended braking
-        public float DynamicBrakeBlendingMinSpeedMpS { get; private set; } = 2.25f; // below this speed, blended braking is disabled
+        public float DynamicBrakeBlendingMinSpeedMpS { get; private set; } = -1.0f; // below this speed, blended braking is disabled
         protected bool DynamicBrakeControllerSetupLock; // if true if dynamic brake lever will lock until dynamic brake is available
 
         public float DynamicBrakeBlendingPercent { get; protected set; } = -1;
@@ -1895,6 +1895,21 @@ namespace Orts.Simulation.RollingStocks
                 DynamicBrakeEngineBrakeReplacementSpeed = DynamicBrakeSpeed2MpS;
             }
 
+            // Define blending minimum speed if it was left undefined (use MSTS minimum dynamic brake speed)
+            if (DynamicBrakeBlendingMinSpeedMpS < 0)
+            {
+                DynamicBrakeBlendingMinSpeedMpS = DynamicBrakeSpeed1MpS;
+            }
+
+            // Define blending retained pressure if it was left undefined
+            if (DynamicBrakeBlendingRetainedPressurePSI < 0)
+            {
+                if (BrakeSystem is AirSinglePipe airSystem)
+                    DynamicBrakeBlendingRetainedPressurePSI = 2.0f * airSystem.BrakeCylinderSpringPressurePSI;
+                else
+                    DynamicBrakeBlendingRetainedPressurePSI = 0.0f;
+            }
+
             // Initialise track sanding parameters
             if (MaxTrackSandBoxCapacityM3 == 0)
             {
@@ -2019,15 +2034,6 @@ namespace Orts.Simulation.RollingStocks
                 if (MaxDynamicBrakeForceN > 0 && MaxContinuousForceN > 0 &&
                 (MaxDynamicBrakeForceN / MaxContinuousForceN < 0.3f && MaxDynamicBrakeForceN == 20000))
                     MaxDynamicBrakeForceN = Math.Min (MaxContinuousForceN * 0.5f, 150000); // 20000 is suggested as standard value in the MSTS documentation, but in general it is a too low value
-            }
-
-            // Define blending retained pressure if it was left undefined
-            if (DynamicBrakeBlendingRetainedPressurePSI < 0)
-            {
-                if (BrakeSystem is AirSinglePipe airSystem)
-                    DynamicBrakeBlendingRetainedPressurePSI = 2.0f * airSystem.BrakeCylinderSpringPressurePSI;
-                else
-                    DynamicBrakeBlendingRetainedPressurePSI = 0.0f;
             }
         }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -81,7 +81,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         protected float ControlResPressurePSI = 64;
         protected float FullServPressurePSI = 50;
         protected float MaxCylPressurePSI;
-        protected float ReferencePressurePSI;
+        public float ReferencePressurePSI { get; protected set; }
         protected float MaxTripleValveCylPressurePSI;
         protected float AuxResVolumeM3;
         protected float AuxCylVolumeRatio;
@@ -143,7 +143,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
         protected float AcceleratedApplicationLimitPSIpS = 5.0f;
         protected float InitialApplicationThresholdPSI;
         protected float TripleValveSensitivityPSI;
-        protected float BrakeCylinderSpringPressurePSI;
+        public float BrakeCylinderSpringPressurePSI { get; protected set; }
         protected float ServiceMaxCylPressurePSI;
         protected float ServiceApplicationRatePSIpS;
         protected float TwoStageLowPressurePSI;
@@ -1721,25 +1721,21 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                             if (loco.Train.DetermineDPLeadLocomotive(loco) is MSTSLocomotive lead && (lead.BailOff || (lead.EngineBrakeController != null && lead.EngineBrakeController.TrainBrakeControllerState == ControllerState.BailOff)))
                             {
                                 if (BrakeValve == BrakeValveType.Distributor)
-                                {
                                     ControlResPressurePSI = 0;
 
-                                    if (loco.AttachedTender?.BrakeSystem is AirSinglePipe tenderBrakes)
-                                        tenderBrakes.ControlResPressurePSI = 0;
-                                }
-                                else
-                                {
-                                    float dp = Math.Max(MaxReleaseRatePSIpS, loco.EngineBrakeReleaseRatePSIpS) * elapsedClockSeconds;
-                                    AutoCylPressurePSI -= dp;
-                                    if (AutoCylPressurePSI < 0)
-                                        AutoCylPressurePSI = 0;
+                                float dp = Math.Max(MaxReleaseRatePSIpS, loco.EngineBrakeReleaseRatePSIpS) * elapsedClockSeconds;
+                                AutoCylPressurePSI -= dp;
+                                if (AutoCylPressurePSI < 0)
+                                    AutoCylPressurePSI = 0;
 
-                                    if (loco.AttachedTender?.BrakeSystem is AirSinglePipe tenderBrakes)
-                                    {
-                                        tenderBrakes.AutoCylPressurePSI -= dp;
-                                        if (tenderBrakes.AutoCylPressurePSI < 0)
-                                            tenderBrakes.AutoCylPressurePSI = 0;
-                                    }
+                                if (loco.AttachedTender?.BrakeSystem is AirSinglePipe tenderBrakes)
+                                {
+                                    if (tenderBrakes.BrakeValve == BrakeValveType.Distributor)
+                                        tenderBrakes.ControlResPressurePSI = 0;
+
+                                    tenderBrakes.AutoCylPressurePSI -= dp;
+                                    if (tenderBrakes.AutoCylPressurePSI < 0)
+                                        tenderBrakes.AutoCylPressurePSI = 0;
                                 }
                             }
                         }
@@ -1750,19 +1746,23 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                         {
                             if (loco.DynamicBrakePartialBailOff)
                             {
-                                var requiredBrakeForceN = MathHelper.Max((AutoCylPressurePSI * RelayValveRatio - BrakeCylinderSpringPressurePSI)
-                                    / (ReferencePressurePSI - BrakeCylinderSpringPressurePSI), 0) * Car.FrictionBrakeBlendingMaxForceN;
-                                var localBrakeForceN = loco.DynamicBrakeForceN + MathHelper.Max((CylPressurePSI - BrakeCylinderSpringPressurePSI)
-                                    / (ReferencePressurePSI - BrakeCylinderSpringPressurePSI), 0) * Car.FrictionBrakeBlendingMaxForceN;
+                                var requiredBrakeForceN = (AutoCylPressurePSI * RelayValveRatio - loco.DynamicBrakeBlendingRetainedPressurePSI)
+                                    / (ReferencePressurePSI - loco.DynamicBrakeBlendingRetainedPressurePSI) * Car.FrictionBrakeBlendingMaxForceN;
+                                var localBrakeForceN = loco.DynamicBrakeForceN + (CylPressurePSI - loco.DynamicBrakeBlendingRetainedPressurePSI)
+                                    / (ReferencePressurePSI - loco.DynamicBrakeBlendingRetainedPressurePSI) * Car.FrictionBrakeBlendingMaxForceN;
                                 if (localBrakeForceN > requiredBrakeForceN - 0.15f * Car.FrictionBrakeBlendingMaxForceN)
                                 {
-                                    demandedPressurePSI = Math.Min(Math.Max((requiredBrakeForceN - loco.DynamicBrakeForceN) / Car.FrictionBrakeBlendingMaxForceN * ReferencePressurePSI
-                                        + BrakeCylinderSpringPressurePSI, 0), MaxCylPressurePSI);
+                                    demandedPressurePSI = MathHelper.Clamp((requiredBrakeForceN - loco.DynamicBrakeForceN) / Car.FrictionBrakeBlendingMaxForceN *
+                                        (ReferencePressurePSI - loco.DynamicBrakeBlendingRetainedPressurePSI) + loco.DynamicBrakeBlendingRetainedPressurePSI,
+                                        loco.DynamicBrakeBlendingRetainedPressurePSI, MaxCylPressurePSI);
                                     if (demandedPressurePSI > CylPressurePSI && demandedPressurePSI < CylPressurePSI + 4) // Allow some margin for unnecessary air brake application
                                     {
                                         demandedPressurePSI = CylPressurePSI;
                                     }
                                     demandedPressurePSI /= RelayValveRatio;
+
+                                    if (demandedPressurePSI > AutoCylPressurePSI)
+                                        demandedPressurePSI = AutoCylPressurePSI;
                                 }
                             }
                             else if (loco.DynamicBrakeAutoBailOff)


### PR DESCRIPTION
I noticed that blended braking wasn't playing nice with the advanced brake cylinder simulation introduced in #912 nor the dynamic brake ramp up/down introduced in #1067, so a few small changes help to fix these issues.

Continuation of https://blueprints.launchpad.net/or/+spec/braking-enhancement

- Added new `Engine(ORTSDynamicBlendingMinimumSpeed` parameter to mirror the `Engine(ORTSDynamicBrakeReplacementWithEngineBrakeAtSpeed` parameter added in #996. Previously this was using `DynamicBrakeSpeed1MpS` and in 996 we decided that we probably [shouldn't use the MSTS dynamic brake parameters](https://github.com/openrails/openrails/pull/996#discussion_r1903343306) since most new content will have left those values undefined, giving potentially unpredictable behavior. If the train speed is below the specified speed (default units mph), blended braking will be disabled. If not given, the MSTS DynamicBrakesMinUsableSpeed parameter will still be used as a fallback, and if neither is specified the default is 5 kph, same as before.
- Added new `Engine(ORTSDynamicBlendingRetainedPressure` parameter. When `Engine(ORTSDynamicBrakesHasPartialBailOff` is used, the blended braking system will retain the specified pressure (default PSI) in the brake cylinders regardless of what the dynamic brake does, and the dynamic brake will only respond to pressures higher than this when using `Engine(ORTSDynamicBlendingForceMatch`. Default pressure is 0 psi, unless a brake cylinder spring pressure has been set, in which case the retained pressure is twice the spring pressure. Many real locomotives do this as it prevents excessive cycling of the brake rigging and keeps the brake shoes warm.
- Fix for blended braking taking forever to turn off when advanced brake cylinder simulation is used; when brake cylinder pressure drops below the retained pressure setting, blended braking turns off (as opposed to waiting for the brake cylinder pressure to drop below 0.1 psi, which takes forever on advanced brake cylinders).
- Revised brake cylinder pressure control to consider the retained pressure feature.
- Fixed an error in the handling of bail off on graduated release brake valves that was slowing down the rate of brake cylinder reduction, interfering with blended braking.
- Revised blended braking dynamic brake control to reduce overshooting of target brake force (especially obvious when using dynamic brake rampup) by slowing down the control system response. Now the system waits for the dynamics to set up before attempting to adjust the force, scales the response speed depending on the magnitude of the difference between the current and target forces (small differences are corrected slowly), and limits the speed of the system response to match the dynamic brake ramp up/down rate. I no longer notice any overshooting/hunting behavior that was present previously.