### PR TITLE
Fix Cabview Animation Edge Case

### DIFF
--- a/Source/Orts.Formats.Msts/CabViewFile.cs
+++ b/Source/Orts.Formats.Msts/CabViewFile.cs
@@ -1150,9 +1150,10 @@ namespace Orts.Formats.Msts
                         if (Positions.Count > 0 && Positions[0] > Positions[Positions.Count - 1])
                         {
                             Reversed ^= true;
+                            int maxPos = Positions.Max();
                             // Recalculate positions in reverse
                             for (int i = 0; i < Positions.Count; i++)
-                                Positions[i] = (FramesCount - 1) - Positions[i];
+                                Positions[i] = maxPos - Positions[i];
                         }
 
                         // Check if eligible for filling

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -4201,7 +4201,7 @@ namespace Orts.Simulation.RollingStocks
         /// Returns the position of the throttle handle considering 
         /// whether it is used for cruise control or not
         /// </summary>
-        /// <param name="intermediateValue">Whather asking for intermediate (for mouse operation) or notched (for displaying) value.</param>
+        /// <param name="intermediateValue">Whether asking for intermediate (for mouse operation) or notched (for displaying) value.</param>
         /// <returns>Position into 0-1 range</returns>
         public float GetThrottleHandleValue(bool intermediateValue)
         {
@@ -4213,7 +4213,7 @@ namespace Orts.Simulation.RollingStocks
             if (CruiseControl?.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto && CruiseControl.UseThrottleAsSpeedSelector)
                 return CruiseControl.SelectedSpeedMpS / MaxSpeedMpS;
 
-            return intermediateValue ? ThrottleController.CurrentValue : ThrottleController.IntermediateValue;
+            return intermediateValue ? ThrottleController.IntermediateValue : ThrottleController.CurrentValue;
         }
 
         #endregion


### PR DESCRIPTION
Back in #943 I made some changes to cab control handling to better support the many cab view controls that have `NumPositions` defined from greatest to least (by re-sorting them to be least to greatest under the hood). However, that implementation made the assumption that *the cab control used all frames of its texture*. I have found that this is not always the case, and if a cab control doesn't use all frames *and* has positions defined in reverse (this is somewhat rare), it will attempt to render the empty frames which won't look right at all.

For example, let's say we have a control using a 3x3 sprite sheet for 9 frames, but only 5 of them are used. The control has `NumPositions ( 5 4 3 2 1 0 )`. We want to re-sort the `4 3 2 1 0` positions to `0 1 2 3 4` to make OR happy. My previous implementation simplified reversing the list by taking each position and subtracting it from the number of frames - 1 (so 9 - 1 = 8, then subtract off the position number). The resulting position list is: 8 - `4 3 2 1 0` = `4 5 6 7 8`, which is correctly in ascending order but is incorrectly using positions `5 6 7 8` which are not meant to be used (depending on how the texture was made, positions 5-8 in the sprite sheet could be transparency, solid colors, or just a static image, instead of the animation we want to see) and fails to even consider positions 0-3. The only way to get the expected output of `0 1 2 3 4` with this method is if there were _exactly_ 5 total frames, anything else produces nonsense.

The fix is quite simple, instead of using the number of frames to reverse the list, the maximum position value is used. In this case, that means subtracting each value from 4 as 4 is the max position: 4 - `4 3 2 1 0` = `0 1 2 3 4`, just as we would hope. This will work regardless of the texture or how many frames are defined.


At the same time, I spotted an issue introduced in #1067 where the method to get the throttle value was returning the current value when we were asking for the intermediate value, and vice versa. That would lead to minor mismatches between what the throttle was expected to show vs where it actually was. I suspect that might be the cause of [this issue](https://www.elvastower.com/forums/index.php?/topic/39004-throttle-position-idle-not-shown-on-throttling-back/).