### PR TITLE
Fix DPMode when last remote is moved to front. (r1.6)

### DIFF
--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -1628,6 +1628,7 @@ namespace Orts.Simulation.Physics
             if (LeadLocomotive == null || (LeadLocomotive as MSTSLocomotive).DPDynamicBrakeController == null)
                 return;
             int idToMove = -1;
+            bool stillHasRemotes = false;
             for (var i = 0; i < Cars.Count; i++)
             {
                 if (!(Cars[i] is MSTSLocomotive))
@@ -1641,7 +1642,12 @@ namespace Orts.Simulation.Physics
                     Cars[i].RemoteControlGroup = 0;
                 else if (idToMove > -1 && Cars[i].RemoteControlGroup == 0)
                     Cars[i].RemoteControlGroup = 1;
+
+                if (Cars[i].RemoteControlGroup == 1)
+                    stillHasRemotes = true;
             }
+            if (!stillHasRemotes)
+                DPMode = 0;
         }
 
         /// <summary>
@@ -1656,6 +1662,7 @@ namespace Orts.Simulation.Physics
             var dpDynamicBrakeCurrentNotch = MathHelper.Clamp((LeadLocomotive as MSTSLocomotive).DPDynamicBrakeController.GetNotch(dpDynamicBrakePercent/100), 0, 8);
             var dpThrottleCurrentNotch = (LeadLocomotive as MSTSLocomotive).ThrottleController.CurrentNotch;
             int idToMove = -1;
+            bool alreadyHasRemotes = false;
             int idLead = LeadLocomotive != null ? (Cars[LeadLocomotiveIndex] as MSTSLocomotive).DPUnitID : -1;
             for (var i = Cars.Count - 1; i >= 0; i--)
             {
@@ -1667,6 +1674,7 @@ namespace Orts.Simulation.Physics
                     dpThrottlePercent = DPThrottlePercent;
                     dpDynamicBrakeCurrentNotch = (LeadLocomotive as MSTSLocomotive).DPDynamicBrakeController.CurrentNotch;
                     dpThrottleCurrentNotch = (LeadLocomotive as MSTSLocomotive).DPThrottleController.CurrentNotch;
+                    alreadyHasRemotes = true;
                     continue;
                 }
                 if (idToMove == -1 && Cars[i].RemoteControlGroup == 0)
@@ -1685,6 +1693,13 @@ namespace Orts.Simulation.Physics
                 }
                 else if (idToMove > -1 && Cars[i].RemoteControlGroup == 1)
                     Cars[i].RemoteControlGroup = 0;
+            }
+            if (!alreadyHasRemotes)
+            {
+                if (LeadLocomotive.ThrottlePercent > 0)
+                    DPMode = 1;
+                else if (LeadLocomotive.DynamicBrakePercent >= 0)  // off is -1
+                    DPMode = -1;
             }
         }
 


### PR DESCRIPTION
This is [PR 1107 ](https://github.com/openrails/openrails/pull/1107)recreated for release 1.6.

When the last remote loco is moved to the front, the train's DPMode remains as is (eg. traction). When the lead consist is moved to the other mode (eg. traction -> dynamic braking), and then a loco is moved to the back, the train's DPMode is still in the previous mode (eg. traction), even though the remote now provides braking. This results in the wrong colour on the Train DPU Info window.

When the last remove is moved to the front, the DPMode needs to be set to idle.

I also added a second change: When the first loco is moved to the back, the DPMode is set based on the lead loco. DPThrottlePercent or DPDynamicBrakePercent is set from the lead, so it does not make sense to leave the DPMode at idle.

I did not like that I had to set traction mode (Ctrl-L) after moving the loco to the rear before I can use the more/less functions (Ctrl-U and Shift-Ctrl-U). I believe that extra step is not required in the real world.

When the lead loco is idle (no traction or dynamic braking), the DPMode remains at idle.

PS: There are additional issues around DPMode. It is used to show the remotes (traction or dynamic braking) in the Train Driving Info window. When the remotes are in idle mode, there is no value for the remotes, even though the fence is up and the remotes have different values from the lead consist.

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)