### PR TITLE
update for V1.6

### DIFF
--- a/Source/Installer/Installer.iss
+++ b/Source/Installer/Installer.iss
@@ -20,7 +20,7 @@
 
 #define DotNETName "Microsoft .NET Framework 4.7.2"
 
-#define MyAppURL "http://openrails.org" ; Not yet HTTPS
+#define MyAppURL "https://openrails.org"
 #define MyAppSourceURL "http://openrails.org/download/source/"
 #define MyAppSupportURL "https://launchpad.net/or"
 
@@ -31,7 +31,7 @@
 #define MyAppDocPath "..\..\Program\Documentation"
 
 #define NetRedistPath "..\..\.NET Framework 4.7.2 web installer"
-#define NetRedist "NDP472-KB4054531-Web.exe"
+#define NetRedist "ndp472-kb4054531-web.exe" ; Has to be lower-case to match download
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
@@ -50,20 +50,26 @@ DefaultDirName  ={commonpf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 AllowNoIcons    =yes
 LicenseFile     ={#MyAppProgPath}\Copying.txt
-InfoBeforeFile   ={#MyAppProgPath}\Prerequisites.txt
+InfoBeforeFile  ={#MyAppProgPath}\Prerequisites.txt
 InfoAfterFile   ={#MyAppProgPath}\Readme.txt
 
-; Remove the following line to run in administrative install mode (install for all users.)
-; PrivilegesRequired=lowest ; Cannot create the directory C:\Program Files\Open Rails
+; Prompt for a destination folder
+DisableDirPage  =no
+; 32-bit is the default, installing in "Program Files (x86)" on 64-bit Windows. "x64compatible" uses Program Files on 64-bit Windows
+ArchitecturesInstallIn64BitMode =x64compatible
+
+; Default is admin install mode.
+; Comment in the following line to run in non-administrative install mode, but that cannot create the directory C:\Program Files\Open Rails
+; PrivilegesRequired=lowest
 
 Compression     =lzma
 SolidCompression=yes
-WizardStyle=modern
+WizardStyle     =modern
 Uninstallable   =yes
-UninstallDisplayIcon={app}\{#MyAppExeName}
-OutputBaseFilename=OpenRailsSetup
+UninstallDisplayIcon ={app}\{#MyAppExeName}
+OutputBaseFilename =OpenRailsSetup
 
-; Windows 7 SP1
+; Windows 7 SP1 Correct value, so ignore final warning message from Build > Compile
 MinVersion      =6.1sp1
 
 [Languages]
@@ -79,7 +85,7 @@ Name: "finnish"; MessagesFile: "compiler:Languages\Finnish.isl"
 Name: "french"; MessagesFile: "compiler:Languages\French.isl"
 Name: "german"; MessagesFile: "compiler:Languages\German.isl"
 Name: "hebrew"; MessagesFile: "compiler:Languages\Hebrew.isl"
-Name: "icelandic"; MessagesFile: "compiler:Languages\Icelandic.isl"
+;Name: "icelandic"; MessagesFile: "compiler:Languages\Icelandic.isl"
 Name: "italian"; MessagesFile: "compiler:Languages\Italian.isl"
 Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "norwegian"; MessagesFile: "compiler:Languages\Norwegian.isl"

--- a/Source/Installer/Using the installer scripts.txt
+++ b/Source/Installer/Using the installer scripts.txt
@@ -1,8 +1,11 @@
 Using the installer scripts.txt
-Last updated: 2022-08-21 by Chris Jakeman
+Last updated: 2025-06-21 by Chris Jakeman
 
-1. If you wish to update the version name from "1.5", then edit the line
-     #define MyAppVersion "1.5"
+Compiling the scripts and data files on your own PC and testing them there or on a virtual machine
+==================================================================================================
+
+1. If you wish to update the version name from "1.6", then edit the line
+     #define MyAppVersion "1.6"
 	 in the file 
    Source\Installer\Version.iss
      and update the Release number and date in:
@@ -10,10 +13,12 @@ Last updated: 2022-08-21 by Chris Jakeman
      and in
    Source\RunActivity\Prerequisites.txt
    
+   The text in these documents is shown by the Installer to the user, so check this is still up to date.
+   
 2. Download and install Inno Setup from http://www.jrsoftware.org/isdl.php
-Initial trials (Apr 2014) used v5.5.4. Open Rails v1.5 uses 6.1.2
+Initial trials (Apr 2014) used v5.5.4. Open Rails v1.6 uses 6.4.3
 
-3. Download Microsoft .NET Framework 4.7.2 web installer for Windows from:
+3. Download Microsoft .NET Framework 4.7.2 web installer package for Windows from:
     https://support.microsoft.com/en-us/topic/microsoft-net-framework-4-7-2-web-installer-for-windows-dda5cddc-b85e-545d-8d4a-d213349b7775
    and save in
   <A>\.NET Framework 4.7.2 web installer\ndp472-kb4054531-web.exe
@@ -23,28 +28,31 @@ Initial trials (Apr 2014) used v5.5.4. Open Rails v1.5 uses 6.1.2
    From Source\Installer, copy OpenRails.iss and Version.iss into <A>\Temp\Installer
   
 5. Repeat the following as often as required:
-  A. Download OR zip file from https://github.com/openrails/openrails/releases, choose the latest (i.e. pre-release) version, open the Assets concertina and pick OpenRails-Stable.zip
+  A. Download OR zip file from https://github.com/openrails/openrails/releases, choose the latest (i.e. pre-release) version, open the Assets concertina and pick Open Rails <version>.zip where <version> is something like "1.6-rc2"
 
   B. Unzip into folder 
-    <A>\Open Rails\Program\
+    <A>\Program\
 
   C. Remove 
-    <A>\Open Rails\Program\Updater.ini 
+    <A>\Program\Updater.ini 
   as James Ross advises because the updater cannot update an installed version yet.
 
-  D. Download source from https://github.com/openrails/openrails/releases, choose the latest (i.e. pre-release) version, open the Assets concertina and pick Source code (openrails-1.5-rc1.zip) and extract the folder Source\Documentation.
+  D. Download source from https://github.com/openrails/openrails/releases, choose the latest (i.e. pre-release) version, open the Assets concertina and pick Source code Open Rails <version> Source.zip where <version> is something like "1.6-rc2" and extract the folder Source\Documentation.
 
   E. Copy contents into folder
-    <A>\Open Rails\Program\Documentation\
+    <A>\Program\Documentation\
+	
+  F. If you made changes to Source\RunActivity\Readme.txt or Source\RunActivity\Prerequisites.txt in Step 1, then
+  copy them to <A>\Program\ to overwrite the downloaded files.
 
-  F. Use Inno Setup > Build > Compile to compile the installer script
+  G. Use Inno Setup Compiler > Build > Compile to compile the installer script
     <A>\Temp\Installer\Installer.iss
 	and generate the Open Rails Installer
   
-  G. The generated file will be found in <A>\Temp\Installer\Output\OpenRailsSetup.exe
+  H. The generated file will be found in <A>\Temp\Installer\Output\OpenRailsSetup.exe
  
 6. Test the installer by building Virtual Machines with a fresh copy of Windows.
-Open Rails v1.5 is compatible with Windows from 7 (SP1) to 11 and, hopefully, beyond.
+Open Rails v1.6 is compatible with Windows from 7 (SP1) to 11 and, hopefully, beyond.
 
 Arrange for the VM to have Internet access and a shared folder.
 Copy OpenRailsSetup.exe to the shared folder.

--- a/Source/Installer/Version.iss
+++ b/Source/Installer/Version.iss
@@ -1,1 +1,1 @@
-#define MyAppVersion "none"
+#define MyAppVersion "1.6"

--- a/Source/RunActivity/Prerequisites.txt
+++ b/Source/RunActivity/Prerequisites.txt
@@ -1,7 +1,6 @@
-﻿Open Rails software Prerequisites.txt - Release v1.5
-September 2022
+﻿Open Rails software Prerequisites.txt - Release v1.6 June 2025
 
-Visit our web-page at http://openrails.org for details and links.
+Visit our web-page at https://openrails.org for details and links.
 
 Please note the distribution and use of Open Rails software is governed by the GNU License - see file Copying.txt. 
 Source code can be downloaded from https://github.com/openrails/openrails

--- a/Source/RunActivity/Readme.txt
+++ b/Source/RunActivity/Readme.txt
@@ -1,29 +1,23 @@
-﻿Open Rails software Readme.txt - Release v1.5
-September 2022
+﻿Open Rails software Readme.txt - Release v1.6 - June 2025
 
-Visit our web-page at http://openrails.org for details and links.
+Visit our web-page at https://openrails.org for details and links.
 
-Please note the distribution and use of Open Rails software is governed by the GNU License - see file Copying.txt. 
-Source code can be downloaded from https://github.com/openrails/openrails
+Please note the distribution and use of Open Rails software is governed by the GNU License - see file Copying.txt. Source code can be downloaded from https://github.com/openrails/openrails
 
 OPERATION
-- You can run Open Rails by clicking on the Desktop icon or the Quick Launch icon or the Start Menu entry or C:\Program Files (x86)\Open Rails\OpenRails.exe
+- You can run Open Rails by clicking on the Desktop icon or the Quick Launch icon or the Start Menu entry or C:\Program Files\Open Rails\OpenRails.exe
 - Help and Game Controls are available in-game using the Help key (F1).
 - Please read the operations manual in Open Rails > Documents > Manual.pdf
 
 CONTENT
 This Open Rails download does not include any content - no routes, trains, activities - just the simulation program. 
 
-If you have content suitable for Open Rails or Microsoft Train Simulator already in place, then you can use the
-Open Rails program to operate those routes and drive those trains straight away.
+If you have content suitable for Open Rails or Microsoft Train Simulator already in place, then you can use the Open Rails program to operate those routes and drive those trains straight away. If not, then you will need to install some models bought from a vendor or free from the community before you can use Open Rails.
 
-If not, then you will need to install some models bought from a vendor or free from the community before you can use Open Rails.
-
-Or you can try out the 2 self-installing models on our home page - both free of charge.
+Use the Content button for some auto-install routes or visit the catalogue at www.openrails.org/download/explore-content
 
 SUPPORT
 Please send bug reports and feature requests to our Bug Tracker at https://launchpad.net/or
 
 UPDATES
-Open Rails checks once a day for new versions and, if found, adds an Update link in the top right of its main menu. 
-Click this Update link to download and update your Open Rails.
+Open Rails checks once a day for new versions and, if found, adds a red marker to the notification icon in the top right of the menu form. Click on the notification to find the details of an update and install it.


### PR DESCRIPTION
Adds settings to Installer to work with 64-bit Windows and prompt for destination folder. Also updates instructions to users to match new mechanisms for updating OR and installing content.

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)