### PR TITLE
Fix Potential Hang in AnimatedPart.SetFrameWrap

### DIFF
--- a/Source/RunActivity/Viewer3D/AnimatedPart.cs
+++ b/Source/RunActivity/Viewer3D/AnimatedPart.cs
@@ -130,9 +130,16 @@ namespace Orts.Viewer3D
         public void SetFrameWrap(float frame)
         {
             // Wrap the frame around 0-MaxFrame without hanging when MaxFrame=0.
-            while (MaxFrame > 0 && frame < 0) frame += MaxFrame;
-            if (frame < 0) frame = 0;
-            frame %= MaxFrame;
+            if (MaxFrame > 0)
+            {
+                frame %= MaxFrame;
+                // If frame was negative (eg: animation run in reverse), it will still be negative
+                // and needs one additional offset by MaxFrame to be in the correct range
+                if (frame < 0)
+                    frame += MaxFrame;
+            }
+            else if (frame < 0)
+                frame = 0;
             SetFrame(frame);
         }
 


### PR DESCRIPTION
AnimatedPart.SetFrameWrap uses a while loop to gradually step a frame that's gone negative back to the appropriate positive range. While this works fine for frames that are negative by small amounts, I encountered a game freeze when an animation frame was set to an extremely negative value (due to wheel slip, it seems) and the while loop used all processing time to attempt to move the animation frame from a value in the negative _billions_ back to a positive value _12_ at a time (ie: requiring hundreds of millions of iterations).

While loops should be used very sparingly and other options that can't hang the entire process should replace while loops where possible. In this case, a simple modulus operation can achieve the same goal of "restore variable to a given range" in a constant number of steps, regardless of how extremely negative the variable originally was.

As pseudocode, the old method was this:
```
while (frame < 0)
     frame += MaxFrame;
frame %= MaxFrame;
```
And the new method is this:
```
frame %= MaxFrame;
if (frame < 0)
     frame += MaxFrame;
```

The new algorithm produces identical results in dramatically less time, needing to add `MaxFrame` only once regardless of the magnitude of `frame`. When `frame` is negative, `frame %= MaxFrame` immediately moves `frame` to the range of -1 to -(MaxFrame - 1) while maintaining the proper "wrap" of the frame counter, so adding on `MaxFrame` one more time is all that's required to finally restore `frame` to the range of 0 to (MaxFrame - 1).

For example:
```
frame = -33                        MaxFrame = 12
Old:                             | New:
frame += MaxFrame (repeatedly)   | frame %= MaxFrame (one time)
-33 += 12                        | -33 %= 12
-21 += 12                        | -9 (not done yet)
-9 += 12                         | frame += MaxFrame (one time)
3 (final result)                 | -9 += 12
                                 | 3 (same final result)
```

For slightly negative values, this doesn't save much time but I saw frame values in the negative billions, in which case avoiding a while loop is dramatically faster.

Another minor change is that if `MaxFrame = 0`, the old code would produce `frame = NaN` as it would run `frame %= MaxFrame` even in this case, but now that calculation is skipped instead, avoiding the NaN which could cause other problems.

I'm also wondering if this caused the problem mentioned in [this bug report](https://www.elvastower.com/forums/index.php?/topic/38892-assertion-failed-open-rails-u20250609-0538-x64/) as I encountered this when wheel slipping, and an adhesion change was introduced before the bug was reported.