### PR TITLE
adds MissingItem type to handle new item types in notifications/menu.json

### DIFF
--- a/Source/Menu/Notifications/NotificationManager.cs
+++ b/Source/Menu/Notifications/NotificationManager.cs
@@ -32,6 +32,7 @@ using ORTS.Updater;
 using static ORTS.Common.SystemInfo;
 using static Menu.Notifications.NotificationPage;
 using Newtonsoft.Json.Serialization;
+using System.Diagnostics;
 
 // Behaviour
 // Notifications are read only once as a background task at start into Notifications.
@@ -250,7 +251,7 @@ namespace Menu.Notifications
                 // Check criteria for each item and add the successful items to the current page
                 foreach (var item in n.ItemList)
                 {
-                    if (AreItemChecksMet(item)) AddItemToPage(Page, item);
+                    if (AreItemChecksMet(item) && !(item is MissingItem)) AddItemToPage(Page, item);
                 }
             }
 
@@ -671,11 +672,24 @@ namespace Menu.Notifications
             {
                 if (assemblyName == "Menu")
                 {
-                    var ns = typeof(Notifications).Namespace;
+                    var @namespace = typeof(Notifications).Namespace;
                     var name = typeName.Split('.').Last();
-                    return typeof(Notifications).Assembly.GetType($"{ns}.{name}");
+                    var result = typeof(Notifications).Assembly.GetType($"{@namespace}.{name}");
+
+                    // Any errors are silenced, so write to the debug output instead.
+                    if (result == null)
+                    {
+                        Debug.WriteLine($"WARNING: {@namespace}.{name} not recognised item type");
+                    }
+
+                    return (result is null)
+                        ? typeof(Notifications).Assembly.GetType("Menu.Notifications.MissingItem")
+                        : typeof(Notifications).Assembly.GetType($"{@namespace}.{name}");
                 }
-                return null;
+                else
+                {
+                    throw new NotImplementedException();
+                }
             }
         }
     }

--- a/Source/Menu/Notifications/NotificationManager.cs
+++ b/Source/Menu/Notifications/NotificationManager.cs
@@ -676,14 +676,14 @@ namespace Menu.Notifications
                     var name = typeName.Split('.').Last();
                     var result = typeof(Notifications).Assembly.GetType($"{@namespace}.{name}");
 
-                    // Any errors are silenced, so write to the debug output instead.
-                    if (result == null)
+                    // Any errors are silenced so, for debugging, write a message instead.
+                    if (result is null)
                     {
                         Debug.WriteLine($"WARNING: {@namespace}.{name} not recognised item type");
                     }
 
                     return (result is null)
-                        ? typeof(Notifications).Assembly.GetType("Menu.Notifications.MissingItem")
+                        ? typeof(MissingItem)
                         : typeof(Notifications).Assembly.GetType($"{@namespace}.{name}");
                 }
                 else

--- a/Source/Menu/Notifications/NotificationManager.cs
+++ b/Source/Menu/Notifications/NotificationManager.cs
@@ -682,9 +682,7 @@ namespace Menu.Notifications
                         Debug.WriteLine($"WARNING: {@namespace}.{name} not recognised item type");
                     }
 
-                    return (result is null)
-                        ? typeof(MissingItem)
-                        : typeof(Notifications).Assembly.GetType($"{@namespace}.{name}");
+                    return result ?? typeof(MissingItem);
                 }
                 else
                 {

--- a/Source/Menu/Notifications/Notifications.cs
+++ b/Source/Menu/Notifications/Notifications.cs
@@ -72,6 +72,14 @@ namespace Menu.Notifications
     class Refresh : ValueItem
     {
     }
+    /// <summary>
+    /// This item indicates that the notification is missing an item type, and is silently ignored.
+    /// The item allows new types of notification elements to be introduced without breaking older versions of Open Rails.
+    /// Instead of BindToType() returning null and raising an exception, the notification is simply ignored and not displayed.
+    /// </summary>
+    class MissingItem : Item
+    {
+    }
     abstract class ValueItem : Item
     {
         public string Value { get; set; }


### PR DESCRIPTION
With this bug fix, notifications/menu.json can add new item types without breaking the Notifications in older versions of Open Rails.

OR v1.6 and v1.6.1 do not have this fix. Before a new item type (e.g. Refresh button) can be added, these versions will need to fetch notifications/menu.json from a different source.