### PR TITLE
Fix Light Position Calculation for Deeper Hierarchy Levels

### DIFF
--- a/Source/RunActivity/Viewer3D/Lights.cs
+++ b/Source/RunActivity/Viewer3D/Lights.cs
@@ -226,8 +226,29 @@ namespace Orts.Viewer3D
 
             // Calculate XNA matrix for shape file objects by offsetting from car's location
             // The new List<int> is intentional, this allows the dictionary to be changed while iterating
+            int maxDepth = trainCarShape.Hierarchy.Max();
             foreach (int index in new List<int>(ShapeXNATranslations.Keys))
-                ShapeXNATranslations[index] = trainCarShape.XNAMatrices[index] * xnaDTileTranslation;
+            {
+                Matrix res = trainCarShape.XNAMatrices[index];
+                int hIndex = trainCarShape.Hierarchy[index];
+
+                int i = 0;
+
+                // Transform the matrix repeatedly for all of its parents
+                while (hIndex > -1 && hIndex < trainCarShape.Hierarchy.Length && i < maxDepth)
+                {
+                    res = res * trainCarShape.XNAMatrices[hIndex];
+                    // Prevent potential infinite loop due to faulty hierarchy definition
+                    if (hIndex != trainCarShape.Hierarchy[hIndex])
+                        hIndex = trainCarShape.Hierarchy[hIndex];
+                    else
+                        break;
+
+                    i++;
+                }
+
+                ShapeXNATranslations[index] = res * xnaDTileTranslation;
+            }
 
             float objectRadius = 20; // Even more arbitrary.
             float objectViewingDistance = Viewer.Settings.ViewingDistance; // Arbitrary.


### PR DESCRIPTION
The ShapeHierarchy implementation on lights from #917 does not correctly iterate through the entire hierarchy of the attached shape. This means that the light will not behave as expected if attached to an element 2 levels deep or further in the hierarchy, as none of the higher levels of the hierarchy would be considered in determining the light position. (For example, attaching a light to a wheel won't allow the light to correctly follow the position/rotation of the wheel, as the position/rotation of the bogie above the wheel is ignored.) This PR adjusts that position calculation to consider deeper levels of the hierarchy, including some error checking to avoid potential infinite loops or crashes from bad shape files.

This fix is redundant with #1126, which has a much more comprehensive implementation for calculating result matrices, but that implementation goes well beyond what is needed for fixing lights (as the other ShapeHierarchy features are not targeting 1.6). This implementation does the same calculations, but for lights only, to reduce risk.

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)