### PR TITLE
Fix Map Window position saved when minimized.

### DIFF
--- a/Source/RunActivity/Viewer3D/Map/MapForm.cs
+++ b/Source/RunActivity/Viewer3D/Map/MapForm.cs
@@ -297,9 +297,12 @@ namespace Orts.Viewer3D.Debugging
             {
                 string name = "Map_" + mapViewer.Name;
 
-                int X = this.Bounds.X;
-                int Y = this.Bounds.Y;
-                Viewer.Settings.GetProperty(name).SetValue(Viewer.Settings, new int[] { X, Y, Size.Width, Size.Height }, null);
+                bool useRestoreBounds = this.WindowState == FormWindowState.Minimized || this.WindowState == FormWindowState.Maximized;
+                int posX = useRestoreBounds ? this.RestoreBounds.X : this.Bounds.X;
+                int posY = useRestoreBounds ? this.RestoreBounds.Y : this.Bounds.Y;
+                int width = useRestoreBounds ? this.RestoreBounds.Width : this.Bounds.Width;
+                int height = useRestoreBounds ? this.RestoreBounds.Height : this.Bounds.Height;
+                Viewer.Settings.GetProperty(name).SetValue(Viewer.Settings, new int[] { posX, posY, width, height }, null);
                 Viewer.Settings.Save(name);
             }
         }


### PR DESCRIPTION
When the Map (Dispatcher) window (Ctrl-9) is minimized, its position was saved as "-32000,-32000,199,34". This is how Windows sizes and hides a minimized window. Subsequently, when the Map window is opened again, it is not visible (far off the screen), and the user may think that the Map is no longer working.

See [discussion on ElvasTower](https://www.elvastower.com/forums/index.php?/topic/37165-reworking-the-dispatcher-window/page__view__findpost__p__322764).

When the window is minimized, use the _restore_ bounds (instead of the current bounds) to save in the settings. This affects both the position and the size.

Common practice seems to be to also save the _restore_ bounds when the window is maximized. So I included this.