### PR TITLE
Correct Use of Wheel Speed vs Ground Speed in Locomotive Physics

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -6271,9 +6271,6 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
 
                         SteamEngines[numberofengine].RealTractiveForceN += N.FromLbf(tangentialWheelTreadForceLbf);
 
-                        if (SteamEngines[numberofengine].RealTractiveForceN < 0)
-                            Trace.WriteLine("why");
-
 #if DEBUG_STEAM_SLIP
                     if (SpeedMpS > 17.88 && SpeedMpS < 18.5 || SpeedMpS > 34.0 && throttle == 0)
                                         {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -324,7 +324,7 @@ namespace Orts.Simulation.RollingStocks
         float[,] TractiveForceAverageN = new float[5, 37];
         float AverageTractiveForceN;
 
-        public Orts.Simulation.Simulation.RollingStocks.SubSystems.PowerSupplies.SteamEngines SteamEngines;
+        public SteamEngines SteamEngines;
 
         // steam performance reporting
         public float SteamPerformanceTimeS = 0.0f; // Records the time since starting movement
@@ -653,7 +653,6 @@ namespace Orts.Simulation.RollingStocks
         float MaxIndicatedHorsePowerHP; // IHP @ max performance for the locomotive
         float DisplayMaxIndicatedHorsePowerHP; // Display value for HUD of IHP @ max performance for the geared locomotive
         float RetainedGearedMaxMaxIndicatedHorsePowerHP; // Retrains maximum IHP value for steam locomotives.
-        float absSpeedMpS;
         float CombFrictionN;  // Temporary parameter to store combined friction values of locomotive and tender
         float CombGravityN;   // Temporary parameter to store combined Gravity values of locomotive and tender
         float CombTunnelN;    // Temporary parameter to store combined Tunnel values of locomotive and tender
@@ -2515,9 +2514,11 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             {
                 var enginethrottle = 0.0f;
 
+                float absSpeedRefMpS = Simulator.UseAdvancedAdhesion ? Math.Abs((float)SteamEngines[i].AttachedAxle.AxleSpeedMpS) : AbsTractionSpeedMpS;
+
                 if (SteamEngines[i].AuxiliarySteamEngineType != SteamEngine.AuxiliarySteamEngineTypes.Booster)
                 {
-                    UpdateCylinders(elapsedClockSeconds, throttle, cutoff, Math.Abs((float)SteamEngines[i].AttachedAxle.AxleSpeedMpS), i);
+                    UpdateCylinders(elapsedClockSeconds, throttle, cutoff, absSpeedRefMpS, i);
                 }
                 else if (SteamEngines[i].AuxiliarySteamEngineType == SteamEngine.AuxiliarySteamEngineTypes.Booster)  // Booster Engine
                 {
@@ -2639,7 +2640,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                         BoosterEngineSpeedRpM = 0.0f;
                     }
 
-                    UpdateCylinders(elapsedClockSeconds, enginethrottle, BoosterCylinderExhaustOpenFactor, Math.Abs((float)SteamEngines[i].AttachedAxle.AxleSpeedMpS), i);
+                    UpdateCylinders(elapsedClockSeconds, enginethrottle, BoosterCylinderExhaustOpenFactor, absSpeedRefMpS, i);
 
                     // Update Booster steam consumption
                     if (SteamBoosterIdleMode)
@@ -2799,6 +2800,8 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             {
                 var TotalNumberCyindersEng1 = 0;
 
+                float absSpeedRefMpS = Simulator.UseAdvancedAdhesion ? Math.Abs((float)SteamEngines[0].AttachedAxle.AxleSpeedMpS) : AbsTractionSpeedMpS;
+
                 if (SteamEngineType == SteamEngineTypes.Compound)
                 {
                     TotalNumberCyindersEng1 = SteamEngines[0].NumberCylinders + SteamEngines[0].LPNumberCylinders;
@@ -2845,8 +2848,8 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                     ExhaustnormalisedCrankAngleRad[i] = normalisedCrankAngleRad;
                     ExhaustexhaustCrankAngleRad[i] = exhaustCrankAngleRadFor;
 
-
-                    if (AbsTractionSpeedMpS > 0.001)
+                    
+                    if (absSpeedRefMpS > 0.001)
                     {
                         if (i == 0 && ((normalisedCrankAngleRad >= exhaustCrankAngleRadFor && normalisedCrankAngleRad <= MathHelper.Pi) || (normalisedCrankAngleRad >= exhaustCrankAngleRadRev && normalisedCrankAngleRad < 2 * MathHelper.Pi )))
                         {
@@ -3045,6 +3048,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                 {
                     var TotalNumberCyindersEng2 = SteamEngines[1].NumberCylinders; // currently assume 2nd engine is non-compound
 
+                    absSpeedRefMpS = Simulator.UseAdvancedAdhesion ? Math.Abs((float)SteamEngines[1].AttachedAxle.AxleSpeedMpS) : AbsTractionSpeedMpS;
          // Engine #2
                     for (int i = 0; i < TotalNumberCyindersEng2; i++)
                     {
@@ -3076,7 +3080,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                             exhaustCrankAngleRadRev -= 2 * (float)Math.PI;
                         }
 
-                        if (AbsTractionSpeedMpS > 0.001)
+                        if (absSpeedRefMpS > 0.001)
                         {
                             if (i == 0 && ((normalisedCrankAngleRad >= exhaustCrankAngleRadFor && normalisedCrankAngleRad <= MathHelper.Pi) || (normalisedCrankAngleRad >= exhaustCrankAngleRadRev && normalisedCrankAngleRad < 2 * MathHelper.Pi)))
                             {
@@ -3378,29 +3382,29 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             GeneratorSteamVelocityMpS = 50.0f;
             GeneratorSteamVolumeM3pS = 4.0f * SteamEffectsFactor;
             GeneratorParticleDurationS = 1.0f;
-            GeneratorParticleDurationS = MathHelper.Clamp(GeneratorParticleDurationS / (absSpeedMpS / 4.0f), 0.1f, 1.0f);
+            GeneratorParticleDurationS = MathHelper.Clamp(GeneratorParticleDurationS / (AbsSpeedMpS / 4.0f), 0.1f, 1.0f);
 
             // Injector Steam Effects
             Injector1SteamVolumeM3pS = (Injector1IsOn ? (5.0f * SteamEffectsFactor) : 0);
             Injector1SteamVelocityMpS = 10.0f;
             Injector1ParticleDurationS = 1.0f;
-            Injector1ParticleDurationS = MathHelper.Clamp(Injector1ParticleDurationS / (absSpeedMpS / 4.0f), 0.1f, 1.0f);
+            Injector1ParticleDurationS = MathHelper.Clamp(Injector1ParticleDurationS / (AbsSpeedMpS / 4.0f), 0.1f, 1.0f);
 
             Injector2SteamVolumeM3pS = (Injector2IsOn ? (5.0f * SteamEffectsFactor) : 0);
             Injector2SteamVelocityMpS = 10.0f;
             Injector2ParticleDurationS = 1.0f;
-            Injector2ParticleDurationS = MathHelper.Clamp(Injector2ParticleDurationS / (absSpeedMpS / 4.0f), 0.1f, 1.0f);
+            Injector2ParticleDurationS = MathHelper.Clamp(Injector2ParticleDurationS / (AbsSpeedMpS / 4.0f), 0.1f, 1.0f);
 
             // Ejector Steam Effects
             SmallEjectorSteamVolumeM3pS = (SmallSteamEjectorIsOn ? (1.5f * SteamEffectsFactor) : 0);
             SmallEjectorSteamVelocityMpS = 10.0f;
             SmallEjectorParticleDurationS = 1.0f;
-            SmallEjectorParticleDurationS = MathHelper.Clamp(SmallEjectorParticleDurationS / (absSpeedMpS / 4.0f), 0.1f, 1.0f);
+            SmallEjectorParticleDurationS = MathHelper.Clamp(SmallEjectorParticleDurationS / (AbsSpeedMpS / 4.0f), 0.1f, 1.0f);
 
             LargeEjectorSteamVolumeM3pS = (LargeSteamEjectorIsOn ? (1.5f * SteamEffectsFactor) : 0);
             LargeEjectorSteamVelocityMpS = 10.0f;
             LargeEjectorParticleDurationS = 1.0f;
-            LargeEjectorParticleDurationS = MathHelper.Clamp(LargeEjectorParticleDurationS / (absSpeedMpS / 4.0f), 0.1f, 1.0f);
+            LargeEjectorParticleDurationS = MathHelper.Clamp(LargeEjectorParticleDurationS / (AbsSpeedMpS / 4.0f), 0.1f, 1.0f);
 
             // Compressor Steam Effects
             // Only show compressor steam effects if it is not a vacuum controlled steam engine
@@ -3409,14 +3413,14 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                 CompressorSteamVelocityMpS = 10.0f;
                 CompressorSteamVolumeM3pS = (CompressorIsOn ? (1.5f * SteamEffectsFactor) : 0);
                 CompressorParticleDurationS = 1.0f;
-                CompressorParticleDurationS = MathHelper.Clamp(CompressorParticleDurationS / (absSpeedMpS / 4.0f), 0.1f, 1.0f);
+                CompressorParticleDurationS = MathHelper.Clamp(CompressorParticleDurationS / (AbsSpeedMpS / 4.0f), 0.1f, 1.0f);
             }
 
             // Whistle Steam Effects
             WhistleSteamVelocityMpS = 10.0f;
             WhistleSteamVolumeM3pS = (Horn ? (5.0f * SteamEffectsFactor) : 0);
             WhistleParticleDurationS = 3.0f;
-            WhistleParticleDurationS = MathHelper.Clamp(WhistleParticleDurationS / (absSpeedMpS / 4.0f), 0.1f, 3.0f);
+            WhistleParticleDurationS = MathHelper.Clamp(WhistleParticleDurationS / (AbsSpeedMpS / 4.0f), 0.1f, 3.0f);
 
             // Safety Valves Steam Effects
 
@@ -3424,7 +3428,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             //SafetyValvesSteamVolumeM3pS = SafetyIsOn ? Kg.FromLb(SafetyValveUsageLBpS) * SteamVaporSpecVolumeAt100DegC1BarM3pKG : 0;
             SafetyValvesSteamVolumeM3pS = SafetyIsOn ? 5.0f : 0;
             SafetyValvesParticleDurationS = 3.0f;
-            SafetyValvesParticleDurationS = MathHelper.Clamp(SafetyValvesParticleDurationS / (absSpeedMpS / 4.0f), 0.1f, 3.0f);
+            SafetyValvesParticleDurationS = MathHelper.Clamp(SafetyValvesParticleDurationS / (AbsSpeedMpS / 4.0f), 0.1f, 3.0f);
 
             // Smoke Stack Smoke Effects
             // Colur for smoke is determined by the amount of air flowing through the fire (ie damper ).
@@ -3437,7 +3441,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             }
             else
             {
-                SmokeColorDamper = absSpeedMpS * DamperFactorManual; // Damper value for manual firing - related to increased speed, and airflow through fire
+                SmokeColorDamper = AbsSpeedMpS * DamperFactorManual; // Damper value for manual firing - related to increased speed, and airflow through fire
             }
 
             SmokeColorDamper = MathHelper.Clamp(SmokeColorDamper, 0.0f, TheoreticalMaxSteamOutputLBpS); // set damper maximum to the max generation rate
@@ -3464,12 +3468,12 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                 }
                 else // when not exhausting
                 {
-                    if (absSpeedMpS < 10)
+                    if (AbsSpeedMpS < 10)
                     {
                         float smokeRestVelocityVariationFactor = 2 * cutoff; // adjust smoke velocity based upon throttle and cutoff settings
                         float smokeRestVolumeVariationFactor = 1 * cutoff; // adjust smoke volume based upon throttle and cutoff settings
 
-                        float velocityRate = (absSpeedMpS < 1 ? 1.0f : 1.0f / AbsSpeedMpS);
+                        float velocityRate = Math.Min(1.0f, 1.0f / AbsSpeedMpS);
                         StackSteamVelocityMpS.Update(elapsedClockSeconds, velocityRate);
                         StackSteamVolumeM3pS = Kg.FromLb(BlowerSteamUsageLBpS + RadiationSteamLossLBpS + CompSteamUsageLBpS + GeneratorSteamUsageLBpS) * smokeRestVolumeVariationFactor * SteamVaporSpecVolumeAt100DegC1BarM3pKG;
                         StackSteamVolumeM3pS = StackSteamVolumeM3pS / StackCount + FireRatio;
@@ -3738,7 +3742,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                 float HeatLossNoWindBTUph = (1- AreaExposedtoWindMovementFraction) * HeatTransferCoefficientBtuphft2F * AssumedSurfaceAreaFt2 * HeatDiff;
 
                 // To compensate for the train movement we need to add a wind factor
-                float WindCoeff = -0.0074f * absSpeedMpS * absSpeedMpS + 0.3817f * absSpeedMpS + 1f;
+                float WindCoeff = -0.0074f * AbsSpeedMpS * AbsSpeedMpS + 0.3817f * AbsSpeedMpS + 1f;
                 WindCoeff = MathHelper.Clamp(WindCoeff, 1.0f, 5.78f); // Wind speed effect will not cause any more impact once over about 25 m/s
 
                 float HeatLossWindBTUph = (1 - AreaExposedtoWindMovementFraction) * HeatTransferCoefficientBtuphft2F * AssumedSurfaceAreaFt2 * HeatDiff * WindCoeff;
@@ -3871,7 +3875,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             Trace.TraceInformation(" Water Percent {0} AuxTenderCoupled {1} SteamAuxTenderCoupled {2}", TenderWaterPercent, Train.IsAuxTenderCoupled, SteamIsAuxTenderCoupled);
             Trace.TraceInformation("Water Controller Current Value {0} Previous Value {1}", WaterController.CurrentValue, PreviousTenderWaterVolumeUKG);
 #endif
-            if (absSpeedMpS > 0.5) // Indicates train has moved, and therefore game started
+            if (AbsSpeedMpS > 0.5) // Indicates train has moved, and therefore game started
             {
                 AuxTenderMoveFlag = true;
             }
@@ -4205,8 +4209,6 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
 
         private void UpdateBoiler(float elapsedClockSeconds)
         {
-            absSpeedMpS = Math.Abs(Train.SpeedMpS);
-
             #region Safety valves - determine number and size
 
             // Determine number and size of safety valves
@@ -4676,14 +4678,14 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             float HighSpeedMpS = 20.0f;
             float KcMinSpeed = 10.45f - LowSpeedMpS + (10.0f * (float)Math.Pow(LowSpeedMpS, 0.5)); // Minimum speed of 2m/s
             float KcMaxSpeed = 10.45f - HighSpeedMpS + (10.0f * (float)Math.Pow(HighSpeedMpS, 0.5)); // Maximum speed of 20m/s
-            float KcActualSpeed = 10.45f - absSpeedMpS + (10.0f * (float)Math.Pow(absSpeedMpS, 0.5));
+            float KcActualSpeed = 10.45f - AbsSpeedMpS + (10.0f * (float)Math.Pow(AbsSpeedMpS, 0.5));
             float KcMovementFraction = 0;
 
-            if (absSpeedMpS > 2 && absSpeedMpS < 20.0f)
+            if (AbsSpeedMpS > 2 && AbsSpeedMpS < 20.0f)
             {
                 KcMovementFraction = KcActualSpeed / KcMinSpeed; // Calculate fraction only between 2 and 20
             }
-            else if (absSpeedMpS < 2)
+            else if (AbsSpeedMpS < 2)
             {
                 KcMovementFraction = 1.0f; // If speed less then 2m/s then set fracftion to give stationary Kc value 
             }
@@ -6602,7 +6604,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             DrawBarPullLbsF = N.ToLbf(Math.Abs(DisplayTractiveForceN) - LocoTenderFrictionForceN); // Locomotive drawbar pull is equal to motive force of locomotive (+ tender) - friction forces of locomotive (+ tender)
             DrawBarPullLbsF = MathHelper.Clamp(DrawBarPullLbsF, 0, DrawBarPullLbsF); // clamp value so it doesn't go negative
 
-            DrawbarHorsePowerHP = (DrawBarPullLbsF * MpS.ToMpH(absSpeedMpS)) / 375.0f;  // TE in this instance is a maximum, and not at the wheel???
+            DrawbarHorsePowerHP = (DrawBarPullLbsF * MpS.ToMpH(AbsSpeedMpS)) / 375.0f;  // TE in this instance is a maximum, and not at the wheel???
             DrawbarHorsePowerHP = MathHelper.Clamp(DrawbarHorsePowerHP, 0, DrawbarHorsePowerHP); // clamp value so it doesn't go negative
 
             // Set Max Velocity of locomotive
@@ -7078,18 +7080,18 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             {
                MaximumWaterMotionPumpFlowRateLBpS = (1.2f * EvaporationLBpS) / 2.0f; // Assume two pumps and that they can pump a fraction more water the the maximum steam production
 
-                if (WaterMotionPump1IsOn && absSpeedMpS > 0)
+                if (WaterMotionPump1IsOn && AbsTractionSpeedMpS > 0)
                 {
-                    WaterMotionPump1FlowRateLBpS = MaximumWaterMotionPumpFlowRateLBpS * absSpeedMpS / MpS.FromMpH(MaxLocoSpeedMpH);
+                    WaterMotionPump1FlowRateLBpS = MaximumWaterMotionPumpFlowRateLBpS * AbsTractionSpeedMpS / MpS.FromMpH(MaxLocoSpeedMpH);
                 }
                 else
                 {
                     WaterMotionPump1FlowRateLBpS = 0;
                 }
 
-                if (WaterMotionPump2IsOn && absSpeedMpS > 0)
+                if (WaterMotionPump2IsOn && AbsTractionSpeedMpS > 0)
                 {
-                    WaterMotionPump2FlowRateLBpS = MaximumWaterMotionPumpFlowRateLBpS * absSpeedMpS / MpS.FromMpH(MaxLocoSpeedMpH);
+                    WaterMotionPump2FlowRateLBpS = MaximumWaterMotionPumpFlowRateLBpS * AbsTractionSpeedMpS / MpS.FromMpH(MaxLocoSpeedMpH);
                 }
                 else
                 {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs
@@ -2517,7 +2517,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
 
                 if (SteamEngines[i].AuxiliarySteamEngineType != SteamEngine.AuxiliarySteamEngineTypes.Booster)
                 {
-                    UpdateCylinders(elapsedClockSeconds, throttle, cutoff, absSpeedMpS, i);
+                    UpdateCylinders(elapsedClockSeconds, throttle, cutoff, Math.Abs((float)SteamEngines[i].AttachedAxle.AxleSpeedMpS), i);
                 }
                 else if (SteamEngines[i].AuxiliarySteamEngineType == SteamEngine.AuxiliarySteamEngineTypes.Booster)  // Booster Engine
                 {
@@ -2639,7 +2639,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                         BoosterEngineSpeedRpM = 0.0f;
                     }
 
-                    UpdateCylinders(elapsedClockSeconds, enginethrottle, BoosterCylinderExhaustOpenFactor, absSpeedMpS, i);
+                    UpdateCylinders(elapsedClockSeconds, enginethrottle, BoosterCylinderExhaustOpenFactor, Math.Abs((float)SteamEngines[i].AttachedAxle.AxleSpeedMpS), i);
 
                     // Update Booster steam consumption
                     if (SteamBoosterIdleMode)
@@ -2758,7 +2758,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                     tractiveforcethrottle = throttle;
                 }
 
-                UpdateSteamTractiveForce(elapsedClockSeconds, tractiveforcethrottle, 0, 0, i);
+                UpdateSteamTractiveForce(elapsedClockSeconds, tractiveforcethrottle, i);
 
                 SteamDrvWheelWeightLbs += Kg.ToLb(SteamEngines[i].AttachedAxle.WheelWeightKg / SteamEngines[i].AttachedAxle.NumWheelsetAxles); // Calculate the weight per axle (used in MSTSLocomotive for friction calculatons)
 
@@ -2846,7 +2846,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                     ExhaustexhaustCrankAngleRad[i] = exhaustCrankAngleRadFor;
 
 
-                    if (absSpeedMpS > 0.001)
+                    if (AbsTractionSpeedMpS > 0.001)
                     {
                         if (i == 0 && ((normalisedCrankAngleRad >= exhaustCrankAngleRadFor && normalisedCrankAngleRad <= MathHelper.Pi) || (normalisedCrankAngleRad >= exhaustCrankAngleRadRev && normalisedCrankAngleRad < 2 * MathHelper.Pi )))
                         {
@@ -3076,7 +3076,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                             exhaustCrankAngleRadRev -= 2 * (float)Math.PI;
                         }
 
-                        if (absSpeedMpS > 0.001)
+                        if (AbsTractionSpeedMpS > 0.001)
                         {
                             if (i == 0 && ((normalisedCrankAngleRad >= exhaustCrankAngleRadFor && normalisedCrankAngleRad <= MathHelper.Pi) || (normalisedCrankAngleRad >= exhaustCrankAngleRadRev && normalisedCrankAngleRad < 2 * MathHelper.Pi)))
                             {
@@ -3509,7 +3509,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                 // Axle code is not executed if it is an AI train, on Autopilot, or Simple adhesion or simple physics is selected. Hence must use wheelspeed in these instances
                 {
                     if (WheelSlip)
-                        variable[i] = Math.Abs(WheelSpeedSlipMpS / SteamEngines[0].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
+                        variable[i] = Math.Abs(DriveWheelSpeedMpS / SteamEngines[0].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
                     else
                     {
                         variable[i] = Math.Abs(WheelSpeedMpS / SteamEngines[0].AttachedAxle.WheelRadiusM / MathHelper.Pi * 5);
@@ -6008,7 +6008,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
         /// <summary>
         /// Calculate the tractive forces for each steam engine
         /// </summary>
-        private void UpdateSteamTractiveForce(float elapsedClockSeconds, float locomotivethrottle, float AbsSpeedMpS, float AbsWheelSpeedMpS, int numberofengine)
+        private void UpdateSteamTractiveForce(float elapsedClockSeconds, float locomotivethrottle, int numberofengine)
         {
 
             #region - Steam Adhesion Model Input for Steam Locomotives
@@ -6029,6 +6029,8 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             // only set advanced wheel slip when advanced adhesion, and simplecontrols/physics is not set and is in the the player train, AI locomotive will not work to this model. 
             // Don't use slip model when train is in auto pilot
             {
+                float absEngineWheelSpeedMpS = Math.Abs((float)SteamEngines[numberofengine].AttachedAxle.AxleSpeedMpS);
+
                 if ((SteamEngineType == SteamEngineTypes.Compound || SteamEngineType == SteamEngineTypes.Simple) && SteamEngines[numberofengine].AuxiliarySteamEngineType != SteamEngine.AuxiliarySteamEngineTypes.Booster)
                 {
 
@@ -6055,48 +6057,48 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                     {
                         if (!CylinderCompoundOn) // Bypass Valve closed - in Compound Mode
                         {
-                            slipInitialPressureAtmPSI = SteamEngines[numberofengine].HPCompPressure_a_AtmPSI;
-                            slipCutoffPressureAtmPSI = SteamEngines[numberofengine].HPCompPressure_b_AtmPSI;
-                            slipCylinderReleasePressureAtmPSI = SteamEngines[numberofengine].HPCompPressure_f_AtmPSI;
-                            slipBackPressureAtmPSI = SteamEngines[numberofengine].Pressure_d_AtmPSI;
-                            slipCompressionPressureAtmPSI = SteamEngines[numberofengine].Pressure_e_AtmPSI;
-                            slipAdmissionPressureAtmPSI = SteamEngines[numberofengine].Pressure_f_AtmPSI;
+                            slipInitialPressureAtmPSI = Math.Max(SteamEngines[numberofengine].HPCompPressure_a_AtmPSI, 0);
+                            slipCutoffPressureAtmPSI = Math.Max(SteamEngines[numberofengine].HPCompPressure_b_AtmPSI, 0);
+                            slipCylinderReleasePressureAtmPSI = Math.Max(SteamEngines[numberofengine].HPCompPressure_f_AtmPSI, 0);
+                            slipBackPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_d_AtmPSI, 0);
+                            slipCompressionPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_e_AtmPSI, 0);
+                            slipAdmissionPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_f_AtmPSI, 0);
 
                             // LP Cylinder
-                            LPslipInitialPressureAtmPSI = SteamEngines[numberofengine].LPCompPressure_g_AtmPSI;
-                            LPslipCutoffPressureAtmPSI = SteamEngines[numberofengine].LPCompPressure_h_AtmPSI;
-                            LPslipCylinderReleasePressureAtmPSI = SteamEngines[numberofengine].LPCompPressure_l_AtmPSI;
-                            LPslipBackPressureAtmPSI = SteamEngines[numberofengine].LPCompPressure_m_AtmPSI;
-                            LPslipCompressionPressureAtmPSI = SteamEngines[numberofengine].LPCompPressure_n_AtmPSI;
-                            LPslipAdmissionPressureAtmPSI = SteamEngines[numberofengine].LPCompPressure_q_AtmPSI;
+                            LPslipInitialPressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPCompPressure_g_AtmPSI, 0);
+                            LPslipCutoffPressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPCompPressure_h_AtmPSI, 0);
+                            LPslipCylinderReleasePressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPCompPressure_l_AtmPSI, 0);
+                            LPslipBackPressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPCompPressure_m_AtmPSI, 0);
+                            LPslipCompressionPressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPCompPressure_n_AtmPSI, 0);
+                            LPslipAdmissionPressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPCompPressure_q_AtmPSI, 0);
                         }
                         else  // Simple mode
                         {
                             // HP Cylinder
-                            slipInitialPressureAtmPSI = SteamEngines[numberofengine].Pressure_a_AtmPSI;
-                            slipCutoffPressureAtmPSI = SteamEngines[numberofengine].Pressure_b_AtmPSI;
-                            slipCylinderReleasePressureAtmPSI = SteamEngines[numberofengine].Pressure_c_AtmPSI;
-                            slipBackPressureAtmPSI = SteamEngines[numberofengine].Pressure_d_AtmPSI;
-                            slipCompressionPressureAtmPSI = SteamEngines[numberofengine].Pressure_e_AtmPSI;
-                            slipAdmissionPressureAtmPSI = SteamEngines[numberofengine].Pressure_f_AtmPSI;
+                            slipInitialPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_a_AtmPSI, 0);
+                            slipCutoffPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_b_AtmPSI, 0);
+                            slipCylinderReleasePressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_c_AtmPSI, 0);
+                            slipBackPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_d_AtmPSI, 0);
+                            slipCompressionPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_e_AtmPSI, 0);
+                            slipAdmissionPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_f_AtmPSI, 0);
 
                             // LP Cylinder
-                            LPslipInitialPressureAtmPSI = SteamEngines[numberofengine].LPPressure_a_AtmPSI;
-                            LPslipCutoffPressureAtmPSI = SteamEngines[numberofengine].LPPressure_b_AtmPSI;
-                            LPslipCylinderReleasePressureAtmPSI = SteamEngines[numberofengine].LPPressure_c_AtmPSI;
-                            LPslipBackPressureAtmPSI = SteamEngines[numberofengine].LPPressure_d_AtmPSI;
-                            LPslipCompressionPressureAtmPSI = SteamEngines[numberofengine].LPPressure_e_AtmPSI;
-                            LPslipAdmissionPressureAtmPSI = SteamEngines[numberofengine].LPPressure_f_AtmPSI;
+                            LPslipInitialPressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPPressure_a_AtmPSI, 0);
+                            LPslipCutoffPressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPPressure_b_AtmPSI, 0);
+                            LPslipCylinderReleasePressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPPressure_c_AtmPSI, 0);
+                            LPslipBackPressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPPressure_d_AtmPSI, 0);
+                            LPslipCompressionPressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPPressure_e_AtmPSI, 0);
+                            LPslipAdmissionPressureAtmPSI = Math.Max(SteamEngines[numberofengine].LPPressure_f_AtmPSI, 0);
                         }
                     }
                     else // simple locomotive
                     {
-                        slipInitialPressureAtmPSI = SteamEngines[numberofengine].Pressure_a_AtmPSI;
-                        slipCutoffPressureAtmPSI = SteamEngines[numberofengine].Pressure_b_AtmPSI;
-                        slipCylinderReleasePressureAtmPSI = SteamEngines[numberofengine].Pressure_c_AtmPSI;
-                        slipBackPressureAtmPSI = SteamEngines[numberofengine].Pressure_d_AtmPSI;
-                        slipCompressionPressureAtmPSI = SteamEngines[numberofengine].Pressure_e_AtmPSI;
-                        slipAdmissionPressureAtmPSI = SteamEngines[numberofengine].Pressure_f_AtmPSI;
+                        slipInitialPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_a_AtmPSI, 0);
+                        slipCutoffPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_b_AtmPSI, 0);
+                        slipCylinderReleasePressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_c_AtmPSI, 0);
+                        slipBackPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_d_AtmPSI, 0);
+                        slipCompressionPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_e_AtmPSI, 0);
+                        slipAdmissionPressureAtmPSI = Math.Max(SteamEngines[numberofengine].Pressure_f_AtmPSI, 0);
                     }
 
                     TractiveForceN = 0;
@@ -6123,7 +6125,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                         float crankCylinderPressure = (SteamEngines[numberofengine].MeanEffectivePressurePSI * CylinderEfficiencyRate); // fallback default value
 
                         // Calculate cylinder position in relation to crank (and hence wheel) position.
-                        // For each full wheel revolution, the cylinder will do two storkes (forward and backwards).
+                        // For each full wheel revolution, the cylinder will do two strokes (forward and backwards).
                         // Each stroke in turn will have a forward component with a corresponding pressure producing a "+ve" force and reverse component producing a "-ve" force.
                         // So each stroke will have a x  and 1-x cylinder position.
                         // In effect it will increase from 0% (0 deg) to 100% (180 deg), then it will decrease from 100% to 0% (360 deg) 
@@ -6161,7 +6163,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                         // forward stroke
                         if (slipcutoff > forwardCylinderPosition) // pressure will be in cutoff section of cylinder
                         {
-                            // In cutoff section of cylinder pressure follows a straight line rperesentation between initial pressure and cutoff pressure
+                            // In cutoff section of cylinder pressure follows a straight line representation between initial pressure and cutoff pressure
                             float pressureGradient = (slipCutoffPressureAtmPSI - slipInitialPressureAtmPSI) / (slipcutoff + CylinderClearancePC - CylinderClearancePC);
                             forwardCylinderPressure = slipInitialPressureAtmPSI + pressureGradient * (forwardCylinderPosition - CylinderClearancePC);
                         }
@@ -6238,7 +6240,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                             connectRodInertiaForcelbf *= -1;
                         }
 
-                        // For more then two cylinder eingines reciprocating inertia is not required as it only applies to the gearing on each side and not the number of cylinders.
+                        // For more then two cylinder engines reciprocating inertia is not required as it only applies to the gearing on each side and not the number of cylinders.
                         // Hence "zero" it out, however reciprocating rods will still apply
                         if ((SteamEngines[numberofengine].NumberCylinders == 3 && i > 1) || (SteamEngines[numberofengine].NumberCylinders == 4 && (i == 1 || i == 3)) )
                         {
@@ -6251,7 +6253,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                         float totalTangentialInertiaForcelbf = totalInertiaForcelbf * tangentialCrankForceFactor;
 
                         // At high speed with the throttle closed the average reciprocating forces should approach zero, however if OR is not sampling enough points then it
-                        // is possible that the force will be diproporionate. So the following code forces a reduction in the reciprocating forces if the throttle is closed
+                        // is possible that the force will be disproportionate. So the following code forces a reduction in the reciprocating forces if the throttle is closed
                         // - to be investigated further later.
 
                         if (throttle < 0.01)
@@ -6267,7 +6269,10 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                         float DrvWheelDiaM = SteamEngines[numberofengine].AttachedAxle.WheelRadiusM * 2.0f;
                         float tangentialWheelTreadForceLbf = tangentialCrankWheelForceLbf * Me.ToIn(SteamEngines[numberofengine].CylindersStrokeM) / Me.ToIn(DrvWheelDiaM);
 
-                        SteamEngines[numberofengine].RealTractiveForceN += N.FromLbf(Math.Max(tangentialWheelTreadForceLbf, -1000));
+                        SteamEngines[numberofengine].RealTractiveForceN += N.FromLbf(tangentialWheelTreadForceLbf);
+
+                        if (SteamEngines[numberofengine].RealTractiveForceN < 0)
+                            Trace.WriteLine("why");
 
 #if DEBUG_STEAM_SLIP
                     if (SpeedMpS > 17.88 && SpeedMpS < 18.5 || SpeedMpS > 34.0 && throttle == 0)
@@ -6312,7 +6317,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                             // weight on each individual wheel, rather then each axle
                             var wheelWeight = SteamEngines[numberofengine].AttachedAxle.WheelWeightKg / (SteamEngines[numberofengine].AttachedAxle.NumWheelsetAxles * 2f);
 
-                            SteamEngines[numberofengine].HammerForceLbs = (1.6047f * Me.ToIn(SteamEngines[numberofengine].CylindersStrokeM) * excessBalanceForceWheelLbs * (float)Math.Pow(MpS.ToMpH(absSpeedMpS), 2)) / ((float)Math.Pow(Me.ToIn(2.0f * SteamEngines[numberofengine].AttachedAxle.WheelRadiusM), 2) * SteamEngines[numberofengine].AttachedAxle.NumWheelsetAxles);
+                            SteamEngines[numberofengine].HammerForceLbs = (1.6047f * Me.ToIn(SteamEngines[numberofengine].CylindersStrokeM) * excessBalanceForceWheelLbs * (float)Math.Pow(MpS.ToMpH(absEngineWheelSpeedMpS), 2)) / ((float)Math.Pow(Me.ToIn(2.0f * SteamEngines[numberofengine].AttachedAxle.WheelRadiusM), 2) * SteamEngines[numberofengine].AttachedAxle.NumWheelsetAxles);
 
                             if (SteamEngines[numberofengine].HammerForceLbs > wheelWeight)
                             {
@@ -6363,10 +6368,10 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                     SteamEngines[numberofengine].AttachedAxle.AxleWeightN = totalDrvWeightN + 9.81f * SteamEngines[numberofengine].AttachedAxle.WheelWeightKg;
                     SteamEngines[numberofengine].SteamStaticWheelForce = N.ToLbf(9.81f * SteamEngines[numberofengine].AttachedAxle.WheelWeightKg) * LocomotiveCoefficientFrictionHUD;
 
-                    // Average tarctive force is calculated for display purposes as tractive force varies dramatically as the wheel rotates, and this is difficult to follow on HuD
+                    // Average tractive force is calculated for display purposes as tractive force varies dramatically as the wheel rotates, and this is difficult to follow on HuD
                     SteamEngines[numberofengine].AverageTractiveForceN = AverageTractiveForce(elapsedClockSeconds, numberofengine, NumberofTractiveForceValues);
 
-                    SteamEngines[numberofengine].IndicatedHorsePowerHP = (N.ToLbf(SteamEngines[numberofengine].AverageTractiveForceN) * pS.TopH(Me.ToMi(absSpeedMpS))) / 375.0f;
+                    SteamEngines[numberofengine].IndicatedHorsePowerHP = (N.ToLbf(SteamEngines[numberofengine].AverageTractiveForceN) * pS.TopH(Me.ToMi(absEngineWheelSpeedMpS))) / 375.0f;
 
                 }
                 else // typically this will be a booster or geared engine
@@ -6405,7 +6410,10 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                     SteamEngines[numberofengine].AttachedAxle.AxleWeightN = 9.81f * SteamEngines[numberofengine].AttachedAxle.WheelWeightKg;
                     SteamEngines[numberofengine].SteamStaticWheelForce = N.ToLbf(9.81f * SteamEngines[numberofengine].AttachedAxle.WheelWeightKg) * LocomotiveCoefficientFrictionHUD;
 
-                    SteamEngines[numberofengine].IndicatedHorsePowerHP = (N.ToLbf(SteamEngines[numberofengine].RealTractiveForceN) * pS.TopH(Me.ToMi(absSpeedMpS))) / 375.0f;
+                    // Average tractive force is calculated for display purposes as tractive force varies dramatically as the wheel rotates, and this is difficult to follow on HuD
+                    SteamEngines[numberofengine].AverageTractiveForceN = AverageTractiveForce(elapsedClockSeconds, numberofengine, NumberofTractiveForceValues);
+
+                    SteamEngines[numberofengine].IndicatedHorsePowerHP = (N.ToLbf(SteamEngines[numberofengine].RealTractiveForceN) * pS.TopH(Me.ToMi(absEngineWheelSpeedMpS))) / 375.0f;
                 }
             }            
             else // Adjust tractive force if  "simple" adhesion is used
@@ -6430,8 +6438,11 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                     // Calculate IHP
                     // IHP = (MEP x Speed (mph)) / 375.0) - this is per cylinder
 
-                    SteamEngines[numberofengine].HPIndicatedHorsePowerHP = (HPTractiveEffortLbsF * pS.TopH(Me.ToMi(absSpeedMpS))) / 375.0f;
-                    SteamEngines[numberofengine].LPIndicatedHorsePowerHP = (LPTractiveEffortLbsF * pS.TopH(Me.ToMi(absSpeedMpS))) / 375.0f;
+                    SteamEngines[numberofengine].HPIndicatedHorsePowerHP = (HPTractiveEffortLbsF * pS.TopH(Me.ToMi(AbsTractionSpeedMpS))) / 375.0f;
+                    SteamEngines[numberofengine].LPIndicatedHorsePowerHP = (LPTractiveEffortLbsF * pS.TopH(Me.ToMi(AbsTractionSpeedMpS))) / 375.0f;
+
+                    // Average tractive force is calculated for display purposes as tractive force varies dramatically as the wheel rotates, and this is difficult to follow on HuD
+                    SteamEngines[numberofengine].AverageTractiveForceN = AverageTractiveForce(elapsedClockSeconds, numberofengine, NumberofTractiveForceValues);
 
                     SteamEngines[numberofengine].IndicatedHorsePowerHP = SteamEngines[numberofengine].HPIndicatedHorsePowerHP + SteamEngines[numberofengine].LPIndicatedHorsePowerHP;
 
@@ -6460,7 +6471,10 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                     }
                     TractiveForceN = MathHelper.Clamp(TractiveForceN, 0, TractiveForceN);
 
-                    SteamEngines[numberofengine].IndicatedHorsePowerHP = (N.ToLbf(SteamEngines[numberofengine].RealTractiveForceN) * pS.TopH(Me.ToMi(absSpeedMpS))) / 375.0f;
+                    // Average tractive force is calculated for display purposes as tractive force varies dramatically as the wheel rotates, and this is difficult to follow on HuD
+                    SteamEngines[numberofengine].AverageTractiveForceN = AverageTractiveForce(elapsedClockSeconds, numberofengine, NumberofTractiveForceValues);
+
+                    SteamEngines[numberofengine].IndicatedHorsePowerHP = (N.ToLbf(SteamEngines[numberofengine].RealTractiveForceN) * pS.TopH(Me.ToMi(AbsTractionSpeedMpS))) / 375.0f;
                 }
 
                 // Calculate the elapse time for the steam performance monitoring
@@ -6477,17 +6491,17 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
                 }
 
                 // On starting allow maximum motive force to be used, unless gear is in neutral (normally only geared locomotive will be zero). Decrease force if steam pressure is not at maximum
-                if (absSpeedMpS < 1.0f && cutoff > 0.70f && locomotivethrottle > 0.98f && MotiveForceGearRatio != 0)
+                if (AbsTractionSpeedMpS < 1.0f && cutoff > 0.70f && locomotivethrottle > 0.98f && MotiveForceGearRatio != 0)
                 {
                     SteamEngines[numberofengine].RealTractiveForceN = MaxForceN * (BoilerPressurePSI / MaxBoilerPressurePSI);
                 }
 
-                if (absSpeedMpS == 0 && cutoff < 0.05f) // If the reverser is set too low then not sufficient steam is admitted to the steam cylinders, and hence insufficient Motive Force will produced to move the train.
+                if (AbsTractionSpeedMpS == 0 && cutoff < 0.05f) // If the reverser is set too low then not sufficient steam is admitted to the steam cylinders, and hence insufficient Motive Force will produced to move the train.
                     SteamEngines[numberofengine].RealTractiveForceN = 0;
 
                 WheelSlip = false;
                 WheelSpeedMpS = SpeedMpS;
-                WheelSpeedSlipMpS = SpeedMpS;
+                DriveWheelSpeedMpS = SpeedMpS;
             }
 
             #endregion
@@ -6505,7 +6519,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
 
             if (SteamEngines[numberofengine].IndicatedHorsePowerHP >= SteamEngines[numberofengine].MaxIndicatedHorsePowerHP)
             {
-                SteamEngines[numberofengine].RealTractiveForceN = N.FromLbf((SteamEngines[numberofengine].MaxIndicatedHorsePowerHP * 375.0f) / pS.TopH(Me.ToMi(SpeedMpS)));
+                SteamEngines[numberofengine].RealTractiveForceN = N.FromLbf((SteamEngines[numberofengine].MaxIndicatedHorsePowerHP * 375.0f) / pS.TopH(Me.ToMi(Math.Abs((float)SteamEngines[numberofengine].AttachedAxle.AxleSpeedMpS))));
                 SteamEngines[numberofengine].IndicatedHorsePowerHP = SteamEngines[numberofengine].MaxIndicatedHorsePowerHP; // Set IHP to maximum value
                 IsCritTELimit = true; // Flag if limiting TE
             }
@@ -6533,15 +6547,11 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             MaxForceN = 0;
             DisplayTractiveForceN = 0;
 
+            // Ensure traction calculations for steam locomotives use the driver wheel speed, not the idler wheel speed
+            // Idler wheels don't slip from excessive tractive effort, drivers do, we want to account for slipping wheels
+            // Note: On geared steam locos, DriveWheelSpeed is the same as WheelSpeed
             PrevAbsTractionSpeedMpS = AbsTractionSpeedMpS;
-            if (WheelSlip && AdvancedAdhesionModel)
-            {
-                AbsTractionSpeedMpS = AbsWheelSpeedMpS;
-            }
-            else
-            {
-                AbsTractionSpeedMpS = AbsSpeedMpS;
-            }
+            AbsTractionSpeedMpS = Math.Abs(DriveWheelSpeedMpS);
 
             // Update tractive effort across all steam engines
             for (int i = 0; i < SteamEngines.Count; i++)
@@ -6582,7 +6592,7 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             }
 
             // Find the maximum TE for debug i.e. @ start and full throttle
-            if (absSpeedMpS < 1.0)
+            if (AbsTractionSpeedMpS < 1.0)
             {
                 if (Math.Abs(TractiveForceN) > absStartTractiveEffortN && Math.Abs(TractiveForceN) < MaxForceN)
                 {
@@ -6830,10 +6840,13 @@ public readonly SmoothedData StackSteamVelocityMpS = new SmoothedData(2);
             // This enables steam locomotives to have different speeds for driven and non-driven wheels.
             if (SteamEngineType != MSTSSteamLocomotive.SteamEngineTypes.Geared)
             {
-                WheelSpeedSlipMpS = (float)LocomotiveAxles[0].AxleSpeedMpS;
+                DriveWheelSpeedMpS = (float)LocomotiveAxles[0].AxleSpeedMpS;
                 WheelSpeedMpS = SpeedMpS;
             }
-            else WheelSpeedMpS = (float)LocomotiveAxles[0].AxleSpeedMpS;
+            else
+            {
+                DriveWheelSpeedMpS = WheelSpeedMpS = (float)LocomotiveAxles[0].AxleSpeedMpS;
+            }
 
         }
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -168,7 +168,7 @@ namespace Orts.Simulation.RollingStocks
         public float Curtius_KnifflerC = 0.161f;             //                                      speedMpS * 3.6 + B
         public float AdhesionK = 0.7f;   //slip characteristics slope
         public float AxleInertiaKgm2;    //axle inertia
-        public float WheelSpeedSlipMpS; // speed of wheel if locomotive is slipping
+        public float DriveWheelSpeedMpS; // wheel speed of steam loco drive wheels, allowing for drive wheels to spin different from idle wheels
         public float SlipWarningThresholdPercent = 70;
         public MSTSNotchController WeightLoadController; // Used to control freight loading in freight cars
 

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -1773,7 +1773,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                                 }
                                 else
                                 {
-                                    var dynforce = loco.DynamicBrakeForceCurves.Get(1.0f, loco.AbsSpeedMpS);
+                                    var dynforce = loco.DynamicBrakeForceCurves.Get(1.0f, loco.AbsTractionSpeedMpS);
                                     if ((loco.MaxDynamicBrakeForceN == 0 && dynforce > 0) || dynforce > loco.MaxDynamicBrakeForceN * 0.6)
                                     {
                                         demandedPressurePSI = 0;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
@@ -1391,7 +1391,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
             {
                 if (LoadPercent != 0)
                 {
-                    CurrentDieselOutputPowerW = GearBox.TractiveForceN * Locomotive.AbsSpeedMpS * 100.0f / LoadPercent;
+                    CurrentDieselOutputPowerW = GearBox.TractiveForceN * Locomotive.AbsTractionSpeedMpS * 100.0f / LoadPercent;
 
                     if (Locomotive.DieselEngines.NumOfActiveEngines > 0)
                     {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
@@ -1292,8 +1292,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                 var wheelRadiusMM = Axle.WheelRadiusM * 1000;
                 var wheelDistanceGaugeMM = Axle.WheelDistanceGaugeM * 1000;
                 var GNm2 = 8.40E+10;
-                wheelLoadN = Axle.AxleWeightN / (Axle.NumWheelsetAxles * 2); // Assume two wheels per axle, and thus wheel weight will be have the value - multiple axles????
-                var wheelLoadkN = Axle.AxleWeightN / (Axle.NumWheelsetAxles * 2 * 1000); // Assume two wheels per axle, and thus wheel weight will be have the value - multiple axles????
+                // Prevent wheel load from going negative, negative wheel load would indicate wheel has lifted off rail which otherwise leads to NaN errors
+                wheelLoadN = Math.Max(Axle.AxleWeightN / (Axle.NumWheelsetAxles * 2), 0.1); // Assume two wheels per axle, and thus wheel weight will be have the value - multiple axles????
+                var wheelLoadkN = wheelLoadN / 1000;
                 var Young_ModulusMPa = 207000;
 
                 // Calculate Hertzian values - assume 2b = 12mm.

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/GearBox.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/GearBox.cs
@@ -461,10 +461,7 @@ public Gear NextGear
         {
             get
             {
-                if(DieselEngine.Locomotive.Direction == Direction.Reverse)
-                    return -(DieselEngine.Locomotive.SpeedMpS);
-                else
-                    return (DieselEngine.Locomotive.SpeedMpS);
+                return DieselEngine.Locomotive.AbsTractionSpeedMpS;
             }
         }
 
@@ -512,7 +509,7 @@ public Gear NextGear
                         {
                             const float perSectoPerMin = 60;
                             var driveWheelCircumferenceM = 2 * Math.PI * Locomotive.DriverWheelRadiusM;
-                            var driveWheelRpm = Locomotive.AbsSpeedMpS * perSectoPerMin / driveWheelCircumferenceM;
+                            var driveWheelRpm = Locomotive.AbsTractionSpeedMpS * perSectoPerMin / driveWheelCircumferenceM;
                             var shaftRPM = driveWheelRpm * CurrentGear.Ratio;
                             return (float)(shaftRPM);
                         }
@@ -941,7 +938,7 @@ public Gear NextGear
                 switch (GearBoxOperation)
                 {
                     case GearBoxOperation.Manual:
-                        if (DieselEngine.Locomotive.ThrottlePercent == 0 && Locomotive.AbsSpeedMpS == 0)
+                        if (DieselEngine.Locomotive.ThrottlePercent == 0 && Locomotive.AbsTractionSpeedMpS == 0)
                         {
                             clutchOn = false;
                             ClutchPercent = 0f;

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -223,13 +223,13 @@ namespace Orts.Viewer3D.Popups
                 if (locoE != null)
                 {
                     LocomotiveGraphsInputPower.AddSample(loco.ThrottlePercent * 0.01f);
-                    LocomotiveGraphsOutputPower.AddSample((loco.MotiveForceN / loco.MaxPowerW) * loco.SpeedMpS);
+                    LocomotiveGraphsOutputPower.AddSample((Math.Abs(loco.MotiveForceN) / loco.MaxPowerW) * loco.AbsTractionSpeedMpS);
                 }
                 //TODO: plot correct values
                 if (locoS != null)
                 {
                     LocomotiveGraphsInputPower.AddSample(loco.ThrottlePercent * 0.01f);
-                    LocomotiveGraphsOutputPower.AddSample((loco.MotiveForceN / loco.MaxPowerW) * loco.SpeedMpS);
+                    LocomotiveGraphsOutputPower.AddSample((Math.Abs(loco.MotiveForceN) / loco.MaxPowerW) * loco.AbsTractionSpeedMpS);
                 }
 
                 LocomotiveGraphs.PrepareFrame(frame);


### PR DESCRIPTION
After years of development, parts of OR have become quite crowded between different types of train speed (is this the speed of the wheels? the true speed relative to the ground? is it the absolute value of speed? or is it negative in reverse and positive forwards?) This has led to a variety of issues like locomotives exceeding their power rating, wheels spinning impossibly fast during wheelslip, wheelslip being too difficult to recover from, and so on.

I talked about this problem 4 years ago in [this Elvas Tower thread](https://www.elvastower.com/forums/index.php?/topic/34909-dubious-traction-calculations-during-wheelslip) but it was only ever partially solved.
Formal bug report can be found [here](https://bugs.launchpad.net/or/+bug/2112223).

This PR refactors all that under one guiding principle: **anything that applies force to the wheels should always use the wheel speed**. Intuitively, this makes sense, but this also makes sense from a conservation of energy perspective. The transmission of a locomotive does not 'know' the ground speed (except if an advanced wheel slip protection system is present, but that does not change the laws of physics), so the best a locomotive transmission can do is output a certain amount of energy to the motors/gearbox/pistons and then hope for the best. The current implementation allows for the transmission to output a certain amount of energy to the _rails_ in some cases, and then the motor/gearbox/piston energy is adjusted accordingly...which can result in the motor/gearbox/piston power exceeding the power available from the wire/engine/boiler, _breaking conservation of energy_ (this generally occurs during wheel slip).

As an example of breaking the laws of physics, let's assume a locomotive has a dynamic brake table that produces 60,000 pounds of dynamic brake force at 25 mph, but, "oh no!", even though the locomotive is currently moving at 25 mph, the wheels are skidding due to poor adhesion and are actually moving at only 5 mph. Before this PR, the dynamic brake force would still be 60,000 pounds at 5 mph wheel speed because dynamic brake force used the ground speed, not the wheel speed. This 60,000 pound force continues to decelerate the wheels, eventually causing the wheels to start turning in the _opposite direction_. Before long, the wheels are spinning at -50 mph in dynamic braking (giving a wheel power of 8,000 hp, when our dynamic brakes should only be capable of 4,000 hp, breaking conservation of energy) despite the locomotive moving at 25 mph, which _(hopefully)_ is obviously nonsensical. After this PR, the wheel speed would determine the dynamic brake force, so the wheels spinning at 5 mph would only be given a dynamic brake force of say 12,000 pounds (assuming the dynamic brake curve linearly drops to 0 pounds at 0 mph), which would not be enough to spin the wheels in the opposite direction, producing more accurate response during wheel skid.

### Expected results of this PR are:
- Locomotives should behave the same as usual when negligible wheel creep is present. (Wheel creep will affect traction calculations now, but as wheel creep is usually less than 1 mph this effect is unnoticeable.)
- Wheelslip during traction for all locomotive types should lead to the wheels slipping at a more reasonable pace (ie: wheel slip shouldn't exceed the locomotive max speed) and should be easier to correct.
- Wheelskid during dynamic braking for all locomotive types should no longer lead to wheels turning the opposite direction (in the worst case, the wheels should almost come to a halt in the direction of travel) and should be easier to correct.
- The transition between nominal adhesion and wheel slip/skid should be smoother and more stable.

Note that the changes here ended up concentrated on steam locomotives, there's a lot going on there that I don't understand/might not be correct, but my goal here was simply to use wheel speed for steam locomotive physics while preventing physics explosions during wheel slip. Multiple parts of steam locomotive code appeared to have been built with the assumption that steam locomotive physics were being driven at the locomotive ground speed, even when wheel slipping (this leads to nonsensical situations like the cylinders consuming steam as if you are moving 5 mph while the cylinders and wheels are actually going crazy at 50 mph), so some subtle tweaking was required to disable those assumptions but I believe I've avoided potential program crashes and made steam locomotive wheelslip sensible, predictable, and correctable.
(I think [this trello card](https://trello.com/c/fB4pRnMt) was created in response to this problem on steam locomotives.)

I've tested out all sorts of rolling stock, but I recommend simply trying a bit of everything in situations where wheelslip is likely and checking to make sure wheelslip doesn't lead to nonsensical situations, such as spinning the wheel speed above the maximum speed of the locomotive.

I consider this PR a prerequisite to some of the other work I want to do, particularly electric motor simulation, that would behave suboptimally with the current implementation's use of ground speed for traction calculations.