### PR TITLE
Fix for system name not extracted by Notifications

### DIFF
--- a/Source/Menu/Notifications/NotificationManager.cs
+++ b/Source/Menu/Notifications/NotificationManager.cs
@@ -448,11 +448,21 @@ namespace Menu.Notifications
             return url;
         }
 
+        /// <summary>
+        /// Given a function that replaces a parameter with its value, this method replaces all parameters in the Notifications object.
+        /// </summary>
         void ReplaceParameters()
         {
             Notifications.ReplaceParameters(ReplaceParameterValues);
         }
 
+        /// <summary>
+        /// Given a string, replaces any parameters in the form {{parameter}} with their value from the ParameterDictionary.
+        /// If the ParameterDictionary is already loaded with override values, these are used first. Otherwise the program is queried for the value.
+        /// If a parameter is not recognised, it is not replaced.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         string ReplaceParameterValues(string value)
         {
             if (value == null) return value;
@@ -507,7 +517,7 @@ namespace Menu.Notifications
                         replacement = Runtime.ToString();
                         break;
                     case "system":
-                        replacement = SystemInfo.OperatingSystem.ToString();
+                        replacement = SystemInfo.OperatingSystem.Name;
                         break;
                     case "memory":
                         replacement = Direct3DFeatureLevels.ToString();

--- a/Source/Menu/Notifications/NotificationManager.cs
+++ b/Source/Menu/Notifications/NotificationManager.cs
@@ -514,26 +514,26 @@ namespace Menu.Notifications
                         replacement = SystemInfo.Application.Version;
                         break;
                     case "runtime":
-                        replacement = Runtime.ToString();
+                        replacement = $"{Runtime.Name} {Runtime.Version}";
                         break;
                     case "system":
-                        replacement = SystemInfo.OperatingSystem.Name;
+                        replacement = $"{SystemInfo.OperatingSystem.Name} {SystemInfo.OperatingSystem.Version}";
                         break;
                     case "memory":
-                        replacement = Direct3DFeatureLevels.ToString();
+                        replacement = InstalledMemoryMB.ToString();
                         break;
                     case "cpu":
                         replacement = "";
                         foreach (var cpu in CPUs)
                         {
-                            replacement += $", {cpu.Name}";
+                            replacement += (replacement == "") ? cpu.Name : ", " + cpu.Name;
                         }
                         break;
                     case "gpu":
                         replacement = "";
                         foreach (var gpu in GPUs)
                         {
-                            replacement += $", {gpu.Name}";
+                            replacement += (replacement == "") ? gpu.Name : ", " + gpu.Name;
                         }
                         break;
                     case "direct3d":

--- a/Source/Menu/Notifications/Notifications.cs
+++ b/Source/Menu/Notifications/Notifications.cs
@@ -24,6 +24,8 @@ namespace Menu.Notifications
     {
         public List<Notification> NotificationList = new List<Notification>();
         public List<Check> CheckList = new List<Check>();
+
+        // Given a function that replaces parameters in a string, replace all parameters in the notifications and checks
         internal void ReplaceParameters(Func<string, string> replaceFunc)
         {
             NotificationList?.ForEach(item => item.ReplaceParameters(replaceFunc));


### PR DESCRIPTION
On moving to .Net 6, Open Rails will no longer be compatible with Windows 7 and 8.1.
A Notification Check will be needed to block the installation of an Open Rails update on such systems.

This fix corrects the code which was returning not a Name like "Microsoft Windows 10 Home Edition" but the object containing property Name.