### PR TITLE
fix: Do not allow non-ACE/DDS textures in content

### DIFF
--- a/Source/Documentation/Manual/features-rollingstock.rst
+++ b/Source/Documentation/Manual/features-rollingstock.rst
@@ -345,7 +345,7 @@ Detailed spec
    no changes are done to the .eng file.
 2) In such folder there is also an ``ORTSLightGlow.png``, which is maybe more realistic.
 3) adding a line within the .eng file it is possible to select either ORTSLightGlow.png or any other picture
-   with extension ``.png, .jpg, bmp, .gif, .ace, or .dds``.
+   with extension ``.ace`` or ``.dds``.
    
 
    Here an example for the legacy Acela loco::
@@ -357,13 +357,13 @@ Detailed spec
 			      Type	( 1 )
 			      Conditions	(...
 
-  The code first searches for the .png file by building its directory starting from the directory of 
+  The code first searches for the file by building its directory starting from the directory of 
   the .eng file; in this case the line could be e.g.::
 
-           ORTSGraphic ( "ORTSAcelaLightGlow.png" )
+           ORTSGraphic ( "ORTSAcelaLightGlow.dds" )
 
 4) The ``ORTSGraphic`` line can be added also for one or more ``Light()`` blocks. In that case the 
-   .png file is used only for the related Light block. Here an example::
+   file is used only for the related Light block. Here an example::
 
     Light	(
 			comment( Head light outer right bright )
@@ -386,7 +386,7 @@ Detailed spec
 					Elevation ( -50 -50 -50 )
 					)
 				)
-			ORTSGraphic (BigLightGlow.png)
+			ORTSGraphic (BigLightGlow.dds)
     )
 
   OR searches for the file as it does for the general file for all lights, as explained above.

--- a/Source/RunActivity/Viewer3D/Lights.cs
+++ b/Source/RunActivity/Viewer3D/Lights.cs
@@ -988,7 +988,7 @@ namespace Orts.Viewer3D
             : base(viewer, textureName)
         {
             // TODO: This should happen on the loader thread.
-            LightGlowTexture = SharedTextureManager.Get(Viewer.RenderProcess.GraphicsDevice, textureName);
+            LightGlowTexture = textureName.StartsWith(Viewer.ContentPath, StringComparison.OrdinalIgnoreCase) ? SharedTextureManager.Get(Viewer.RenderProcess.GraphicsDevice, textureName) : Viewer.TextureManager.Get(textureName);
         }
 
         public override void SetState(GraphicsDevice graphicsDevice, Material previousMaterial)

--- a/Source/RunActivity/Viewer3D/MSTSSky.cs
+++ b/Source/RunActivity/Viewer3D/MSTSSky.cs
@@ -543,8 +543,8 @@ namespace Orts.Viewer3D
                 string mstsSkySunTexture = Viewer.Simulator.RoutePath + @"\envfiles\textures\" + mstsskysatellitetexture[0].TextureName.ToString();
                 string mstsSkyMoonTexture = Viewer.Simulator.RoutePath + @"\envfiles\textures\" + mstsskysatellitetexture[1].TextureName.ToString();
 
-                MSTSSkySunTexture = SharedTextureManager.Get(Viewer.RenderProcess.GraphicsDevice, mstsSkySunTexture);
-                MSTSSkyMoonTexture = SharedTextureManager.Get(Viewer.RenderProcess.GraphicsDevice, mstsSkyMoonTexture);
+                MSTSSkySunTexture = Viewer.TextureManager.Get(mstsSkySunTexture);
+                MSTSSkyMoonTexture = Viewer.TextureManager.Get(mstsSkyMoonTexture);
             }
             else
                 MSTSSkyMoonTexture = SharedTextureManager.Get(Viewer.RenderProcess.GraphicsDevice, System.IO.Path.Combine(Viewer.ContentPath, "MoonMap.png"));

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -145,7 +145,10 @@ namespace Orts.Viewer3D
                         }
                     }
                     else
+                    {
+                        Trace.TraceWarning("Unsupported texture format: {0}", path);
                         return defaultTexture;
+                    }
 
                     Textures.Add(path, texture);
                     return texture;


### PR DESCRIPTION
Remove support for non-ACE/DDS textures from content that were unexpectedly added by #981

Bug report: Missing (please add Elvas Tower, Trello, Launchpad link if one exists)