### PR TITLE
Minor Fix for Brake Pipe Charging

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs
@@ -2171,7 +2171,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS
                                     float supplyPressure = locoAirSystem.SupplyReservoirPresent ? locoAirSystem.SupplyResPressurePSI : loco.MainResPressurePSI; // Pressure of reservoir used for brake pipe charging
 
                                     if (supplyPressure - locoAirSystem.BrakeLine1PressurePSI < 15.0f) // Reduce recharge rate if near MR pressure as per reality
-                                        PressureDiffEqualToPipePSI *= MathHelper.Lerp(0, 1.0f, (supplyPressure - train.EqualReservoirPressurePSIorInHg) / 15.0f);
+                                        PressureDiffEqualToPipePSI *= MathHelper.Lerp(0, 1.0f, (supplyPressure - locoAirSystem.BrakeLine1PressurePSI) / 15.0f);
                                     if (train.EqualReservoirPressurePSIorInHg - locoAirSystem.BrakeLine1PressurePSI < chargeSlowdown) // Reduce recharge rate if near EQ to simulate feed valve behavior
                                         PressureDiffEqualToPipePSI *= (float)Math.Pow((train.EqualReservoirPressurePSIorInHg - locoAirSystem.BrakeLine1PressurePSI) / chargeSlowdown,
                                             1.0f/3.0f);


### PR DESCRIPTION
Back with #912 I implemented some changes to add smoothing to brake pipe charging. One of these smoothing factors was supposed to reduce the rate of charging as the _brake pipe pressure_ approached the main res pressure (as the pressure drop across the feed valve decreases, the flow rate decreases due to fluid dynamics), but it was instead mistakenly implemented as a reduction when the _equalizing res pressure_ approached the main res pressure.
Obviously, that doesn't make as much sense, and we can even see the if statement uses the difference between MR and BP pressure, so I do not know how that MR vs ER pressure calculation made it to the final version of the air brake PR.