### PR TITLE
Support for higher-resolution terrain

### DIFF
--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -373,13 +373,10 @@ namespace Orts.Viewer3D
                         Materials[materialKey] = new SpriteBatchMaterial(Viewer, effect: effect);
                         break;
                     case "Terrain":
-                        Materials[materialKey] = new TerrainMaterial(Viewer, textureName, SharedMaterialManager.MissingTexture);
+                        Materials[materialKey] = new TerrainMaterial(Viewer, textureName, MissingTexture);
                         break;
-                    case "TerrainShared":
-                        Materials[materialKey] = new TerrainSharedMaterial(Viewer, textureName);
-                        break;
-                    case "TerrainSharedDistantMountain":
-                        Materials[materialKey] = new TerrainSharedDistantMountain(Viewer, textureName);
+                    case "TerrainDistantMountain":
+                        Materials[materialKey] = new TerrainDistantMountain(Viewer, textureName);
                         break;
                     case "Transfer":
                         Materials[materialKey] = new TransferMaterial(Viewer, textureName);

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -373,10 +373,13 @@ namespace Orts.Viewer3D
                         Materials[materialKey] = new SpriteBatchMaterial(Viewer, effect: effect);
                         break;
                     case "Terrain":
-                        Materials[materialKey] = new TerrainMaterial(Viewer, textureName, MissingTexture);
+                        Materials[materialKey] = new TerrainMaterial(Viewer, textureName, SharedMaterialManager.MissingTexture);
                         break;
-                    case "TerrainDistantMountain":
-                        Materials[materialKey] = new TerrainDistantMountain(Viewer, textureName);
+                    case "TerrainShared":
+                        Materials[materialKey] = new TerrainSharedMaterial(Viewer, textureName);
+                        break;
+                    case "TerrainSharedDistantMountain":
+                        Materials[materialKey] = new TerrainSharedDistantMountain(Viewer, textureName);
                         break;
                     case "Transfer":
                         Materials[materialKey] = new TransferMaterial(Viewer, textureName);

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -1,4 +1,4 @@
-// COPYRIGHT 2009, 2010, 2011, 2012, 2013 by the Open Rails project.
+﻿// COPYRIGHT 2009, 2010, 2011, 2012, 2013 by the Open Rails project.
 // 
 // This file is part of Open Rails.
 // 
@@ -778,7 +778,6 @@ namespace Orts.Viewer3D
 
             // Render terrain shadow items now, with their magic.
             if (logging) Console.WriteLine("      {0,-5} * TerrainMaterial (normal)", RenderShadowTerrainItems[shadowMapIndex].Count);
-            graphicsDevice.Indices = TerrainPrimitive.SharedPatchIndexBuffer;
             ShadowMapMaterial.Render(graphicsDevice, RenderShadowTerrainItems[shadowMapIndex], ref ShadowMapLightView[shadowMapIndex], ref ShadowMapLightProj[shadowMapIndex]);
 
             // Prepare for blocking rendering of terrain.
@@ -905,7 +904,7 @@ namespace Orts.Viewer3D
                     }
                     else
                     {
-                        if (Game.Settings.DistantMountains && (sequenceMaterial.Key is TerrainSharedDistantMountain || sequenceMaterial.Key is SkyMaterial
+                        if (Game.Settings.DistantMountains && (sequenceMaterial.Key is TerrainDistantMountain || sequenceMaterial.Key is SkyMaterial
                             || sequenceMaterial.Key is MSTSSkyMaterial))
                             continue;
                         // Opaque: single material, render in one go.
@@ -935,7 +934,7 @@ namespace Orts.Viewer3D
                 {
                     if (sequenceMaterial.Value.Count == 0)
                         continue;
-                    if (sequenceMaterial.Key is TerrainSharedDistantMountain || sequenceMaterial.Key is SkyMaterial || sequenceMaterial.Key is MSTSSkyMaterial)
+                    if (sequenceMaterial.Key is TerrainDistantMountain || sequenceMaterial.Key is SkyMaterial || sequenceMaterial.Key is MSTSSkyMaterial)
                     {
                         // Opaque: single material, render in one go.
                         sequenceMaterial.Key.SetState(graphicsDevice, null);

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -904,7 +904,7 @@ namespace Orts.Viewer3D
                     }
                     else
                     {
-                        if (Game.Settings.DistantMountains && (sequenceMaterial.Key is TerrainDistantMountain || sequenceMaterial.Key is SkyMaterial
+                        if (Game.Settings.DistantMountains && (sequenceMaterial.Key is TerrainSharedDistantMountain || sequenceMaterial.Key is SkyMaterial
                             || sequenceMaterial.Key is MSTSSkyMaterial))
                             continue;
                         // Opaque: single material, render in one go.
@@ -934,7 +934,7 @@ namespace Orts.Viewer3D
                 {
                     if (sequenceMaterial.Value.Count == 0)
                         continue;
-                    if (sequenceMaterial.Key is TerrainDistantMountain || sequenceMaterial.Key is SkyMaterial || sequenceMaterial.Key is MSTSSkyMaterial)
+                    if (sequenceMaterial.Key is TerrainSharedDistantMountain || sequenceMaterial.Key is SkyMaterial || sequenceMaterial.Key is MSTSSkyMaterial)
                     {
                         // Opaque: single material, render in one go.
                         sequenceMaterial.Key.SetState(graphicsDevice, null);

--- a/Source/RunActivity/Viewer3D/Terrain.cs
+++ b/Source/RunActivity/Viewer3D/Terrain.cs
@@ -192,7 +192,7 @@ namespace Orts.Viewer3D
     public class TerrainPrimitive : RenderPrimitive
     {
         readonly Viewer Viewer;
-        readonly int TileX, TileZ, Size, PatchX, PatchZ, PatchSize;
+        readonly int TileX, TileZ, Size, PatchX, PatchZ, PatchSize, PatchSampleCount;
         readonly float AverageElevation;
 
         readonly Vector3 PatchLocation;        // In MSTS world coordinates relative to the center of the tile
@@ -203,8 +203,7 @@ namespace Orts.Viewer3D
         readonly VertexBufferBinding[] VertexBufferBindings;
 
         // These can be shared since they are the same for all patches
-        public static IndexBuffer SharedPatchIndexBuffer;
-        public static int SharedPatchVertexStride;
+        static readonly Dictionary<int, IndexBuffer> SharedPatchIndexBuffers = new Dictionary<int, IndexBuffer>();
 
         // These are only used while the contructor runs and are discarded after.
         readonly TileManager TileManager;
@@ -221,6 +220,7 @@ namespace Orts.Viewer3D
             PatchX = x;
             PatchZ = z;
             PatchSize = tile.Size * 2048 / tile.PatchCount;
+            PatchSampleCount = tile.SampleCount / tile.PatchCount;
 
             TileManager = tileManager;
             Tile = tile;
@@ -241,8 +241,8 @@ namespace Orts.Viewer3D
             else
                 PatchMaterial = viewer.MaterialManager.Load(terrainMaterial, Helpers.GetTerrainTextureFile(viewer.Simulator, ts[0].Filename) + "\0" + Helpers.GetTerrainTextureFile(viewer.Simulator, "microtex.ace"));
 
-            if (SharedPatchIndexBuffer == null)
-                SetupSharedData(Viewer.GraphicsDevice);
+            if (!SharedPatchIndexBuffers.ContainsKey(PatchSampleCount))
+                SetupSharedData(Viewer.GraphicsDevice, PatchSampleCount);
 
             Tile = null;
             Patch = null;
@@ -265,18 +265,18 @@ namespace Orts.Viewer3D
         public override void Draw(GraphicsDevice graphicsDevice)
         {
             graphicsDevice.SetVertexBuffers(VertexBufferBindings);
-            graphicsDevice.Indices = PatchIndexBuffer ?? SharedPatchIndexBuffer;
+            graphicsDevice.Indices = PatchIndexBuffer ?? SharedPatchIndexBuffers[PatchSampleCount];
             graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: 0, PatchPrimitiveCount);
         }
 
         float Elevation(int x, int z)
         {
-            return TileManager.GetElevation(Tile, PatchX * 16 + x, PatchZ * 16 + z);
+            return TileManager.GetElevation(Tile, PatchX * PatchSampleCount + x, PatchZ * PatchSampleCount + z);
         }
 
         bool IsVertexHidden(int x, int z)
         {
-            return TileManager.IsVertexHidden(Tile, PatchX * 16 + x, PatchZ * 16 + z);
+            return TileManager.IsVertexHidden(Tile, PatchX * PatchSampleCount + x, PatchZ * PatchSampleCount + z);
         }
 
         Vector3 TerrainNormal(int x, int z)
@@ -359,17 +359,17 @@ namespace Orts.Viewer3D
 
         IndexBuffer GetIndexBuffer(out int primitiveCount)
         {
-            // 16 x 16 squares * 2 triangles per square * 3 indices per triangle
-            var indexData = new List<short>(16 * 16 * 2 * 3);
+            // 16 x 16 squares (or more...) * 2 triangles per square * 3 indices per triangle
+            var indexData = new List<short>(PatchSampleCount * PatchSampleCount * 2 * 3);
 
             // For each 8 meter rectangle
-            for (var z = 0; z < 16; ++z)
+            for (var z = 0; z < PatchSampleCount; ++z)
             {
-                for (var x = 0; x < 16; ++x)
+                for (var x = 0; x < PatchSampleCount; ++x)
                 {
-                    var nw = (short)(z * 17 + x);  // Vertex index in the north west corner
+                    var nw = (short)(z * (1 + PatchSampleCount) + x);  // Vertex index in the north west corner
                     var ne = (short)(nw + 1);
-                    var sw = (short)(nw + 17);
+                    var sw = (short)(nw + (1 + PatchSampleCount));
                     var se = (short)(sw + 1);
 
                     if ((z & 1) == (x & 1))  // Triangles alternate
@@ -408,7 +408,7 @@ namespace Orts.Viewer3D
             primitiveCount = indexData.Count / 3;
 
             // If this patch has no holes, use the shared IndexBuffer for better performance.
-            if (indexData.Count == 16 * 16 * 6)
+            if (indexData.Count == PatchSampleCount * PatchSampleCount * 6)
                 return null;
 
             var indexBuffer = new IndexBuffer(Viewer.GraphicsDevice, typeof(short), indexData.Count, BufferUsage.WriteOnly);
@@ -419,11 +419,12 @@ namespace Orts.Viewer3D
         VertexBuffer GetVertexBuffer(out float averageElevation)
         {
             var totalElevation = 0f;
-            var vertexData = new List<VertexPositionNormalTexture>(17 * 17);
+            var patchSampleCountPlus = 1 + PatchSampleCount;
+            var vertexData = new List<VertexPositionNormalTexture>(patchSampleCountPlus * patchSampleCountPlus);
             var step = Tile.SampleSize;
-            for (var z = 0; z < 17; ++z)
+            for (var z = 0; z < patchSampleCountPlus; ++z)
             {
-                for (var x = 0; x < 17; ++x)
+                for (var x = 0; x < patchSampleCountPlus; ++x)
                 {
                     var e = -Patch.RadiusM + x * step;
                     var n = -Patch.RadiusM + z * step;
@@ -456,19 +457,19 @@ namespace Orts.Viewer3D
             PatchMaterial.Mark();
         }
 
-        static void SetupSharedData(GraphicsDevice graphicsDevice)
+        static void SetupSharedData(GraphicsDevice graphicsDevice, int patchSampleCount)
         {
-            // 16 x 16 squares * 2 triangles per square * 3 indices per triangle
-            var indexData = new List<short>(16 * 16 * 2 * 3);
+            // 16 x 16 squares (or more...) * 2 triangles per square * 3 indices per triangle
+            var indexData = new List<short>(patchSampleCount * patchSampleCount * 2 * 3);
 
             // For each 8 meter rectangle
-            for (var z = 0; z < 16; ++z)
+            for (var z = 0; z < patchSampleCount; ++z)
             {
-                for (var x = 0; x < 16; ++x)
+                for (var x = 0; x < patchSampleCount; ++x)
                 {
-                    var nw = (short)(z * 17 + x);  // Vertex index in the north west corner
+                    var nw = (short)(z * (1 + patchSampleCount) + x);  // Vertex index in the north west corner
                     var ne = (short)(nw + 1);
-                    var sw = (short)(nw + 17);
+                    var sw = (short)(nw + (1 + patchSampleCount));
                     var se = (short)(sw + 1);
 
                     if ((z & 1) == (x & 1))  // Triangles alternate
@@ -492,8 +493,8 @@ namespace Orts.Viewer3D
                 }
             }
 
-            SharedPatchIndexBuffer = new IndexBuffer(graphicsDevice, typeof(short), indexData.Count, BufferUsage.WriteOnly);
-            SharedPatchIndexBuffer.SetData(indexData.ToArray());
+            SharedPatchIndexBuffers[patchSampleCount] = new IndexBuffer(graphicsDevice, typeof(short), indexData.Count, BufferUsage.WriteOnly);
+            SharedPatchIndexBuffers[patchSampleCount].SetData(indexData.ToArray());
         }
     }
 
@@ -570,7 +571,7 @@ namespace Orts.Viewer3D
         public override void SetState(GraphicsDevice graphicsDevice, Material previousMaterial)
         {
             base.SetState(graphicsDevice, previousMaterial);
-            
+
             graphicsDevice.BlendState = BlendState.Opaque; // Override the normal terrain blending!
             graphicsDevice.RasterizerState = RasterizerState.CullNone;
         }

--- a/Source/RunActivity/Viewer3D/Terrain.cs
+++ b/Source/RunActivity/Viewer3D/Terrain.cs
@@ -232,7 +232,7 @@ namespace Orts.Viewer3D
             PatchVertexBuffer = GetVertexBuffer(out AverageElevation);
             PatchIndexBuffer = GetIndexBuffer(out PatchPrimitiveCount);
 
-            var terrainMaterial = tile.Size > 2 ? "TerrainDistantMountain" : "Terrain";
+            var terrainMaterial = tile.Size > 2 ? "TerrainSharedDistantMountain" : PatchIndexBuffer == null ? "TerrainShared" : "Terrain";
             var ts = Tile.Shaders[Patch.ShaderIndex].terrain_texslots;
             var uv = Tile.Shaders[Patch.ShaderIndex].terrain_uvcalcs;
             if (ts.Length > 1)
@@ -561,9 +561,22 @@ namespace Orts.Viewer3D
         }
     }
 
-    public class TerrainDistantMountain : TerrainMaterial
+    public class TerrainSharedMaterial : TerrainMaterial
     {
-        public TerrainDistantMountain(Viewer viewer, string terrainTexture)
+        public TerrainSharedMaterial(Viewer viewer, string terrainTexture)
+            : base(viewer, terrainTexture, Helpers.IsSnow(viewer.Simulator) ? SharedMaterialManager.DefaultSnowTexture : SharedMaterialManager.MissingTexture)
+        {
+        }
+
+        public override void SetState(GraphicsDevice graphicsDevice, Material previousMaterial)
+        {
+            base.SetState(graphicsDevice, previousMaterial);
+        }
+    }
+
+    public class TerrainSharedDistantMountain : TerrainMaterial
+    {
+        public TerrainSharedDistantMountain(Viewer viewer, string terrainTexture)
             : base(viewer, terrainTexture, Helpers.IsSnow(viewer.Simulator) ? SharedMaterialManager.DefaultDMSnowTexture : SharedMaterialManager.MissingTexture)
         {
         }

--- a/Source/RunActivity/Viewer3D/Terrain.cs
+++ b/Source/RunActivity/Viewer3D/Terrain.cs
@@ -232,7 +232,7 @@ namespace Orts.Viewer3D
             PatchVertexBuffer = GetVertexBuffer(out AverageElevation);
             PatchIndexBuffer = GetIndexBuffer(out PatchPrimitiveCount);
 
-            var terrainMaterial = tile.Size > 2 ? "TerrainSharedDistantMountain" : PatchIndexBuffer == null ? "TerrainShared" : "Terrain";
+            var terrainMaterial = tile.Size > 2 ? "TerrainDistantMountain" : "Terrain";
             var ts = Tile.Shaders[Patch.ShaderIndex].terrain_texslots;
             var uv = Tile.Shaders[Patch.ShaderIndex].terrain_uvcalcs;
             if (ts.Length > 1)
@@ -265,8 +265,7 @@ namespace Orts.Viewer3D
         public override void Draw(GraphicsDevice graphicsDevice)
         {
             graphicsDevice.SetVertexBuffers(VertexBufferBindings);
-            if (PatchIndexBuffer != null)
-                graphicsDevice.Indices = PatchIndexBuffer;
+            graphicsDevice.Indices = PatchIndexBuffer ?? SharedPatchIndexBuffer;
             graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex: 0, startIndex: 0, PatchPrimitiveCount);
         }
 
@@ -561,23 +560,9 @@ namespace Orts.Viewer3D
         }
     }
 
-    public class TerrainSharedMaterial : TerrainMaterial
+    public class TerrainDistantMountain : TerrainMaterial
     {
-        public TerrainSharedMaterial(Viewer viewer, string terrainTexture)
-            : base(viewer, terrainTexture, Helpers.IsSnow(viewer.Simulator) ? SharedMaterialManager.DefaultSnowTexture : SharedMaterialManager.MissingTexture)
-        {
-        }
-
-        public override void SetState(GraphicsDevice graphicsDevice, Material previousMaterial)
-        {
-            base.SetState(graphicsDevice, previousMaterial);
-            graphicsDevice.Indices = TerrainPrimitive.SharedPatchIndexBuffer;
-        }
-    }
-
-    public class TerrainSharedDistantMountain : TerrainMaterial
-    {
-        public TerrainSharedDistantMountain(Viewer viewer, string terrainTexture)
+        public TerrainDistantMountain(Viewer viewer, string terrainTexture)
             : base(viewer, terrainTexture, Helpers.IsSnow(viewer.Simulator) ? SharedMaterialManager.DefaultDMSnowTexture : SharedMaterialManager.MissingTexture)
         {
         }
@@ -585,8 +570,7 @@ namespace Orts.Viewer3D
         public override void SetState(GraphicsDevice graphicsDevice, Material previousMaterial)
         {
             base.SetState(graphicsDevice, previousMaterial);
-            graphicsDevice.Indices = TerrainPrimitive.SharedPatchIndexBuffer;
-
+            
             graphicsDevice.BlendState = BlendState.Opaque; // Override the normal terrain blending!
             graphicsDevice.RasterizerState = RasterizerState.CullNone;
         }


### PR DESCRIPTION
This change allows for MSTS tile terrain patches (typically 16x16 of them per tile in the highest density) to use whatever elevation sampling rate they like, not just 8m.

Note that the UV coordinates in the tile file must be correctly adjusted when using different resolutions.