### PR TITLE
Temporary fix for bug 2121985: F9 TCO out-of-range after resume (release/1.6)

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs
@@ -29,6 +29,7 @@ using ORTS.Common;
 using ORTS.Common.Input;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
@@ -167,6 +168,12 @@ namespace Orts.Viewer3D.Popups
             outf.Write(Location.Width);
             outf.Write(Location.Height);
 
+            // rwf-rr: temporary fix for bug 2121985
+            if (CarPosition >= Owner.Viewer.PlayerTrain.Cars.Count)
+            {
+                Trace.TraceWarning("TrainCarOperationsViewerWindow.CarPosition {0} out of range [0..{1}]", CarPosition, Owner.Viewer.PlayerTrain.Cars.Count - 1);
+                CarPosition = Owner.Viewer.PlayerTrain.Cars.Count - 1;
+            }
             outf.Write(CarPosition);
             outf.Write(ResetAllSymbols);
         }
@@ -574,6 +581,9 @@ namespace Orts.Viewer3D.Popups
 
                 //required by traincarwindow to ModifyWindowSize()
                 windowHeight = Vbox != null ? Vbox.Position.Height : 0;
+
+                // rwf-rr: part of debugging bug 2121985
+                // System.Diagnostics.Debug.Assert(CarPosition < PlayerTrain.Cars.Count, "Viewer SelectedCar (index) out of range");
             }
         }
 

--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
@@ -35,6 +35,7 @@ using Orts.Simulation.RollingStocks.SubSystems.PowerSupplies;
 using Orts.Viewer3D.RollingStock;
 using Orts.MultiPlayer;
 using Orts.Viewer3D;
+using System.Diagnostics;
 
 namespace Orts.Viewer3D.Popups
 {
@@ -178,6 +179,12 @@ namespace Orts.Viewer3D.Popups
             outf.Write(Location.Width);
             outf.Write(Location.Height);
 
+            // rwf-rr: temporary fix for bug 2121985
+            if (SelectedCarPosition >= Owner.Viewer.PlayerTrain.Cars.Count)
+            {
+                Trace.TraceWarning("TrainCarOperationsWindow.SelectedCarPosition {0} out of range [0..{1}]", SelectedCarPosition, Owner.Viewer.PlayerTrain.Cars.Count - 1);
+                SelectedCarPosition = Owner.Viewer.PlayerTrain.Cars.Count - 1;
+            }
             outf.Write(SelectedCarPosition);
             outf.Write(Owner.Viewer.FrontCamera.IsCameraFront);
         }
@@ -642,6 +649,13 @@ namespace Orts.Viewer3D.Popups
                     SupplyStatusChanged = false;
                     Layout();
                     updateLayoutSize();
+
+                    // rwf-rr: potential partial fix for bug 2121985
+                    // if (trainCarViewer.CouplerChanged && CarPosition >= Owner.Viewer.PlayerTrain.Cars.Count)
+                    // {
+                    //     SelectedCarPosition = CarPosition = Owner.Viewer.PlayerTrain.Cars.Count - 1;
+                    //     LastCarIDSelected = PlayerTrain.Cars[SelectedCarPosition].CarID;
+                    // }
                 }
                 if (OldPositionHeight != Vbox.Position.Height)
                 {
@@ -754,6 +768,11 @@ namespace Orts.Viewer3D.Popups
                     FontToBold = !FontToBold;
                     UpdateWindowSize();
                 }
+
+                // rwf-rr: part of debugging bug 2121985
+                // System.Diagnostics.Debug.Assert(SelectedCarPosition < Owner.Viewer.PlayerTrain.Cars.Count, "Window SelectedCarPosition (index) out of range");
+                // System.Diagnostics.Debug.Assert(CarPosition < Owner.Viewer.PlayerTrain.Cars.Count, "Window SelectedCar (index) out of range");
+                // System.Diagnostics.Debug.Assert(CurrentCarPosition < Owner.Viewer.PlayerTrain.Cars.Count, "Window CurrentCarPosition (index) out of range");
             }
         }
 

--- a/Source/RunActivity/Viewer3D/WebServices/TrainCarOperationsWebpage.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/TrainCarOperationsWebpage.cs
@@ -233,6 +233,12 @@ namespace Orts.Viewer3D.WebServices
         public void Save(BinaryWriter outf) 
         {
             outf.Write(TrainCarSelected);
+            // rwf-rr: temporary fix for bug 2121985
+            if (TrainCarSelectedPosition >= Viewer.PlayerTrain.Cars.Count)
+            {
+                Trace.TraceWarning("TrainCarOperationsWebpage.TrainCarSelectedPosition {0} out of range [0..{1}]", TrainCarSelectedPosition, Viewer.PlayerTrain.Cars.Count - 1);
+                TrainCarSelectedPosition = Viewer.PlayerTrain.Cars.Count - 1;
+            }
             outf.Write(TrainCarSelectedPosition);
         }
 
@@ -371,6 +377,9 @@ namespace Orts.Viewer3D.WebServices
 
                 carPosition++;
             }
+
+            // rwf-rr: part of debugging bug 2121985
+            // System.Diagnostics.Debug.Assert(TrainCarSelectedPosition < Viewer.PlayerTrain.Cars.Count, "Web TrainCarSelectedPosition (index) out of range");
         }
 
         private string getCarId(TrainCar trainCar, int carPosition)


### PR DESCRIPTION
Bug [2121985 ](https://bugs.launchpad.net/or/+bug/2121985)- it is present in **1.6-rc8**

This is a temporary fix. It prevents writing an out of range index into the save file. As a comment it contains a better fix for the Window, but I could not come up with a simple fix for the Webpage.

The problem with the Web-Page happens when the Window is closed. Thus the web page cannot easily change state in the window.

For master, we will need a better fix. There are issues with the interaction between the Window and the Web-Page. Maybe have a separate state object and use the window and web-page objects for the UI parts only.