### PR TITLE
Fix color of DB in DrivingInfo when in setup with DPU fenced. (r1.6)

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
@@ -771,7 +771,7 @@ namespace Orts.Viewer3D.Popups
                 {
                     FirstCol = Viewer.Catalog.GetString(locomotive is MSTSSteamLocomotive ? "Regulator" : "Throttle"),
                     LastCol = $"{Round(locomotive.ThrottlePercent)}%" +
-                    (locomotive is MSTSDieselLocomotive && train.DPMode == 1 ? $"({Round(train.DPThrottlePercent)}%)" : ""),
+                        (locomotive is MSTSDieselLocomotive && train.DPMode == 1 ? $" | {Round(train.DPThrottlePercent)}%" : ""),
                     KeyPressed = throttleKey,
                     SymbolCol = ""//throttleKey,
                 });
@@ -1048,23 +1048,27 @@ namespace Orts.Viewer3D.Popups
 
             if (dynamicBrakeStatus != null && locomotive.IsLeadLocomotive())
             {
-                if (locomotive.DynamicBrakePercent >= 0)
+                var dynBrakeString = "";
+                var dynBrakeColor = "";
+
+                if (locomotive.DynamicBrakePercent < 0)
+                    dynBrakeString = Viewer.Catalog.GetString("Off");
+                else if (!locomotive.DynamicBrake)
                 {
-                    AddLabel(new ListLabel
-                    {
-                        FirstCol = Viewer.Catalog.GetString("Dynamic brake"),
-                        LastCol = locomotive.DynamicBrake ? dynamicBrakeStatus : Viewer.Catalog.GetString("Setup") + ColorCode[Color.Cyan] +
-                         (locomotive is MSTSDieselLocomotive && train.DPMode == -1 ? string.Format("({0:F0}%)", train.DPDynamicBrakePercent) : string.Empty),
-                    });
+                    dynBrakeString = Viewer.Catalog.GetString("Setup");
+                    dynBrakeColor = ColorCode[Color.Cyan];
                 }
                 else
+                    dynBrakeString = dynamicBrakeStatus;
+
+                if (locomotive is MSTSDieselLocomotive && train.DPMode == -1)
+                    dynBrakeString += string.Format(" | {0:F0}%", train.DPDynamicBrakePercent);
+
+                AddLabel(new ListLabel
                 {
-                    AddLabel(new ListLabel
-                    {
-                        FirstCol = Viewer.Catalog.GetString("Dynamic brake"),
-                        LastCol = Viewer.Catalog.GetString("Off") + (locomotive is MSTSDieselLocomotive && train.DPMode == -1 ? string.Format("({0:F0}%)", train.DPDynamicBrakePercent) : string.Empty),
-                    });
-                }
+                    FirstCol = Viewer.Catalog.GetString("Dynamic brake"),
+                    LastCol = dynBrakeString + dynBrakeColor,
+                });
             }
 
             AddSeparator();

--- a/Source/RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs
@@ -314,7 +314,8 @@ namespace Orts.Viewer3D.WebServices
                 AddLabel(new ListLabel
                 {
                     FirstCol = Viewer.Catalog.GetString(locomotive is MSTSSteamLocomotive ? "Regulator" : "Throttle"),
-                    LastCol = $"{Round(locomotive.ThrottlePercent)}%",
+                    LastCol = $"{Round(locomotive.ThrottlePercent)}%" +
+                        (locomotive is MSTSDieselLocomotive && train.DPMode == 1 ? $" | {Round(train.DPThrottlePercent)}%" : ""),
                     KeyPressed = throttleKey,
                     SymbolCol = throttleKey,
                 });
@@ -589,23 +590,27 @@ namespace Orts.Viewer3D.WebServices
 
             if (dynamicBrakeStatus != null && locomotive.IsLeadLocomotive())
             {
-                if (locomotive.DynamicBrakePercent >= 0)
+                var dynBrakeString = "";
+                var dynBrakeColor = "";
+
+                if (locomotive.DynamicBrakePercent < 0)
+                    dynBrakeString = Viewer.Catalog.GetString("Off");
+                else if (!locomotive.DynamicBrake)
                 {
-                    AddLabel(new ListLabel
-                    {
-                        FirstCol = Viewer.Catalog.GetString("Dynamic brake"),
-                        LastCol = locomotive.DynamicBrake ? dynamicBrakeStatus : Viewer.Catalog.GetString("Setup") + ColorCode[Color.Cyan] +
-                         (locomotive is MSTSDieselLocomotive && train.DPMode == -1 ? string.Format("({0:F0}%)", train.DPDynamicBrakePercent) : string.Empty),
-                    });
+                    dynBrakeString = Viewer.Catalog.GetString("Setup");
+                    dynBrakeColor = ColorCode[Color.Cyan];
                 }
                 else
+                    dynBrakeString = dynamicBrakeStatus;
+
+                if (locomotive is MSTSDieselLocomotive && train.DPMode == -1)
+                    dynBrakeString += string.Format(" | {0:F0}%", train.DPDynamicBrakePercent);
+
+                AddLabel(new ListLabel
                 {
-                    AddLabel(new ListLabel
-                    {
-                        FirstCol = Viewer.Catalog.GetString("Dynamic brake"),
-                        LastCol = Viewer.Catalog.GetString("Off") + (locomotive is MSTSDieselLocomotive && train.DPMode == -1 ? string.Format("({0:F0}%)", train.DPDynamicBrakePercent) : string.Empty),
-                    });
-                }
+                    FirstCol = Viewer.Catalog.GetString("Dynamic brake"),
+                    LastCol = dynBrakeString + dynBrakeColor,
+                });
             }
 
             AddSeparator();


### PR DESCRIPTION
**This is a PR for release 1.6.** _Since my other PR (DPMode) is desired for 1.6, I though I also do this for 1.6._

This affects the Train Driving Info window and its web-server presentation.

When the lead consist is in dynamic brake setup and the back consist is already in dynamic braking, instead of the cyan colour, a string with "%%%" is presented. The cause is that the value for the back consist is appended after the colour code. The colour code needs to be at the end of the string.

Also add the back-consist throttle percentage to the web-server presentation. It was missing.

Lastly, I changed the DPU value separator, from parenthesis to a vertical bar. This is more readable, and better matches the presentation in the DPU window.

Before:
![DynamicBrakeInfo-before](https://github.com/user-attachments/assets/aefb2f80-8559-472a-919f-8fc44ea410d1)

After:
![DynamicBrakeInfo-after](https://github.com/user-attachments/assets/912163fe-7cfa-476f-a2a4-e19b11be1a7d)

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)