### PR TITLE
Fixes For Correct Questionable Braking Parameters

### DIFF
--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -863,21 +863,23 @@ are a problem for OR, which has a more sophisticated braking model. The
 problem usually is that the train brakes require a long time to release,
 and in some times do not release at all.
 
-.. index::
-   single: AirBrakesAirCompressorPowerRating
-
 The following checks and corrections are performed if the option is
-checked (only for single-pipe brake system):
+checked:
 
 - if the compressor restart pressure is smaller or very near to the max
   system pressure, the compressor restart pressure and if necessary the max
-  main reservoir pressure are increased;
+  main reservoir pressure are increased (single pipe air brakes only)
 - if the main reservoir volume is smaller than 0.3 m\ :sup:`3` and the
   engine mass is higher than 20 tons, the reservoir volume is raised to 0.78
-  m\ :sup:`3`;
-- the charging rate of the reservoir is derived from the .eng parameter
-  ``AirBrakesAirCompressorPowerRating`` (if this generates a value greater
-  than 0.5 psi/s) instead of using a default value.
+  m\ :sup:`3`
+- the maximum brake cylinder pressure will be reduced to the maximum pressure
+  possible from a full service train brake application if it was set above this
+  amount
+- any brake pipe leakage specified by ``TrainPipeLeakRate`` is disabled
+- the dynamic brake delay on electric locomotives is reduced to 2 seconds
+  if it was defined to be above 4 seconds
+- dynamic brake force left at the default value of 20kN will be increased to
+  half the locomotive's continuous force, or 150kN, whichever is lower
 
 For a full list of parameters, see :ref:`Developing ORTS Content - Parameters and Tokens<parameters_and_tokens>`
 

--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -875,7 +875,7 @@ checked:
 - the maximum brake cylinder pressure will be reduced to the maximum pressure
   possible from a full service train brake application if it was set above this
   amount
-- any brake pipe leakage specified by ``TrainPipeLeakRate`` is disabled
+- any brake pipe leakage specified by ``TrainPipeLeakRate`` is limited to 2.5 psi/minute
 - the dynamic brake delay on electric locomotives is reduced to 2 seconds
   if it was defined to be above 4 seconds
 - dynamic brake force left at the default value of 20kN will be increased to

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -389,7 +389,7 @@ namespace Orts.Simulation.RollingStocks
         public float CompressorRestartPressurePSI = 110;
         public float CompressorChargingRateM3pS = 0.075f;
         public bool CompressorIsMUControlled = false;
-        public float MainResChargingRatePSIpS = 0.4f;
+        public float MainResChargingRatePSIpS = -1.0f;
         public float EngineBrakeReleaseRatePSIpS = 12.5f;
         public float EngineBrakeApplyRatePSIpS = 12.5f;
         public float BrakePipeTimeFactorS = 0.0015f;
@@ -1990,16 +1990,18 @@ namespace Orts.Simulation.RollingStocks
                     // correct questionable MaxCylPressurePSI
                     BrakeSystem.CorrectMaxCylPressurePSI(this);
                 }
-                if (MainResChargingRatePSIpS <= 0)
-                {
-                    MainResChargingRatePSIpS = Math.Max(0.5f, (CompressorChargingRateM3pS * Bar.ToPSI(1)) / MainResVolumeM3);
-                }
+                // Disable brake pipe leak to prevent stuck brakes
+                if (TrainBrakePipeLeakPSIorInHgpS > 0)
+                    TrainBrakePipeLeakPSIorInHgpS = 0;
             }
-            else if (MainResChargingRatePSIpS <= 0) MainResChargingRatePSIpS = 0.4f;
+            // No OR compressor speed defined, use MSTS compressor speed or 0.025 m^3/s (whichever is higher)
+            if (MainResChargingRatePSIpS < 0) 
+            {
+                MainResChargingRatePSIpS = Math.Max(0.025f, CompressorChargingRateM3pS) * OneAtmospherePSI / MainResVolumeM3;
+            }
 
             // Corrections for dynamic braking parameters
 
-            if (this is MSTSElectricLocomotive && DynamicBrakeDelayS > 4) DynamicBrakeDelayS = 2; // Electric locomotives have short engaging delays
             if (DynamicBrakeSpeed2MpS > 0 && DynamicBrakeSpeed3MpS > 0 && DynamicBrakeSpeed2MpS > DynamicBrakeSpeed3MpS)
             {
                 // also exchanging DynamicBrakesMaximumEffectiveSpeed with DynamicBrakesFadingSpeed is a frequent error that upsets operation of
@@ -2010,8 +2012,11 @@ namespace Orts.Simulation.RollingStocks
             }
             if (Simulator.Settings.CorrectQuestionableBrakingParams)
             {
+                if (this is MSTSElectricLocomotive && DynamicBrakeDelayS > 4)
+                    DynamicBrakeDelayS = 2; // Electric locomotives have short engaging delays
+
                 if (MaxDynamicBrakeForceN > 0 && MaxContinuousForceN > 0 &&
-                (MaxDynamicBrakeForceN / MaxContinuousForceN < 0.3f && MaxDynamicBrakeForceN == 20000))
+                    (MaxDynamicBrakeForceN / MaxContinuousForceN < 0.3f && MaxDynamicBrakeForceN == 20000))
                     MaxDynamicBrakeForceN = Math.Min (MaxContinuousForceN * 0.5f, 150000); // 20000 is suggested as standard value in the MSTS documentation, but in general it is a too low value
             }
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -1869,21 +1869,6 @@ namespace Orts.Simulation.RollingStocks
                 }
             }
 
-            // Initialise Train Pipe Leak Rate
-            if (TrainBrakePipeLeakPSIorInHgpS == 0) // Check to see if TrainBrakePipeLeakPSIorInHgpS has been set in the ENG file.
-            {
-                // Set Default Train Brake Pipe Leak depending upon whether locomotive has Vacuum or air brakes - overwritten by ENG file setting.
-                // Default currently set to zero - means that by default function is off, and a value must be entered into the ENG file to get it to work
-                if ((BrakeSystem is VacuumSinglePipe))
-                {
-                    TrainBrakePipeLeakPSIorInHgpS = 0.0f; // Vacuum brakes
-                }
-                else
-                {
-                    TrainBrakePipeLeakPSIorInHgpS = 0.0f; // Air brakes
-                }
-            }
-
             if (DynamicBrakeEngineBrakeReplacement && DynamicBrakeEngineBrakeReplacementSpeed == 0)
             {
                 DynamicBrakeEngineBrakeReplacementSpeed = DynamicBrakeSpeed2MpS;
@@ -1990,9 +1975,9 @@ namespace Orts.Simulation.RollingStocks
                     // correct questionable MaxCylPressurePSI
                     BrakeSystem.CorrectMaxCylPressurePSI(this);
                 }
-                // Disable brake pipe leak to prevent stuck brakes
-                if (TrainBrakePipeLeakPSIorInHgpS > 0)
-                    TrainBrakePipeLeakPSIorInHgpS = 0;
+                // Limit brake pipe leak to 2.5 psi/min (~ 1 bar every 6 minutes) to prevent stuck brakes
+                if (TrainBrakePipeLeakPSIorInHgpS > 2.5f / 60f)
+                    TrainBrakePipeLeakPSIorInHgpS = 2.5f / 60f;
             }
             // No OR compressor speed defined, use MSTS compressor speed or 0.025 m^3/s (whichever is higher)
             if (MainResChargingRatePSIpS < 0) 


### PR DESCRIPTION
Since `TrainPipeLeakRate` was fixed back in #912, some users have noticed their locomotives are unable to keep up with the leak rate defined in the .eng file because the leak rate was set too high (presumably in an attempt to counteract the bug preventing the leak from working as expected) and/or because the locomotive compressor was unreasonably weak.

The simplest approach that does not interfere with creator's choice (I cannot judge someone for intentionally wanting a high leakage for an activity or something) nor require excessive effort from the user is to use the Correct Questionable Braking Parameters setting.

- `TrainPipeLeakRate` is limited to 2.5 psi/min if CQBP option is enabled
- Fixed calculation of main res charging rate for MSTS locomotives, so MSTS locomotives should have more appropriate brake pipe charging performance
- Cleaned up `CorrectBrakingParams` by moving the electric locomotive dynamic brake setup timer to only be adjusted if CQBP is enabled instead of all the time (I'm not sure why this feature is there, but it's not correct to enforce arbitrary limits like that all the time)
- Adjusted documentation for CQBP to reflect what the option actually does, as the documentation was missing many pieces

A note on MSTS main res charging rate: The previous code would never function as it was checking for `MainResChargingRatePSIpS <= 0` but MainResChargingRatePSIpS defaulted to 0.4 psi/s, so that calculation never ran. The charging rate now defaults to -1 to indicate it has not been set, which allows the correction code to run as expected on MSTS locomotives (but not on ORTS locomotives, where the charging rate should be defined already). MSTS locomotives should no longer get stuck with the pitifully slow 0.4 psi/s charge rate, and the minimum charge rate has been changed to 0.025 m^3/s so main res volume doesn't impact the 'actual' minimum rate of air pumping.

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)