### PR TITLE
Fix ORTSDefaultSnow Terrain Texture Behavior

### DIFF
--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -107,8 +107,15 @@ namespace Orts.Viewer3D
                             {
                                 return Textures[textureKey] = Formats.Msts.AceFile.Texture2DFromFile(GraphicsDevice, ace);
                             }
-                            // When a texture is not found, and it is in a selector directory (e.g. "Snow"), we
-                            // go up a level and try again. This repeats a fixed number of times, or until we run
+                            if (defaultTexture != SharedMaterialManager.MissingTexture)
+                            {
+                                // This texture has been set to use a non-standard default texture,
+                                // use this default texture instead of searching other folders
+                                return defaultTexture;
+                            }
+                            // When a texture is not found, there is no special missing texture defined,
+                            // and it is in a selector directory (e.g. "Snow"), we go up a level and
+                            // try again. This repeats a fixed number of times, or until we run
                             // out of known selector directories.
                             var directory = Path.GetDirectoryName(depthPath);
                             if (string.IsNullOrEmpty(directory) || !SelectorDirectoryNames.Contains(Path.GetFileName(directory))) break;


### PR DESCRIPTION
Bug reported on [Elvas Tower](https://www.elvastower.com/forums/index.php?/topic/39589-default-snow-not-working/)

Since PR #1166 changed the way texture loading works, the default snow terrain texture has not been functioning.
This is supposed to work by replacing any missing snow terrain textures with the _ORTSDefaultSnow.ace/.dds_ texture file, but that PR changed this to replace **any** missing snow texture (terrain or not) with the non-snow version of the texture. This is an intended feature, making it so that seasonal textures are handled universally instead of for some folders only, but this should not have been applied to terrain textures. We actually want snowy terrain textures to be replaced with the default texture (in this case, _ORTSDefaultSnow is_ the default texture).

In what I think is a decent compromise between the new behavior, which is more flexible at handling seasonal textures than the old system, and the intended behavior of _ORTSDefaultSnow_, I have changed `SharedTextureManager.Get` to scan other folders for missing seasonal textures **only** when the `defaultTexture` given is the standard default texture `SharedMaterialManager.MissingTexture`. For snowy terrain textures, `defaultTexture` is set to `SharedMaterialManager.DefaultSnowTexture` or `SharedMaterialManager.DefaultDMSnowTexture`, so terrain textures and terrain textures **only** _(**all** other texture loading is hardcoded to use `SharedMaterialManager.MissingTexture` as `defaultTexture`, so this change only ever affects terrain)_ will **not** look for a file in a different folder, and will instead 'give up' and use the specified default texture (ie: _ORTSDefaultSnow_).

This specific approach also allows similar behavior to be easily added for other textures, not just terrain. For now, terrain is the only time when `defaultTexture != SharedMaterialManager.MissingTexture`, but with a modified call to `SharedTextureManager.Get`, this could also be done for any other system where a texture should not be replaced by its non-seasonal counterparts. Just give a different default texture and the system knows not to check other folders.