### PR TITLE
Fix bug in PR 1045: load any activity from JSON.

### DIFF
--- a/Source/Menu/MainForm.cs
+++ b/Source/Menu/MainForm.cs
@@ -1389,10 +1389,9 @@ namespace Menu
             }
             else
             {
-                // when explore-in-activity mode, try the content route info
+                // try the content route info
                 var routes = Settings.Content.ContentRouteSettings.Routes;
-                if ((SelectedActivity != null && SelectedActivity is ExploreThroughActivity) &&
-                    (SelectedFolder != null && routes.ContainsKey(SelectedFolder.Name) && routes[SelectedFolder.Name].Installed) &&
+                if ((SelectedFolder != null && routes.ContainsKey(SelectedFolder.Name) && routes[SelectedFolder.Name].Installed) &&
                     (!string.IsNullOrEmpty(routes[SelectedFolder.Name].Start.Route)))
                 {
                     var route = routes[SelectedFolder.Name];


### PR DESCRIPTION
This fixes a bug in [PR 1045](https://github.com/openrails/openrails/pull/1045), specifically undoes the [commit a9316c718](https://github.com/openrails/openrails/pull/1045/commits/a9316c71810b3137a3540a1b86afa5445fb53f10). 

Due to a misunderstood comment in the discussion, the main menu only loaded route data from the JSON for explore-in-activity-mode. The proper behaviour is to load JSON data for an activity or for explore. The comment meant that for activities, the extra data is not relevant.

The code, original or with this PR, does not explicitly ignore extra data. The part that will run the activity handles that, preferring data from the activity over the data loaded into the extra fields.
