### PR TITLE
specifies precedence of DDS over ACE

### DIFF
--- a/Source/Documentation/Manual/features-route.rst
+++ b/Source/Documentation/Manual/features-route.rst
@@ -715,11 +715,10 @@ In the ``.trk`` file of the route the parameter ``loadingscreen`` can be used as
 
 	LoadingScreen ( Load.ace )
 
-If in the main directory of the route there is a file with the same name but with extension ``.dds`` 
-and the :ref:`DDS texture support<options-dds-textures>` is enabled
+A DDS extension takes precedence over ACE so, if
+in the main directory of the route there is a file with the same name but with extension ``.dds``,
 the latter is displayed instead of that with ``.ace`` extension.
-If the parameter is omitted then the file ``load.ace`` is loaded (as in MSTS) or ``load.dds`` 
-(if present and, again, the dds support is enabled).
+If the filename parameter is omitted then the file ``load.ace`` is loaded (as in MSTS) or ``load.dds`` if present.
 
 The loading screen image can have any resolution and aspect ratio; it will be displayed letter-boxed
 on the screen keeping the aspect ratio.

--- a/Source/Documentation/Manual/software-platform.rst
+++ b/Source/Documentation/Manual/software-platform.rst
@@ -227,5 +227,16 @@ Note: To avoid overloading the simulator, please keep API calls to once or twice
      - | ``Orts.Viewer3D.WebServices .WebServer.ORTSApiController .ApiSampleData``
 
 
+.. _dds-and-ace:
 
+DDS and ACE Texture Files
+=========================
+
+Open Rails prefers DDS over ACE texture files, but is tolerant where these don't match references in other files.
+
+If a texture file is referenced with no extension, then ``.dds`` is added, searched for and loaded.
+If not found, then ``.ace`` is added, searched for and loaded.
+
+If a texture file is referenced with either a ``dds`` or ``ace`` extension, then that is searched for and loaded
+but, if not found, then the other extension is substituted, searched for and loaded.
 


### PR DESCRIPTION
Describes the tolerant behaviour if filenames don't match references.
Also removes a mention of the option "DDS texture support is enabled" as this support is now always enabled.

See also [https://github.com/openrails/openrails/pull/1151](https://github.com/openrails/openrails/pull/1151)