### PR TITLE
Set missing texture color depending on shape warning option (was: build mode)

### DIFF
--- a/Source/Documentation/Manual/compatibility.rst
+++ b/Source/Documentation/Manual/compatibility.rst
@@ -47,7 +47,8 @@ file and run properly. Open Rails software logs these errors in a log file on
 the user's desktop. This log file may be used to correct problems identified 
 by the Open Rails software. The parser will also correct some of the problems 
 that stumped MSTS.  For example, if a texture is missing Open Rails will 
-substitute a neutral gray texture and continue.
+substitute a neutral gray texture (or high-vis magenta texture when compiled 
+in DEBUG mode) and continue.
 
 MSTS Files Used in Whole or Part by Open Rails
 ==============================================

--- a/Source/Documentation/Manual/compatibility.rst
+++ b/Source/Documentation/Manual/compatibility.rst
@@ -47,8 +47,8 @@ file and run properly. Open Rails software logs these errors in a log file on
 the user's desktop. This log file may be used to correct problems identified 
 by the Open Rails software. The parser will also correct some of the problems 
 that stumped MSTS.  For example, if a texture is missing Open Rails will 
-substitute a neutral gray texture (or high-vis magenta texture when compiled 
-in DEBUG mode) and continue.
+substitute a neutral gray texture (or high-vis magenta texture when the 
+experimental option "Show shape warnings" is checked) and continue.
 
 MSTS Files Used in Whole or Part by Open Rails
 ==============================================

--- a/Source/Documentation/Manual/options.rst
+++ b/Source/Documentation/Manual/options.rst
@@ -851,9 +851,12 @@ Multi-gauge routes are not fully supported at the moment.
 Show shape warnings
 -------------------
 
-When this option is selected, when ORTS is loading the shape (.s) files it
-will report errors in syntax and structure (even if these don't cause
-runtime errors) in the :ref:`Log file <driving-logfile>` ``OpenRailsLog.txt`` on the desktop.
+When this option is selected, ORTS will:
+
+- when loading the shape (.s) files,
+  report errors in syntax and structure (even if these don't cause
+  runtime errors) in the :ref:`Log file <driving-logfile>` ``OpenRailsLog.txt`` on the desktop;
+- use high-visible magenta for missing textures (instead of grey).
 
 
 Correct questionable braking parameters

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -131,7 +131,11 @@ namespace Orts.Viewer3D
         internal static Texture2D GetInternalMissingTexture(GraphicsDevice graphicsDevice)
         {
             var texture = new Texture2D(graphicsDevice, 1, 1);
-            texture.SetData(new[] { Color.Magenta });
+#if DEBUG
+            texture.SetData(new[] { Color.Magenta});
+#else
+            texture.SetData(new[] { Color.Gray });
+#endif
             return texture;
         }
 

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -54,11 +54,14 @@ namespace Orts.Viewer3D
         Dictionary<string, Texture2D> Textures = new Dictionary<string, Texture2D>();
         Dictionary<string, bool> TextureMarks = new Dictionary<string, bool>();
 
+        internal static bool HighlightMissingTextures = false;
+
         [CallOnThread("Render")]
         internal SharedTextureManager(Viewer viewer, GraphicsDevice graphicsDevice)
         {
             Viewer = viewer;
             GraphicsDevice = graphicsDevice;
+            if (Viewer.Settings?.SuppressShapeWarnings == false) HighlightMissingTextures = true;
         }
 
         /// <summary>
@@ -131,11 +134,8 @@ namespace Orts.Viewer3D
         internal static Texture2D GetInternalMissingTexture(GraphicsDevice graphicsDevice)
         {
             var texture = new Texture2D(graphicsDevice, 1, 1);
-#if DEBUG
-            texture.SetData(new[] { Color.Magenta});
-#else
-            texture.SetData(new[] { Color.Gray });
-#endif
+            if (HighlightMissingTextures) texture.SetData(new[] { Color.Magenta });
+            else texture.SetData(new[] { Color.Gray });
             return texture;
         }
 


### PR DESCRIPTION
Gray (grey) ~~for the release (and testing) build~~ by default.
Magenta (highly visible) ~~for the debug build~~ when "Show shape warnings" is checked (enabled) in the experimental options, so that missing textures stand out.

This was triggered by [this thread](https://www.elvastower.com/forums/index.php?/topic/39453-please-explain-what-is-going-on-here/).

The solution is not entirely clean, as GetInternalMissingTexture() is a static, but checking options requires a SharedTextureManager object.

However, the only textures that are loaded before the Viewer is initialized are BMP and PNG images for the splash (loading) screen. If those were missing, even grey would make it obvious.

All simulation (global, route, trains) textures are loaded (SharedTextureManager initialize) well after the settings are read.

Roadmap: https://trello.com/c/chR6f9OT/629-set-missing-texture-color-depending-on-build-mode