### PR TITLE
fix for illegal characters in refeerence to Shape file

### DIFF
--- a/Source/RunActivity/Viewer3D/Scenery.cs
+++ b/Source/RunActivity/Viewer3D/Scenery.cs
@@ -332,7 +332,16 @@ namespace Orts.Viewer3D
                 var shapeFilePath = fileNameIsNotShape || String.IsNullOrEmpty(worldObject.FileName) ? null : global ? viewer.Simulator.BasePath + @"\Global\Shapes\" + worldObject.FileName : viewer.Simulator.RoutePath + @"\Shapes\" + worldObject.FileName;
                 if (shapeFilePath != null)
                 {
-                    shapeFilePath = Path.GetFullPath(shapeFilePath);
+                    try
+                    {
+                        shapeFilePath = Path.GetFullPath(shapeFilePath);
+                    }
+                    catch (Exception e)
+                    {
+                        Trace.TraceWarning("Invalid reference in World file {0} to scenery file {1} for {2}: {3}", WFilePath, shapeFilePath, worldObject.FileName, e.Message);
+                        Trace.TraceInformation("Illegal characters in a file path are: \\ / : * ? \" < > |");
+                        shapeFilePath = null;
+                    }
                     if (!File.Exists(shapeFilePath))
                     {
                         Trace.TraceWarning("{0} scenery object {1} with StaticFlags {3:X8} references non-existent {2}", WFileName, worldObject.UID, shapeFilePath, worldObject.StaticFlags);


### PR DESCRIPTION
Where a World File contains a bad reference to a Shape File (e.g. a path containing an illegal ">" character, this led to a fatal error without identifying the file.

This fix changes that to a Warning in the log, so Open Rails can continue, and provides location information.

It solves a problem reported by Chris Gerlach.