### PR TITLE
Revise TrainCar.SetUpWheels to Better Handle Unusual Rolling Stock

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1693,6 +1693,8 @@ namespace Orts.Simulation.RollingStocks
             CarWidthM = copy.CarWidthM;
             CarHeightM = copy.CarHeightM;
             CarLengthM = copy.CarLengthM;
+            FrontArticulation = copy.FrontArticulation;
+            RearArticulation = copy.RearArticulation;
             TrackGaugeM = copy.TrackGaugeM;
             CentreOfGravityM = copy.CentreOfGravityM;
             InitialCentreOfGravityM = copy.InitialCentreOfGravityM;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/CruiseControl.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/CruiseControl.cs
@@ -432,7 +432,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 SelectedNumberOfAxles = 0;
                 foreach (TrainCar tc in Locomotive.Train.Cars)
                 {
-                    SelectedNumberOfAxles += tc.WheelAxles.Count;
+                    SelectedNumberOfAxles += tc.WheelAxles.Sum(w => w.Fake ? 0 : 1);
                 }
             }
         }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -911,9 +911,11 @@ namespace Orts.Simulation.RollingStocks
             // Initialize RigidWheelBaseM in first loop if not defined in ENG file, then ignore
             if (RigidWheelBaseM == 0 && !RigidWheelBaseInitialised)   // Calculate default values if no value in Wag File
             {
-                float Axles = WheelAxles.Count;
-                float Bogies = Parts.Count - 1;
-                float BogieSize = Axles / Bogies;
+                int Axles = WheelAxles.Sum(w => w.Fake ? 0 : 1); // Only consider real axles
+                int Bogies = Parts.Sum(p => p.Bogie ? 1 : 0);
+                int BogieSize = Axles;
+                if (Bogies > 0)
+                    BogieSize = (int)(WheelAxles.Sum(w => !w.Fake && w.Part.Bogie ? 1 : 0) / Bogies); // Only consider axles attached to bogies
 
                 RigidWheelBaseM = 1.6764f;       // Set a default in case no option is found - assume a standard 4 wheel (2 axle) bogie - wheel base - 5' 6" (1.6764m)
 
@@ -2804,16 +2806,20 @@ public string GetCurveDirection()
             // No parts means no bogies (always?), so make sure we've got Parts[0] for the car itself.
             if (Parts.Count == 0)
                 Parts.Add(new TrainCarPart(Vector3.Zero, 0));
-            // No axles but we have bogies.
-            if (WheelAxles.Count == 0 && Parts.Count > 1)
+            // Determine how many parts are considered bogies (used to calculate position of the car)
+            int bogieCount = 0;
+            foreach (TrainCarPart p in Parts)
+                if (p.Bogie == true)
+                    bogieCount++;
+            // No axles but we have bogies. Each bogie needs axles to function correctly
+            if (WheelAxles.Count == 0 && bogieCount > 0)
             {
-                // Fake the axles by pretending each bogie has 1 axle.
+                // Add a fake axle to each bogie, a second fake axle will be added later if needed
                 for (int i = 1; i < Parts.Count; i++)
-                    WheelAxles.Add(new WheelAxle(Parts[i].OffsetM, i, Parts[i].iMatrix));
-                Trace.TraceInformation("Wheel axle data faked based on {1} bogies for {0}", WagFilePath, Parts.Count - 1);
+                    if (Parts[i].Bogie == true)
+                        WheelAxles.Add(new WheelAxle(Parts[i].OffsetM, i, Parts[i].iMatrix, true));
+                Trace.TraceInformation("Wheel axle data faked based on {1} bogies for {0}", WagFilePath, bogieCount);
             }
-            bool articFront = !WheelAxles.Any(a => a.OffsetM.Z < 0);
-            bool articRear = !WheelAxles.Any(a => a.OffsetM.Z > 0);
             // Validate the axles' assigned bogies and count up the axles on each bogie.
             if (WheelAxles.Count > 0)
             {
@@ -2833,10 +2839,6 @@ public string GetCurveDirection()
                     w.Part = Parts[w.BogieIndex];
                     w.Part.SumWgt++;
                 }
-
-                // Make sure the axles are sorted by OffsetM along the car.
-                // Attempting to sort car w/o WheelAxles will resort to an error.
-                WheelAxles.Sort(WheelAxles[0]);
             }
 
             //fix bogies with only one wheel set:
@@ -2856,7 +2858,7 @@ public string GetCurveDirection()
                         {
                             if (w.OffsetM.Z.AlmostEqual(Parts[i].OffsetM.Z, 0.6f))
                             {
-                                var w1 = new WheelAxle(new Vector3(w.OffsetM.X, w.OffsetM.Y, w.OffsetM.Z - 0.5f), w.BogieIndex, i);
+                                var w1 = new WheelAxle(new Vector3(w.OffsetM.X, w.OffsetM.Y, w.OffsetM.Z - 0.5f), w.BogieIndex, i, true);
                                 w1.Part = Parts[w1.BogieIndex]; //create virtual wheel
                                 w1.Part.SumWgt++;
                                 WheelAxles.Add(w1);
@@ -2869,34 +2871,29 @@ public string GetCurveDirection()
                 }
             }
 
-            // Count up the number of bogies (parts) with at least 2 axles.
+            // Check how many parts can drive the position of the car itself
+            // Each part needs at least 2 components (sum of weights > 1.5) for position calculation to work
             for (var i = 1; i < Parts.Count; i++)
                 if (Parts[i].SumWgt > 1.5)
                     Parts[0].SumWgt++;
 
-            // This check is for the single axle/bogie issue.
-            // Check SumWgt using Parts[0].SumWgt.
-            // Certain locomotives do not test well when using Part.SumWgt versus Parts[0].SumWgt.
-            // Make sure test using Parts[0] is performed after the above for loop.
+            // Check if articulation is desired on this car, as this requires different handling
+            bool articFront = (FrontArticulation == 1 || (FrontArticulation == -1 && !WheelAxles.Any(a => a.OffsetM.Z < 0)));
+            bool articRear = (RearArticulation == 1 || (RearArticulation == -1 && !WheelAxles.Any(a => a.OffsetM.Z > 0)));
+
+            // If car has insufficient bogies and it's not because of articulation, attempt to avoid position calculation errors
+            // Detach wheels from the last bogie, and instead attach to the main part, which should allow calculations to work properly
             if (!articFront && !articRear && (Parts[0].SumWgt < 1.5))
             {
-                foreach (var w in WheelAxles)
+                foreach (WheelAxle w in WheelAxles)
                 {
                     if (w.BogieIndex >= Parts.Count - 1)
                     {
                         w.BogieIndex = 0;
                         w.Part = Parts[w.BogieIndex];
-
                     }
                 }
             }
-            // Using WheelAxles.Count test to control WheelAxlesLoaded flag.
-            if (WheelAxles.Count >= 2) // Some cars only have two axles.
-            {
-                WheelAxles.Sort(WheelAxles[0]);
-                WheelAxlesLoaded = true;
-            }
-
 
 #if DEBUG_WHEELS
             Console.WriteLine(WagFilePath);
@@ -2907,43 +2904,49 @@ public string GetCurveDirection()
             foreach (var p in Parts)
                 Console.WriteLine("  part:  matrix {1,5:F0}  offset {0,10:F4}  weight {2,5:F0}", p.OffsetM, p.iMatrix, p.SumWgt);
 #endif
-            // Decided to control what is sent to SetUpWheelsArticulation()by using
-            // WheelAxlesLoaded as a flag.  This way, wagons that have to be processed are included
-            // and the rest left out.
+            // Add fake axle(s) to train car for articulation when desired
+            // Adding fake axles automatically is only allowed on non-engines with 0, 2, or 3 axles
+            // These limitations prevent various incompatibilities with existing content
+            bool allowAutoArticulate = WagonType != WagonTypes.Engine && WheelAxles.Count != 1 && WheelAxles.Count <= 3;
+            articFront &= !(FrontArticulation == -1 && !allowAutoArticulate);
+            articRear &= !(RearArticulation == -1 && !allowAutoArticulate);
 
-            // Force articulation if stock is configured as such
-            // Otherwise, use default behavior which gives articulation if there are no axles forward/rearward on the model,
-            // disables articulation on engines, and only allows articulation with 3 or fewer axles, but not 1 axle
-            bool articulatedFront = (FrontArticulation == 1 ||
-                (FrontArticulation == -1 && !WheelAxles.Any(a => a.OffsetM.Z < 0) && WagonType != WagonTypes.Engine && WheelAxles.Count != 1 && WheelAxles.Count <= 3));
-            bool articulatedRear = (RearArticulation == 1 ||
-                (RearArticulation == -1 && !WheelAxles.Any(a => a.OffsetM.Z > 0) && WagonType != WagonTypes.Engine && WheelAxles.Count != 1 && WheelAxles.Count <= 3));
+            if (articFront || articRear)
+                SetUpWheelsArticulation(articFront, articRear);
 
-            if (articulatedFront || articulatedRear)
-            {
+            // Other calculations require axles to be sorted based on their Z-offset
+            WheelAxles.Sort(WheelAxles[0]);
+
+            // After all processing is complete, check if the car can have its position calculated
+            // using the position of the axles, which is indicated by the 'WheelAxlesLoaded' flag.
+            // The train car must have at least 2 position references. These references can be either
+            // an axle or a bogie, but each bogie itself needs 2 position references.
+            int[] posReferences = new int[Parts.Count];
+            // Count the number of axles associated with each part (including main object)
+            foreach (WheelAxle w in WheelAxles)
+                posReferences[w.BogieIndex]++;
+            // Add a position reference to the main object for each bogie itself with at least 2 position references
+            for (int i = 1; i < Parts.Count; i++)
+                if (posReferences[i] >= 2) 
+                    posReferences[0]++;
+            // Car has a suitable arrangement of axles for position calculation if the main object has at least 2 position references
+            if (posReferences[0] >= 2) 
                 WheelAxlesLoaded = true;
-                SetUpWheelsArticulation(articulatedFront, articulatedRear);
-            }
         } // end SetUpWheels()
 
         protected void SetUpWheelsArticulation(bool front, bool rear)
         {
-            // If there are no forward wheels, this car is articulated (joined
+            // If there are no forward axles, this car is articulated (joined
             // to the car in front) at the front. Likewise for the rear.
-            // Original process originally used caused too many issues.
-            // The original process did include the below process of just using WheelAxles.Add
-            //  if the initial test did not work.  Since the below process is working without issues the
-            //  original process was stripped down to what is below
-            if (front || rear)
-            {
-                if (front)
-                    WheelAxles.Add(new WheelAxle(new Vector3(0.0f, BogiePivotHeightM, -CarLengthM / 2.0f), 0, 0) { Part = Parts[0] });
+            // This will cause the car to move incorrectly, so to produce the
+            // expected motion, a fake axle is added at the articulated end(s)
+            // of the car, attached to the car itself. This will drive the positioning
+            // of the car as expected.
+            if (front)
+                WheelAxles.Add(new WheelAxle(new Vector3(0.0f, BogiePivotHeightM, -CarLengthM / 2.0f), 0, 0, true) { Part = Parts[0] });
 
-                if (rear)
-                    WheelAxles.Add(new WheelAxle(new Vector3(0.0f, BogiePivotHeightM, CarLengthM / 2.0f), 0, 0) { Part = Parts[0] });
-
-                WheelAxles.Sort(WheelAxles[0]);
-            }
+            if (rear)
+                WheelAxles.Add(new WheelAxle(new Vector3(0.0f, BogiePivotHeightM, CarLengthM / 2.0f), 0, 0, true) { Part = Parts[0] });
 
 
 #if DEBUG_WHEELS
@@ -3718,14 +3721,16 @@ public string GetCurveDirection()
     public class WheelAxle : IComparer<WheelAxle>
     {
         public Vector3 OffsetM;   // Offset from the bogie center
-        public int BogieIndex;
-        public int BogieMatrix;
-        public TrainCarPart Part;
-        public WheelAxle(Vector3 offset, int bogie, int parentMatrix)
+        public int BogieIndex;    // Index in the Parts list of the bogie this is attached to
+        public int BogieMatrix;   // Index in the matrix hierarchy of the bogie this is attached to
+        public TrainCarPart Part; // Reference to the object for the bogie this is attached to
+        public bool Fake;         // True for axles that aren't present in the 3D model
+        public WheelAxle(Vector3 offset, int bogie, int parentMatrix, bool fake = false)
         {
             OffsetM = offset;
             BogieIndex = bogie;
             BogieMatrix = parentMatrix;
+            Fake = fake;
         }
         public int Compare(WheelAxle a, WheelAxle b)
         {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -2912,7 +2912,7 @@ public string GetCurveDirection()
             // and the rest left out.
 
             // Force articulation if stock is configured as such
-            // Otherwise, use default behavior which gives articulation if there are no axles forward/reareward on the model,
+            // Otherwise, use default behavior which gives articulation if there are no axles forward/rearward on the model,
             // disables articulation on engines, and only allows articulation with 3 or fewer axles, but not 1 axle
             bool articulatedFront = (FrontArticulation == 1 ||
                 (FrontArticulation == -1 && !WheelAxles.Any(a => a.OffsetM.Z < 0) && WagonType != WagonTypes.Engine && WheelAxles.Count != 1 && WheelAxles.Count <= 3));
@@ -3020,8 +3020,17 @@ public string GetCurveDirection()
                 if (p.SumWgt > 1.5f)
                     p0.AddPartLocation(1, p);
             }
-            // Determine facing direction and position of train car
-            p0.FindCenterLine();
+            if (Parts.Count == 2)
+            {
+                // Train car lacks sufficient parts to locate using linear regression
+                p0.Dir = Parts[1].Dir;
+                p0.Pos = Parts[1].Pos;
+            }
+            else
+            {
+                // Determine facing direction and position of train car
+                p0.FindCenterLine();
+            }
             Vector3 fwd = new Vector3(p0.Dir[0], p0.Dir[1], -p0.Dir[2]);
             // Check if null (0-length) vector
             if (!(fwd.X == 0 && fwd.Y == 0 && fwd.Z == 0))
@@ -3739,7 +3748,7 @@ public string GetCurveDirection()
         public double[] SumPos = new double[3]; // Sum of component locations [x, y, z]
         public double[] SumPosZOffset = new double[3]; // Sum of component locations [x, y, z] times Z-offsets
         public float[] Pos = new float[3]; // Position [x, y, z] of this part, calculated with y-intercept of linear regression
-        public float[] Dir = new float[3]; // Oritentation [x, y, z] of this part, calculated with slope of linear regression
+        public float[] Dir = new float[3]; // Orientation [x, y, z] of this part, calculated with slope of linear regression
         public float SumRoll; // Sum of all roll angles of components
         public float Roll; // Roll angle of this part
         public bool Bogie; // True if this is a bogie
@@ -3804,7 +3813,7 @@ public string GetCurveDirection()
             // 2D Least regression between the offsets (along longitudinal axis of rail vehicle)
             // and actual positions in 3D space, repeated 3 times for each dimension in 3D.
 
-            // Follows format of y = M * x + B where x is the foward/backward position along the train car axis
+            // Follows format of y = M * x + B where x is the forward/backward position along the train car axis
             // and y is the actual (x, y, or z) position in 3D space. We need to determine vectors B (the 3D
             // position of this part) and M (the 3D orientation of this part) using the offsets and positions added previously.
 
@@ -3819,18 +3828,15 @@ public string GetCurveDirection()
                     Dir[i] = (float)((SumWgt * SumPosZOffset[i] - SumZOffset * SumPos[i]) / denominator);
                     // The position (B) is defined as 'B = [sum(y) - M * sum(x)] / N', where N is the total
                     // weight, x is the offset, y is the 3D position, and M is the direction value from earlier.
-                    // This uses an equivalent form that doesn't use the result of the above calulcation to avoid
+                    // This uses an equivalent form that doesn't use the result of the above calculation to avoid
                     // precision errors from the value being converted to a float.
                     Pos[i] = (float)((SumZOffsetSq * SumPos[i] - SumZOffset * SumPosZOffset[i]) / denominator);
                 }
             }
-            else
+            else // Improperly defined wagon, fallback to basic calculation
             {
                 for (int i = 0; i < 3; i++)
-                {
                     Pos[i] = (float)(SumPos[i] / SumWgt);
-                    Dir[i] = 0;
-                }
             }
 
             Roll = SumRoll / (float)SumWgt;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -3025,6 +3025,7 @@ public string GetCurveDirection()
                 // Train car lacks sufficient parts to locate using linear regression
                 p0.Dir = Parts[1].Dir;
                 p0.Pos = Parts[1].Pos;
+                p0.Roll = Parts[1].Roll;
             }
             else
             {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -2807,9 +2807,9 @@ public string GetCurveDirection()
             // No axles but we have bogies.
             if (WheelAxles.Count == 0 && Parts.Count > 1)
             {
-                // Fake the axles by pretending each has 1 axle.
-                foreach (var part in Parts)
-                    WheelAxles.Add(new WheelAxle(part.OffsetM, part.iMatrix, 0));
+                // Fake the axles by pretending each bogie has 1 axle.
+                for (int i = 1; i < Parts.Count; i++)
+                    WheelAxles.Add(new WheelAxle(Parts[i].OffsetM, i, Parts[i].iMatrix));
                 Trace.TraceInformation("Wheel axle data faked based on {1} bogies for {0}", WagFilePath, Parts.Count - 1);
             }
             bool articFront = !WheelAxles.Any(a => a.OffsetM.Z < 0);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -3020,7 +3020,7 @@ public string GetCurveDirection()
                 if (p.SumWgt > 1.5f)
                     p0.AddPartLocation(1, p);
             }
-            if (Parts.Count == 2)
+            if (Parts.Count == 2 && p0.SumWgt < 1.5f)
             {
                 // Train car lacks sufficient parts to locate using linear regression
                 p0.Dir = Parts[1].Dir;
@@ -3837,7 +3837,10 @@ public string GetCurveDirection()
             else // Improperly defined wagon, fallback to basic calculation
             {
                 for (int i = 0; i < 3; i++)
+                {
                     Pos[i] = (float)(SumPos[i] / SumWgt);
+                    Dir[i] = 0;
+                }
             }
 
             Roll = SumRoll / (float)SumWgt;

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -2915,7 +2915,8 @@ public string GetCurveDirection()
                 SetUpWheelsArticulation(articFront, articRear);
 
             // Other calculations require axles to be sorted based on their Z-offset
-            WheelAxles.Sort(WheelAxles[0]);
+            if (WheelAxles.Count > 0)
+                WheelAxles.Sort(WheelAxles[0]);
 
             // After all processing is complete, check if the car can have its position calculated
             // using the position of the axles, which is indicated by the 'WheelAxlesLoaded' flag.

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -608,53 +608,66 @@ namespace Orts.Viewer3D.Popups
 
                 foreach (var axle in car.WheelAxles)
                 {
-                    if (!axle.Part.Bogie) // if not a bogie then check for the number of axles.
+                    // Do not consider fake axles
+                    if (!axle.Fake)
                     {
-                        if (currentBogie != axle.BogieIndex && currentCount != 0)
+                        if (!axle.Part.Bogie) // if not a bogie then check for the number of axles.
                         {
-                            whyte.Add(currentCount.ToString());
-                            currentBogie = axle.BogieIndex;
-                            currentCount = 0;
-                        }
-
-                        if (steamloco.SteamEngines[i].AuxiliarySteamEngineType != SteamEngine.AuxiliarySteamEngineTypes.Booster)
-                        {
-                            currentCount += 2;
-                            axlesCount += 1;
-
-                            if (axlesCount >= steamloco.SteamEngines[i].AttachedAxle.NumWheelsetAxles && currentCount != 0)
+                            if (currentBogie != axle.BogieIndex)
                             {
-                                whyte.Add(currentCount.ToString());
+                                if (currentCount != 0)
+                                {
+                                    whyte.Add(currentCount.ToString());
+                                    currentCount = 0;
+                                }
                                 currentBogie = axle.BogieIndex;
-                                currentCount = 0;
-                                axlesCount = 0;
-                                i = i + 1;
+                            }
+
+                            if (steamloco.SteamEngines[i].AuxiliarySteamEngineType != SteamEngine.AuxiliarySteamEngineTypes.Booster)
+                            {
+                                currentCount += 2;
+                                axlesCount += 1;
+
+                                if (axlesCount >= steamloco.SteamEngines[i].AttachedAxle.NumWheelsetAxles)
+                                {
+                                    if (currentCount != 0)
+                                    {
+                                        whyte.Add(currentCount.ToString());
+                                        currentCount = 0;
+                                    }
+                                    currentBogie = axle.BogieIndex;
+                                    axlesCount = 0;
+                                    i = i + 1;
+                                }
                             }
                         }
-                    }
-                    else if (axle.Part.Bogie) // this is a bogie
-                    {
-                        if ( PreviousAxlePart)
+                        else if (axle.Part.Bogie) // this is a bogie
                         {
-                            currentBogie = axle.BogieIndex;
+                            if (PreviousAxlePart)
+                            {
+                                currentBogie = axle.BogieIndex;
+                            }
+
+                            if (currentBogie != axle.BogieIndex)
+                            {
+                                if (currentCount != 0)
+                                {
+                                    whyte.Add(currentCount.ToString());
+                                    currentCount = 0;
+                                }
+                                currentBogie = axle.BogieIndex;
+                            }
+                            currentCount += 2;
                         }
 
-                        if (currentBogie != axle.BogieIndex && currentCount != 0)
+                        if (axle.Part.Bogie)
                         {
-                            whyte.Add(currentCount.ToString());
-                            currentBogie = axle.BogieIndex;
-                            currentCount = 0;
+                            PreviousAxlePart = true;
                         }
-                        currentCount += 2;
-                    }
-
-                    if (axle.Part.Bogie)
-                    {
-                        PreviousAxlePart = true;
-                    }
-                    else
-                    {
-                        PreviousAxlePart = false;
+                        else
+                        {
+                            PreviousAxlePart = false;
+                        }
                     }
                 }
 
@@ -665,13 +678,20 @@ namespace Orts.Viewer3D.Popups
             {
                 foreach (var axle in car.WheelAxles)
                 {
-                    if (currentBogie != axle.BogieIndex && currentCount != 0)
+                    // Do not consider fake axles
+                    if (!axle.Fake)
                     {
-                        whyte.Add(currentCount.ToString());
-                        currentBogie = axle.BogieIndex;
-                        currentCount = 0;
+                        if (currentBogie != axle.BogieIndex)
+                        {
+                            if (currentCount != 0)
+                            {
+                                whyte.Add(currentCount.ToString());
+                                currentCount = 0;
+                            }
+                            currentBogie = axle.BogieIndex;
+                        }
+                        currentCount += 2;
                     }
-                    currentCount += 2;
                 }
                 whyte.Add(currentCount.ToString());
                 return String.Join("-", whyte.ToArray());


### PR DESCRIPTION
Semi follow up to #1121 and #1160. A seemingly innocent change made in #1160 allowed for train cars with insufficient information to compute their position to use `TrainCar.ComputePosition()` anyway. This would result in said train cars appearing invisible, as noted in [this bug](https://www.elvastower.com/forums/index.php?/topic/39187-stock-missing-in-consists/) and [this bug](https://www.elvastower.com/forums/index.php?/topic/39269-missing-loco-shapes-in-rmd-east-route/page__pid__322641#entry322641).

This is because `TrainCar.ComputePosition` requires at least two points in 3D space to position a train car, as linear regression is used and linear regression needs at least two points. These two reference points can be the position of an axle on the train car, or a bogie on the train car (though if a bogie is used, the _bogie itself needs an additional two or more reference points_ to determine its position). Whether or not `TrainCar.ComputePosition` is used at all depends on the state of `TrainCar.WheelAxlesLoaded`, where a true value indicates `TrainCar.ComputePosition` can be used, and a false value indicates it cannot be used. This means that `TrainCar.WheelAxlesLoaded` should only be true if the train car has at least two reference points for its position.

However, the process to determine `TrainCar.WheelAxlesLoaded` in `TrainCar.SetUpWheels` hasn't really been touched in 10 years and was suboptimal. Previously, `TrainCar.WheelAxlesLoaded` was set to true if the train car had **3 or more simulated axles**. This was merely a rough approximation of the actual check to see "are there two or more reference points for position?" as models with 3 simulated axles _usually_ have enough reference points for `TrainCar.ComputePosition` to do its thing. However, #1160 revealed how problematic this strategy was by changing the condition to be **_2_ or more simulated axles**. Unlike checking for **3** or more simulated axles, many models with **2** simulated axles do _not_ have two reference points for `TrainCar.ComputePosition`. The most obvious example is a model with one bogie, and that bogie having two axles. Because the model has only one bogie, it has only one positional reference point, and thus `TrainCar.WheelAxlesLoaded` should be set to false for this model. But with the changes made, `TrainCar.WheelAxlesLoaded` would be set to true for this model and calculating its position with `TrainCar.ComputePosition` would fail.


While the change made in #1160 could be reverted, going back to checking for 3 or more simulated axles, that would break track sounds on models with 2 axles. Instead, `TrainCar.SetUpWheels` has been greatly refactored to achieve the actual intended result, instead of some approximation of it. With this PR, `TrainCar.SetUpWheels` will inspect the configuration of simulated axles and bogies and will only set `TrainCar.WheelAxlesLoaded` to true if the train car has 2 or more axles attached to it, 2 or more bogies (which themselves have 2 or more axles attached) attached to it, or some combination of axles and bogies that adds up to at least 2 positional references.

This won't necessarily provide the same resulting behavior as previous versions, but any changes should be imperceptible. I think this might even help content creators, by removing some of the jank that was previously present (you should no longer need to add fake axles or fake bogies to non-bogie rolling stock).

Additionally, should `TrainCar.WheelAxlesLoaded` somehow be set to true incorrectly, a fallback calculation has been added to `TrainCar.ComputePosition` that will still produce a reasonable position instead of causing the model to become invisible.


While refactoring `TrainCar.SetUpWheels`, some related problems that have been observed were also fixed. `ORTSFrontArticulation` and `ORTSRearArticulation` were not being copied to subsequent instances of a train car, so they have been added to `MSTSWagon.Copy`. Fake axles were not being added to all bogies that were missing axles, resulting in nonsense position calculations that would [cause said bogies to spin](https://www.elvastower.com/forums/index.php?/topic/39191-rapidly-rotating-bogies/), so that was rebuilt to work reliably. And when fake axles were added, a few systems were treating these fake axles as if they were real axles, so the distinction has been made more clear.

Bug report: https://www.elvastower.com/forums/index.php?/topic/39191-rapidly-rotating-bogies/