### PR TITLE
Fix Speed Limit Warning Signs in Track Monitor

### DIFF
--- a/Source/Orts.Simulation/Simulation/Physics/Train.cs
+++ b/Source/Orts.Simulation/Simulation/Physics/Train.cs
@@ -14873,14 +14873,20 @@ namespace Orts.Simulation.Physics
                             PlayerTrainSignals[dir][SignalFunction.NORMAL].Add(thisItem);
                             signalProcessed = true;
                         }
-                        else if (signalObjectItem.ObjectType == ObjectItemInfo.ObjectItemType.Speedlimit && signalObjectItem.actual_speed > 0)
+                        else if (signalObjectItem.ObjectType == ObjectItemInfo.ObjectItemType.Speedlimit)
                         {
-                            thisItem = new TrainObjectItem(thisSpeedMpS: signalObjectItem.actual_speed,
-                                isWarning: signalObjectItem.speed_isWarning,
-                                thisDistanceM: signalObjectItem.distance_to_train,
-                                signalObject: signalObjectItem.ObjectDetails,
-                                speedObjectType: (TrainObjectItem.SpeedItemType)signalObjectItem.speed_noSpeedReductionOrIsTempSpeedReduction);
-                            PlayerTrainSpeedposts[dir].Add(thisItem);
+                            float validSpeed = Math.Min(TrainMaxSpeedMpS, IsFreight ? signalObjectItem.speed_freight : signalObjectItem.speed_passenger);
+
+                            if (validSpeed > 0)
+                            {
+                                thisItem = new TrainObjectItem(
+                                    validSpeed,
+                                    signalObjectItem.speed_isWarning,
+                                    signalObjectItem.distance_to_train,
+                                    signalObjectItem.ObjectDetails,
+                                    (TrainObjectItem.SpeedItemType)signalObjectItem.speed_noSpeedReductionOrIsTempSpeedReduction);
+                                PlayerTrainSpeedposts[dir].Add(thisItem);
+                            }
                         }
                     }
                     if (!signalProcessed && NextSignalObject[0] != null && NextSignalObject[0].enabledTrain != null && NextSignalObject[0].enabledTrain.Train == this)
@@ -14995,7 +15001,7 @@ namespace Orts.Simulation.Physics
                                     }
                                     else
                                     {
-                                        validSpeed = IsFreight ? thisSpeedInfo.speed_freight : thisSpeedInfo.speed_pass;
+                                        validSpeed = Math.Min(TrainMaxSpeedMpS, IsFreight ? thisSpeedInfo.speed_freight : thisSpeedInfo.speed_pass);
 
                                         if (!thisSpeedInfo.speed_isWarning && validSpeed > 0f)
                                         {

--- a/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrackMonitorWindow.cs
@@ -913,7 +913,7 @@ namespace Orts.Viewer3D.Popups
                 var labelPoint = new Point(offset.X + speedTextOffset, offset.Y + newLabelPosition + textOffset[forward ? 0 : 1]);
                 var speedString = FormatStrings.FormatSpeedLimitNoUoM(allowedSpeed, metric);
                 Font.Draw(spriteBatch, labelPoint, speedString, thisItem.SpeedObjectType == Train.TrainObjectItem.SpeedItemType.Standard ? (thisItem.IsWarning ? Color.Yellow : Color.White) :
-                    (thisItem.SpeedObjectType == Train.TrainObjectItem.SpeedItemType.TempRestrictedStart ? Color.Red : Color.LightGreen));
+                    (thisItem.SpeedObjectType == Train.TrainObjectItem.SpeedItemType.TempRestrictedStart ? Color.OrangeRed : Color.LightGreen));
 
                 if (itemOffset < firstLabelPosition && !firstLabelShown)
                 {

--- a/Source/RunActivity/Viewer3D/WebServices/TrackMonitorDisplay.cs
+++ b/Source/RunActivity/Viewer3D/WebServices/TrackMonitorDisplay.cs
@@ -918,7 +918,10 @@ namespace Orts.Viewer3D.WebServices
                 switch (Item.SpeedObjectType)
                 {
                     case SpeedItemType.Standard:
-                        color = Color.White;
+                        if (Item.IsWarning)
+                            color = Color.Yellow;
+                        else
+                            color = Color.White;
                         break;
                     case SpeedItemType.TempRestrictedStart:
                         color = Color.OrangeRed;


### PR DESCRIPTION
This PR fixes an inconsistency I recently noticed; the track monitor would display speed limit warning signs (with the speed text in yellow, instead of white), but only in explorer mode. With some minor changes, the track monitor can also display speed limit warning signs in automatic mode (the normal mode during activities) too, giving a bit more information to help with driving.

- Changed `UpdatePlayerTainData` in AUTO mode to consider warning speed limit signs. Previously, only speed limit signs with `actual_speed > 0` would be considered, but for warning signs the `actual_speed` is set to -1 (thus, warning signs were not considered). Now, the freight/passenger speed limit (depending on the train type) and the train max speed are considered when determining if a speed limit sign is valid, so warning signs will be included in the AUTO mode list.
- Changed speed limit signs in `UpdatePlayerTrainData` in MANUAL/EXPLORER mode to consider the max speed of the train, so the track monitor speed limits shown in this mode should reflect the actual train speed.
- Added support for speed limit warning signs on the web interface track monitor. Warning speeds are displayed in `Yellow` (same behavior as the in-game track monitor).
- Changed the color of the beginning of a restricted speed limit zone on the track monitor from `Red` to `OrangeRed` for consistency between the track monitor window and the web interface track monitor (both use `OrangeRed` now).