### PR TITLE
Don't Assume MSTS ENG and WAG Files

### DIFF
--- a/Source/Orts.Common/ORFileHelper.cs
+++ b/Source/Orts.Common/ORFileHelper.cs
@@ -24,13 +24,20 @@ namespace Orts.Common
     {
         /// <summary>
         /// Given any file path, returns a path to the same file type and name but contained inside an
-        /// "OpenRails" subfolder inside the same folder as the original file. Usually used to specify
-        /// an "Open Rails only" file to be loaded instead of an original MSTS file.
+        /// "OpenRails" subfolder inside the same folder as the original file. Usually used to determine
+        /// the location of an "Open Rails specific" version of a file to load alongside the original
+        /// "MSTS specific" file. <br />
+        /// (See <see cref="FindORTSFile(string)"/> if the ORTS-specific file should not be returned
+        /// unless it exists.)
         /// 
-        /// eg: Given "MSTS\TRAINS\TRAINSET\DASH9\dash9.eng", returns "MSTS\TRAINS\TRAINSET\DASH9\OpenRails\dash9.eng"
+        /// <para>
+        /// eg: Given <c>"MSTS\TRAINS\TRAINSET\DASH9\dash9.eng"</c>, returns <c>"MSTS\TRAINS\TRAINSET\DASH9\OpenRails\dash9.eng"</c>
+        /// </para>
+        /// 
+        /// See pull request #1215 for additional context.
         /// </summary>
-        /// <param name="path">File path to the "MSTS" file to be replaced with an "OpenRails" file.</param>
-        /// <returns>File path string pointing to the same file given in the 'path' parameter,
+        /// <param name="path">File path to a file that an OR-specific equivalent is desired for.</param>
+        /// <returns>File path string pointing to the same file given in the <paramref name="path"/> parameter,
         /// but contained inside an "OpenRails" subfolder.</returns>
         public static string GetORTSFilePath(string path)
         {
@@ -41,11 +48,24 @@ namespace Orts.Common
         }
 
         /// <summary>
+        /// <para>
         /// Given any file path, returns a path to the same file type and name but contained inside an
-        /// "OpenRails" subfolder if such a file exists. Otherwise, returns the original file path.
+        /// "OpenRails" subfolder if such a file exists. Otherwise, returns the original file path. Usually
+        /// used to determine which file should be loaded in any case where an "Open Rails specific" file
+        /// should outright replace an "MSTS specific" file. <br />
+        /// (See <see cref="GetORTSFilePath(string)"/> if the OR-specific file path should be returned
+        /// even if it does not exist.)
+        /// </para>
+        /// 
+        /// <para>
+        /// eg: Given <c>"MSTS\TRAINS\TRAINSET\DASH9\dash9.eng"</c>, returns <c>"MSTS\TRAINS\TRAINSET\DASH9\OpenRails\dash9.eng"</c>
+        /// if that file exists, else returns <c>"MSTS\TRAINS\TRAINSET\DASH9\dash9.eng"</c>
+        /// </para>
+        /// 
+        /// See pull request #1215 for additional context.
         /// </summary>
-        /// <param name="path">File path to the "MSTS" file to be replaced with an "OpenRails" file.</param>
-        /// <returns>If it exists, file path string pointing to the same file given in the 'path' parameter,
+        /// <param name="path">File path to a file to be replaced with an OR-specific file, if available.</param>
+        /// <returns>If it exists, file path string pointing to the same file given in the <paramref name="path"/> parameter,
         /// but contained inside an "OpenRails" subfolder. Otherwise, returns original path.</returns>
         public static string FindORTSFile(string path)
         {

--- a/Source/Orts.Common/ORFileHelper.cs
+++ b/Source/Orts.Common/ORFileHelper.cs
@@ -20,7 +20,7 @@ using System.IO;
 
 namespace Orts.Common
 {
-    public class ORFileHelper
+    public static class ORFileHelper
     {
         /// <summary>
         /// Given any file path, returns a path to the same file type and name but contained inside an

--- a/Source/Orts.Common/ORFileHelper.cs
+++ b/Source/Orts.Common/ORFileHelper.cs
@@ -1,0 +1,60 @@
+﻿// COPYRIGHT 2009 - 2026 by the Open Rails project.
+//
+// This file is part of Open Rails.
+//
+// Open Rails is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Open Rails is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+
+namespace Orts.Common
+{
+    public class ORFileHelper
+    {
+        /// <summary>
+        /// Given any file path, returns a path to the same file type and name but contained inside an
+        /// "OpenRails" subfolder inside the same folder as the original file. Usually used to specify
+        /// an "Open Rails only" file to be loaded instead of an original MSTS file.
+        /// 
+        /// eg: Given "MSTS\TRAINS\TRAINSET\DASH9\dash9.eng", returns "MSTS\TRAINS\TRAINSET\DASH9\OpenRails\dash9.eng"
+        /// </summary>
+        /// <param name="path">File path to the "MSTS" file to be replaced with an "OpenRails" file.</param>
+        /// <returns>File path string pointing to the same file given in the 'path' parameter,
+        /// but contained inside an "OpenRails" subfolder.</returns>
+        public static string GetORTSFilePath(string path)
+        {
+            if (String.IsNullOrEmpty(path))
+                return "";
+
+            return Path.GetDirectoryName(path) + @"\OpenRails\" + Path.GetFileName(path);
+        }
+
+        /// <summary>
+        /// Given any file path, returns a path to the same file type and name but contained inside an
+        /// "OpenRails" subfolder if such a file exists. Otherwise, returns the original file path.
+        /// </summary>
+        /// <param name="path">File path to the "MSTS" file to be replaced with an "OpenRails" file.</param>
+        /// <returns>If it exists, file path string pointing to the same file given in the 'path' parameter,
+        /// but contained inside an "OpenRails" subfolder. Otherwise, returns original path.</returns>
+        public static string FindORTSFile(string path)
+        {
+            string orPath = GetORTSFilePath(path);
+
+            if (File.Exists(orPath))
+                return orPath;
+            else
+                return path;
+        }
+    }
+}

--- a/Source/Orts.Formats.Msts/EngineFile.cs
+++ b/Source/Orts.Formats.Msts/EngineFile.cs
@@ -15,9 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Open Rails.  If not, see <http://www.gnu.org/licenses/>.
 
-using System;
-using System.Collections;
 using System.IO;
+using Orts.Common;
 using Orts.Parsers.Msts;
 
 namespace Orts.Formats.Msts
@@ -41,13 +40,10 @@ namespace Orts.Formats.Msts
 
         public EngineFile(string filePath)
         {
-            string dir = Path.GetDirectoryName(filePath);
-            string file = Path.GetFileName(filePath);
-            string orFile = dir + @"\openrails\" + file;
-            if (File.Exists(orFile))
-                filePath = orFile;
+            filePath = ORFileHelper.FindORTSFile(filePath);
 
             Name = Path.GetFileNameWithoutExtension(filePath);
+
             using (var stf = new STFReader(filePath, false))
             {
                 stf.ParseFile(new STFReader.TokenProcessor[] {

--- a/Source/Orts.Formats.Msts/EngineFile.cs
+++ b/Source/Orts.Formats.Msts/EngineFile.cs
@@ -41,6 +41,12 @@ namespace Orts.Formats.Msts
 
         public EngineFile(string filePath)
         {
+            string dir = Path.GetDirectoryName(filePath);
+            string file = Path.GetFileName(filePath);
+            string orFile = dir + @"\openrails\" + file;
+            if (File.Exists(orFile))
+                filePath = orFile;
+
             Name = Path.GetFileNameWithoutExtension(filePath);
             using (var stf = new STFReader(filePath, false))
             {

--- a/Source/Orts.Formats.Msts/RouteFile.cs
+++ b/Source/Orts.Formats.Msts/RouteFile.cs
@@ -18,7 +18,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Orts.Parsers.Msts;
-using System.IO;
+using Orts.Common;
 using ORTS.Common;
 using System.Linq;
 
@@ -28,11 +28,8 @@ namespace Orts.Formats.Msts
     {
         public RouteFile(string filename)
         {
-            string dir = Path.GetDirectoryName(filename);
-            string file = Path.GetFileName(filename);
-            string orFile = dir + @"\openrails\" + file;
-            if (File.Exists(orFile))
-                filename = orFile;
+            filename = ORFileHelper.FindORTSFile(filename);
+
             try
             {
                 using (STFReader stf = new STFReader(filename, false))

--- a/Source/Orts.Formats.Msts/WagonFile.cs
+++ b/Source/Orts.Formats.Msts/WagonFile.cs
@@ -31,7 +31,7 @@ namespace Orts.Formats.Msts
         public string Name;
         public string WagonType;
         public float MassKG;
-        public CarSize WagonSize;
+        public CarSize WagonSize = new CarSize(2.5f, 4.0f, 40f);
         public int NumWagAxles;  // ORTS
         public float NumWagWheels;  // MSTS
         public string BrakeSystemType;
@@ -52,6 +52,13 @@ namespace Orts.Formats.Msts
                 HeightM = stf.ReadFloat(STFReader.UNITS.Distance, null);
                 LengthM = stf.ReadFloat(STFReader.UNITS.Distance, null);
                 stf.MustMatch(")");
+            }
+
+            public CarSize(float width, float height, float length)
+            {
+                WidthM = width;
+                HeightM = height;
+                LengthM = length;
             }
 
             public override string ToString()
@@ -100,6 +107,12 @@ namespace Orts.Formats.Msts
 
         public WagonFile(string filePath)
         {
+            string dir = Path.GetDirectoryName(filePath);
+            string file = Path.GetFileName(filePath);
+            string orFile = dir + @"\openrails\" + file;
+            if (File.Exists(orFile))
+                filePath = orFile;
+
             Name = Path.GetFileNameWithoutExtension(filePath);
             using (var stf = new STFReader(filePath, false))
             {

--- a/Source/Orts.Formats.Msts/WagonFile.cs
+++ b/Source/Orts.Formats.Msts/WagonFile.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.IO;
+using Orts.Common;
 using Orts.Parsers.Msts;
 
 namespace Orts.Formats.Msts
@@ -107,13 +108,10 @@ namespace Orts.Formats.Msts
 
         public WagonFile(string filePath)
         {
-            string dir = Path.GetDirectoryName(filePath);
-            string file = Path.GetFileName(filePath);
-            string orFile = dir + @"\openrails\" + file;
-            if (File.Exists(orFile))
-                filePath = orFile;
+            filePath = ORFileHelper.FindORTSFile(filePath);
 
             Name = Path.GetFileNameWithoutExtension(filePath);
+
             using (var stf = new STFReader(filePath, false))
             {
                 stf.ParseFile(new STFReader.TokenProcessor[] {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -37,6 +37,7 @@
 //#define DEBUG_VARIABLE_MASS
 
 using Microsoft.Xna.Framework;
+using Orts.Common;
 using Orts.Formats.Msts;
 using Orts.Parsers.Msts;
 using Orts.Simulation.RollingStocks.SubSystems;
@@ -394,11 +395,7 @@ namespace Orts.Simulation.RollingStocks
         /// </summary>
         public virtual void LoadFromWagFile(string wagFilePath)
         {
-            string dir = Path.GetDirectoryName(wagFilePath);
-            string file = Path.GetFileName(wagFilePath);
-            string orFile = dir + @"\openrails\" + file;
-            if (File.Exists(orFile))
-                wagFilePath = orFile;
+            wagFilePath = ORFileHelper.FindORTSFile(wagFilePath);
 
             // Get the path starting at the TRAINS folder, in order to produce a shorter, more legible, path
             string shortPath = wagFilePath.Remove(0, Simulator.BasePath.Length);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/RollingStock.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/RollingStock.cs
@@ -109,6 +109,12 @@ namespace Orts.Simulation.RollingStocks
 
             public static GenericWAGFile Get(string path)
             {
+                string dir = Path.GetDirectoryName(path);
+                string file = Path.GetFileName(path);
+                string orFile = dir + @"\openrails\" + file;
+                if (File.Exists(orFile))
+                    path = orFile;
+
                 if (!SharedWAGFiles.ContainsKey(path))
                 {
                     GenericWAGFile wagFile = new GenericWAGFile(path);

--- a/Source/Orts.Simulation/Simulation/RollingStocks/RollingStock.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/RollingStock.cs
@@ -34,10 +34,7 @@ namespace Orts.Simulation.RollingStocks
             GenericWAGFile mstsWagFile = SharedGenericWAGFileManager.Get(wagFilePath);
             GenericWAGFile wagFile = null;
 
-            string dir = Path.GetDirectoryName(wagFilePath);
-            string file = Path.GetFileName(wagFilePath);
-            string orFile = dir + @"\openrails\" + file;
-
+            string orFile = ORFileHelper.GetORTSFilePath(wagFilePath);
             bool ortsWag = File.Exists(orFile);
 
             if (ortsWag)
@@ -83,9 +80,9 @@ namespace Orts.Simulation.RollingStocks
                 // its an ordinary MSTS engine of some type.
                 string engType = "";
 
-                if (wagFile.Engine.Type == null)
+                if (String.IsNullOrEmpty(wagFile.Engine.Type))
                 {
-                    if (ortsWag && mstsWagFile.Engine.Type != null)
+                    if (ortsWag && !String.IsNullOrEmpty(mstsWagFile.Engine.Type))
                     {
                         engType = mstsWagFile.Engine.Type;
                         Trace.TraceWarning("Engine type missing from " + orFile + ", assuming " + engType + " engine type.");
@@ -152,9 +149,9 @@ namespace Orts.Simulation.RollingStocks
         /// </summary>
         public class GenericWAGFile
         {
-            public bool IsEngine { get { return Engine != null; } }
-            public EngineClass Engine;
-            public OpenRailsData OpenRails;
+            public bool IsEngine = false;
+            public EngineClass Engine = new EngineClass();
+            public OpenRailsData OpenRails = new OpenRailsData();
 
             public GenericWAGFile(string filenamewithpath)
             {
@@ -165,8 +162,8 @@ namespace Orts.Simulation.RollingStocks
             {
                 using (STFReader stf = new STFReader(filenamewithpath, false))
                     stf.ParseBlock(new STFReader.TokenProcessor[] {
-                        new STFReader.TokenProcessor("engine", ()=>{ Engine = new EngineClass(stf); }),
-                        new STFReader.TokenProcessor("_openrails", ()=>{ OpenRails = new OpenRailsData(stf); }),
+                        new STFReader.TokenProcessor("engine", ()=>{ IsEngine = true; Engine.Parse(stf); }),
+                        new STFReader.TokenProcessor("_openrails", ()=>{ OpenRails.Parse(stf); }),
                     });
             }
 
@@ -174,7 +171,9 @@ namespace Orts.Simulation.RollingStocks
             {
                 public string Type;
 
-                public EngineClass(STFReader stf)
+                public EngineClass() { }
+
+                public void Parse(STFReader stf)
                 {
                     stf.MustMatch("(");
                     stf.ParseBlock(new STFReader.TokenProcessor[] {
@@ -187,7 +186,9 @@ namespace Orts.Simulation.RollingStocks
             {
                 public string DLL;
 
-                public OpenRailsData(STFReader stf)
+                public OpenRailsData() { }
+
+                public void Parse(STFReader stf)
                 {
                     stf.MustMatch("(");
                     stf.ParseBlock(new STFReader.TokenProcessor[] {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/RollingStock.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/RollingStock.cs
@@ -31,7 +31,20 @@ namespace Orts.Simulation.RollingStocks
     {
         public static TrainCar Load(Simulator simulator, Train train, string wagFilePath, bool initialize = true)
         {
-            GenericWAGFile wagFile = SharedGenericWAGFileManager.Get(wagFilePath);
+            GenericWAGFile mstsWagFile = SharedGenericWAGFileManager.Get(wagFilePath);
+            GenericWAGFile wagFile = null;
+
+            string dir = Path.GetDirectoryName(wagFilePath);
+            string file = Path.GetFileName(wagFilePath);
+            string orFile = dir + @"\openrails\" + file;
+
+            bool ortsWag = File.Exists(orFile);
+
+            if (ortsWag)
+                wagFile = SharedGenericWAGFileManager.Get(orFile);
+            else
+                wagFile = SharedGenericWAGFileManager.Get(wagFilePath);
+
             TrainCar car;
             if (wagFile.OpenRails != null
                && wagFile.OpenRails.DLL != null)
@@ -68,10 +81,22 @@ namespace Orts.Simulation.RollingStocks
             else
             {
                 // its an ordinary MSTS engine of some type.
-                if (wagFile.Engine.Type == null)
-                    throw new InvalidDataException(wagFilePath + "\r\n\r\nEngine type missing");
+                string engType = "";
 
-                switch (wagFile.Engine.Type.ToLower())
+                if (wagFile.Engine.Type == null)
+                {
+                    if (ortsWag && mstsWagFile.Engine.Type != null)
+                    {
+                        engType = mstsWagFile.Engine.Type;
+                        Trace.TraceWarning("Engine type missing from " + orFile + ", assuming " + engType + " engine type.");
+                    }
+                    else
+                        throw new InvalidDataException(wagFilePath + "\r\n\r\nEngine type missing");
+                }
+                else
+                    engType = wagFile.Engine.Type;
+
+                switch (engType.ToLower())
                 {
                     // TODO complete parsing of proper car types
                     case "electric": car = new MSTSElectricLocomotive(simulator, wagFilePath); break;
@@ -109,12 +134,6 @@ namespace Orts.Simulation.RollingStocks
 
             public static GenericWAGFile Get(string path)
             {
-                string dir = Path.GetDirectoryName(path);
-                string file = Path.GetFileName(path);
-                string orFile = dir + @"\openrails\" + file;
-                if (File.Exists(orFile))
-                    path = orFile;
-
                 if (!SharedWAGFiles.ContainsKey(path))
                 {
                     GenericWAGFile wagFile = new GenericWAGFile(path);

--- a/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
+++ b/Source/Orts.Simulation/Simulation/Signalling/Signals.cs
@@ -26,8 +26,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Microsoft.Xna.Framework;
+using Orts.Common;
 using Orts.Formats.Msts;
 using Orts.Formats.OR;
 using Orts.MultiPlayer;
@@ -506,7 +506,7 @@ namespace Orts.Simulation.Signalling
                         {
                             if (!extendedWFileRead)
                             {
-                                WFilePath = Simulator.RoutePath + @"\World\Openrails\" + Path.GetFileName(fileName);
+                                WFilePath = ORFileHelper.GetORTSFilePath(fileName);
                                 if (File.Exists(WFilePath))
                                 {
                                     // We have an OR-specific addition to world file

--- a/Source/Orts.Simulation/Simulation/Simulator.cs
+++ b/Source/Orts.Simulation/Simulation/Simulator.cs
@@ -338,19 +338,19 @@ namespace Orts.Simulation
                 RDB = new RoadDatabaseFile(rdbFile);
             }
 
-            var carSpawnFile = RoutePath + @"\carspawn.dat";
+            string carSpawnFile = RoutePath + @"\carspawn.dat";
             if (File.Exists(carSpawnFile))
             {
                 CarSpawnerLists = new List<CarSpawnerList>();
-                CarSpawnerFile = new CarSpawnerFile(RoutePath + @"\carspawn.dat", RoutePath + @"\shapes\", CarSpawnerLists);
+                CarSpawnerFile = new CarSpawnerFile(carSpawnFile, RoutePath + @"\shapes\", CarSpawnerLists);
             }
 
             // Extended car spawner file
-            var extCarSpawnFile = RoutePath + @"\openrails\carspawn.dat";
+            string extCarSpawnFile = ORFileHelper.GetORTSFilePath(carSpawnFile);
             if (File.Exists(extCarSpawnFile))
             {
                 if (CarSpawnerLists == null) CarSpawnerLists = new List<CarSpawnerList>();
-                ExtCarSpawnerFile = new ExtCarSpawnerFile(RoutePath + @"\openrails\carspawn.dat", RoutePath + @"\shapes\", CarSpawnerLists);
+                ExtCarSpawnerFile = new ExtCarSpawnerFile(extCarSpawnFile, RoutePath + @"\shapes\", CarSpawnerLists);
             }
 
             // Load animated clocks if file "animated.clocks-or" exists --------------------------------------------------------
@@ -381,7 +381,7 @@ namespace Orts.Simulation
 
             // check for existence of activity file in OpenRails subfolder
 
-            activityPath = RoutePath + @"\Activities\Openrails\" + ActivityFileName + ".act";
+            activityPath = ORFileHelper.GetORTSFilePath(activityPath);
             if (File.Exists(activityPath))
             {
                 // We have an OR-specific addition to world file

--- a/Source/RunActivity/Viewer3D/Scenery.cs
+++ b/Source/RunActivity/Viewer3D/Scenery.cs
@@ -277,8 +277,7 @@ namespace Orts.Viewer3D
             var WFile = new Orts.Formats.Msts.WorldFile(WFilePath);
 
             // check for existence of world file in OpenRails subfolder
-
-            WFilePath = viewer.Simulator.RoutePath + @"\World\Openrails\" + WFileName;
+            WFilePath = Orts.Common.ORFileHelper.GetORTSFilePath(WFilePath);
             if (File.Exists(WFilePath))
             {
                 // We have an OR-specific addition to world file

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2022,9 +2022,7 @@ namespace Orts.Viewer3D
         {
             var filePath = FilePath;
             // commented lines allow reading the animation block from an additional file in an Openrails subfolder
-//           string dir = Path.GetDirectoryName(filePath);
-//            string file = Path.GetFileName(filePath);
-//            string orFilePath = dir + @"\openrails\" + file;
+//            string orFilePath = ORFileHelper.GetORTSFilePath(filePath);
             var sFile = new ShapeFile(filePath, Viewer.Settings.SuppressShapeWarnings);
 //            if (file.ToLower().Contains("turntable") && File.Exists(orFilePath))
 //            {


### PR DESCRIPTION
Bug report: https://www.elvastower.com/forums/index.php?/topic/37448-ammeter-configuration-steeringcarriages-emudmu/page__view__findpost__p__325239

Some cab cars do not work as expected when overriding a vehicle implemented in MSTS as a locomotive, then overwritten as a control car inside an `OpenRails` folder. Related to #1176 

It appears that some parts of the program were not scanning the `OpenRails` folder for an OR replacement of an MSTS engine or wagon, leading to an assortment of inconsistent results. This PR changes the cases I noticed to ensure that engine and wagon parsing will prefer to load the OR version of an engine or wagon file, as long as it is available.

To make all these cases cleaner, some helper methods were added in the new class `ORFileHelper` to give a shorthand way to replace a path to an MSTS file like `MSTS\TRAINS\TRAINSET\DASH9\dash9.eng` with the OR-specific path `MSTS\TRAINS\TRAINSET\DASH9\OpenRails\dash9.eng` without duplicating code.

For other devs: `ORFileHelper.GetORTSFilePath(string path)` would take in `MSTS\TRAINS\TRAINSET\DASH9\dash9.eng` as input, and return `MSTS\TRAINS\TRAINSET\DASH9\OpenRails\dash9.eng` _even if that file doesn't exist_.
On the other hand, `ORFileHelper.FindORTSFile(string path)` would take in `MSTS\TRAINS\TRAINSET\DASH9\dash9.eng` as input, and would return `MSTS\TRAINS\TRAINSET\DASH9\OpenRails\dash9.eng` _only if that file actually exists_. If that OpenRails file doesn't exist, then the original path `MSTS\TRAINS\TRAINSET\DASH9\dash9.eng` would be returned instead (note: it does not check if the original path exists, only if the OR-specific path exists).
In my inspection of existing processes, I found that there were cases where we want to replace the MSTS path with the OR-specific path (if it exists), but also cases where both the MSTS path and the OR-specific path were needed, so the two methods will cover both these use cases.

The cases where I noticed loading OR-specific files wasn't working are:

- `GenericWAGFile` was ignoring OR-specific engines and wagons, this resolves the control car vs electric locomotive problem in the original bug thread. Because some people have already made content that relies on this bug to function, if the engine type is missing from the `OpenRails` engine but not the MSTS one, the MSTS engine type will be used and a warning will be logged about the missing engine type.
- `Orts.Formats.Msts` `EngineFile` and `WagonFile` were ignoring OR-specific engines and wagons, which meant that non-simulator parts of the program (such as the main menu) would only load the MSTS versions of engines and wagons for displaying data. That data will now correctly reflect any changes/corrections made to the OR-specific files.