### PR TITLE
Adds clarity for ORTSUserPreferenceRemoveForestTreesFromRoads

### DIFF
--- a/Source/Documentation/Manual/features-route.rst
+++ b/Source/Documentation/Manual/features-route.rst
@@ -799,11 +799,11 @@ Alternatively, the original .trk file can be left unmodified, and a new .trk fil
 inserted into an ``OpenRails`` folder in the root folder of the route. This is 
 explained :ref:`here <features-route-modify-trk>`. 
 
-To avoid also forest trees on roads following line::
+To avoid also forest trees on roads insert the following line which sets the Boolean value to true::
 
   ORTSUserPreferenceRemoveForestTreesFromRoads ( 1 )
 
-must be added below line::
+and must be added below line::
 
   ORTSUserPreferenceForestClearDistance ( 2 )
 


### PR DESCRIPTION
To indicate in
`ORTSUserPreferenceRemoveForestTreesFromRoads ( 1 )`
that ( 1 ) is a Boolean, not a distance in metres.