### PR TITLE
When the OR main form does not have the focus, hovering above the main OR form makes the mouse cursor disappear. 

### DIFF
--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -1508,7 +1508,7 @@ namespace Orts.Viewer3D
             if (UserInput.IsMouseMoved || RenderProcess.IsMouseVisible && UserInput.IsMouseWheelChanged)
                 MouseVisibleTillRealTime = RealTime + 1;
 
-            RenderProcess.IsMouseVisible = ForceMouseVisible || RealTime < MouseVisibleTillRealTime;
+            RenderProcess.IsMouseVisible = ForceMouseVisible || RealTime < MouseVisibleTillRealTime || !Game.IsActive;
 
             UserInput.Handled();
         }


### PR DESCRIPTION
When the OR main form does not have the focus, hovering above the main OR form makes the mouse cursor disappear. To get the focus again on that form, you have to click the mouse on that form without knowing where. Risking clicking on some control by accident. See [https://bugs.launchpad.net/or/+bug/2111749](url)