### PR TITLE
Fix for pantograph events not sent in AI trains

### DIFF
--- a/Source/Orts.Simulation/Common/Scripting/PowerSupply/LocomotivePowerSupply.cs
+++ b/Source/Orts.Simulation/Common/Scripting/PowerSupply/LocomotivePowerSupply.cs
@@ -376,7 +376,7 @@ namespace ORTS.Scripting.Api
         /// </summary>
         protected void SignalEventToOtherTrainVehiclesWithId(PowerSupplyEvent evt, int id)
         {
-            if (Locomotive == Train.LeadLocomotive)
+            if (Locomotive == Train.LeadLocomotive || (Train.LeadLocomotive == null && IndexOfLocomotive() == 0))
             {
                 foreach (TrainCar car in Train.Cars)
                 {


### PR DESCRIPTION
AI trains do not have a lead locomotive. SignalEventToOtherTrainVehicles already handled this case, but seems that I forgot to add that to SignalEventToOtherTrainVehiclesWithId

https://www.elvastower.com/forums/index.php?/topic/39016-mu-locos-power-on-behaves-differently-between-or-mg-versions/page__view__findpost__p__320385