### PR TITLE
Don't Crash With Multiple ORTSDieselEngines Blocks

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
@@ -102,6 +102,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
                 case "engine(ortsdieselengines":
                     stf.MustMatch("(");
                     int count = stf.ReadInt(0);
+                    DEList.Clear(); // Remove any existing diesel engines to prevent errors
                     for (int i = 0; i < count; i++)
                     {
                         string setting = stf.ReadString().ToLower();


### PR DESCRIPTION
As reported on [this ElvasTower thread](https://www.elvastower.com/forums/index.php?/topic/39572-systemnullreferenceexception-u20260330-1907/), a crash occurs when attempting to run a diesel locomotive that has multiple `ORTSDieselEngines` blocks. In this case, the locomotive had multiple `ORTSDieselEngines` blocks because both the original .eng file and .inc files included `ORTSDieselEngines`.

The crash happens because subsequent `ORTSDieselEngines` blocks after the first one cause additional engine(s) to be added to the existing diesel engine list `DEList`, but instead of parsing data for the newly added diesel engine(s), the already existing engine(s) are overwritten with the new data. The result is that the `DEList` contains some engine(s) which have been initialized followed by some that have not been initialized. The uninitialized engines at the end of the list cause a crash when attempting to use them.

I believe the intent of this process is that any `ORTSDieselEngines` block should overwrite whatever diesel engine data was given in previous `ORTSDieselEngines` blocks (this is how OR usually handles duplicate blocks, the latter block overwrites earlier ones) instead of adding to it, so the fix is to clear the `DEList` every time a new `ORTSDieselEngines` block is encountered. This prevents uninitialized diesel engines from being added to the list and allows .inc files to overwrite existing diesel engine settings.

This fix was implemented in #1186 as it caused problems when using hot reloading, but evidently it is possible to cause this problem without using hot reloading, so it has been split off here.