### PR TITLE
Add Support for Dynamic Road Sections

### DIFF
--- a/Source/Orts.Formats.Msts/WorldFile.cs
+++ b/Source/Orts.Formats.Msts/WorldFile.cs
@@ -508,6 +508,7 @@ namespace Orts.Formats.Msts
         public float Elevation;
         public uint CollideFlags;
         public JNodePosn JNodePosn;
+        public string ShapeTemplate;
 
         public TrackObj(SBR block, int detailLevel)
         {
@@ -527,6 +528,7 @@ namespace Orts.Formats.Msts
                 case TokenID.Elevation: Elevation = subBlock.ReadFloat(); break;
                 case TokenID.CollideFlags: CollideFlags = subBlock.ReadUInt(); break;
                 case TokenID.FileName: FileName = subBlock.ReadString(); break;
+                case TokenID.ShapeTemplate: ShapeTemplate = subBlock.ReadString(); break;
                 case TokenID.StaticFlags: StaticFlags = subBlock.ReadUInt(); break;
                 case TokenID.Position: Position = new STFPositionItem(subBlock); break;
                 case TokenID.QDirection: QDirection = new STFQDirectionItem(subBlock); break;
@@ -540,10 +542,14 @@ namespace Orts.Formats.Msts
 
     public class DyntrackObj : WorldObject
     {
+        const uint RoadStaticFlag = 0x00000100;
+
         public readonly uint SectionIdx;
         public readonly float Elevation;
         public readonly uint CollideFlags;
         public readonly TrackSections trackSections;
+        public readonly string ShapeTemplate;
+        public bool IsRoad { get { return (StaticFlags & RoadStaticFlag) != 0; } }
 
         public DyntrackObj(SBR block, int detailLevel)
         {
@@ -559,6 +565,7 @@ namespace Orts.Formats.Msts
                         case TokenID.SectionIdx: SectionIdx = subBlock.ReadUInt(); break;
                         case TokenID.Elevation: Elevation = subBlock.ReadFloat(); break;
                         case TokenID.CollideFlags: CollideFlags = subBlock.ReadUInt(); break;
+                        case TokenID.ShapeTemplate: ShapeTemplate = subBlock.ReadString(); break;
                         case TokenID.StaticFlags: StaticFlags = subBlock.ReadUInt(); break;
                         case TokenID.Position: Position = new STFPositionItem(subBlock); break;
                         case TokenID.QDirection: QDirection = new STFQDirectionItem(subBlock); break;
@@ -576,6 +583,7 @@ namespace Orts.Formats.Msts
             this.SectionIdx = copy.SectionIdx;
             this.Elevation = copy.Elevation;
             this.CollideFlags = copy.CollideFlags;
+            this.ShapeTemplate = copy.ShapeTemplate;
             this.StaticFlags = copy.StaticFlags;
             this.Position = new STFPositionItem(copy.Position);
             this.QDirection = new STFQDirectionItem(copy.QDirection);

--- a/Source/Orts.Parsers.Msts/TokenID.cs
+++ b/Source/Orts.Parsers.Msts/TokenID.cs
@@ -1720,7 +1720,8 @@ namespace Orts.Parsers.Msts
         Flipped,
 
         // TSRE specific
-        Ruler
+        Ruler,
+        ShapeTemplate
     }
 
 }

--- a/Source/RunActivity/Viewer3D/DynamicTrack.cs
+++ b/Source/RunActivity/Viewer3D/DynamicTrack.cs
@@ -334,7 +334,110 @@ namespace Orts.Viewer3D
     public class TRPFile
     {
         public TrProfile TrackProfile; // Represents the track profile
+        public string FileName { get; private set; }
+        static readonly HashSet<string> ProfileWarnings =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         //public RenderProcess RenderProcess; // TODO: Pass this along in function calls
+
+        static TRPFile FindNamedProfile(List<TRPFile> profiles, string name)
+        {
+            TRPFile fileMatch = profiles.FirstOrDefault(profile =>
+                string.Equals(profile.FileName, name,
+                    StringComparison.OrdinalIgnoreCase));
+            if (fileMatch != null)
+                return fileMatch;
+
+            List<TRPFile> declaredNameMatches = profiles.Where(profile =>
+                profile.TrackProfile != null &&
+                string.Equals(profile.TrackProfile.Name, name,
+                    StringComparison.OrdinalIgnoreCase)).ToList();
+            return declaredNameMatches.Count == 1 ? declaredNameMatches[0] : null;
+        }
+
+        static void WarnProfileOnce(string key, string message)
+        {
+            lock (ProfileWarnings)
+            {
+                if (ProfileWarnings.Add(key))
+                    Trace.TraceWarning(message);
+            }
+        }
+
+        public static TrProfile ResolveDynamicTrackProfile(List<TRPFile> profiles,
+            string shapeTemplate, bool isRoad)
+        {
+            if (profiles == null || profiles.Count == 0)
+                return null;
+
+            TrProfile defaultProfile = profiles[0].TrackProfile;
+            string requestedName = shapeTemplate?.Trim();
+
+            if (string.IsNullOrEmpty(requestedName))
+            {
+                if (!isRoad)
+                    return defaultProfile;
+
+                TRPFile roadProfile = FindNamedProfile(profiles, "default_road")
+                    ?? FindNamedProfile(profiles, "TrProfileRoad");
+                if (roadProfile != null)
+                    return roadProfile.TrackProfile;
+
+                WarnProfileOnce("missing-road-profile",
+                    "Road DynTrack profile default_road or TrProfileRoad was " +
+                    "not found; using the default track profile.");
+                return defaultProfile;
+            }
+
+            if (string.Equals(requestedName, "DEFAULT",
+                    StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(requestedName, "DISABLED",
+                    StringComparison.OrdinalIgnoreCase))
+                return defaultProfile;
+
+            TRPFile selectedProfile = FindNamedProfile(profiles, requestedName);
+            if (selectedProfile != null)
+                return selectedProfile.TrackProfile;
+
+            WarnProfileOnce("missing-profile:" + requestedName,
+                "DynTrack ShapeTemplate '" + requestedName +
+                "' was not found or its declared profile name is ambiguous; " +
+                "using the default track profile.");
+            return defaultProfile;
+        }
+
+        public static bool TryResolveStaticTrackProfile(List<TRPFile> profiles,
+            string shapeTemplate, out TrProfile trackProfile)
+        {
+            trackProfile = null;
+            if (profiles == null || profiles.Count == 0)
+                return false;
+
+            string requestedName = shapeTemplate?.Trim();
+            if (string.IsNullOrEmpty(requestedName) ||
+                string.Equals(requestedName, "DISABLED",
+                    StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            if (string.Equals(requestedName, "DEFAULT",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                trackProfile = profiles[0].TrackProfile;
+                return trackProfile != null;
+            }
+
+            TRPFile selectedProfile = FindNamedProfile(profiles, requestedName);
+            if (selectedProfile != null)
+            {
+                trackProfile = selectedProfile.TrackProfile;
+                return trackProfile != null;
+            }
+
+            WarnProfileOnce("missing-static-profile:" + requestedName,
+                "TrackObj ShapeTemplate '" + requestedName +
+                "' was not found or its declared profile name is ambiguous; " +
+                "using the original static shape.");
+            return false;
+        }
 
         /// <summary>
         /// Creates a List<TRPFile></TRPFile> instance from a set of track profile file(s)
@@ -369,9 +472,12 @@ namespace Orts.Viewer3D
                 else // Add the canned (Kuju) track profile if no default is given
                     trpFiles.Add(new TRPFile(viewer, ""));
 
-                // Get all .xml/.stf files that start with "TrProfile"
-                string[] xmlProfiles = Directory.GetFiles(path, "TrProfile*.xml");
-                string[] stfProfiles = Directory.GetFiles(path, "TrProfile*.stf");
+                // ORTS profiles traditionally start with "TrProfile".
+                // TSRE reserves "default_*" for portable built-in profile IDs.
+                string[] xmlProfiles = Directory.GetFiles(path, "TrProfile*.xml")
+                    .Concat(Directory.GetFiles(path, "default_*.xml")).ToArray();
+                string[] stfProfiles = Directory.GetFiles(path, "TrProfile*.stf")
+                    .Concat(Directory.GetFiles(path, "default_*.stf")).ToArray();
 
                 foreach (string xmlProfile in xmlProfiles)
                 {
@@ -416,6 +522,8 @@ namespace Orts.Viewer3D
         /// <param name="filespec">Complete filepath string to track profile file.</param>
         public TRPFile(Viewer viewer, string filespec)
         {
+            FileName = string.IsNullOrEmpty(filespec)
+                ? "TrProfile" : Path.GetFileNameWithoutExtension(filespec);
             if (filespec == "")
             {
                 // No track profile provided, use default

--- a/Source/RunActivity/Viewer3D/Scenery.cs
+++ b/Source/RunActivity/Viewer3D/Scenery.cs
@@ -46,6 +46,7 @@ using Microsoft.Xna.Framework;
 using Orts.Formats.Msts;
 using Orts.Formats.OR;
 using ORTS.Common;
+using Orts.Simulation;
 using Orts.Simulation.RollingStocks;
 using System;
 using System.Collections.Generic;
@@ -53,7 +54,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Orts.Simulation;
 
 namespace Orts.Viewer3D
 {

--- a/Source/RunActivity/Viewer3D/Scenery.cs
+++ b/Source/RunActivity/Viewer3D/Scenery.cs
@@ -53,6 +53,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Orts.Simulation;
 
 namespace Orts.Viewer3D
 {
@@ -384,40 +385,34 @@ namespace Orts.Viewer3D
                         }
                         else
                         {
-                            // See if superelevation should be used on this piece of track
-                            if (viewer.Simulator.UseSuperElevation
-                                && SuperElevationManager.DecomposeStaticSuperElevation(viewer, trackObj, worldMatrix, dTrackList, shapeFilePath))
+                            // Determine if this is a turntable or transfertable
+                            MovingTable movingTable = null;
+                            if (containsMovingTable)
                             {
-                                // Don't add scenery for this section of track, dynamic superelevated track will be created instead
+                                movingTable = Program.Simulator.MovingTables.FirstOrDefault(table =>
+                                    worldObject.UID == table.UID &&
+                                    WFileName == table.WFile);
                             }
-                            // No superelevation, use static shapes
-                            else if (!containsMovingTable)
-                                sceneryObjects.Add(new StaticTrackShape(viewer, shapeFilePath, worldMatrix));
-                            else
+
+                            if (movingTable != null)
                             {
-                                var found = false;
-                                foreach (var movingTable in Program.Simulator.MovingTables)
+                                if (movingTable is Turntable turntable)
                                 {
-                                    if (worldObject.UID == movingTable.UID && WFileName == movingTable.WFile)
-                                    {
-                                        found = true;
-                                        if (movingTable is Simulation.Turntable)
-                                        {
-                                            var turntable = movingTable as Simulation.Turntable;
-                                            turntable.ComputeCenter(worldMatrix);
-                                            var startingY = Math.Asin(-2 * (worldObject.QDirection.A * worldObject.QDirection.C - worldObject.QDirection.B * worldObject.QDirection.D));
-                                            sceneryObjects.Add(new TurntableShape(viewer, shapeFilePath, worldMatrix, shadowCaster ? ShapeFlags.ShadowCaster : ShapeFlags.None, turntable, startingY));
-                                        }
-                                        else
-                                        {
-                                            var transfertable = movingTable as Simulation.Transfertable;
-                                            transfertable.ComputeCenter(worldMatrix);
-                                            sceneryObjects.Add(new TransfertableShape(viewer, shapeFilePath, worldMatrix, shadowCaster ? ShapeFlags.ShadowCaster : ShapeFlags.None, transfertable));
-                                        }
-                                        break;
-                                    }
+                                    turntable.ComputeCenter(worldMatrix);
+                                    var startingY = Math.Asin(-2 * (worldObject.QDirection.A * worldObject.QDirection.C - worldObject.QDirection.B * worldObject.QDirection.D));
+                                    sceneryObjects.Add(new TurntableShape(viewer, shapeFilePath, worldMatrix, shadowCaster ? ShapeFlags.ShadowCaster : ShapeFlags.None, turntable, startingY));
                                 }
-                                if (!found) sceneryObjects.Add(new StaticTrackShape(viewer, shapeFilePath, worldMatrix));
+                                else if (movingTable is Transfertable transfertable)
+                                {
+                                    transfertable.ComputeCenter(worldMatrix);
+                                    sceneryObjects.Add(new TransfertableShape(viewer, shapeFilePath, worldMatrix, shadowCaster ? ShapeFlags.ShadowCaster : ShapeFlags.None, transfertable));
+                                }
+                            }
+                            // Regular track; Only add scenery object if superelevation is NOT used
+                            else if (!(viewer.Simulator.UseSuperElevation
+                                && SuperElevationManager.DecomposeStaticSuperElevation(viewer, trackObj, worldMatrix, dTrackList, shapeFilePath)))
+                            {
+                                sceneryObjects.Add(new StaticTrackShape(viewer, shapeFilePath, worldMatrix));
                             }
                         }
                         if (viewer.Simulator.Settings.Wire == true && viewer.Simulator.TRK.Tr_RouteFile.Electrified == true
@@ -433,10 +428,16 @@ namespace Orts.Viewer3D
                     }
                     else if (worldObject.GetType() == typeof(DyntrackObj))
                     {
-                        if (viewer.Simulator.Settings.Wire == true && viewer.Simulator.TRK.Tr_RouteFile.Electrified == true)
-                            Wire.DecomposeDynamicWire(viewer, dTrackList, (DyntrackObj)worldObject, worldMatrix);
+                        // Dynamic track objects may be road or track
+                        // Only add wires to track
+                        DyntrackObj dyntrackObj = (DyntrackObj)worldObject;
+                        if (!dyntrackObj.IsRoad &&
+                            viewer.Simulator.Settings.Wire == true &&
+                            viewer.Simulator.TRK.Tr_RouteFile.Electrified == true)
+                            Wire.DecomposeDynamicWire(viewer, dTrackList, dyntrackObj, worldMatrix);
                         // Add DyntrackDrawers for individual subsections
-                        SuperElevationManager.DecomposeDynamicSuperElevation(viewer, dTrackList, (DyntrackObj)worldObject, worldMatrix);
+                        SuperElevationManager.DecomposeDynamicSuperElevation(
+                            viewer, dTrackList, dyntrackObj, worldMatrix);
 
                     }
                     // Objects other than tracks

--- a/Source/RunActivity/Viewer3D/SuperElevation.cs
+++ b/Source/RunActivity/Viewer3D/SuperElevation.cs
@@ -61,6 +61,10 @@ namespace Orts.Viewer3D
 
             bool dontRender = false; // Should this shape be left as a static object?
             bool removePhys = false; // Should superelevation physics be removed from this object?
+            string requestedTemplate = trackObj.ShapeTemplate?.Trim();
+            bool templateDisabled = string.Equals(requestedTemplate, "DISABLED",
+                StringComparison.OrdinalIgnoreCase);
+            bool explicitProcedural = false;
             SectionIdx[] SectionIdxs;
 
             // Using the track object, determine the track sections
@@ -90,37 +94,46 @@ namespace Orts.Viewer3D
             // 0 = centered, positive = rotation axis moves to inside of curve, negative = moves to outside of curve
             float rollOffsetM = 0.0f;
 
-            // Determine the track profile to use for this section based on the shape file
-            int trpIndex = DynamicTrackViewer.GetBestTrackProfile(viewer, shapeFilePath);
-
             TrProfile trProfile = null;
-            // If a track profile is found (index exists), continue processing
-            if (trpIndex >= 0 && trpIndex < viewer.TRPs.Count)
+            if (templateDisabled)
+                dontRender = true;
+            else if (!string.IsNullOrEmpty(requestedTemplate))
             {
-                trProfile = viewer.TRPs[trpIndex].TrackProfile;
-
-                // If this track profile has superelevation disabled, don't bother rendering anything
-                if (trProfile.ElevationType == TrProfile.SuperElevationMethod.None)
+                explicitProcedural = TRPFile.TryResolveStaticTrackProfile(
+                    viewer.TRPs, requestedTemplate, out trProfile);
+                if (!explicitProcedural)
                     dontRender = true;
-                else // Superelevation enabled, check the roll offset
+            }
+            else
+            {
+                // Preserve the legacy ORTS profile selection when no explicit template is present.
+                int trpIndex = DynamicTrackViewer.GetBestTrackProfile(viewer, shapeFilePath);
+                if (trpIndex >= 0 && trpIndex < viewer.TRPs.Count)
                 {
-                    switch (trProfile.ElevationType)
-                    {
-                        case TrProfile.SuperElevationMethod.Outside: // Only outside rail should elevate
-                            rollOffsetM = trProfile.TrackGaugeM / 2.0f;
-                            break;
-                        case TrProfile.SuperElevationMethod.Inside: // Only inside rail should elevate
-                            rollOffsetM = -trProfile.TrackGaugeM / 2.0f;
-                            break;
-                        case TrProfile.SuperElevationMethod.Both: // Both rails should elevate
-                        default:
-                            rollOffsetM = 0.0f;
-                            break;
-                    }
+                    trProfile = viewer.TRPs[trpIndex].TrackProfile;
+                    if (trProfile.ElevationType == TrProfile.SuperElevationMethod.None)
+                        dontRender = true;
+                }
+                else
+                    dontRender = true;
+            }
+
+            if (!dontRender && trProfile.ElevationType != TrProfile.SuperElevationMethod.None)
+            {
+                switch (trProfile.ElevationType)
+                {
+                    case TrProfile.SuperElevationMethod.Outside: // Only outside rail should elevate
+                        rollOffsetM = trProfile.TrackGaugeM / 2.0f;
+                        break;
+                    case TrProfile.SuperElevationMethod.Inside: // Only inside rail should elevate
+                        rollOffsetM = -trProfile.TrackGaugeM / 2.0f;
+                        break;
+                    case TrProfile.SuperElevationMethod.Both: // Both rails should elevate
+                    default:
+                        rollOffsetM = 0.0f;
+                        break;
                 }
             }
-            else // No track profile suitable, don't render with superelevation
-                dontRender = true;
 
             // Right now it's not confirmed if superelevation viewers are actually needed, so they are added to a temporary list
             List<DynamicTrackViewer> tempViewers = new List<DynamicTrackViewer>();
@@ -165,13 +178,15 @@ namespace Orts.Viewer3D
                     {
                         superElevationSections.Add(tmp);
 
-                        if (!dontRender)
+                        if (!dontRender && trProfile.ElevationType != TrProfile.SuperElevationMethod.None)
                         {
                             tmp.ElevOffsetM = rollOffsetM;
 
                             // Processing done, prepare to generate section with superelevation
                             tempViewers.Add(new SuperElevationViewer(viewer, root, nextRoot, radius, length, trProfile, tmp.VisElevTable, tmp.ElevOffsetM, reversed));
                         }
+                        else if (!dontRender)
+                            tempViewers.Add(new SuperElevationViewer(viewer, root, nextRoot, radius, length, trProfile));
                     }
                     else if (!dontRender) // Section doesn't have superelevation, prepare to generate it without superelevation
                         tempViewers.Add(new SuperElevationViewer(viewer, root, nextRoot, radius, length, trProfile));
@@ -187,11 +202,11 @@ namespace Orts.Viewer3D
                 return false;
             }
             // We are rendering superelevation, add all superelevation viewers to the global list to be rendered
-            else if (superElevationSections.Count > 0 && tempViewers.Count > 0)
+            else if ((superElevationSections.Count > 0 || explicitProcedural) && tempViewers.Count > 0)
                 dTrackList.AddRange(tempViewers);
 
-            // If no sections with superelevation were found, WorldFile should render with static shapes
-            return superElevationSections.Count > 0;
+            // Explicit templates also replace static shapes which have no superelevated sections.
+            return superElevationSections.Count > 0 || explicitProcedural;
         }
 
         /// <summary>
@@ -519,6 +534,8 @@ namespace Orts.Viewer3D
 
             // Right now it's not confirmed if superelevation viewers are actually needed, so they are added to a temporary list
             List<DynamicTrackViewer> tempViewers = new List<DynamicTrackViewer>();
+            TrProfile trProfile = TRPFile.ResolveDynamicTrackProfile(
+                viewer.TRPs, dTrackObj.ShapeTemplate, dTrackObj.IsRoad);
 
             // Iterate through all subsections
             foreach (DyntrackObj.TrackSection dSection in dTrackObj.trackSections)
@@ -554,13 +571,13 @@ namespace Orts.Viewer3D
                 localV = localProjectedV; // Move position to next subsection
 
                 // To determine if this section needs superelevation, search for it in the global superelevation dictionary
-                TrVectorSection tmp = FindSuperElevationSection(viewer, section, dTrackObj.UID, root, nextRoot, out bool reversed);
+                bool reversed = false;
+                TrVectorSection tmp = dTrackObj.IsRoad ? null :
+                    FindSuperElevationSection(viewer, section, dTrackObj.UID,
+                        root, nextRoot, out reversed);
 
                 if (tmp != null) // Section does have superelevation
                 {
-                    // FUTURE: Allow dynamic track to use track profiles other than the 0th one
-                    TrProfile trProfile = viewer.TRPs[0].TrackProfile;
-                    
                     // Superelevation is enabled, generate track section with superelevation
                     if (viewer.Simulator.UseSuperElevation)
                     {
@@ -592,7 +609,8 @@ namespace Orts.Viewer3D
                         tempViewers.Add(new SuperElevationViewer(viewer, root, nextRoot, radius, length, trProfile));
                 }
                 else // Section doesn't have superelevation, prepare to generate it without superelevation
-                    tempViewers.Add(new SuperElevationViewer(viewer, root, nextRoot, radius, length));
+                    tempViewers.Add(new SuperElevationViewer(
+                        viewer, root, nextRoot, radius, length, trProfile));
             }
 
             // Add all the generated sections to the main list


### PR DESCRIPTION
Extension of #954 
Code originally written by goku

Discuss on [Elvas Tower](https://www.elvastower.com/forums/index.php?/topic/38114-multiple-track-profiles/)
[Trello card](https://trello.com/c/AwthpV6y)

This PR adds support for dynamic road sections and custom track profiles for dynamic track. Previously, only tracks could have dynamic sections (with arbitrary length and curve radius) generated, and these sections would only use the default track profile.

With the addition of a `ShapeTemplate` parameter to world objects, regular track and dynamic track can now define a specific track profile to use (the given value is interpreted as the file name of the track profile to use, or the `Name` of the track profile if none of the file names match, `ShapeTemplate ( "DEFAULT" )` uses the default track profile while `ShapeTemplate ( "DISABLED" )` forces the static shape to be used instead of a track profile) instead of the previous behavior that automatically selected a track profile. Using this feature will require editing a route, so the previous behavior has been retained (as long as `ShapeTemplate` is not given) so track profiles still work without editing a route.

Dynamic track objects with the 8th bit of `StaticFlags` set (hex flag 0x00000100) will be interpreted as dynamic *road* objects instead (this flag only applies to dynamic track objects). This allows for different behavior when using a "track" profile to procedurally generate these shapes. Namely, no superelevation will be applied (superelevation isn't calculated for the road database), no overhead wires will be generated, and different track profiles will be used (ideally, these "track" profiles should be built to have the appearance of a road). Otherwise, the capabilites and functionality are the same as for dynamic track, as much of the existing code is reused.
Unlike for track profiles, there is no hardcoded default road profile, so if dynamic roads are to be used then custom profiles must be provided (else dynamic roads will have the appearance of dynamic track). The track profile named `TrProfileRoad` (name pending) will be used as the default profile for roads, unless a specific profile is given by `ShapeTemplate`.

This system is probably expandable to things other than roads, additional behavior may be added for generic scenery objects (think of fences, walls) or the existing terminology might be rephrased to be less road-centric.

Todo:

- [ ] Decide on file naming convention
- [ ] Add some way to differentiate between profiles meant for track and profiles meant for road, to prevent the two being mixed
- [ ] Add support for multiple track profiles in a singular track profile file to reduce clutter in the TRACKPROFILES folder
- [ ] Documentation