### PR TITLE
Fix Stuck Locomotive Brakes After Initialization

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -594,10 +594,38 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
 
         public override void Initialize(bool handbrakeOn, float maxPressurePSI, float fullServPressurePSI, bool immediateRelease)
         {
+            MSTSLocomotive loco = Car as MSTSLocomotive;
+
             BrakeLine1PressurePSI = Car.Train.EqualReservoirPressurePSIorInHg;
             BrakeLine2PressurePSI = Car.Train.BrakeLine2PressurePSI;
-            if (Car is MSTSLocomotive && Car.Train.LeadLocomotive is MSTSLocomotive lead)
-                lead.EngineBrakeController?.UpdateEngineBrakePressure(ref BrakeLine3PressurePSI, 1000);
+            // Initialize locomotive brakes
+            if (loco != null && Car.Train.LeadLocomotive is MSTSLocomotive lead)
+            {
+                bool brakeLine3Init = false;
+
+                if (loco == lead) // Always initialize loco brakes on lead loco
+                    brakeLine3Init = true;
+                else
+                {
+                    foreach (List<TrainCar> group in Car.Train.LocoGroups)
+                    {
+                        if (group.Contains(loco))
+                        {
+                            if (group.Contains(lead))
+                                brakeLine3Init = true; // Always initialize loco brakes on locos in same group as lead loco
+                            else if (loco.DPSyncIndependent && lead.DPSyncIndependent)
+                                brakeLine3Init = true; // Otherwise, only initialize loco brakes if synchronized by DP system
+
+                            break;
+                        }
+                    }
+                }
+
+                if (brakeLine3Init) // Sync loco brakes with lead brake system
+                    lead.EngineBrakeController?.UpdateEngineBrakePressure(ref BrakeLine3PressurePSI, 1000);
+                else // Release loco brakes
+                    BrakeLine3PressurePSI = 0.0f;
+            }
             if (maxPressurePSI > 0)
                 ControlResPressurePSI = maxPressurePSI;
 
@@ -623,7 +651,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
             IsolationValve = ValveState.Release;
             HandbrakePercent = handbrakeOn & HandBrakePresent ? 100 : 0;
             SetRetainer(RetainerSetting.Exhaust);
-            if (Car is MSTSLocomotive loco) 
+            if (loco != null) 
                 loco.MainResPressurePSI = loco.MaxMainResPressurePSI;
 
             // Prevent initialization triggering emergency vent valves

--- a/Source/RunActivity/Viewer3D/Popups/MessagesWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/MessagesWindow.cs
@@ -139,7 +139,8 @@ namespace Orts.Viewer3D.Popups
             }
 
             foreach (var message in Messages)
-                message.LabelShadow.Color.A = message.LabelText.Color.A = (byte)MathHelper.Lerp(255, 0, MathHelper.Clamp((float)((Owner.Viewer.Simulator.GameTime - message.EndTime) / FadeTime), 0, 1));
+                if (message.LabelShadow != null && message.LabelText != null) // It seems LabelShadow and LabelText aren't guaranteed to be initialized, causing rare crashes
+                    message.LabelShadow.Color.A = message.LabelText.Color.A = (byte)MathHelper.Lerp(255, 0, MathHelper.Clamp((float)((Owner.Viewer.RealTime - message.EndTime) / FadeTime), 0, 1));
         }
 
         class Message
@@ -184,7 +185,7 @@ namespace Orts.Viewer3D.Popups
         public void AddMessage(string key, string text, double duration)
         {
             var clockTime = Owner.Viewer.Simulator.ClockTime;
-            var gameTime = Owner.Viewer.Simulator.GameTime;
+            var realTime = Owner.Viewer.RealTime;
             while (true)
             {
                 // Store the original list and make a clone for replacing it thread-safely.
@@ -196,18 +197,18 @@ namespace Orts.Viewer3D.Popups
 
                 // Clean out any existing duplicate key and expired messages.
                 newMessages = (from m in newMessages
-                               where (String.IsNullOrEmpty(key) || m.Key != key) && m.EndTime + FadeTime > Owner.Viewer.Simulator.GameTime
+                               where (String.IsNullOrEmpty(key) || m.Key != key) && m.EndTime + FadeTime > realTime
                                select m).ToList();
 
                 // Add the new message.
-                newMessages.Add(new Message(key, String.Format("{0} {1}", FormatStrings.FormatTime(clockTime), text), existingMessage != null ? existingMessage.StartTime : gameTime, gameTime + duration));
+                newMessages.Add(new Message(key, String.Format("{0} {1}", FormatStrings.FormatTime(clockTime), text), existingMessage != null ? existingMessage.StartTime : realTime, realTime + duration));
 
                 // Sort the messages.
                 newMessages = (from m in newMessages
                                orderby m.StartTime descending
                                select m).ToList();
 
-                // Thread-safely switch from the old list to the new list; we've only suceeded if the previous (return) value is the old list.
+                // Thread-safely switch from the old list to the new list; we've only succeeded if the previous (return) value is the old list.
                 if (Interlocked.CompareExchange(ref Messages, newMessages, oldMessages) == oldMessages)
                     break;
             }


### PR DESCRIPTION
Another quick fix for the next version, a nagging issue left in the wake of #916 and #997 is that locomotives not connected to the lead locomotive would get their locomotive brakes stuck on during initialization if the lead locomotive was initialized with the locomotive brakes applied if the locomotive brake was not synchronized by the distributed power system. This is because the locomotive brake would be initialized as if all locomotives were synchronized with the lead locomotive, but once initialized the trailing locomotive would ignore locomotive brake commands, resulting in stuck brakes (until re-initializing with the locomotive brake released).

Now, the locomotive brake won't be applied during initialization on any locomotives not connected to the lead locomotive unless independent brake sync is active. The locomotive may still develop brake cylinder pressure if the train brake is applied, but the train brake won't be stuck applied unlike the locomotive brake.

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)