### PR TITLE
Mark MSTS Environment Textures

### DIFF
--- a/Source/RunActivity/Viewer3D/MSTSSky.cs
+++ b/Source/RunActivity/Viewer3D/MSTSSky.cs
@@ -673,6 +673,16 @@ namespace Orts.Viewer3D
         static Vector3 startColor = new Vector3(0.647f, 0.651f, 0.655f); // Original daytime fog color - must be preserved!
         static Vector3 finishColor = new Vector3(0.05f, 0.05f, 0.05f); //Darkest nighttime fog color
 
+        public override void Mark()
+        {
+            Viewer.TextureManager.Mark(MSTSDayTexture);
+            Viewer.TextureManager.Mark(MSTSSkyStarTexture);
+            Viewer.TextureManager.Mark(MSTSSkyMoonTexture);
+            Viewer.TextureManager.Mark(MSTSSkyMoonMask);
+            Viewer.TextureManager.Mark(MSTSSkyCloudTexture[0]);
+            base.Mark();
+        }
+
         /// <summary>
         /// This function darkens the fog color as night begins to fall
         /// as well as with increasing overcast.


### PR DESCRIPTION
Follow up to #1209 
Bug reported [here on ElvasTower](https://www.elvastower.com/forums/index.php?/topic/39615-black-sky/)

After adding support for DDS textures in MSTS environments, some routes were giving a black sky with MSTS environments enabled, even when ACE textures were still available. The sky was black because the sky texture had been disposed of by the loader process, leaving no color data left to be rendered. The loader process disposed of the sky texture because there was nothing marking the sky texture as in-use, which would have prevented the loader process from disposing of it.

This is despite [MSTSSky.cs line 233](https://github.com/openrails/openrails/blob/05cf5d46b0659b7e9335315986d53178f5b50a52/Source/RunActivity/Viewer3D/MSTSSky.cs#L233) calling ``MSTSSkyMaterial.Mark()``, as this method simply wasn't set up. So this PR adds it, ``MSTSSkyMaterial.Mark()`` will be called by the loader process to mark all MSTS textures used by the sky shader as in-use, and they will not be automatically unloaded.

The reason the sky didn't go black previously is that the loader only disposes of shared textures, but the textures used in MSTSSky.cs were previously unmanaged and thus outside the view of the loader process. There are a few reasons this is a bad idea, but lack of support for DDS textures was just one of the downsides.