### PR TITLE
Fix TrItems in track viewer (events were over-writing mileposts)

### DIFF
--- a/Source/Contrib/TrackViewer/Drawing/DrawTrackDB.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawTrackDB.cs
@@ -107,36 +107,12 @@ namespace ORTS.TrackViewer.Drawing
                 //sigcfgFile = null; // default initialization
             }
 
-            // read the activity location events and store them in the TrackDB.TrItemTable
+            // read the activity location events and add them to the TrackDB.TrItemTable
 
             ActivityNames.Clear();
             var directory = System.IO.Path.Combine(routePath, "ACTIVITIES");
             if (System.IO.Directory.Exists(directory))
             {
-                // counting
-                int cnt = 0;
-
-                foreach (var file in Directory.GetFiles(directory, "*.act"))
-                {
-                    try
-                    {
-                        var activityFile = new ActivityFile(file);
-                        Events events = activityFile.Tr_Activity.Tr_Activity_File.Events;
-                        if (events != null)
-                        {
-                            for (int i = 0; i < events.EventList.Count; i++)
-                            {
-                                if (events.EventList[i].GetType() == typeof(EventCategoryLocation))
-                                {
-                                    cnt++;
-                                }
-                            }
-                        }
-                    }
-                    catch { }
-                }
-
-                // adding
                 int index = TrackDB.TrItemTable.Length;
                 List<TrItem> eventItems = new List<TrItem>();
                 foreach (var file in Directory.GetFiles(directory, "*.act"))
@@ -169,15 +145,18 @@ namespace ORTS.TrackViewer.Drawing
                             ActivityNames.Add(activityFile.Tr_Activity.Tr_Activity_Header.Name);
                         }
                     }
-                    catch { }
+                    catch { /* just ignore activity files with problems */ }
                 }
 
                 // extend the track items array and append the event items
-                int oldSize = TrackDB.TrItemTable.Length;
-                Array.Resize<TrItem>(ref TrackDB.TrItemTable, index);
-                int newSize = TrackDB.TrItemTable.Length;
-                int eventSize = eventItems.Count;
-                for (int toIdx = oldSize, fromIdx = 0; toIdx < newSize && fromIdx < eventSize; toIdx++, fromIdx++) { TrackDB.TrItemTable[toIdx] = eventItems[fromIdx]; }
+                if (eventItems.Count > 0)
+                {
+                    int oldSize = TrackDB.TrItemTable.Length;
+                    Array.Resize<TrItem>(ref TrackDB.TrItemTable, index);
+                    int newSize = TrackDB.TrItemTable.Length;
+                    int eventSize = eventItems.Count;
+                    for (int toIdx = oldSize, fromIdx = 0; toIdx < newSize && fromIdx < eventSize; toIdx++, fromIdx++) { TrackDB.TrItemTable[toIdx] = eventItems[fromIdx]; }
+                }
             }
         }
 

--- a/Source/Contrib/TrackViewer/Drawing/DrawTrackDB.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawTrackDB.cs
@@ -137,7 +137,8 @@ namespace ORTS.TrackViewer.Drawing
                 }
 
                 // adding
-                uint index = 0;
+                int index = TrackDB.TrItemTable.Length;
+                List<TrItem> eventItems = new List<TrItem>();
                 foreach (var file in Directory.GetFiles(directory, "*.act"))
                 {
                     try
@@ -157,8 +158,8 @@ namespace ORTS.TrackViewer.Drawing
                                         eventCategoryLocation.Outcomes.DisplayMessage,
                                         eventCategoryLocation.TileX, eventCategoryLocation.TileZ,
                                         eventCategoryLocation.X, 0, eventCategoryLocation.Z,
-                                        index);
-                                    TrackDB.TrItemTable[index] = eventItem;
+                                        (uint)index);
+                                    eventItems.Add(eventItem);
                                     index++;
                                     found = true;
                                 }
@@ -171,6 +172,12 @@ namespace ORTS.TrackViewer.Drawing
                     catch { }
                 }
 
+                // extend the track items array and append the event items
+                int oldSize = TrackDB.TrItemTable.Length;
+                Array.Resize<TrItem>(ref TrackDB.TrItemTable, index);
+                int newSize = TrackDB.TrItemTable.Length;
+                int eventSize = eventItems.Count;
+                for (int toIdx = oldSize, fromIdx = 0; toIdx < newSize && fromIdx < eventSize; toIdx++, fromIdx++) { TrackDB.TrItemTable[toIdx] = eventItems[fromIdx]; }
             }
         }
 

--- a/Source/Contrib/TrackViewer/Editing/Charts/DrawPathChart.cs
+++ b/Source/Contrib/TrackViewer/Editing/Charts/DrawPathChart.cs
@@ -54,6 +54,9 @@ namespace ORTS.TrackViewer.Editing.Charts
 
         private bool ChartWindowIsOpen { get { return chartWindow.Visibility == Visibility.Visible; } }
 
+        // save window title from properies, so that the window's title can be changed when the selected path is changed
+        private readonly String WindowTitle;
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -64,6 +67,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                 OnJsonSaveClick = OnJsonSave
             };
             TrackViewer.Localize(chartWindow);
+            if (WindowTitle == null) WindowTitle = chartWindow.Title;
         }
 
         /// <summary>
@@ -113,6 +117,7 @@ namespace ORTS.TrackViewer.Editing.Charts
             {   // it path is broken, OnPathChanged performed a close
                 return;
             }
+            chartWindow.Title = String.Format("{0}: {1}", WindowTitle, pathEditor.CurrentTrainPath.PathName);
             chartWindow.Show();
 
         }
@@ -160,6 +165,7 @@ namespace ORTS.TrackViewer.Editing.Charts
                 return;
             }
             pathData.Update(trainpath);
+            chartWindow.Title = String.Format("{0}: {1}", WindowTitle, pathEditor.CurrentTrainPath.PathName);
             chartWindow.Draw();
         }
         


### PR DESCRIPTION
The track viewer also displays activity events. It uses the TrItemTable to capture the events. The bug causes the events to over-write some existing TrItem, instead of appending them to the TrItemTable.

TrItemTable is an array, making it more complex to append.

An alternative fix would be to change the TrItemTable into a List. But that affects a lot of main code.

The bug was discovered because the path chart (and track view) was missing some mileposts.

**Update**: I added another, unrelated commit. It adds the path name to the chart window title. It has been tested with multiple languages.