### PR TITLE
Fix scripts not working in .NET 6

### DIFF
--- a/Source/Orts.Simulation/Common/Scripting/ScriptManager.cs
+++ b/Source/Orts.Simulation/Common/Scripting/ScriptManager.cs
@@ -35,14 +35,19 @@ namespace Orts.Common.Scripting
     public class ScriptManager
     {
         readonly IDictionary<string, Assembly> Scripts = new Dictionary<string, Assembly>();
-        static readonly string[] ReferenceAssemblies = new[]
-        {
-            typeof(System.Object).Assembly.Location,
-            typeof(System.Diagnostics.Debug).Assembly.Location,
-            typeof(ORTS.Common.ElapsedTime).Assembly.Location,
-            typeof(ORTS.Scripting.Api.Timer).Assembly.Location,
-            typeof(System.Linq.Enumerable).Assembly.Location,
-        };
+        static readonly string[] ReferenceAssemblies =
+            ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+                .Split(Path.PathSeparator)
+                .Where(path => string.Equals(
+                    Path.GetDirectoryName(path),
+                    Path.GetDirectoryName(typeof(object).Assembly.Location),
+                    StringComparison.OrdinalIgnoreCase))
+                .Concat(new[]
+                {
+                    typeof(ORTS.Common.ElapsedTime).Assembly.Location,
+                    typeof(ORTS.Scripting.Api.Timer).Assembly.Location,
+                })
+                .ToArray();
         static MetadataReference[] References = ReferenceAssemblies.Select(r => MetadataReference.CreateFromFile(r)).ToArray();
         static CSharpCompilationOptions CompilationOptions = new CSharpCompilationOptions(
             OutputKind.DynamicallyLinkedLibrary,


### PR DESCRIPTION
C# scripts stopped working due to missing referenced assemblies during compilation

https://www.elvastower.com/forums/index.php?/topic/39858-latest-testing-418-and-latest-unstable-u20260822-1838-dont-load-scripts/page__pid__328049#entry328049