### PR TITLE
Fix Erroneous Detection of Departure Before Passenger Boarding Completed

### DIFF
--- a/Source/Orts.Simulation/Simulation/Activity.cs
+++ b/Source/Orts.Simulation/Simulation/Activity.cs
@@ -884,6 +884,8 @@ namespace Orts.Simulation
                         double sinceActArriveS = (new DateTime().Add(TimeSpan.FromSeconds(Simulator.ClockTime))
                                                 - ActArrive).Value.TotalSeconds;
                         BoardingEndS -= sinceActArriveS;
+
+                        ldbfevaldepartbeforeboarding = false; // reset flag. Debrief Eval
                     }
                     else
                     {
@@ -900,29 +902,30 @@ namespace Orts.Simulation
                         if (BoardingS > 0 || ((double)(SchDepart - SchArrive).TotalSeconds > 0 &&
                             MyPlayerTrain.PassengerCarsNumber == 1 && MyPlayerTrain.Cars.Count > 10 ))
                         {
-                        // accepted station stop because either freight train or passenger train or fake passenger train with passenger car on platform or fake passenger train
+                            // accepted station stop because either freight train or passenger train or fake passenger train with passenger car on platform or fake passenger train
                             // with Scheduled Depart > Scheduled Arrive
-                                // ActArrive is usually same as ClockTime
-                                BoardingEndS = Simulator.ClockTime + BoardingS;
+                            // ActArrive is usually same as ClockTime
+                            BoardingEndS = Simulator.ClockTime + BoardingS;
 
-                                if (ActArrive == null)
-                                {
-                                    ActArrive = new DateTime().Add(TimeSpan.FromSeconds(Simulator.ClockTime));
-                                }
-
-                                arrived = true;
-                                // But not if game starts after scheduled arrival. In which case actual arrival is assumed to be same as schedule arrival.
-                                double sinceActArriveS = (new DateTime().Add(TimeSpan.FromSeconds(Simulator.ClockTime))
-                                                        - ActArrive).Value.TotalSeconds;
-                                BoardingEndS -= sinceActArriveS;
-                                double SchDepartS = SchDepart.Subtract(new DateTime()).TotalSeconds;
-                                BoardingEndS = CompareTimes.LatestTime((int)SchDepartS, (int)BoardingEndS);
-
+                            if (ActArrive == null)
+                            {
+                                ActArrive = new DateTime().Add(TimeSpan.FromSeconds(Simulator.ClockTime));
                             }
+
+                            arrived = true;
+                            // But not if game starts after scheduled arrival. In which case actual arrival is assumed to be same as schedule arrival.
+                            double sinceActArriveS = (new DateTime().Add(TimeSpan.FromSeconds(Simulator.ClockTime))
+                                                    - ActArrive).Value.TotalSeconds;
+                            BoardingEndS -= sinceActArriveS;
+                            double SchDepartS = SchDepart.Subtract(new DateTime()).TotalSeconds;
+                            BoardingEndS = CompareTimes.LatestTime((int)SchDepartS, (int)BoardingEndS);
+
                         }
+
+                        ldbfevaldepartbeforeboarding = false; // reset flag. Debrief Eval
+                    }
                     if  (MyPlayerTrain.NextSignalObject[0] != null)
                            distanceToNextSignal =  MyPlayerTrain.NextSignalObject[0].DistanceTo(MyPlayerTrain.FrontTDBTraveller);
-
                 }
             }
             else if (EventType == ActivityEventType.TrainStart)
@@ -936,6 +939,15 @@ namespace Orts.Simulation
                     IsCompleted = maydepart;
                     if (MyPlayerTrain.TrainType != Train.TRAINTYPE.AI_PLAYERHOSTING)
                        MyPlayerTrain.ClearStation(PlatformEnd1.LinkedPlatformItemId, PlatformEnd2.LinkedPlatformItemId, true);
+
+                    // Debrief Eval: departure before boarding completed
+                    if (!maydepart && !ldbfevaldepartbeforeboarding)
+                    {
+                        var train = Simulator.PlayerLocomotive.Train;
+                        ldbfevaldepartbeforeboarding = true;
+                        DbfEvalDepartBeforeBoarding.Add(PlatformEnd1.Station);
+                        train.DbfEvalValueChanged = true;
+                    }
 
                     if (LogStationStops)
                     {
@@ -981,15 +993,6 @@ namespace Orts.Simulation
                     {
                         DisplayMessage = Simulator.Catalog.GetStringFmt("Passenger boarding completes in {0:D2}:{1:D2}",
                             remaining / 60, remaining % 60);
-
-                        //Debrief Eval
-                        if (Simulator.PlayerLocomotive.SpeedMpS > 0 && !ldbfevaldepartbeforeboarding)
-                        {
-                            var train = Simulator.PlayerLocomotive.Train;
-                            ldbfevaldepartbeforeboarding = true;
-                            DbfEvalDepartBeforeBoarding.Add(PlatformEnd1.Station);
-                            train.DbfEvalValueChanged = true;
-                        }
                     }
                     // May depart
                     else if (!maydepart)
@@ -1007,8 +1010,6 @@ namespace Orts.Simulation
                             DisplayMessage = Simulator.Catalog.GetString("Passenger boarding completed. You may depart now.");
                             if (MyPlayerTrain.IsActualPlayerTrain) Simulator.SoundNotify = Event.PermissionToDepart;
                         }
-
-                        ldbfevaldepartbeforeboarding = false;//reset flag. Debrief Eval
 
                         // if last task, show closure window
                         // also set times in logfile


### PR DESCRIPTION
I have consistently noticed that every single passenger stop I make gets flagged for departure before passenger boarding completed. It seems this is down to an oversight between the original implementation of debrief evaluations and a subsequent bugfix to change the detection of a "stopped" train from having exactly 0 speed to having a speed less than 0.2 meters per second.

The detection of departure before boarding completed was _not_ changed to respect that 0.2 m/s counted as "stopped", instead checking for exactly 0 speed. This would cause departure before boarding completed to be triggered at every stop in the few frames that the train was decelerating from 0.2 m/s to 0 m/s.

The fix here is to simply move the check for departure before boarding completed from the Timer event to the TrainStart event. TrainStart only occurs when the train accelerates from less than 0.2 m/s to more than 0.2 m/s, which will prevent false detection of early departure when decelerating.

To check functionality, make sure that departure before passenger boarding completed only triggers when moving away from a station stop before you are cleared to depart, and is not triggered as the train comes to a stop.

(Note that a few lines of this diff are me changing the indentation of some lines that weren't quite right.)

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)