### PR TITLE
Make Control Confirmations Fade Out in Real Time

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/MessagesWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/MessagesWindow.cs
@@ -139,7 +139,8 @@ namespace Orts.Viewer3D.Popups
             }
 
             foreach (var message in Messages)
-                message.LabelShadow.Color.A = message.LabelText.Color.A = (byte)MathHelper.Lerp(255, 0, MathHelper.Clamp((float)((Owner.Viewer.Simulator.GameTime - message.EndTime) / FadeTime), 0, 1));
+                if (message.LabelShadow != null && message.LabelText != null) // It seems LabelShadow and LabelText aren't guaranteed to be initialized, causing rare crashes
+                    message.LabelShadow.Color.A = message.LabelText.Color.A = (byte)MathHelper.Lerp(255, 0, MathHelper.Clamp((float)((Owner.Viewer.RealTime - message.EndTime) / FadeTime), 0, 1));
         }
 
         class Message
@@ -184,7 +185,7 @@ namespace Orts.Viewer3D.Popups
         public void AddMessage(string key, string text, double duration)
         {
             var clockTime = Owner.Viewer.Simulator.ClockTime;
-            var gameTime = Owner.Viewer.Simulator.GameTime;
+            var realTime = Owner.Viewer.RealTime;
             while (true)
             {
                 // Store the original list and make a clone for replacing it thread-safely.
@@ -196,18 +197,18 @@ namespace Orts.Viewer3D.Popups
 
                 // Clean out any existing duplicate key and expired messages.
                 newMessages = (from m in newMessages
-                               where (String.IsNullOrEmpty(key) || m.Key != key) && m.EndTime + FadeTime > Owner.Viewer.Simulator.GameTime
+                               where (String.IsNullOrEmpty(key) || m.Key != key) && m.EndTime + FadeTime > realTime
                                select m).ToList();
 
                 // Add the new message.
-                newMessages.Add(new Message(key, String.Format("{0} {1}", FormatStrings.FormatTime(clockTime), text), existingMessage != null ? existingMessage.StartTime : gameTime, gameTime + duration));
+                newMessages.Add(new Message(key, String.Format("{0} {1}", FormatStrings.FormatTime(clockTime), text), existingMessage != null ? existingMessage.StartTime : realTime, realTime + duration));
 
                 // Sort the messages.
                 newMessages = (from m in newMessages
                                orderby m.StartTime descending
                                select m).ToList();
 
-                // Thread-safely switch from the old list to the new list; we've only suceeded if the previous (return) value is the old list.
+                // Thread-safely switch from the old list to the new list; we've only succeeded if the previous (return) value is the old list.
                 if (Interlocked.CompareExchange(ref Messages, newMessages, oldMessages) == oldMessages)
                     break;
             }


### PR DESCRIPTION
A few users have complained that control confirmation fade out doesn't make sense when the simulation speed isn't 100%. At high simulation speed, confirmers disappear too quickly to be read, but at low simulation speed confirmers stick around uncomfortably long, sometimes [sticking around in screenshots](https://www.trainsim.com/forums/forum/open-rails/open-rails-route-projects-and-questions/2300839-trainsimulations-sand-patch-csx-mainline-subdivision-development-thread#post2300839) when the user uses slow motion to frame their shot better.

With some investigation, it seems that confirmation messages were simply using game time when real time would have made more sense, so this was simply replaced to use real time.

Also fixed a crash I have randomly gotten a few times over the years, seemingly caused by the confirmation window attempting to manipulate the LabelText and/or LabelShadow before they were fully initialized. A null check should prevent that crash by waiting to update the objects until they are initialized.