### PR TITLE
Fix for bug https://bugs.launchpad.net/or/+bug/2117357. 

### DIFF
--- a/Source/RunActivity/Viewer3D/WebServices/TrainCarOperationsWebpage.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/TrainCarOperationsWebpage.cs
@@ -710,6 +710,10 @@ namespace Orts.Viewer3D.WebServices
                 TrainCarViewer.NewCarPosition = carPosition - 1;
                 if (Viewer.CarOperationsWindow.CarPosition > carPosition - 1)
                     Viewer.CarOperationsWindow.Visible = false;
+                if (Viewer.TrainCarOperationsWindow.SelectedCarPosition >= Viewer.PlayerTrain.Cars.Count())
+                {
+                    Viewer.TrainCarOperationsWindow.SelectedCarPosition = Viewer.PlayerTrain.Cars.Count - 1;
+                }
             }
         }
 
@@ -808,6 +812,10 @@ namespace Orts.Viewer3D.WebServices
                 TrainCarViewer.CouplerChanged = true;
                 if (Viewer.CarOperationsWindow.CarPosition > carPosition)
                     Viewer.CarOperationsWindow.Visible = false;
+                if (Viewer.TrainCarOperationsWindow.SelectedCarPosition >= Viewer.PlayerTrain.Cars.Count())
+                {
+                    Viewer.TrainCarOperationsWindow.SelectedCarPosition = Viewer.PlayerTrain.Cars.Count - 1;
+                }
             }
         }
 

--- a/Source/RunActivity/Viewer3D/WebServices/TrainCarOperationsWebpage.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/TrainCarOperationsWebpage.cs
@@ -31,8 +31,6 @@ using Orts.Common;
 using Orts.Simulation.RollingStocks.SubSystems.Brakes.MSTS;
 using ORTS.Scripting.Api;
 using System.IO;
-using Orts.Simulation.Physics;
-using Orts.Simulation.RollingStocks.SubSystems.Brakes;
 
 namespace Orts.Viewer3D.WebServices
 {
@@ -710,10 +708,7 @@ namespace Orts.Viewer3D.WebServices
                 TrainCarViewer.NewCarPosition = carPosition - 1;
                 if (Viewer.CarOperationsWindow.CarPosition > carPosition - 1)
                     Viewer.CarOperationsWindow.Visible = false;
-                if (Viewer.TrainCarOperationsWindow.SelectedCarPosition >= Viewer.PlayerTrain.Cars.Count())
-                {
-                    Viewer.TrainCarOperationsWindow.SelectedCarPosition = Viewer.PlayerTrain.Cars.Count - 1;
-                }
+                Viewer.TrainCarOperationsWindow.SelectedCarPosition = 0;
             }
         }
 
@@ -812,10 +807,7 @@ namespace Orts.Viewer3D.WebServices
                 TrainCarViewer.CouplerChanged = true;
                 if (Viewer.CarOperationsWindow.CarPosition > carPosition)
                     Viewer.CarOperationsWindow.Visible = false;
-                if (Viewer.TrainCarOperationsWindow.SelectedCarPosition >= Viewer.PlayerTrain.Cars.Count())
-                {
-                    Viewer.TrainCarOperationsWindow.SelectedCarPosition = Viewer.PlayerTrain.Cars.Count - 1;
-                }
+                Viewer.TrainCarOperationsWindow.SelectedCarPosition = 0;
             }
         }
 


### PR DESCRIPTION
https://bugs.launchpad.net/or/+bug/2117357

Exception index of of range when opening Train Car Operations window:

reproduction:

- after starting OR open http://localhost:2150/TrainCarOperations/index.html: Train Car Operations
- select last car (click twice on it) on above mentioned page
- decouple last car
- open Train Car Operations with F9
- Exception in:

                    if (LastCarIDSelected == null)
                    {
                        LastCarIDSelected = PlayerTrain.Cars[SelectedCarPosition].CarID;
                    }

  SelectedCarPosition has value of last car before uncoupling --> Index was out of range