### PR TITLE
Fix Activity Runner persists after loading exception

### DIFF
--- a/Source/RunActivity/Viewer3D/Processes/WebServerProcess.cs
+++ b/Source/RunActivity/Viewer3D/Processes/WebServerProcess.cs
@@ -43,6 +43,15 @@ namespace Orts.Viewer3D.Processes
         {
             Game = game;
             Thread = new Thread(WebServerThread);
+
+            // Once the content has been loaded and the simulator is simulating, an exception will cause the web server process
+            // to terminate itself.
+            // However, an exception during loading will not terminate the web server process, so the application Open Rails Activity Runner
+            // will persist until it is removed by the user.
+            // A workaround to avoid this behaviour is to push the thread into the background.
+
+            // This thread is pushed into the background, so it will be terminated automatically when the main thread exits.
+            Thread.IsBackground = true;
         }
 
         public void Start()


### PR DESCRIPTION
Fix for problem reported in the private Project Team forum at [https://www.elvastower.com/forums/index.php?/topic/36794-ormt-sessions/page__view__findpost__p__317666](https://www.elvastower.com/forums/index.php?/topic/36794-ormt-sessions/page__view__findpost__p__317666)

"_Something that's been bugging me for probably over a year at this point is that the activity runner does not terminate properly after (most?) crashes. The window disappears, but the process is still there in the background and the menu does not re-open, and the only way to get back to normal is to manually terminate the process with task manager._"

Tests show that the problem appears always and only when an exception is raised while content is being loaded. Once the simulation begins, an exception will close the application cleanly.

It is the thread for the Web Server process that is persisting and that is handled in a different way from the other process threads.

In the absence of a better solution, this fix pushes the thread into the background. This means it behaves just as the other foreground thread but is automatically terminated when the application exits.

Fixes https://bugs.launchpad.net/or/+bug/2065814