### PR TITLE
Content Manager: Fix exception when searching; path added twice to search list.

### DIFF
--- a/Source/Contrib/ContentManager/ContentManagerGUI.cs
+++ b/Source/Contrib/ContentManager/ContentManagerGUI.cs
@@ -286,7 +286,8 @@ namespace ORTS.ContentManager
                         finds.Add(new SearchResult(content, path));
 
                     foreach (var child in ((ContentType[])Enum.GetValues(typeof(ContentType))).SelectMany(ct => content.Get(ct)))
-                        pending.Add(path + " / " + child.Name, child);
+                        if (!pending.ContainsKey(path + " / " + child.Name))
+                            pending.Add(path + " / " + child.Name, child);
 
                     foreach (var child in ContentLink.Matches(ContentInfo.GetText(content)).Cast<Match>().Select(linkMatch => content.Get(linkMatch.Groups[1].Value, (ContentType)Enum.Parse(typeof(ContentType), linkMatch.Groups[2].Value))).Where(linkContent => linkContent != null))
                         if (!pending.ContainsKey(path + " -> " + child.Name))


### PR DESCRIPTION
Any search in the Content Manager throws an exception. The cause is that paths are added twice to the pending search list, once as part of the Service, and once all paths as part of the route (an addition by [PR 1052](https://github.com/openrails/openrails/pull/1052)). 

This is a simple fix. I am not sure why paths are a problem, but consists are not. Both appear twice in the hierarchy.

The problem was introduced with [PR 1052](https://github.com/openrails/openrails/pull/1052), which is in Release 1.6. It needs to be fixed in 1.6.