### PR TITLE
Fix Curve Resistance Calculation

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -37,14 +37,12 @@ using Microsoft.Xna.Framework;
 using Orts.Common;
 using Orts.Formats.Msts;
 using Orts.Parsers.Msts;
-using Orts.Simulation.AIs;
 using Orts.Simulation.Physics;
 using Orts.Simulation.RollingStocks.Coupling;
 using Orts.Simulation.RollingStocks.SubSystems;
 using Orts.Simulation.RollingStocks.SubSystems.Brakes;
 using Orts.Simulation.RollingStocks.SubSystems.PowerSupplies;
 using Orts.Simulation.Signalling;
-using Orts.Simulation.Timetables;
 using ORTS.Common;
 using ORTS.Scripting.Api;
 using System;
@@ -2089,14 +2087,13 @@ namespace Orts.Simulation.RollingStocks
                 // Base Curve Resistance (from refernce i)) = (Vehicle mass x Coeff Friction) * (Track Gauge + Vehicle Fixed Wheelbase) / (2 * curve radius)
                 // Vehicle Fixed Wheel base is the distance between the wheels, ie bogie or fixed wheels
 
-                var rBaseWagonN = 9.81f * MassKG * Train.WagonCoefficientFriction * (TrackGaugeM + RigidWheelBaseM) / (2.0f * CurrentCurveRadiusM);
+                float rBaseWagonN = GravitationalAccelerationMpS2 * MassKG * Train.WagonCoefficientFriction * (TrackGaugeM + RigidWheelBaseM) / (2.0f * CurrentCurveRadiusM);
 
                 // Speed Curve Resistance (from reference ii) - second term only) = ((Speed^2 / Curve Radius) - (Superelevation / Track Gauge) * Gravitational acceleration) * Constant
 
-                var speedConstant = 1.5f;
-                var MToMM = 1000;
-                var rspeedKgpTonne = speedConstant * Math.Abs((SpeedMpS * SpeedMpS / CurrentCurveRadiusM) - ((MToMM * SuperElevationM / MToMM * TrackGaugeM) * GravitationalAccelerationMpS2));
-                var rSpeedWagonN = GravitationalAccelerationMpS2 * (Kg.ToTonne(MassKG) * rspeedKgpTonne);
+                float speedConstant = 1.5f;
+                float rspeedKgpTonne = speedConstant * Math.Abs((SpeedMpS * SpeedMpS / CurrentCurveRadiusM) - (GravitationalAccelerationMpS2 * SuperElevationM / TrackGaugeM));
+                float rSpeedWagonN = GravitationalAccelerationMpS2 * (Kg.ToTonne(MassKG) * rspeedKgpTonne);
 
                 CurveForceN = rBaseWagonN + rSpeedWagonN;
             }


### PR DESCRIPTION
Reported on [Elvas Tower](https://www.elvastower.com/forums/index.php?/topic/38114-multiple-track-profiles/page__view__findpost__p__319908), it seems that curve resistance was causing some trouble. A quick look at the curve resistance calculations revealed a mistake in order of operations that was causing consistent miscalculation of curve resistance force, potentially related to the problem described on the forums.

One step of curve resistance calculation requires knowing the value of `superelevation ÷ track gauge`, however, the curve resistance calculation mistakenly implemented this as `1000 * SuperElevationM / 1000 * TrackGaugeM)`. First of all, the factor of 1000 (which converts meters to millimeters) is unneeded as it is present in both the numerator and denominator, thus (hypothetically, but not actually) cancelling out. This calculation would work perfectly fine if superelevation and track gauge were measured in light years, there is absolutely no reason to waste time converting units (and introducing mistakes)! Second, due to the order of operations in C#, `1000 * SuperElevationM / 1000 * TrackGaugeM)` simplifies to `1000 * (SuperElevationM / 1000) * TrackGaugeM)` and then `SuperElevationM * TrackGaugeM`...which is very different from the intended result of `SuperElevationM / TrackGaugeM`. This causes some serious discrepancies in curve resistance calculations!

This PR corrects the curve resistance calculation (and replaces some soft-typed 'var' with 'float' as it's obvious everything here should be a float, and also replaces a magic number 9.81 with the variable for gravity) to use the intended `SuperElevationM / TrackGaugeM` calculation. The unneeded conversion to millimeters introduced added complexity and a mistake, so this should be a reminder to everyone to do dimensional analysis, simplify your calculations, and respect the C# operator precedence!