### PR TITLE
Remove transmission from axle module

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/Axle.cs
@@ -638,7 +638,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                 switch(DriveType)
                 {
                     case AxleDriveType.MotorDriven:
-                        totalInertiaKgm2 = inertiaKgm2 + transmissionRatio * transmissionRatio * motor.InertiaKgm2;
+                        totalInertiaKgm2 = inertiaKgm2 + motor.TransmissionRatio * motor.TransmissionRatio * motor.InertiaKgm2;
                         break;
                     default:
                         totalInertiaKgm2 = inertiaKgm2;
@@ -684,7 +684,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                     case AxleDriveType.NotDriven:
                         break;
                     case AxleDriveType.MotorDriven:
-                        totalInertiaKgm2 = inertiaKgm2 + transmissionRatio * transmissionRatio * motor.InertiaKgm2;
+                        totalInertiaKgm2 = inertiaKgm2 + motor.TransmissionRatio * motor.TransmissionRatio * motor.InertiaKgm2;
                         break;
                     case AxleDriveType.ForceDriven:
                         totalInertiaKgm2 = inertiaKgm2;
@@ -709,54 +709,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         /// Pre-calculation of slip characteristics at 0 slip speed
         /// </summary>
         double axleStaticForceN;
-
-        /// <summary>
-        /// Transmission ratio on gearbox covered by TransmissionRatio interface
-        /// </summary>
-        float transmissionRatio;
-        /// <summary>
-        /// Read/Write positive nonzero transmission ratio, given by n1:n2 ratio
-        /// Throws an exception when negative or zero value is passed
-        /// </summary>
-        public float TransmissionRatio
-        {
-            set
-            {
-                if (value <= 0.0)
-                    throw new NotSupportedException("Transmission ratio must be greater than zero");
-                transmissionRatio = value;
-            }
-            get
-            {
-                return transmissionRatio;
-            }
-        }
-
-        /// <summary>
-        /// Transmission efficiency, relative to 1.0, covered by TransmissionEfficiency interface
-        /// </summary>
-        float transmissionEfficiency;
-        /// <summary>
-        /// Read/Write transmission efficiency, relative to 1.0, within range of 0.0 to 1.0 (1.0 means 100%, 0.5 means 50%)
-        /// Throws an exception when out of range value is passed
-        /// When 0.0 is set the value of 0.99 is used instead
-        /// </summary>
-        public float TransmissionEfficiency
-        {
-            set
-            {
-                if (value > 1.0f)
-                    throw new NotSupportedException("Value must be within the range of 0.0 and 1.0");
-                if (value <= 0.0f)
-                    transmissionEfficiency = 1.0f;
-                else
-                    transmissionEfficiency = value;
-            }
-            get
-            {
-                return transmissionEfficiency;
-            }
-        }
 
         /// <summary>
         /// Radius of wheels connected to axle
@@ -1081,7 +1033,6 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         public Axle(TrainCar car)
         {
             Car = car;
-            transmissionEfficiency = 1.0f;
             SlipWarningTresholdPercent = 70.0f;
             DriveType = AxleDriveType.ForceDriven;
             totalInertiaKgm2 = inertiaKgm2;
@@ -1212,9 +1163,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             // Compute force produced by the engine
             double axleInForceN = 0;
             if (DriveType == AxleDriveType.ForceDriven)
-                axleInForceN = DriveForceN * transmissionEfficiency;
+                axleInForceN = DriveForceN;
             else if (DriveType == AxleDriveType.MotorDriven)
-                axleInForceN = motor.GetDevelopedTorqueNm(axleSpeedMpS * transmissionRatio / WheelRadiusM) * transmissionEfficiency / WheelRadiusM;
+                axleInForceN = motor.GetAxleTorqueNm(axleSpeedMpS / WheelRadiusM) / WheelRadiusM;
 
             double frictionForceN = FrictionN + DampingNs * Math.Abs(slipSpeedMpS); // Rolling friction
             double totalFrictionForceN = BrakeRetardForceN + frictionForceN; // Dissipative forces: they will never increase wheel speed
@@ -1236,7 +1187,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                 if (Math.Abs(slipSpeedMpS) < 0.1f)
                 {
                     axleBrakeForceN = Math.Min(BrakeRetardForceN, Math.Max(MaximumWheelAdhesion * AxleGradientForceN - frictionForceN + Math.Abs(axleInForceN), 0));
-                    return (accelerationMpSS, axleSpeedMpS / WheelRadiusM, axleInForceN / transmissionEfficiency, axleMotiveForceN, axleBrakeForceN, frictionForceN);
+                    return (accelerationMpSS, axleSpeedMpS / WheelRadiusM, axleInForceN, axleMotiveForceN, axleBrakeForceN, frictionForceN);
                 }
             }
             // In the static adhesion regime (low speeds for Polach formula), unless the static adhesion coefficient is exceeded,
@@ -1257,7 +1208,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             {
                 axleMotiveForceN = axleOutForceN + Math.Sign(TrainSpeedMpS) * totalFrictionForceN;
             }
-            return (accelerationMpSS, axleSpeedMpS / WheelRadiusM, axleInForceN / transmissionEfficiency, axleMotiveForceN, axleBrakeForceN, frictionForceN);
+            return (accelerationMpSS, axleSpeedMpS / WheelRadiusM, axleInForceN, axleMotiveForceN, axleBrakeForceN, frictionForceN);
         }
 
         /// <summary>
@@ -1527,10 +1478,10 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         {
             float axleInForceN = 0;        
             if (DriveType == AxleDriveType.ForceDriven)
-                axleInForceN = DriveForceN * transmissionEfficiency;
+                axleInForceN = DriveForceN;
             else if (DriveType == AxleDriveType.MotorDriven)
-                axleInForceN = (float)motor.GetDevelopedTorqueNm(TrainSpeedMpS * transmissionRatio / WheelRadiusM) * transmissionEfficiency / WheelRadiusM;
-            DriveForceN = axleInForceN / transmissionEfficiency;
+                axleInForceN = (float)motor.GetAxleTorqueNm(TrainSpeedMpS / WheelRadiusM) / WheelRadiusM;
+            DriveForceN = axleInForceN;
 
             float frictionForceN = FrictionN;
             float totalFrictionForceN = BrakeRetardForceN + frictionForceN; // Dissipative forces: they will never increase wheel speed

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/ElectricMotor.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/ElectricMotor.cs
@@ -36,7 +36,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         /// <summary>
         /// Positive nonzero transmission ratio, given by n1:n2 ratio
         /// </summary>
-        public float TransmissionRatio { get; protected set; }
+        public float TransmissionRatio { get; protected set; } = 1.0f;
 
         /// <summary>
         /// Transmission efficiency, relative to 1.0, within range of 0.0 to 1.0 (1.0 means 100%, 0.5 means 50%)

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/ElectricMotor.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/ElectricMotor.cs
@@ -33,6 +33,16 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         public float SurfaceM;
         public float WeightKg;
 
+        /// <summary>
+        /// Positive nonzero transmission ratio, given by n1:n2 ratio
+        /// </summary>
+        public float TransmissionRatio { get; protected set; }
+
+        /// <summary>
+        /// Transmission efficiency, relative to 1.0, within range of 0.0 to 1.0 (1.0 means 100%, 0.5 means 50%)
+        /// </summary>
+        public float TransmissionEfficiency { get; protected set; } = 1.0f;
+
         protected float powerLossesW;
 
         public float CoolingPowerW;
@@ -54,17 +64,21 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             WeightKg = 5.0f;
             AxleConnected = axle;
             AxleConnected.Motor = this;
-            AxleConnected.TransmissionRatio = 1;
         }
 
-        public virtual double GetDevelopedTorqueNm(double motorSpeedRadpS)
+        public double GetAxleTorqueNm(double axleSpeedRadpS)
+        {
+            return GetTorqueNm(axleSpeedRadpS * TransmissionRatio) * TransmissionRatio * TransmissionEfficiency;
+        }
+        protected virtual double GetTorqueNm(double speedRadpS)
         {
             return 0;
         }
 
         public virtual void Update(float timeSpan)
         {
-            temperatureK = tempIntegrator.Integrate(timeSpan, (temperatureK) => 1.0f/(SpecificHeatCapacityJ_kg_C * WeightKg)*((powerLossesW - CoolingPowerW) / (ThermalCoeffJ_m2sC * SurfaceM) - temperatureK));
+            powerLossesW = AxleConnected.DriveForceN * AxleConnected.WheelRadiusM / TransmissionRatio * (1 - TransmissionEfficiency) / TransmissionEfficiency * (float)AxleConnected.AxleSpeedMpS / AxleConnected.WheelRadiusM / TransmissionRatio;
+            temperatureK = tempIntegrator.Integrate(timeSpan, (temperatureK) => 1.0f / (SpecificHeatCapacityJ_kg_C * WeightKg) * ((powerLossesW - CoolingPowerW) / (ThermalCoeffJ_m2sC * SurfaceM) - temperatureK));
         }
         public virtual void Initialize()
         {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/InductionMotor.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/InductionMotor.cs
@@ -44,16 +44,16 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
         {
             base.Initialize();
         }
-        public override double GetDevelopedTorqueNm(double motorSpeedRadpS)
+        protected override double GetTorqueNm(double speedRadpS)
         {
-            return requiredTorqueNm * MathHelper.Clamp((float)(DriveSpeedRadpS - motorSpeedRadpS) / OptimalAsyncSpeedRadpS, -1, 1);
+            return requiredTorqueNm * MathHelper.Clamp((float)(DriveSpeedRadpS - speedRadpS) / OptimalAsyncSpeedRadpS, -1, 1);
         }
         public override void Update(float timeSpan)
         {
             TargetForceN = Locomotive.TractiveForceN * AxleConnected.TractiveForceFraction;
             EngineMaxSpeedMpS = Locomotive.MaxSpeedMpS;
             SlipControl = Locomotive.SlipControlSystem == MSTSLocomotive.SlipControlType.Full;
-            float linToAngFactor = AxleConnected.TransmissionRatio / AxleConnected.WheelRadiusM;
+            float linToAngFactor = TransmissionRatio / AxleConnected.WheelRadiusM;
             if (SlipControl)
             {
                 if (TargetForceN > 0) DriveSpeedRadpS = (AxleConnected.TrainSpeedMpS + AxleConnected.WheelSlipThresholdMpS * 0.95f) * linToAngFactor + OptimalAsyncSpeedRadpS;
@@ -64,7 +64,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
                 if (TargetForceN > 0) DriveSpeedRadpS = EngineMaxSpeedMpS * linToAngFactor + OptimalAsyncSpeedRadpS;
                 else if (TargetForceN < 0) DriveSpeedRadpS = -EngineMaxSpeedMpS * linToAngFactor - OptimalAsyncSpeedRadpS;
             }
-            requiredTorqueNm = Math.Abs(TargetForceN) * AxleConnected.WheelRadiusM / AxleConnected.TransmissionRatio;
+            requiredTorqueNm = Math.Abs(TargetForceN) * AxleConnected.WheelRadiusM / TransmissionRatio / TransmissionEfficiency;
             base.Update(timeSpan);
         }
     }

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/SeriesMotor.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerTransmissions/SeriesMotor.cs
@@ -136,9 +136,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerTransmissions
             NominalRevolutionsRad = nomRevolutionsRad;
         }
 
-        public override double GetDevelopedTorqueNm(double revolutionsRad)
+        protected override double GetTorqueNm(double revolutionsRadpS)
         {
-            BackEMFvoltageV = (float)revolutionsRad * fieldWb;
+            BackEMFvoltageV = (float)revolutionsRadpS * fieldWb;
             return fieldWb * armatureCurrentA/* - (frictionTorqueNm * revolutionsRad / NominalRevolutionsRad * revolutionsRad / NominalRevolutionsRad)*/;
         }
 


### PR DESCRIPTION
For diesel-mechanical locomotives, it should depend on the gearbox. For electric locomotives, moved to ElectricMotor class. Since it is always set to 1, it does not change anything.