### PR TITLE
Fix Diesel Starting Behavior

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs
@@ -1296,7 +1296,7 @@ namespace Orts.Simulation.RollingStocks.SubSystems.PowerSupplies
         /// <returns>The current target RPM value, limited between IdleRPM and MaxRPM</returns>
         public float GetTargetRPM(float elapsedClockSeconds)
         {
-            float targetRPM = 0f;
+            float targetRPM = DemandedRPM;
 
             if (State == DieselEngineState.Running)
             {


### PR DESCRIPTION
Fix for [this bug](https://www.elvastower.com/forums/index.php?/topic/39866-is-the-diesel-engine-start-function-broken-mg174/page__gopid__328146#entry328146).

The diesel engine demanded RPM should not be reset to 0 if no demanded RPM can be calculated, it should instead remain at whatever the previous demanded RPM was. Resetting the demanded RPM to 0 overrides the demanded RPM that's set once when engine start-up is requested.