### PR TITLE
mouse scroll wheel behaviour

### DIFF
--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -269,12 +269,17 @@ namespace Orts.Viewer3D
         // TODO: Add a way to record this zoom operation for Replay.
         protected void ZoomByMouseWheel(float speed)
         {
-            // Will not zoom-in-out when help windows is up.
             // TODO: Property input processing through WindowManager.
-            if (UserInput.IsMouseWheelChanged && (!UserInput.IsDown(UserCommand.GameSwitchWithMouse) || !(this is ThreeDimCabCamera)) && !Viewer.HelpWindow.Visible)
+            if (UserInput.IsMouseWheelChanged && (!UserInput.IsDown(UserCommand.GameSwitchWithMouse) || !(this is ThreeDimCabCamera)))
             {
-                var fieldOfView = MathHelper.Clamp(FieldOfView - speed * UserInput.MouseWheelChange / 10, 1, 135);
-                new FieldOfViewCommand(Viewer.Log, fieldOfView);
+                Point mousePosition = new Point(UserInput.MouseX, UserInput.MouseY);
+                Window mouseActiveWindow = Viewer.WindowManager.VisibleWindows.LastOrDefault(w => w.Interactive && w.Location.Contains(mousePosition));
+                // Will not zoom-in-out when mouse pointer above a window
+                if (mouseActiveWindow == null) 
+                {
+                    var fieldOfView = MathHelper.Clamp(FieldOfView - speed * UserInput.MouseWheelChange / 10, 1, 135);
+                    new FieldOfViewCommand(Viewer.Log, fieldOfView);
+                }
             }
         }
 

--- a/Source/RunActivity/Viewer3D/Popups/WindowControls.cs
+++ b/Source/RunActivity/Viewer3D/Popups/WindowControls.cs
@@ -503,7 +503,8 @@ namespace Orts.Viewer3D.Popups
 
         internal override bool HandleUserInput(WindowMouseEvent e)
         {
-            foreach (var control in controls.Where(c => c.Position.Contains(e.MouseDownPosition)))
+            foreach (var control in controls.Where(c => c.Position.Contains(e.MousePosition)))
+                // mouse pointer within window (for instance the F1 help window)
                 if (control.HandleUserInput(e))
                     return true;
             return base.HandleUserInput(e);

--- a/Source/RunActivity/Viewer3D/Popups/WindowManager.cs
+++ b/Source/RunActivity/Viewer3D/Popups/WindowManager.cs
@@ -304,7 +304,7 @@ namespace Orts.Viewer3D.Popups
 		Point mouseDownPosition;
 		public Point MouseDownPosition { get { return mouseDownPosition; } }
 
-		Window mouseActiveWindow;
+        Window mouseActiveWindow;
 		public Window MouseActiveWindow { get { return mouseActiveWindow; } }
 
 		double LastUpdateRealTime;
@@ -321,8 +321,8 @@ namespace Orts.Viewer3D.Popups
 
             if (UserInput.IsMouseWheelChanged)
             {
-                mouseActiveWindow = VisibleWindows.LastOrDefault(w => w.Interactive && w.Location.Contains(mouseDownPosition));
-                
+                Point mousePosition = new Point(UserInput.MouseX, UserInput.MouseY);
+                mouseActiveWindow = VisibleWindows.LastOrDefault(w => w.Interactive && w.Location.Contains(mousePosition));
                 if (mouseActiveWindow != null)
                     mouseActiveWindow.HandleUserInput();
             }

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -1538,7 +1538,11 @@ namespace Orts.Viewer3D
             if (UserInput.IsMouseMoved || RenderProcess.IsMouseVisible && UserInput.IsMouseWheelChanged)
                 MouseVisibleTillRealTime = RealTime + 1;
 
-            RenderProcess.IsMouseVisible = ForceMouseVisible || RealTime < MouseVisibleTillRealTime || !Game.IsActive;
+            // keep mouse pointer visible when mouse pointer is within a window (for instance the F1 help window)
+            Point mousePosition = new Point(UserInput.MouseX, UserInput.MouseY);
+            bool inWindow = WindowManager.VisibleWindows.LastOrDefault(w => w.Interactive && w.Location.Contains(mousePosition)) != null;
+
+            RenderProcess.IsMouseVisible = ForceMouseVisible || RealTime < MouseVisibleTillRealTime || !Game.IsActive || inWindow;
 
             UserInput.Handled();
         }


### PR DESCRIPTION
changes: when mouse pointer within window (for instance the F1 help window)

 - mouse pointer stays visible
 - mouse scroll wheel scrolls contents window when applicable
 - for 3d models: changing FOV not possible, only when mouse pointer outside window
 
Bug report: https://www.elvastower.com/forums/index.php?/topic/39697-mouse-scroll-wheel-behaviour-in-or/page__pid__326598#entry326598