### PR TITLE
Partial bug fix for https://bugs.launchpad.net/or/+bug/2148806 Switch state isn't synced in multiplayer mode

### DIFF
--- a/Source/Orts.Simulation/MultiPlayer/Message.cs
+++ b/Source/Orts.Simulation/MultiPlayer/Message.cs
@@ -1172,6 +1172,7 @@ namespace Orts.MultiPlayer
                 {
                     if (!SwitchOccupiedByPlayerTrain(t.Value))
                     {
+                        MPManager.Simulator.Signals.RequestSetSwitch(t.Value.TN, state);
                         SetSwitch(t.Value.TN, state);
                         //t.Value.SelectedRoute = state;
                     }


### PR DESCRIPTION
See https://www.elvastower.com/forums/index.php?/topic/39601-switches-and-signals-dont-respond-correctly-in-multiplayer/