### PR TITLE
adds Log Motion Data to DataLogger

### DIFF
--- a/Source/Menu/Options.Designer.cs
+++ b/Source/Menu/Options.Designer.cs
@@ -234,6 +234,7 @@
             this.checkUseSuperElevation = new System.Windows.Forms.CheckBox();
             this.ElevationText = new System.Windows.Forms.Label();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.checkDataLogMotion = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.numericBrakePipeChargingRate)).BeginInit();
             this.tabOptions.SuspendLayout();
             this.tabPageGeneral.SuspendLayout();
@@ -2054,6 +2055,7 @@
             // 
             // tabPageDataLogger
             // 
+            this.tabPageDataLogger.Controls.Add(this.checkDataLogMotion);
             this.tabPageDataLogger.Controls.Add(this.checkDataLogSteamPowerCurve);
             this.tabPageDataLogger.Controls.Add(this.pbDataLoggerOptions);
             this.tabPageDataLogger.Controls.Add(this.comboDataLogSpeedUnits);
@@ -3043,6 +3045,16 @@
             this.ElevationText.MouseEnter += new System.EventHandler(this.HelpIcon_MouseEnter);
             this.ElevationText.MouseLeave += new System.EventHandler(this.HelpIcon_MouseLeave);
             // 
+            // checkDataLogMotion
+            // 
+            this.checkDataLogMotion.AutoSize = true;
+            this.checkDataLogMotion.Location = new System.Drawing.Point(6, 203);
+            this.checkDataLogMotion.Name = "checkDataLogMotion";
+            this.checkDataLogMotion.Size = new System.Drawing.Size(102, 17);
+            this.checkDataLogMotion.TabIndex = 27;
+            this.checkDataLogMotion.Text = "Log motion data";
+            this.checkDataLogMotion.UseVisualStyleBackColor = true;
+            // 
             // OptionsForm
             // 
             this.AcceptButton = this.buttonOK;
@@ -3369,5 +3381,6 @@
         private System.Windows.Forms.CheckBox checkDataLogSteamPowerCurve;
         private System.Windows.Forms.NumericUpDown dataLoggerInterval;
         private System.Windows.Forms.Label dataLoggerIntervalLabel;
+        private System.Windows.Forms.CheckBox checkDataLogMotion;
     }
 }

--- a/Source/Menu/Options.cs
+++ b/Source/Menu/Options.cs
@@ -477,6 +477,7 @@ namespace Menu
             Settings.DataLogPhysics = checkDataLogPhysics.Checked;
             Settings.DataLogExclusiveSteamPerformance = checkDataLogSteamPerformance.Checked;
             Settings.DataLogExclusiveSteamPowerCurve = checkDataLogSteamPowerCurve.Checked;
+            Settings.DataLogMotion = checkDataLogMotion.Checked;
             Settings.DataLoggerInterval = (int)dataLoggerInterval.Value;
             Settings.VerboseConfigurationMessages = checkVerboseConfigurationMessages.Checked;
 

--- a/Source/Orts.Settings/UserSettings.cs
+++ b/Source/Orts.Settings/UserSettings.cs
@@ -218,6 +218,8 @@ namespace ORTS.Settings
         public bool DataLogExclusiveSteamPerformance { get; set; }
         [Default(false)]
         public bool DataLogExclusiveSteamPowerCurve { get; set; }
+        [Default(false)]
+        public bool DataLogMotion { get; set; }
         [Default(0)]
         public int DataLoggerInterval { get; set; }
         [Default(false)]

--- a/Source/RunActivity/Viewer3D/InfoDisplay.cs
+++ b/Source/RunActivity/Viewer3D/InfoDisplay.cs
@@ -23,6 +23,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Orts.Simulation.RollingStocks;
+using Orts.Viewer3D.RollingStock;
 using ORTS.Common;
 using ORTS.Common.Input;
 
@@ -166,6 +167,13 @@ namespace Orts.Viewer3D
                 Logger.Data(VersionInfo.Version);
                 Logger.Data(FrameNumber.ToString("F0"));
                 Logger.Data(FormatStrings.FormatPreciseTime(Viewer.Simulator.ClockTime));
+                if (Viewer.Settings.DataLogMotion)
+                {
+                    DataLoggerLogSpeed(Viewer.PlayerLocomotive.SpeedMpS);
+                    Logger.Data(MSTSWagonViewer.WheelCumulativeR.ToString("F5"));
+                    Logger.Data(MSTSWagonViewer.RunningGearCumulativeR.ToString("F5"));
+                    Logger.Data((MSTSWagonViewer.WheelCumulativeR - MSTSWagonViewer.RunningGearCumulativeR).ToString("F5"));
+                }
                 if (Viewer.Settings.DataLogPerformance)
                 {
                     Logger.Data(Viewer.Game.HostProcess.CPUMemoryWorkingSet.ToString("F0"));
@@ -337,6 +345,14 @@ namespace Orts.Viewer3D
                 Logger.Data("Version");
                 Logger.Data("Frame");
                 Logger.Data("Time");
+                if (Viewer.Settings.DataLogMotion)
+                {
+                    Logger.Data($"Player Speed [{Viewer.Settings.DataLogSpeedUnits}]");
+                    Logger.Data("WheelCumulativeR");
+                    Logger.Data("RunningGearCumulativeR");
+                    Logger.Data("Cumulative Difference");
+                }
+
                 if (Viewer.Settings.DataLogPerformance)
                 {
                     Logger.Data("Memory");

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSWagonViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSWagonViewer.cs
@@ -805,6 +805,8 @@ namespace Orts.Viewer3D.RollingStock
             }
         }
 
+        public static float RunningGearCumulativeR;
+        public static float WheelCumulativeR;
 
         private void UpdateAnimation(RenderFrame frame, ElapsedTime elapsedTime)
         {
@@ -818,18 +820,22 @@ namespace Orts.Viewer3D.RollingStock
                 // To achieve the same result with other means, without flipping trainset physics, the line should be changed as follows:
                 //                                distanceTravelledM = MSTSWagon.SpeedMpS * elapsedTime.ClockSeconds;
                 distanceTravelledM = ((MSTSWagon.Train != null && MSTSWagon.Train.IsPlayerDriven && loco.UsingRearCab) ? -1 : 1) * MSTSWagon.SpeedMpS * elapsedTime.ClockSeconds;
+                var logdata = "";
                 foreach (var kvp in RunningGears)
                 {
                     if (!kvp.Value.Empty())
                     {
                         var axle = kvp.Key >= 0 && kvp.Key < loco.LocomotiveAxles.Count ? loco.LocomotiveAxles[kvp.Key] : null;
                         if (axle != null)
+                        {
                             //TODO: next code line has been modified to flip trainset physics in order to get viewing direction coincident with loco direction when using rear cab.
                             kvp.Value.UpdateLoop(((MSTSWagon.Train != null && MSTSWagon.Train.IsPlayerDriven && loco.UsingRearCab) ? -1 : 1) * (float)axle.AxleSpeedMpS * elapsedTime.ClockSeconds / MathHelper.TwoPi / axle.WheelRadiusM);
+                            var rotation = (float)axle.AxleSpeedMpS * elapsedTime.ClockSeconds / axle.WheelRadiusM;
+                            RunningGearCumulativeR += rotation;
+                        }
                         else if (AnimationDriveWheelRadiusM > 0.001)
                             kvp.Value.UpdateLoop(distanceTravelledM / MathHelper.TwoPi / AnimationDriveWheelRadiusM);
-                    }
-                        
+                    }                        
                 }
                 foreach (var kvp in WheelPartIndexes)
                 {
@@ -837,7 +843,13 @@ namespace Orts.Viewer3D.RollingStock
                     if (axle != null)
                     {
                         //TODO: next code line has been modified to flip trainset physics in order to get viewing direction coincident with loco direction when using rear cab.
-                        WheelRotationR = ((MSTSWagon.Train != null && MSTSWagon.Train.IsPlayerDriven && loco.UsingRearCab) ? -1 : 1) * -(float)axle.AxlePositionRad;
+                        WheelRotationR = ((MSTSWagon.Train != null && MSTSWagon.Train.IsPlayerDriven && loco.UsingRearCab) ? -1 : 1) 
+                            * -(float)axle.AxlePositionRad;
+                        if (kvp.Key == 0)
+                        {
+                            WheelCumulativeR = -WheelRotationR;
+                            logdata += $", WheelCumulativeR = {WheelCumulativeR:F5}, difference = {RunningGearCumulativeR - WheelCumulativeR:F6}";
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
This is a temporary addition to the DataLogger in order to track down an anomaly in which the steam loco running gear (i.e. coupling rods and cranks) drift out of sync with the driving wheels.

DRAFT as not intended to be merged into the Testing Version.

Instructions: 
On the Options > Data Logger, select "Log motion data" and set the "Logging interval" to 2,000 msecs.
Start the loco moving and press F12 to start the logger. Run the loco for 15 mins to provoke drift and press F12 to stop the logger.
The results will be in file OpenRailsDump.csv on the Windows Desktop.