### PR TITLE
Allow DDS textures in MSTS environments, microtex, Track Viewer

### DIFF
--- a/Source/Contrib/TrackViewer/Drawing/BasicShapes.cs
+++ b/Source/Contrib/TrackViewer/Drawing/BasicShapes.cs
@@ -16,8 +16,8 @@
 // along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Text;
 using System.Windows.Media.Imaging;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -308,9 +308,23 @@ namespace ORTS.TrackViewer.Drawing
                 string textureName = filename;
                 string path = directory + filename;
                 oldAceFiles = new List<string>();
-                if (System.IO.File.Exists(path))
+                if (File.Exists(path))
                 {
-                    Texture2D texture = Orts.Formats.Msts.AceFile.Texture2DFromFile(graphicsDevice, path);
+                    Texture2D texture;
+                    try
+                    {
+                        if (Path.GetExtension(path) == ".dds")
+                            DDSLib.DDSFromFile(path, graphicsDevice, true, out texture);
+                        else if (Path.GetExtension(path) == ".ace")
+                            texture = Orts.Formats.Msts.AceFile.Texture2DFromFile(graphicsDevice, path);
+                        else
+                            continue;
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+
                     textures[textureName] = texture;
                     textureScales[textureName] = texture.Width;
                     textureOffsets[textureName] = new Vector2(texture.Width / 2, texture.Height / 2);

--- a/Source/Contrib/TrackViewer/Drawing/DrawTerrain.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawTerrain.cs
@@ -1,4 +1,4 @@
-// COPYRIGHT 2014, 2018 by the Open Rails project.
+﻿// COPYRIGHT 2014, 2018 by the Open Rails project.
 // 
 // This file is part of Open Rails.
 // 
@@ -623,7 +623,7 @@ namespace ORTS.TrackViewer.Drawing
             }
 
             string path = terrtexPath + filename;
-            if (System.IO.File.Exists(path))
+            if (File.Exists(path))
             {
                 //The message delegate has quite some overhead, so print it only so often to keep the user informed
                 if (loadedAceFilesCounter % 100 == 0)
@@ -631,7 +631,22 @@ namespace ORTS.TrackViewer.Drawing
                     messageDelegate(String.Format(TrackViewer.catalog.GetString("Loading terrain ace-files {0}-{1} (scaled down with a factor {2})"), loadedAceFilesCounter, loadedAceFilesCounter + 99, CurrentScaleFactor));
                 }
                 loadedAceFilesCounter++;
-                var originalTexture = Orts.Formats.Msts.AceFile.Texture2DFromFile(this.device, path);
+
+                Texture2D originalTexture;
+                try
+                {
+                    if (Path.GetExtension(path) == ".dds")
+                        DDSLib.DDSFromFile(path, device, true, out originalTexture);
+                    else if (Path.GetExtension(path) == ".ace")
+                        originalTexture = AceFile.Texture2DFromFile(device, path);
+                    else
+                        return false;
+                }
+                catch
+                {
+                    return false;
+                }
+
                 var reducableTexture = new ReducableTexture2D(device, originalTexture);
                 reducableTexture.ReduceToFactor(CurrentScaleFactor);
                 this[filename] = reducableTexture;

--- a/Source/RunActivity/Viewer3D/MSTSSky.cs
+++ b/Source/RunActivity/Viewer3D/MSTSSky.cs
@@ -504,7 +504,7 @@ namespace Orts.Viewer3D
                 for (int i = 0; i < Viewer.ENVFile.SkyLayers.Count; i++)
                 {
                     mstsSkyTexture[i] = Viewer.Simulator.RoutePath + @"\envfiles\textures\" + mstsskytexture[i].TextureName.ToString();
-                    MSTSSkyTexture.Add(Orts.Formats.Msts.AceFile.Texture2DFromFile(Viewer.RenderProcess.GraphicsDevice, mstsSkyTexture[i]));
+                    MSTSSkyTexture.Add(Viewer.TextureManager.Get(mstsSkyTexture[i], true));
                     if( i == 0 )
                     {
                         MSTSDayTexture = MSTSSkyTexture[i];
@@ -520,7 +520,7 @@ namespace Orts.Viewer3D
                     }
                     else
                     {
-                        MSTSSkyCloudTexture.Add(Orts.Formats.Msts.AceFile.Texture2DFromFile(Viewer.RenderProcess.GraphicsDevice, mstsSkyTexture[i]));
+                        MSTSSkyCloudTexture.Add(Viewer.TextureManager.Get(mstsSkyTexture[i]));
                         mstscloudtexturex = mstsskytexture[i].TileX;
                         mstscloudtexturey = mstsskytexture[i].TileY;
                     }

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -270,21 +270,26 @@ namespace Orts.Viewer3D
             PopupWindowShader = new PopupWindowShader(viewer, viewer.RenderProcess.GraphicsDevice);
             PrecipitationShader = new PrecipitationShader(viewer.RenderProcess.GraphicsDevice);
             SceneryShader = new SceneryShader(viewer.RenderProcess.GraphicsDevice);
-            var microtexPath = viewer.Simulator.RoutePath + @"\TERRTEX\microtex.ace";
-            if (File.Exists(microtexPath))
+            var microtexPath = viewer.Simulator.RoutePath + @"\TERRTEX\microtex";
+            try
             {
-                try
+                if (File.Exists(microtexPath + ".dds"))
                 {
-                    SceneryShader.OverlayTexture = Orts.Formats.Msts.AceFile.Texture2DFromFile(viewer.GraphicsDevice, microtexPath);
+                    DDSLib.DDSFromFile(microtexPath + ".dds", viewer.GraphicsDevice, true, out Texture2D microtex);
+                    SceneryShader.OverlayTexture = microtex;
                 }
-                catch (InvalidDataException error)
+                else if (File.Exists(microtexPath + ".ace"))
                 {
-                    Trace.TraceWarning("Skipped texture with error: {1} in {0}", microtexPath, error.Message);
+                    SceneryShader.OverlayTexture = Formats.Msts.AceFile.Texture2DFromFile(viewer.GraphicsDevice, microtexPath + ".ace");
                 }
-                catch (Exception error)
-                {
-                    Trace.WriteLine(new FileLoadException(microtexPath, error));
-                }
+            }
+            catch (InvalidDataException error)
+            {
+                Trace.TraceWarning("Skipped texture with error: {1} in {0}", microtexPath, error.Message);
+            }
+            catch (Exception error)
+            {
+                Trace.WriteLine(new FileLoadException(microtexPath, error));
             }
             ShadowMapShader = new ShadowMapShader(viewer.RenderProcess.GraphicsDevice);
             SkyShader = new SkyShader(viewer.RenderProcess.GraphicsDevice);


### PR DESCRIPTION
Bug report: https://www.elvastower.com/forums/index.php?/topic/39524-dds-sky-texture-crashes-msts-environments/

An unlucky user experienced a crash when attempting to use MSTS environments on a TrainSimulations route. It turns out, MSTS environments was configured to _explicitly_ load .ace textures _only_, while the TrainSimulations routes have .dds textures for environments. Due to the lack of error handling, the mismatched file type causes a crash (as opposed to replacing the sky textures with the missing texture).

I did some checking and found that the track viewer (when showing terrain textures) and microtex both had a similar problem: explicitly assuming .ace textures are used. This PR adjusts all these cases to allow for both .dds and .ace textures.

Note that no functional changes have been made to MSTS environments, they still have a habit of looking terrible.