### PR TITLE
MSTS legacy shaders

### DIFF
--- a/Source/Orts.Formats.Msts/AceFile.cs
+++ b/Source/Orts.Formats.Msts/AceFile.cs
@@ -159,21 +159,24 @@ namespace Orts.Formats.Msts
                         scanlineOffsets[imageIndex][y] = reader.ReadInt32();
                 }
 
-                var scanlineDataEnd = reader.BaseStream.Position;
-                for (var imageIndex = 0; imageIndex < imageCount; imageIndex++)
+                if (reader.BaseStream is BufferedInMemoryStream)
                 {
-                    var imageWidth = width / (int)Math.Pow(2, imageIndex);
-                    var imageHeight = height / (int)Math.Pow(2, imageIndex);
-                    var scanlineLength = channels.Sum(channel => (channel.Size * imageWidth + 7) / 8);
-                    for (var y = 0; y < imageHeight; y++)
-                        scanlineDataEnd = Math.Max(scanlineDataEnd, offsetBase + scanlineOffsets[imageIndex][y] + scanlineLength);
-                }
+                    var scanlineDataEnd = reader.BaseStream.Position;
+                    for (var imageIndex = 0; imageIndex < imageCount; imageIndex++)
+                    {
+                        var imageWidth = width / (int)Math.Pow(2, imageIndex);
+                        var imageHeight = height / (int)Math.Pow(2, imageIndex);
+                        var scanlineLength = channels.Sum(channel => (channel.Size * imageWidth + 7) / 8);
+                        for (var y = 0; y < imageHeight; y++)
+                            scanlineDataEnd = Math.Max(scanlineDataEnd, offsetBase + scanlineOffsets[imageIndex][y] + scanlineLength);
+                    }
 
-                while (reader.BaseStream.Position < scanlineDataEnd)
-                {
-                    var bytesToRead = (int)Math.Min(4096, scanlineDataEnd - reader.BaseStream.Position);
-                    if (reader.ReadBytes(bytesToRead).Length == 0)
-                        throw new EndOfStreamException();
+                    while (reader.BaseStream.Position < scanlineDataEnd)
+                    {
+                        var bytesToRead = (int)Math.Min(4096, scanlineDataEnd - reader.BaseStream.Position);
+                        if (reader.ReadBytes(bytesToRead).Length == 0)
+                            throw new EndOfStreamException();
+                    }
                 }
 
                 var buffer = new int[width * height];

--- a/Source/Orts.Formats.Msts/AceFile.cs
+++ b/Source/Orts.Formats.Msts/AceFile.cs
@@ -149,8 +149,31 @@ namespace Orts.Formats.Msts
             else
             {
                 // Structured data is stored as a table of 32bit offsets to each scanline of each image.
+                var scanlineOffsets = new int[imageCount][];
                 for (var imageIndex = 0; imageIndex < imageCount; imageIndex++)
-                    reader.ReadBytes(4 * height / (int)Math.Pow(2, imageIndex));
+                {
+                    var imageHeight = height / (int)Math.Pow(2, imageIndex);
+                    scanlineOffsets[imageIndex] = new int[imageHeight];
+                    for (var y = 0; y < imageHeight; y++)
+                        scanlineOffsets[imageIndex][y] = reader.ReadInt32();
+                }
+
+                var scanlineDataEnd = reader.BaseStream.Position;
+                for (var imageIndex = 0; imageIndex < imageCount; imageIndex++)
+                {
+                    var imageWidth = width / (int)Math.Pow(2, imageIndex);
+                    var imageHeight = height / (int)Math.Pow(2, imageIndex);
+                    var scanlineLength = channels.Sum(channel => (channel.Size * imageWidth + 7) / 8);
+                    for (var y = 0; y < imageHeight; y++)
+                        scanlineDataEnd = Math.Max(scanlineDataEnd, scanlineOffsets[imageIndex][y] + scanlineLength);
+                }
+
+                while (reader.BaseStream.Position < scanlineDataEnd)
+                {
+                    var bytesToRead = (int)Math.Min(4096, scanlineDataEnd - reader.BaseStream.Position);
+                    if (reader.ReadBytes(bytesToRead).Length == 0)
+                        throw new EndOfStreamException();
+                }
 
                 var buffer = new int[width * height];
                 var channelBuffers = new byte[8][];
@@ -160,6 +183,8 @@ namespace Orts.Formats.Msts
                     var imageHeight = height / (int)Math.Pow(2, imageIndex);
                     for (var y = 0; y < imageHeight; y++)
                     {
+                        Array.Clear(channelBuffers, 0, channelBuffers.Length);
+                        reader.BaseStream.Seek(scanlineOffsets[imageIndex][y], SeekOrigin.Begin);
                         foreach (var channel in channels)
                         {
                             if (channel.Size == 1)

--- a/Source/Orts.Formats.Msts/AceFile.cs
+++ b/Source/Orts.Formats.Msts/AceFile.cs
@@ -72,6 +72,7 @@ namespace Orts.Formats.Msts
 
         static Texture2D Texture2DFromReader(GraphicsDevice graphicsDevice, BinaryReader reader)
         {
+            var offsetBase = reader.BaseStream.Position;
             var signature = new String(reader.ReadChars(4));
             if (signature != "\x01\x00\x00\x00") throw new InvalidDataException(String.Format("Incorrect signature; expected '01 00 00 00', got '{0}'", StringToHex(signature)));
             var options = (SimisAceFormatOptions)reader.ReadInt32();
@@ -165,7 +166,7 @@ namespace Orts.Formats.Msts
                     var imageHeight = height / (int)Math.Pow(2, imageIndex);
                     var scanlineLength = channels.Sum(channel => (channel.Size * imageWidth + 7) / 8);
                     for (var y = 0; y < imageHeight; y++)
-                        scanlineDataEnd = Math.Max(scanlineDataEnd, scanlineOffsets[imageIndex][y] + scanlineLength);
+                        scanlineDataEnd = Math.Max(scanlineDataEnd, offsetBase + scanlineOffsets[imageIndex][y] + scanlineLength);
                 }
 
                 while (reader.BaseStream.Position < scanlineDataEnd)
@@ -184,7 +185,7 @@ namespace Orts.Formats.Msts
                     for (var y = 0; y < imageHeight; y++)
                     {
                         Array.Clear(channelBuffers, 0, channelBuffers.Length);
-                        reader.BaseStream.Seek(scanlineOffsets[imageIndex][y], SeekOrigin.Begin);
+                        reader.BaseStream.Seek(offsetBase + scanlineOffsets[imageIndex][y], SeekOrigin.Begin);
                         foreach (var channel in channels)
                         {
                             if (channel.Size == 1)

--- a/Source/Orts.Formats.Msts/ShapeFile.cs
+++ b/Source/Orts.Formats.Msts/ShapeFile.cs
@@ -22,8 +22,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
-// TODO - UV_OPS
-
 namespace Orts.Formats.Msts
 {
     public class ShapeFile
@@ -736,35 +734,32 @@ namespace Orts.Formats.Msts
     public class uv_op_uniformscale : uv_op
     {
         public int SrcUVIdx;
-        public float UnknownParameter3;
-        public float UnknownParameter4;
+        public float Scale;
 
         public uv_op_uniformscale(SBR block)
         {
             block.VerifyID(TokenID.uv_op_uniformscale);
             TexAddrMode = block.ReadInt();
             SrcUVIdx = block.ReadInt();
-            UnknownParameter3 = block.ReadFloat();
+            Scale = block.ReadFloat();
             block.VerifyEndOfBlock();
-            block.TraceInformation(String.Format("{0} was treated as uv_op_copy", block.ID.ToString()));
         }
     }
 
     public class uv_op_nonuniformscale : uv_op
     {
         public int SrcUVIdx;
-        public float UnknownParameter3;
-        public float UnknownParameter4;
+        public float ScaleU;
+        public float ScaleV;
 
         public uv_op_nonuniformscale(SBR block)
         {
             block.VerifyID(TokenID.uv_op_nonuniformscale);
             TexAddrMode = block.ReadInt();
             SrcUVIdx = block.ReadInt();
-            UnknownParameter3 = block.ReadFloat();
-            UnknownParameter4 = block.ReadFloat();
+            ScaleU = block.ReadFloat();
+            ScaleV = block.ReadFloat();
             block.VerifyEndOfBlock();
-            block.TraceInformation(String.Format("{0} was treated as uv_op_copy", block.ID.ToString()));
         }
     }
 

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -597,7 +597,35 @@ float4 PSGlossMap(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
 	if (ShaderModel3) litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
 	// Headlights effect use original Color.
 	_PSApplyHeadlights(litColor, Color.rgb, In);
-	litColor += tex2D(Detail, PSDetailTexCoords(In)).rgb;
+	litColor += tex2D(Detail, PSDetailTexCoords(In)).rgb * SurfaceColor.a;
+	// And fogging is last.
+	_PSApplyFog(litColor, In);
+	if (ShaderModel3) _PSSceneryFade(SurfaceColor, In);
+	return float4(litColor, SurfaceColor.a);
+}
+
+float4 PSAlphRefMap(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
+{
+	const float FullBrightness = 1.0;
+	const float ShadowBrightness = 0.5;
+
+	float4 BaseColor = tex2D(Image, In.TexCoords.xy);
+	float4 DetailColor = tex2D(Detail, PSDetailTexCoords(In));
+	float4 Color = float4(BaseColor.rgb + (1 - BaseColor.a) * DetailColor.rgb, saturate(BaseColor.a + lerp(0, In.Color.a, VertexLightingEnabled)));
+	float4 SurfaceColor = float4(Color.rgb * In.Color.rgb, Color.a);
+	// Alpha testing:
+	clip(SurfaceColor.a - ReferenceAlpha);
+	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
+	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
+	// Specular effect next.
+	litColor += _PSGetSpecularEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In);
+	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
+	litColor = lerp(litColor, _PSGetOvercastColor(SurfaceColor, In), Overcast.x);
+	// Night-time darkens everything, except night-time textures.
+	litColor *= NightColorModifier;
+	if (ShaderModel3) litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
+	// Headlights effect use original Color.
+	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	if (ShaderModel3) _PSSceneryFade(SurfaceColor, In);
@@ -632,6 +660,11 @@ float4 PSDetailMod2X9_1(in VERTEX_OUTPUT In) : COLOR0
 float4 PSGlossMap9_3(in VERTEX_OUTPUT In) : COLOR0
 {
     return PSGlossMap(true, In);
+}
+
+float4 PSAlphRefMap9_3(in VERTEX_OUTPUT In) : COLOR0
+{
+    return PSAlphRefMap(true, In);
 }
 
 
@@ -818,6 +851,20 @@ technique GlossMapLevel9_3 {
 	pass Pass_0 {
 		VertexShader = compile vs_4_0_level_9_3 VSGeneral9_3();
 		PixelShader = compile ps_4_0_level_9_3 PSGlossMap9_3();
+	}
+}
+
+technique AlphRefMapLevel9_1 {
+	pass Pass_0 {
+		VertexShader = compile vs_4_0_level_9_1 VSGeneral9_1();
+		PixelShader = compile ps_4_0_level_9_1 PSImage9_1();
+	}
+}
+
+technique AlphRefMapLevel9_3 {
+	pass Pass_0 {
+		VertexShader = compile vs_4_0_level_9_3 VSGeneral9_3();
+		PixelShader = compile ps_4_0_level_9_3 PSAlphRefMap9_3();
 	}
 }
 

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -26,7 +26,6 @@
 float4x4 World;         // model -> world
 float4x4 View;          // world -> view
 float4x4 Projection;    // view -> projection
-float4x4 EnvMapTransform; // current object -> root/captured object transform for sphere maps
 float4x4 LightViewProjectionShadowProjection0;  // world -> light view -> light projection -> shadow map projection
 float4x4 LightViewProjectionShadowProjection1;
 float4x4 LightViewProjectionShadowProjection2;
@@ -186,7 +185,8 @@ float2 _VSReflectMapFullTexCoords(float3 relPosition, float3 normal)
 {
 	float3 viewDirection = normalize(relPosition);
 	float3 reflection = normalize(2 * dot(viewDirection, normal) * normal - viewDirection);
-	reflection = mul(reflection, (float3x3)EnvMapTransform).xyz;
+	reflection = mul(reflection, (float3x3)World).xyz;
+	reflection.z = -reflection.z;
 	float sphereMapScale = 0.5 / max(length(float3(reflection.xy, reflection.z + 1)), 0.0001);
 	return reflection.xy * sphereMapScale + 0.5;
 }

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -143,6 +143,13 @@ struct VERTEX_INPUT_FOREST
 	float3 Normal    : NORMAL;
 };
 
+struct VERTEX_INPUT_TERRAIN
+{
+	float4 Position  : POSITION;
+	float2 TexCoords : TEXCOORD0;
+	float3 Normal    : NORMAL;
+};
+
 struct VERTEX_INPUT_SIGNAL
 {
 	float4 Position  : POSITION;
@@ -172,14 +179,14 @@ struct VERTEX_OUTPUT
 
 ////////////////////    V E R T E X   S H A D E R S    /////////////////////////
 
-void _VSNormalProjection(in VERTEX_INPUT In, inout VERTEX_OUTPUT Out)
+void _VSNormalProjection(in float4 InPosition, in float2 InTexCoords, in float3 InNormal, inout VERTEX_OUTPUT Out)
 {
 	// Project position, normal and copy texture coords
-	Out.Position = mul(mul(mul(In.Position, World), View), Projection);
-	Out.RelPosition.xyz = mul(In.Position, World).xyz - ViewerPos;
+	Out.Position = mul(mul(mul(InPosition, World), View), Projection);
+	Out.RelPosition.xyz = mul(InPosition, World).xyz - ViewerPos;
 	Out.RelPosition.w = Out.Position.z;
-	Out.TexCoords.xy = In.TexCoords * UVScale;
-	Out.Normal_Light.xyz = normalize(mul(In.Normal, (float3x3)World).xyz);
+	Out.TexCoords.xy = InTexCoords * UVScale;
+	Out.Normal_Light.xyz = normalize(mul(InNormal, (float3x3)World).xyz);
 	
 	// Normal lighting (range 0.0 - 1.0)
 	// Need to calc. here instead of _VSLightsAndShadows() to avoid calling it from VSForest(), where it has gone into pre-shader in Shaders.cs
@@ -247,7 +254,7 @@ VERTEX_OUTPUT VSGeneral(uniform bool ShaderModel3, in VERTEX_INPUT In)
 		}
 	}
 
-	_VSNormalProjection(In, Out);
+	_VSNormalProjection(In.Position, In.TexCoords, In.Normal, Out);
 	Out.Color.rgb = lerp(float3(1, 1, 1), In.Color1.rgb * VertexLightingDay, VertexLightingEnabled);
 	Out.Color.a = 1;
 	Out.BakedColor.rgb = lerp(float3(0, 0, 0), In.Color2.rgb, VertexLightingEnabled);
@@ -297,20 +304,20 @@ VERTEX_OUTPUT VSTransfer9_1(in VERTEX_INPUT_TRANSFER In)
     return VSTransfer(false, In);
 }
 
-VERTEX_OUTPUT VSTerrain(uniform bool ShaderModel3, in VERTEX_INPUT In)
+VERTEX_OUTPUT VSTerrain(uniform bool ShaderModel3, in VERTEX_INPUT_TERRAIN In)
 {
 	VERTEX_OUTPUT Out = (VERTEX_OUTPUT)0;
-	_VSNormalProjection(In, Out);
+	_VSNormalProjection(In.Position, In.TexCoords, In.Normal, Out);
 	_VSLightsAndShadows(ShaderModel3, In.Position, Out);
 	return Out;
 }
 
-VERTEX_OUTPUT VSTerrain9_3(in VERTEX_INPUT In)
+VERTEX_OUTPUT VSTerrain9_3(in VERTEX_INPUT_TERRAIN In)
 {
     return VSTerrain(true, In);
 }
 
-VERTEX_OUTPUT VSTerrain9_1(in VERTEX_INPUT In)
+VERTEX_OUTPUT VSTerrain9_1(in VERTEX_INPUT_TERRAIN In)
 {
     return VSTerrain(false, In);
 }

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -55,6 +55,7 @@ float3   SideVector;
 float    ReferenceAlpha;
 float2   UVScale;
 texture  ImageTexture;
+texture  DetailTexture;
 texture  OverlayTexture;
 float	 OverlayScale;
 
@@ -76,6 +77,15 @@ sampler Overlay = sampler_state
 	MipLodBias = 0;
 	AddressU = Wrap;
 	AddressV = Wrap;
+};
+
+sampler Detail = sampler_state
+{
+	Texture = (DetailTexture);
+	MagFilter = Linear;
+	MinFilter = Anisotropic;
+	MipFilter = Linear;
+	MaxAnisotropy = 16;
 };
 
 sampler ShadowMap0 = sampler_state
@@ -487,6 +497,31 @@ float4 PSImage(uniform bool ShaderModel3, uniform bool ClampTexCoords, in VERTEX
 	return float4(litColor, Color.a);
 }
 
+float4 PSDetailMod2X(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
+{
+	const float FullBrightness = 1.0;
+	const float ShadowBrightness = 0.5;
+
+	float4 Color = tex2D(Image, In.TexCoords.xy);
+	Color.rgb *= tex2D(Detail, In.TexCoords.xy).rgb * 2;
+	// Alpha testing:
+	clip(Color.a - ReferenceAlpha);
+	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
+	float3 litColor = Color.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
+	// Specular effect next.
+	litColor += _PSGetSpecularEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In);
+	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
+	litColor = lerp(litColor, _PSGetOvercastColor(Color, In), Overcast.x);
+	// Night-time darkens everything, except night-time textures.
+	litColor *= NightColorModifier;
+	// Headlights effect use original Color.
+	_PSApplyHeadlights(litColor, Color.rgb, In);
+	// And fogging is last.
+	_PSApplyFog(litColor, In);
+	if (ShaderModel3) _PSSceneryFade(Color, In);
+	return float4(litColor, Color.a);
+}
+
 float4 PSImage9_3(in VERTEX_OUTPUT In) : COLOR0
 {
     return PSImage(true, false, In);
@@ -500,6 +535,16 @@ float4 PSImage9_3Clamp(in VERTEX_OUTPUT In) : COLOR0
 float4 PSImage9_1(in VERTEX_OUTPUT In) : COLOR0
 {
     return PSImage(false, false, In);
+}
+
+float4 PSDetailMod2X9_3(in VERTEX_OUTPUT In) : COLOR0
+{
+    return PSDetailMod2X(true, In);
+}
+
+float4 PSDetailMod2X9_1(in VERTEX_OUTPUT In) : COLOR0
+{
+    return PSDetailMod2X(false, In);
 }
 
 float4 PSVegetation(in VERTEX_OUTPUT In) : COLOR0
@@ -649,6 +694,20 @@ technique ImageLevel9_3 {
 	pass Pass_0 {
 		VertexShader = compile vs_4_0_level_9_3 VSGeneral9_3();
 		PixelShader = compile ps_4_0_level_9_3 PSImage9_3();
+	}
+}
+
+technique DetailMod2XLevel9_1 {
+	pass Pass_0 {
+		VertexShader = compile vs_4_0_level_9_1 VSGeneral9_1();
+		PixelShader = compile ps_4_0_level_9_1 PSDetailMod2X9_1();
+	}
+}
+
+technique DetailMod2XLevel9_3 {
+	pass Pass_0 {
+		VertexShader = compile vs_4_0_level_9_3 VSGeneral9_3();
+		PixelShader = compile ps_4_0_level_9_3 PSDetailMod2X9_3();
 	}
 }
 

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -56,6 +56,7 @@ float    ReferenceAlpha;
 float2   UVScale;
 float    VertexLightingEnabled;
 float    VertexLightingDay;
+float    NightLightModifier;
 texture  ImageTexture;
 texture  DetailTexture;
 texture  OverlayTexture;
@@ -676,6 +677,7 @@ float4 PSFullBright(in VERTEX_OUTPUT In) : COLOR0
     clip(Color.a - ReferenceAlpha);
 	// Fixed ambient and shadow effects at brightest level.
 	float3 litColor = mad(Color.rgb, In.BakedColor.rgb, _PSGetVertexLitColor(Color.rgb, In));
+	litColor *= NightLightModifier;
 	// No specular effect for full-bright.
 	// No overcast effect for full-bright.
 	// No night-time effect for full-bright.

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -56,6 +56,7 @@ float    ReferenceAlpha;
 float2   UVScale;
 float2   DetailUVScaleRatio;
 float    UVOpReflectMapFull;
+float    DetailUVOpReflectMapFull;
 float    VertexLightingEnabled;
 float    VertexLightingDay;
 float    NightLightModifier;
@@ -180,6 +181,24 @@ struct VERTEX_OUTPUT
 
 ////////////////////    V E R T E X   S H A D E R S    /////////////////////////
 
+float2 _VSReflectMapFullTexCoords(float3 relPosition, float3 normal)
+{
+	const float InvPI = 0.31830988618;
+	const float InvTwoPI = 0.15915494309;
+	float3 viewDirection = normalize(relPosition);
+	float3 reflection = normalize(reflect(viewDirection, normal));
+	return float2(
+		atan2(reflection.z, reflection.x) * InvTwoPI + 0.5,
+		asin(clamp(reflection.y, -1, 1)) * InvPI + 0.5);
+}
+
+float2 _VSDetailTexCoords(float2 texCoords, float3 relPosition, float3 normal)
+{
+	if (DetailUVOpReflectMapFull > 0.5)
+		return _VSReflectMapFullTexCoords(relPosition, normal);
+	return texCoords * UVScale * DetailUVScaleRatio;
+}
+
 void _VSNormalProjection(in float4 InPosition, in float2 InTexCoords, in float3 InNormal, inout VERTEX_OUTPUT Out)
 {
 	// Project position, normal and copy texture coords
@@ -189,15 +208,8 @@ void _VSNormalProjection(in float4 InPosition, in float2 InTexCoords, in float3 
 	Out.Normal_Light.xyz = normalize(mul(InNormal, (float3x3)World).xyz);
 	Out.TexCoords.xy = InTexCoords * UVScale;
 
-	if (UVOpReflectMapFull > 0.5) {
-		const float InvPI = 0.31830988618;
-		const float InvTwoPI = 0.15915494309;
-		float3 viewDirection = normalize(Out.RelPosition.xyz);
-		float3 reflection = normalize(reflect(viewDirection, Out.Normal_Light.xyz));
-		Out.TexCoords.xy = float2(
-			atan2(reflection.z, reflection.x) * InvTwoPI + 0.5,
-			asin(clamp(reflection.y, -1, 1)) * InvPI + 0.5);
-	}
+	if (UVOpReflectMapFull > 0.5)
+		Out.TexCoords.xy = _VSReflectMapFullTexCoords(Out.RelPosition.xyz, Out.Normal_Light.xyz);
 	
 	// Normal lighting (range 0.0 - 1.0)
 	// Need to calc. here instead of _VSLightsAndShadows() to avoid calling it from VSForest(), where it has gone into pre-shader in Shaders.cs
@@ -271,6 +283,9 @@ VERTEX_OUTPUT VSGeneral(uniform bool ShaderModel3, in VERTEX_INPUT In)
 	Out.BakedColor.rgb = lerp(float3(0, 0, 0), In.Color2.rgb, VertexLightingEnabled);
 	Out.BakedColor.a = 1;
 	_VSLightsAndShadows(ShaderModel3, In.Position, Out);
+	float2 detailTexCoords = _VSDetailTexCoords(In.TexCoords, Out.RelPosition.xyz, Out.Normal_Light.xyz);
+	Out.BakedColor.a = detailTexCoords.x;
+	Out.Shadow.w = detailTexCoords.y;
 
 	// Z-bias to reduce and eliminate z-fighting on track ballast. ZBias is 0 or 1.
 	Out.Position.z -= ZBias_Lighting.x * saturate(In.TexCoords.x) / 1000;
@@ -393,19 +408,19 @@ float3 _Level9_3GetShadowEffect(in VERTEX_OUTPUT In)
 	float depth = In.RelPosition.w;
 	float3 rv = 0;
 	if (depth < ShadowMapLimit.x) {
-		float3 pos0 = mul(In.Shadow, LightViewProjectionShadowProjection0).xyz;
+		float3 pos0 = mul(float4(In.Shadow.xyz, 1), LightViewProjectionShadowProjection0).xyz;
 		rv = float3(tex2D(ShadowMap0, pos0.xy).xy, pos0.z);
 	} else {
 		if (depth < ShadowMapLimit.y) {
-			float3 pos1 = mul(In.Shadow, LightViewProjectionShadowProjection1).xyz;
+			float3 pos1 = mul(float4(In.Shadow.xyz, 1), LightViewProjectionShadowProjection1).xyz;
 			rv = float3(tex2D(ShadowMap1, pos1.xy).xy, pos1.z);
 		} else {
 			if (depth < ShadowMapLimit.z) {
-				float3 pos2 = mul(In.Shadow, LightViewProjectionShadowProjection2).xyz;
+				float3 pos2 = mul(float4(In.Shadow.xyz, 1), LightViewProjectionShadowProjection2).xyz;
 				rv = float3(tex2D(ShadowMap2, pos2.xy).xy, pos2.z);
 			} else {
 				if (depth < ShadowMapLimit.w) {
-					float3 pos3 = mul(In.Shadow, LightViewProjectionShadowProjection3).xyz;
+					float3 pos3 = mul(float4(In.Shadow.xyz, 1), LightViewProjectionShadowProjection3).xyz;
 					rv = float3(tex2D(ShadowMap3, pos3.xy).xy, pos3.z);
 				}
 			}
@@ -557,6 +572,38 @@ float4 PSDetailMod2X(uniform bool ShaderModel3, uniform bool DetailUVScaled, in 
 	return float4(litColor, SurfaceColor.a);
 }
 
+float2 PSDetailTexCoords(in VERTEX_OUTPUT In)
+{
+	return float2(In.BakedColor.a, In.Shadow.w);
+}
+
+float4 PSGlossMap(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
+{
+	const float FullBrightness = 1.0;
+	const float ShadowBrightness = 0.5;
+
+	float4 Color = tex2D(Image, In.TexCoords.xy);
+	float4 SurfaceColor = Color * In.Color;
+	// Alpha testing:
+	clip(SurfaceColor.a - ReferenceAlpha);
+	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
+	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
+	// Specular effect next.
+	litColor += _PSGetSpecularEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In);
+	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
+	litColor = lerp(litColor, _PSGetOvercastColor(SurfaceColor, In), Overcast.x);
+	// Night-time darkens everything, except night-time textures.
+	litColor *= NightColorModifier;
+	if (ShaderModel3) litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
+	// Headlights effect use original Color.
+	_PSApplyHeadlights(litColor, Color.rgb, In);
+	litColor += tex2D(Detail, PSDetailTexCoords(In)).rgb;
+	// And fogging is last.
+	_PSApplyFog(litColor, In);
+	if (ShaderModel3) _PSSceneryFade(SurfaceColor, In);
+	return float4(litColor, SurfaceColor.a);
+}
+
 float4 PSImage9_3(in VERTEX_OUTPUT In) : COLOR0
 {
     return PSImage(true, false, In);
@@ -581,6 +628,12 @@ float4 PSDetailMod2X9_1(in VERTEX_OUTPUT In) : COLOR0
 {
     return PSDetailMod2X(false, false, In);
 }
+
+float4 PSGlossMap9_3(in VERTEX_OUTPUT In) : COLOR0
+{
+    return PSGlossMap(true, In);
+}
+
 
 float4 PSVegetation(in VERTEX_OUTPUT In) : COLOR0
 {
@@ -751,6 +804,20 @@ technique DetailMod2XLevel9_3 {
 	pass Pass_0 {
 		VertexShader = compile vs_4_0_level_9_3 VSGeneral9_3();
 		PixelShader = compile ps_4_0_level_9_3 PSDetailMod2X9_3();
+	}
+}
+
+technique GlossMapLevel9_1 {
+	pass Pass_0 {
+		VertexShader = compile vs_4_0_level_9_1 VSGeneral9_1();
+		PixelShader = compile ps_4_0_level_9_1 PSImage9_1();
+	}
+}
+
+technique GlossMapLevel9_3 {
+	pass Pass_0 {
+		VertexShader = compile vs_4_0_level_9_3 VSGeneral9_3();
+		PixelShader = compile ps_4_0_level_9_3 PSGlossMap9_3();
 	}
 }
 

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -54,6 +54,8 @@ float4   EyeVector;
 float3   SideVector;
 float    ReferenceAlpha;
 float2   UVScale;
+float    VertexLightingEnabled;
+float    VertexLightingDay;
 texture  ImageTexture;
 texture  DetailTexture;
 texture  OverlayTexture;
@@ -127,6 +129,8 @@ struct VERTEX_INPUT
 	float4 Position  : POSITION;
 	float2 TexCoords : TEXCOORD0;
 	float3 Normal    : NORMAL;
+	float4 Color1    : COLOR0;
+	float4 Color2    : COLOR1;
 	float4x4 Instance : TEXCOORD1;
 };
 
@@ -158,6 +162,7 @@ struct VERTEX_OUTPUT
 	float4 RelPosition  : TEXCOORD0; // rel position x, y, z; position z
 	float2 TexCoords    : TEXCOORD1; // tex coords x, y
 	float4 Color        : COLOR0;    // color r, g, b, a
+	float4 BakedColor   : COLOR1;    // baked vertex color r, g, b, a
 	float4 Normal_Light : TEXCOORD2; // normal x, y, z; light dot
 	float4 LightDir_Fog : TEXCOORD3; // light dir x, y, z; fog fade
 	float4 Shadow       : TEXCOORD4; // Level9_1<shadow map texture and depth x, y, z> Level9_3<abs position x, y, z, w>
@@ -241,12 +246,21 @@ VERTEX_OUTPUT VSGeneral(uniform bool ShaderModel3, in VERTEX_INPUT In)
 	}
 
 	_VSNormalProjection(In, Out);
+	Out.Color.rgb = lerp(float3(1, 1, 1), In.Color1.rgb * VertexLightingDay, VertexLightingEnabled);
+	Out.Color.a = 1;
+	Out.BakedColor.rgb = lerp(float3(0, 0, 0), In.Color2.rgb, VertexLightingEnabled);
+	Out.BakedColor.a = 1;
 	_VSLightsAndShadows(ShaderModel3, In.Position, Out);
 
 	// Z-bias to reduce and eliminate z-fighting on track ballast. ZBias is 0 or 1.
 	Out.Position.z -= ZBias_Lighting.x * saturate(In.TexCoords.x) / 1000;
 
 	return Out;
+}
+
+float3 _PSGetVertexLitColor(in float3 Color, in VERTEX_OUTPUT In)
+{
+	return Color * In.Color.rgb;
 }
 
 VERTEX_OUTPUT VSGeneral9_3(in VERTEX_INPUT In)
@@ -481,13 +495,15 @@ float4 PSImage(uniform bool ShaderModel3, uniform bool ClampTexCoords, in VERTEX
 	// Alpha testing:
 	clip(Color.a - ReferenceAlpha);
 	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
-	float3 litColor = Color.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
+	float3 surfaceColor = _PSGetVertexLitColor(Color.rgb, In);
+	float3 litColor = surfaceColor * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
 	// Specular effect next.
 	litColor += _PSGetSpecularEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In);
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
-	litColor = lerp(litColor, _PSGetOvercastColor(Color, In), Overcast.x);
+	litColor = lerp(litColor, _PSGetOvercastColor(float4(surfaceColor, Color.a), In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
+	if (ShaderModel3) litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
 	// Headlights effect use original Color.
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
@@ -507,13 +523,15 @@ float4 PSDetailMod2X(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
 	// Alpha testing:
 	clip(Color.a - ReferenceAlpha);
 	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
-	float3 litColor = Color.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
+	float3 surfaceColor = _PSGetVertexLitColor(Color.rgb, In);
+	float3 litColor = surfaceColor * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
 	// Specular effect next.
 	litColor += _PSGetSpecularEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In);
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
-	litColor = lerp(litColor, _PSGetOvercastColor(Color, In), Overcast.x);
+	litColor = lerp(litColor, _PSGetOvercastColor(float4(surfaceColor, Color.a), In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
+	if (ShaderModel3) litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
 	// Headlights effect use original Color.
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
@@ -553,12 +571,14 @@ float4 PSVegetation(in VERTEX_OUTPUT In) : COLOR0
     // Alpha testing:
     clip(Color.a - ReferenceAlpha);
 	// Ambient effect applies first; no shadow effect for vegetation; night-time textures cancel out all normal lighting.
-	float3 litColor = Color.rgb * VegetationAmbientModifier;
+	float3 surfaceColor = _PSGetVertexLitColor(Color.rgb, In);
+	float3 litColor = surfaceColor * VegetationAmbientModifier;
 	// No specular effect for vegetation.
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
-	litColor = lerp(litColor, _PSGetOvercastColor(Color, In), Overcast.x);
+	litColor = lerp(litColor, _PSGetOvercastColor(float4(surfaceColor, Color.a), In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
+	litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
 	// Headlights effect use original Color.
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
@@ -609,12 +629,14 @@ float4 PSDarkShade(in VERTEX_OUTPUT In) : COLOR0
     // Alpha testing:
     clip(Color.a - ReferenceAlpha);
 	// Fixed ambient and shadow effects at darkest level.
-	float3 litColor = Color.rgb * ShadowBrightness;
+	float3 surfaceColor = _PSGetVertexLitColor(Color.rgb, In);
+	float3 litColor = surfaceColor * ShadowBrightness;
 	// No specular effect for dark shade.
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
-	litColor = lerp(litColor, _PSGetOvercastColor(Color, In), Overcast.x);
+	litColor = lerp(litColor, _PSGetOvercastColor(float4(surfaceColor, Color.a), In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
+	litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
 	// Headlights effect use original Color.
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
@@ -631,12 +653,14 @@ float4 PSHalfBright(in VERTEX_OUTPUT In) : COLOR0
     // Alpha testing:
     clip(Color.a - ReferenceAlpha);
 	// Fixed ambient and shadow effects at mid-dark level.
-	float3 litColor = Color.rgb * HalfShadowBrightness;
+	float3 surfaceColor = _PSGetVertexLitColor(Color.rgb, In);
+	float3 litColor = surfaceColor * HalfShadowBrightness;
 	// No specular effect for half-bright.
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
-	litColor = lerp(litColor, _PSGetOvercastColor(Color, In), Overcast.y);
+	litColor = lerp(litColor, _PSGetOvercastColor(float4(surfaceColor, Color.a), In), Overcast.y);
 	// Night-time darkens everything, except night-time textures.
 	litColor *= HalfNightColorModifier;
+	litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
 	// Headlights effect use original Color.
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
@@ -651,7 +675,7 @@ float4 PSFullBright(in VERTEX_OUTPUT In) : COLOR0
     // Alpha testing:
     clip(Color.a - ReferenceAlpha);
 	// Fixed ambient and shadow effects at brightest level.
-	float3 litColor = Color.rgb;
+	float3 litColor = mad(Color.rgb, In.BakedColor.rgb, _PSGetVertexLitColor(Color.rgb, In));
 	// No specular effect for full-bright.
 	// No overcast effect for full-bright.
 	// No night-time effect for full-bright.

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -53,6 +53,7 @@ float    SignalLightIntensity;
 float4   EyeVector;
 float3   SideVector;
 float    ReferenceAlpha;
+float2   UVScale;
 texture  ImageTexture;
 texture  OverlayTexture;
 float	 OverlayScale;
@@ -160,7 +161,7 @@ void _VSNormalProjection(in VERTEX_INPUT In, inout VERTEX_OUTPUT Out)
 	Out.Position = mul(mul(mul(In.Position, World), View), Projection);
 	Out.RelPosition.xyz = mul(In.Position, World).xyz - ViewerPos;
 	Out.RelPosition.w = Out.Position.z;
-	Out.TexCoords.xy = In.TexCoords;
+	Out.TexCoords.xy = In.TexCoords * UVScale;
 	Out.Normal_Light.xyz = normalize(mul(In.Normal, (float3x3)World).xyz);
 	
 	// Normal lighting (range 0.0 - 1.0)

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -302,10 +302,38 @@ VERTEX_OUTPUT VSGeneral9_1(in VERTEX_INPUT In)
     return VSGeneral(false, In);
 }
 
+VERTEX_OUTPUT VSImageNoColor(uniform bool ShaderModel3, in VERTEX_INPUT_TERRAIN In)
+{
+	VERTEX_OUTPUT Out = (VERTEX_OUTPUT)0;
+	_VSNormalProjection(In.Position, In.TexCoords, In.Normal, Out);
+	Out.Color = float4(1, 1, 1, 1);
+	Out.BakedColor = float4(0, 0, 0, 1);
+	_VSLightsAndShadows(ShaderModel3, In.Position, Out);
+	Out.BakedColor.a = In.TexCoords.x;
+	Out.Shadow.w = In.TexCoords.y;
+
+	// Z-bias to reduce and eliminate z-fighting on track ballast. ZBias is 0 or 1.
+	Out.Position.z -= ZBias_Lighting.x * saturate(In.TexCoords.x) / 1000;
+
+	return Out;
+}
+
+VERTEX_OUTPUT VSImageNoColor9_3(in VERTEX_INPUT_TERRAIN In)
+{
+    return VSImageNoColor(true, In);
+}
+
+VERTEX_OUTPUT VSImageNoColor9_1(in VERTEX_INPUT_TERRAIN In)
+{
+    return VSImageNoColor(false, In);
+}
+
 VERTEX_OUTPUT VSTransfer(uniform bool ShaderModel3, in VERTEX_INPUT_TRANSFER In)
 {
 	VERTEX_OUTPUT Out = (VERTEX_OUTPUT)0;
 	_VSTransferProjection(In, Out);
+	Out.Color = float4(1, 1, 1, 1);
+	Out.BakedColor = float4(0, 0, 0, 1);
 	_VSLightsAndShadows(ShaderModel3, In.Position, Out);
 
 	// Z-bias to reduce and eliminate z-fighting on track ballast. ZBias is 0 or 1.
@@ -361,6 +389,8 @@ VERTEX_OUTPUT VSForest(in VERTEX_INPUT_FOREST In)
 	Out.RelPosition.w = Out.Position.z;
 	Out.TexCoords.xy = In.TexCoords;
 	Out.Normal_Light = EyeVector;
+	Out.Color = float4(1, 1, 1, 1);
+	Out.BakedColor = float4(0, 0, 0, 1);
 
 	_VSLightsAndShadows(false, In.Position, Out);
 
@@ -821,6 +851,20 @@ technique ImageLevel9_1 {
 technique ImageLevel9_3 {
 	pass Pass_0 {
 		VertexShader = compile vs_4_0_level_9_3 VSGeneral9_3();
+		PixelShader = compile ps_4_0_level_9_3 PSImage9_3();
+	}
+}
+
+technique ImageNoColorLevel9_1 {
+	pass Pass_0 {
+		VertexShader = compile vs_4_0_level_9_1 VSImageNoColor9_1();
+		PixelShader = compile ps_4_0_level_9_1 PSImage9_1();
+	}
+}
+
+technique ImageNoColorLevel9_3 {
+	pass Pass_0 {
+		VertexShader = compile vs_4_0_level_9_3 VSImageNoColor9_3();
 		PixelShader = compile ps_4_0_level_9_3 PSImage9_3();
 	}
 }

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -682,7 +682,19 @@ float4 PSDetailMod2X9_3(in VERTEX_OUTPUT In) : COLOR0
 
 float4 PSDetailMod2X9_1(in VERTEX_OUTPUT In) : COLOR0
 {
-    return PSDetailMod2X(false, false, In);
+	const float FullBrightness = 1.0;
+	const float ShadowBrightness = 0.5;
+
+	float4 Color = tex2D(Image, In.TexCoords.xy);
+	Color.rgb *= tex2D(Detail, PSDetailTexCoords(In)).rgb * 2;
+	float4 SurfaceColor = Color * In.Color;
+	clip(SurfaceColor.a - ReferenceAlpha);
+
+	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(false, true, In) + ImageTextureIsNight));
+	litColor *= NightColorModifier;
+	_PSApplyHeadlights(litColor, Color.rgb, In);
+	_PSApplyFog(litColor, In);
+	return float4(litColor, SurfaceColor.a);
 }
 
 float4 PSGlossMap9_3(in VERTEX_OUTPUT In) : COLOR0

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -256,7 +256,7 @@ VERTEX_OUTPUT VSGeneral(uniform bool ShaderModel3, in VERTEX_INPUT In)
 
 	_VSNormalProjection(In.Position, In.TexCoords, In.Normal, Out);
 	Out.Color.rgb = lerp(float3(1, 1, 1), In.Color1.rgb * VertexLightingDay, VertexLightingEnabled);
-	Out.Color.a = 1;
+	Out.Color.a = lerp(1, In.Color1.a, VertexLightingEnabled);
 	Out.BakedColor.rgb = lerp(float3(0, 0, 0), In.Color2.rgb, VertexLightingEnabled);
 	Out.BakedColor.a = 1;
 	_VSLightsAndShadows(ShaderModel3, In.Position, Out);
@@ -265,11 +265,6 @@ VERTEX_OUTPUT VSGeneral(uniform bool ShaderModel3, in VERTEX_INPUT In)
 	Out.Position.z -= ZBias_Lighting.x * saturate(In.TexCoords.x) / 1000;
 
 	return Out;
-}
-
-float3 _PSGetVertexLitColor(in float3 Color, in VERTEX_OUTPUT In)
-{
-	return Color * In.Color.rgb;
 }
 
 VERTEX_OUTPUT VSGeneral9_3(in VERTEX_INPUT In)
@@ -494,22 +489,22 @@ float4 PSImage(uniform bool ShaderModel3, uniform bool ClampTexCoords, in VERTEX
 	const float ShadowBrightness = 0.5;
 
 	float4 Color = tex2D(Image, In.TexCoords.xy);
+	float4 SurfaceColor = Color * In.Color;
 	if (ShaderModel3 && ClampTexCoords) {
 		// We need to clamp the rendering to within the [0..1] range only.
 		if (saturate(In.TexCoords.x) != In.TexCoords.x || saturate(In.TexCoords.y) != In.TexCoords.y) {
-			Color.a = 0;
+			SurfaceColor.a = 0;
 		}
 	}
 
 	// Alpha testing:
-	clip(Color.a - ReferenceAlpha);
+	clip(SurfaceColor.a - ReferenceAlpha);
 	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
-	float3 surfaceColor = _PSGetVertexLitColor(Color.rgb, In);
-	float3 litColor = surfaceColor * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
+	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
 	// Specular effect next.
 	litColor += _PSGetSpecularEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In);
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
-	litColor = lerp(litColor, _PSGetOvercastColor(float4(surfaceColor, Color.a), In), Overcast.x);
+	litColor = lerp(litColor, _PSGetOvercastColor(SurfaceColor, In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	if (ShaderModel3) litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
@@ -517,9 +512,9 @@ float4 PSImage(uniform bool ShaderModel3, uniform bool ClampTexCoords, in VERTEX
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
-	if (ShaderModel3) _PSSceneryFade(Color, In);
+	if (ShaderModel3) _PSSceneryFade(SurfaceColor, In);
 	//if (ShaderModel3) _PSApplyShadowColor(litColor, In);
-	return float4(litColor, Color.a);
+	return float4(litColor, SurfaceColor.a);
 }
 
 float4 PSDetailMod2X(uniform bool ShaderModel3, uniform bool DetailUVScaled, in VERTEX_OUTPUT In) : COLOR0
@@ -531,15 +526,15 @@ float4 PSDetailMod2X(uniform bool ShaderModel3, uniform bool DetailUVScaled, in 
 	float2 detailTexCoords = In.TexCoords.xy;
 	if (DetailUVScaled) detailTexCoords *= DetailUVScaleRatio;
 	Color.rgb *= tex2D(Detail, detailTexCoords).rgb * 2;
+	float4 SurfaceColor = Color * In.Color;
 	// Alpha testing:
-	clip(Color.a - ReferenceAlpha);
+	clip(SurfaceColor.a - ReferenceAlpha);
 	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
-	float3 surfaceColor = _PSGetVertexLitColor(Color.rgb, In);
-	float3 litColor = surfaceColor * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
+	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
 	// Specular effect next.
 	litColor += _PSGetSpecularEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In);
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
-	litColor = lerp(litColor, _PSGetOvercastColor(float4(surfaceColor, Color.a), In), Overcast.x);
+	litColor = lerp(litColor, _PSGetOvercastColor(SurfaceColor, In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	if (ShaderModel3) litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
@@ -547,8 +542,8 @@ float4 PSDetailMod2X(uniform bool ShaderModel3, uniform bool DetailUVScaled, in 
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
-	if (ShaderModel3) _PSSceneryFade(Color, In);
-	return float4(litColor, Color.a);
+	if (ShaderModel3) _PSSceneryFade(SurfaceColor, In);
+	return float4(litColor, SurfaceColor.a);
 }
 
 float4 PSImage9_3(in VERTEX_OUTPUT In) : COLOR0
@@ -579,14 +574,14 @@ float4 PSDetailMod2X9_1(in VERTEX_OUTPUT In) : COLOR0
 float4 PSVegetation(in VERTEX_OUTPUT In) : COLOR0
 {
 	float4 Color = tex2D(Image, In.TexCoords.xy);
+	float4 SurfaceColor = Color * In.Color;
     // Alpha testing:
-    clip(Color.a - ReferenceAlpha);
+    clip(SurfaceColor.a - ReferenceAlpha);
 	// Ambient effect applies first; no shadow effect for vegetation; night-time textures cancel out all normal lighting.
-	float3 surfaceColor = _PSGetVertexLitColor(Color.rgb, In);
-	float3 litColor = surfaceColor * VegetationAmbientModifier;
+	float3 litColor = SurfaceColor.rgb * VegetationAmbientModifier;
 	// No specular effect for vegetation.
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
-	litColor = lerp(litColor, _PSGetOvercastColor(float4(surfaceColor, Color.a), In), Overcast.x);
+	litColor = lerp(litColor, _PSGetOvercastColor(SurfaceColor, In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
@@ -594,8 +589,8 @@ float4 PSVegetation(in VERTEX_OUTPUT In) : COLOR0
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
-	_PSSceneryFade(Color, In);
-	return float4(litColor, Color.a);
+	_PSSceneryFade(SurfaceColor, In);
+	return float4(litColor, SurfaceColor.a);
 }
 
 float4 PSTerrain(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
@@ -637,14 +632,14 @@ float4 PSDarkShade(in VERTEX_OUTPUT In) : COLOR0
 	const float ShadowBrightness = 0.5;
 
 	float4 Color = tex2D(Image, In.TexCoords.xy);
+	float4 SurfaceColor = Color * In.Color;
     // Alpha testing:
-    clip(Color.a - ReferenceAlpha);
+    clip(SurfaceColor.a - ReferenceAlpha);
 	// Fixed ambient and shadow effects at darkest level.
-	float3 surfaceColor = _PSGetVertexLitColor(Color.rgb, In);
-	float3 litColor = surfaceColor * ShadowBrightness;
+	float3 litColor = SurfaceColor.rgb * ShadowBrightness;
 	// No specular effect for dark shade.
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
-	litColor = lerp(litColor, _PSGetOvercastColor(float4(surfaceColor, Color.a), In), Overcast.x);
+	litColor = lerp(litColor, _PSGetOvercastColor(SurfaceColor, In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
@@ -652,8 +647,8 @@ float4 PSDarkShade(in VERTEX_OUTPUT In) : COLOR0
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
-	_PSSceneryFade(Color, In);
-	return float4(litColor, Color.a);
+	_PSSceneryFade(SurfaceColor, In);
+	return float4(litColor, SurfaceColor.a);
 }
 
 float4 PSHalfBright(in VERTEX_OUTPUT In) : COLOR0
@@ -661,14 +656,14 @@ float4 PSHalfBright(in VERTEX_OUTPUT In) : COLOR0
 	const float HalfShadowBrightness = 0.75;
 
 	float4 Color = tex2D(Image, In.TexCoords.xy);
+	float4 SurfaceColor = Color * In.Color;
     // Alpha testing:
-    clip(Color.a - ReferenceAlpha);
+    clip(SurfaceColor.a - ReferenceAlpha);
 	// Fixed ambient and shadow effects at mid-dark level.
-	float3 surfaceColor = _PSGetVertexLitColor(Color.rgb, In);
-	float3 litColor = surfaceColor * HalfShadowBrightness;
+	float3 litColor = SurfaceColor.rgb * HalfShadowBrightness;
 	// No specular effect for half-bright.
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
-	litColor = lerp(litColor, _PSGetOvercastColor(float4(surfaceColor, Color.a), In), Overcast.y);
+	litColor = lerp(litColor, _PSGetOvercastColor(SurfaceColor, In), Overcast.y);
 	// Night-time darkens everything, except night-time textures.
 	litColor *= HalfNightColorModifier;
 	litColor = mad(Color.rgb, In.BakedColor.rgb, litColor);
@@ -676,17 +671,18 @@ float4 PSHalfBright(in VERTEX_OUTPUT In) : COLOR0
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
-	_PSSceneryFade(Color, In);
-	return float4(litColor, Color.a);
+	_PSSceneryFade(SurfaceColor, In);
+	return float4(litColor, SurfaceColor.a);
 }
 
 float4 PSFullBright(in VERTEX_OUTPUT In) : COLOR0
 {
 	float4 Color = tex2D(Image, In.TexCoords.xy);
+	float4 SurfaceColor = Color * In.Color;
     // Alpha testing:
-    clip(Color.a - ReferenceAlpha);
+    clip(SurfaceColor.a - ReferenceAlpha);
 	// Fixed ambient and shadow effects at brightest level.
-	float3 litColor = mad(Color.rgb, In.BakedColor.rgb, _PSGetVertexLitColor(Color.rgb, In));
+	float3 litColor = mad(Color.rgb, In.BakedColor.rgb, SurfaceColor.rgb);
 	litColor *= NightLightModifier;
 	// No specular effect for full-bright.
 	// No overcast effect for full-bright.
@@ -695,8 +691,8 @@ float4 PSFullBright(in VERTEX_OUTPUT In) : COLOR0
 	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
-	_PSSceneryFade(Color, In);
-	return float4(litColor, Color.a);
+	_PSSceneryFade(SurfaceColor, In);
+	return float4(litColor, SurfaceColor.a);
 }
 
 float4 PSSignalLight(in VERTEX_OUTPUT In) : COLOR0

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -571,22 +571,26 @@ float4 PSImage(uniform bool ShaderModel3, uniform bool ClampTexCoords, in VERTEX
 	return float4(litColor, SurfaceColor.a);
 }
 
-float4 PSDetailMod2X(uniform bool ShaderModel3, uniform bool DetailUVScaled, in VERTEX_OUTPUT In) : COLOR0
+float2 PSDetailTexCoords(in VERTEX_OUTPUT In)
+{
+	return float2(In.BakedColor.a, In.Shadow.w);
+}
+
+float4 PSDetailMod2X(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
 {
 	const float FullBrightness = 1.0;
 	const float ShadowBrightness = 0.5;
 
 	float4 Color = tex2D(Image, In.TexCoords.xy);
-	float2 detailTexCoords = In.TexCoords.xy;
-	if (DetailUVScaled) detailTexCoords *= DetailUVScaleRatio;
-	Color.rgb *= tex2D(Detail, detailTexCoords).rgb * 2;
+	Color.rgb *= tex2D(Detail, PSDetailTexCoords(In)).rgb * 2;
 	float4 SurfaceColor = Color * In.Color;
 	// Alpha testing:
 	clip(SurfaceColor.a - ReferenceAlpha);
 	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
-	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
+	float shadowEffect = _PSGetShadowEffect(ShaderModel3, true, In);
+	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * shadowEffect + ImageTextureIsNight));
 	// Specular effect next.
-	litColor += _PSGetSpecularEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In);
+	litColor += _PSGetSpecularEffect(In) * shadowEffect;
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
 	litColor = lerp(litColor, _PSGetOvercastColor(SurfaceColor, In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
@@ -600,11 +604,6 @@ float4 PSDetailMod2X(uniform bool ShaderModel3, uniform bool DetailUVScaled, in 
 	return float4(litColor, SurfaceColor.a);
 }
 
-float2 PSDetailTexCoords(in VERTEX_OUTPUT In)
-{
-	return float2(In.BakedColor.a, In.Shadow.w);
-}
-
 float4 PSGlossMap(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
 {
 	const float FullBrightness = 1.0;
@@ -615,9 +614,10 @@ float4 PSGlossMap(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
 	// Alpha testing:
 	clip(SurfaceColor.a - ReferenceAlpha);
 	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
-	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
+	float shadowEffect = _PSGetShadowEffect(ShaderModel3, true, In);
+	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * shadowEffect + ImageTextureIsNight));
 	// Specular effect next.
-	litColor += _PSGetSpecularEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In);
+	litColor += _PSGetSpecularEffect(In) * shadowEffect;
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
 	litColor = lerp(litColor, _PSGetOvercastColor(SurfaceColor, In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
@@ -644,9 +644,10 @@ float4 PSAlphRefMap(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
 	// Alpha testing:
 	clip(SurfaceColor.a - ReferenceAlpha);
 	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
-	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In) + ImageTextureIsNight));
+	float shadowEffect = _PSGetShadowEffect(ShaderModel3, true, In);
+	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * shadowEffect + ImageTextureIsNight));
 	// Specular effect next.
-	litColor += _PSGetSpecularEffect(In) * _PSGetShadowEffect(ShaderModel3, true, In);
+	litColor += _PSGetSpecularEffect(In) * shadowEffect;
 	// Overcast blanks out ambient, shadow and specular effects (so use original Color).
 	litColor = lerp(litColor, _PSGetOvercastColor(SurfaceColor, In), Overcast.x);
 	// Night-time darkens everything, except night-time textures.
@@ -677,7 +678,7 @@ float4 PSImage9_1(in VERTEX_OUTPUT In) : COLOR0
 
 float4 PSDetailMod2X9_3(in VERTEX_OUTPUT In) : COLOR0
 {
-    return PSDetailMod2X(true, true, In);
+    return PSDetailMod2X(true, In);
 }
 
 float4 PSDetailMod2X9_1(in VERTEX_OUTPUT In) : COLOR0

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -185,7 +185,6 @@ float2 _VSReflectMapFullTexCoords(float3 relPosition, float3 normal)
 {
 	float3 viewDirection = normalize(relPosition);
 	float3 reflection = normalize(2 * dot(viewDirection, normal) * normal - viewDirection);
-	reflection = mul(reflection, (float3x3)World).xyz;
 	reflection.z = -reflection.z;
 	float sphereMapScale = 0.5 / max(length(float3(reflection.xy, reflection.z + 1)), 0.0001);
 	return reflection.xy * sphereMapScale + 0.5;

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -26,6 +26,7 @@
 float4x4 World;         // model -> world
 float4x4 View;          // world -> view
 float4x4 Projection;    // view -> projection
+float4x4 EnvMapTransform; // current object -> root/captured object transform for sphere maps
 float4x4 LightViewProjectionShadowProjection0;  // world -> light view -> light projection -> shadow map projection
 float4x4 LightViewProjectionShadowProjection1;
 float4x4 LightViewProjectionShadowProjection2;
@@ -181,18 +182,19 @@ struct VERTEX_OUTPUT
 
 ////////////////////    V E R T E X   S H A D E R S    /////////////////////////
 
-float2 _VSReflectMapFullTexCoords(float3 normal)
+float2 _VSReflectMapFullTexCoords(float3 relPosition, float3 normal)
 {
-	float3 cameraNormal = normalize(mul(normal, (float3x3)View).xyz);
-	float3 reflection = normalize(2 * cameraNormal.z * cameraNormal - float3(0, 0, 1));
+	float3 viewDirection = normalize(relPosition);
+	float3 reflection = normalize(2 * dot(viewDirection, normal) * normal - viewDirection);
+	reflection = mul(reflection, (float3x3)EnvMapTransform).xyz;
 	float sphereMapScale = 0.5 / max(length(float3(reflection.xy, reflection.z + 1)), 0.0001);
 	return reflection.xy * sphereMapScale + 0.5;
 }
 
-float2 _VSDetailTexCoords(float2 texCoords, float3 normal)
+float2 _VSDetailTexCoords(float2 texCoords, float3 relPosition, float3 normal)
 {
 	if (DetailUVOpReflectMapFull > 0.5)
-		return _VSReflectMapFullTexCoords(normal);
+		return _VSReflectMapFullTexCoords(relPosition, normal);
 	return texCoords * UVScale * DetailUVScaleRatio;
 }
 
@@ -206,7 +208,7 @@ void _VSNormalProjection(in float4 InPosition, in float2 InTexCoords, in float3 
 	Out.TexCoords.xy = InTexCoords * UVScale;
 
 	if (UVOpReflectMapFull > 0.5)
-		Out.TexCoords.xy = _VSReflectMapFullTexCoords(Out.Normal_Light.xyz);
+		Out.TexCoords.xy = _VSReflectMapFullTexCoords(Out.RelPosition.xyz, Out.Normal_Light.xyz);
 	
 	// Normal lighting (range 0.0 - 1.0)
 	// Need to calc. here instead of _VSLightsAndShadows() to avoid calling it from VSForest(), where it has gone into pre-shader in Shaders.cs
@@ -280,7 +282,7 @@ VERTEX_OUTPUT VSGeneral(uniform bool ShaderModel3, in VERTEX_INPUT In)
 	Out.BakedColor.rgb = lerp(float3(0, 0, 0), In.Color2.rgb, VertexLightingEnabled);
 	Out.BakedColor.a = 1;
 	_VSLightsAndShadows(ShaderModel3, In.Position, Out);
-	float2 detailTexCoords = _VSDetailTexCoords(In.TexCoords, Out.Normal_Light.xyz);
+	float2 detailTexCoords = _VSDetailTexCoords(In.TexCoords, Out.RelPosition.xyz, Out.Normal_Light.xyz);
 	Out.BakedColor.a = detailTexCoords.x;
 	Out.Shadow.w = detailTexCoords.y;
 

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -55,6 +55,7 @@ float3   SideVector;
 float    ReferenceAlpha;
 float2   UVScale;
 float2   DetailUVScaleRatio;
+float    UVOpReflectMapFull;
 float    VertexLightingEnabled;
 float    VertexLightingDay;
 float    NightLightModifier;
@@ -185,8 +186,18 @@ void _VSNormalProjection(in float4 InPosition, in float2 InTexCoords, in float3 
 	Out.Position = mul(mul(mul(InPosition, World), View), Projection);
 	Out.RelPosition.xyz = mul(InPosition, World).xyz - ViewerPos;
 	Out.RelPosition.w = Out.Position.z;
-	Out.TexCoords.xy = InTexCoords * UVScale;
 	Out.Normal_Light.xyz = normalize(mul(InNormal, (float3x3)World).xyz);
+	Out.TexCoords.xy = InTexCoords * UVScale;
+
+	if (UVOpReflectMapFull > 0.5) {
+		const float InvPI = 0.31830988618;
+		const float InvTwoPI = 0.15915494309;
+		float3 viewDirection = normalize(Out.RelPosition.xyz);
+		float3 reflection = normalize(reflect(viewDirection, Out.Normal_Light.xyz));
+		Out.TexCoords.xy = float2(
+			atan2(reflection.z, reflection.x) * InvTwoPI + 0.5,
+			asin(clamp(reflection.y, -1, 1)) * InvPI + 0.5);
+	}
 	
 	// Normal lighting (range 0.0 - 1.0)
 	// Need to calc. here instead of _VSLightsAndShadows() to avoid calling it from VSForest(), where it has gone into pre-shader in Shaders.cs

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -192,7 +192,7 @@ float2 _VSReflectMapFullTexCoords(float3 normal)
 float2 _VSDetailTexCoords(float2 texCoords, float3 normal)
 {
 	if (DetailUVOpReflectMapFull > 0.5)
-		return _VSReflectMapFullTexCoords(normal) * UVScale * DetailUVScaleRatio;
+		return _VSReflectMapFullTexCoords(normal);
 	return texCoords * UVScale * DetailUVScaleRatio;
 }
 
@@ -206,7 +206,7 @@ void _VSNormalProjection(in float4 InPosition, in float2 InTexCoords, in float3 
 	Out.TexCoords.xy = InTexCoords * UVScale;
 
 	if (UVOpReflectMapFull > 0.5)
-		Out.TexCoords.xy = _VSReflectMapFullTexCoords(Out.Normal_Light.xyz) * UVScale;
+		Out.TexCoords.xy = _VSReflectMapFullTexCoords(Out.Normal_Light.xyz);
 	
 	// Normal lighting (range 0.0 - 1.0)
 	// Need to calc. here instead of _VSLightsAndShadows() to avoid calling it from VSForest(), where it has gone into pre-shader in Shaders.cs

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -690,9 +690,42 @@ float4 PSGlossMap9_3(in VERTEX_OUTPUT In) : COLOR0
     return PSGlossMap(true, In);
 }
 
+float4 PSGlossMap9_1(in VERTEX_OUTPUT In) : COLOR0
+{
+	const float FullBrightness = 1.0;
+	const float ShadowBrightness = 0.5;
+
+	float4 Color = tex2D(Image, In.TexCoords.xy);
+	float4 SurfaceColor = Color * In.Color;
+	clip(SurfaceColor.a - ReferenceAlpha);
+
+	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(false, true, In) + ImageTextureIsNight));
+	litColor *= NightColorModifier;
+	litColor += tex2D(Detail, PSDetailTexCoords(In)).rgb * SurfaceColor.a;
+	_PSApplyFog(litColor, In);
+	return float4(litColor, SurfaceColor.a);
+}
+
 float4 PSAlphRefMap9_3(in VERTEX_OUTPUT In) : COLOR0
 {
     return PSAlphRefMap(true, In);
+}
+
+float4 PSAlphRefMap9_1(in VERTEX_OUTPUT In) : COLOR0
+{
+	const float FullBrightness = 1.0;
+	const float ShadowBrightness = 0.5;
+
+	float4 BaseColor = tex2D(Image, In.TexCoords.xy);
+	float4 DetailColor = tex2D(Detail, PSDetailTexCoords(In));
+	float4 Color = float4(BaseColor.rgb + (1 - BaseColor.a) * DetailColor.rgb, saturate(BaseColor.a + lerp(0, In.Color.a, VertexLightingEnabled)));
+	float4 SurfaceColor = float4(Color.rgb * In.Color.rgb, Color.a);
+	clip(SurfaceColor.a - ReferenceAlpha);
+
+	float3 litColor = SurfaceColor.rgb * lerp(ShadowBrightness, FullBrightness, saturate(_PSGetAmbientEffect(In) * _PSGetShadowEffect(false, true, In) + ImageTextureIsNight));
+	litColor *= NightColorModifier;
+	_PSApplyFog(litColor, In);
+	return float4(litColor, SurfaceColor.a);
 }
 
 
@@ -885,7 +918,7 @@ technique DetailMod2XLevel9_3 {
 technique GlossMapLevel9_1 {
 	pass Pass_0 {
 		VertexShader = compile vs_4_0_level_9_1 VSGeneral9_1();
-		PixelShader = compile ps_4_0_level_9_1 PSImage9_1();
+		PixelShader = compile ps_4_0_level_9_1 PSGlossMap9_1();
 	}
 }
 
@@ -899,7 +932,7 @@ technique GlossMapLevel9_3 {
 technique AlphRefMapLevel9_1 {
 	pass Pass_0 {
 		VertexShader = compile vs_4_0_level_9_1 VSGeneral9_1();
-		PixelShader = compile ps_4_0_level_9_1 PSImage9_1();
+		PixelShader = compile ps_4_0_level_9_1 PSAlphRefMap9_1();
 	}
 }
 

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -54,6 +54,7 @@ float4   EyeVector;
 float3   SideVector;
 float    ReferenceAlpha;
 float2   UVScale;
+float2   DetailUVScaleRatio;
 float    VertexLightingEnabled;
 float    VertexLightingDay;
 float    NightLightModifier;
@@ -514,13 +515,15 @@ float4 PSImage(uniform bool ShaderModel3, uniform bool ClampTexCoords, in VERTEX
 	return float4(litColor, Color.a);
 }
 
-float4 PSDetailMod2X(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
+float4 PSDetailMod2X(uniform bool ShaderModel3, uniform bool DetailUVScaled, in VERTEX_OUTPUT In) : COLOR0
 {
 	const float FullBrightness = 1.0;
 	const float ShadowBrightness = 0.5;
 
 	float4 Color = tex2D(Image, In.TexCoords.xy);
-	Color.rgb *= tex2D(Detail, In.TexCoords.xy).rgb * 2;
+	float2 detailTexCoords = In.TexCoords.xy;
+	if (DetailUVScaled) detailTexCoords *= DetailUVScaleRatio;
+	Color.rgb *= tex2D(Detail, detailTexCoords).rgb * 2;
 	// Alpha testing:
 	clip(Color.a - ReferenceAlpha);
 	// Ambient and shadow effects apply first; night-time textures cancel out all normal lighting.
@@ -558,12 +561,12 @@ float4 PSImage9_1(in VERTEX_OUTPUT In) : COLOR0
 
 float4 PSDetailMod2X9_3(in VERTEX_OUTPUT In) : COLOR0
 {
-    return PSDetailMod2X(true, In);
+    return PSDetailMod2X(true, true, In);
 }
 
 float4 PSDetailMod2X9_1(in VERTEX_OUTPUT In) : COLOR0
 {
-    return PSDetailMod2X(false, In);
+    return PSDetailMod2X(false, false, In);
 }
 
 float4 PSVegetation(in VERTEX_OUTPUT In) : COLOR0

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -181,21 +181,18 @@ struct VERTEX_OUTPUT
 
 ////////////////////    V E R T E X   S H A D E R S    /////////////////////////
 
-float2 _VSReflectMapFullTexCoords(float3 relPosition, float3 normal)
+float2 _VSReflectMapFullTexCoords(float3 normal)
 {
-	const float InvPI = 0.31830988618;
-	const float InvTwoPI = 0.15915494309;
-	float3 viewDirection = normalize(relPosition);
-	float3 reflection = normalize(reflect(viewDirection, normal));
-	return float2(
-		atan2(reflection.z, reflection.x) * InvTwoPI + 0.5,
-		asin(clamp(reflection.y, -1, 1)) * InvPI + 0.5);
+	float3 cameraNormal = normalize(mul(normal, (float3x3)View).xyz);
+	float3 reflection = normalize(2 * cameraNormal.z * cameraNormal - float3(0, 0, 1));
+	float sphereMapScale = 0.5 / max(length(float3(reflection.xy, reflection.z + 1)), 0.0001);
+	return reflection.xy * sphereMapScale + 0.5;
 }
 
-float2 _VSDetailTexCoords(float2 texCoords, float3 relPosition, float3 normal)
+float2 _VSDetailTexCoords(float2 texCoords, float3 normal)
 {
 	if (DetailUVOpReflectMapFull > 0.5)
-		return _VSReflectMapFullTexCoords(relPosition, normal);
+		return _VSReflectMapFullTexCoords(normal) * UVScale * DetailUVScaleRatio;
 	return texCoords * UVScale * DetailUVScaleRatio;
 }
 
@@ -209,7 +206,7 @@ void _VSNormalProjection(in float4 InPosition, in float2 InTexCoords, in float3 
 	Out.TexCoords.xy = InTexCoords * UVScale;
 
 	if (UVOpReflectMapFull > 0.5)
-		Out.TexCoords.xy = _VSReflectMapFullTexCoords(Out.RelPosition.xyz, Out.Normal_Light.xyz);
+		Out.TexCoords.xy = _VSReflectMapFullTexCoords(Out.Normal_Light.xyz) * UVScale;
 	
 	// Normal lighting (range 0.0 - 1.0)
 	// Need to calc. here instead of _VSLightsAndShadows() to avoid calling it from VSForest(), where it has gone into pre-shader in Shaders.cs
@@ -283,7 +280,7 @@ VERTEX_OUTPUT VSGeneral(uniform bool ShaderModel3, in VERTEX_INPUT In)
 	Out.BakedColor.rgb = lerp(float3(0, 0, 0), In.Color2.rgb, VertexLightingEnabled);
 	Out.BakedColor.a = 1;
 	_VSLightsAndShadows(ShaderModel3, In.Position, Out);
-	float2 detailTexCoords = _VSDetailTexCoords(In.TexCoords, Out.RelPosition.xyz, Out.Normal_Light.xyz);
+	float2 detailTexCoords = _VSDetailTexCoords(In.TexCoords, Out.Normal_Light.xyz);
 	Out.BakedColor.a = detailTexCoords.x;
 	Out.Shadow.w = detailTexCoords.y;
 

--- a/Source/RunActivity/Content/ShadowMap.fx
+++ b/Source/RunActivity/Content/ShadowMap.fx
@@ -26,6 +26,7 @@
 float4x4 WorldViewProjection;  // model -> world -> view -> projection
 float3   SideVector;
 float    ImageBlurStep;  // = 1 / shadow map texture width and height
+float2   UVScale;
 texture  ImageTexture;
 
 sampler ImageSampler = sampler_state
@@ -96,7 +97,7 @@ VERTEX_OUTPUT VSShadowMap(in VERTEX_INPUT In)
 	}
 
 	Out.Position = mul(In.Position, WorldViewProjection);
-	Out.TexCoord_Depth.xy = In.TexCoord;
+	Out.TexCoord_Depth.xy = In.TexCoord * UVScale;
 	Out.TexCoord_Depth.z = Out.Position.z;
 
 	return Out;

--- a/Source/RunActivity/Viewer3D/Common/Helpers.cs
+++ b/Source/RunActivity/Viewer3D/Common/Helpers.cs
@@ -139,6 +139,8 @@ namespace Orts.Viewer3D.Common
             { "Tex", SceneryMaterialOptions.None },
             { "TexDiff", SceneryMaterialOptions.Diffuse },
             { "DetailMod2X", SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.DetailMod2X },
+            { "NightLight", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright | SceneryMaterialOptions.NightTexture | SceneryMaterialOptions.NightLight },
+            { "nightlight", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright | SceneryMaterialOptions.NightTexture | SceneryMaterialOptions.NightLight },
             { "BlendATex", SceneryMaterialOptions.AlphaBlendingBlend },
             { "BlendATexDiff", SceneryMaterialOptions.AlphaBlendingBlend | SceneryMaterialOptions.Diffuse },
             { "AddATex", SceneryMaterialOptions.AlphaBlendingAdd },
@@ -183,6 +185,9 @@ namespace Orts.Viewer3D.Common
                 options |= LightingModelNames[lod.LightModelName];
             else
                 Trace.TraceWarning("Skipped unknown lighting model index {1} in shape {0}", lod.Name, lod.LightModelName);
+
+            if ((options & SceneryMaterialOptions.NightLight) != 0)
+                options = (options & ~SceneryMaterialOptions.ShaderMask) | SceneryMaterialOptions.ShaderFullBright;
 
             if ((lod.ESD_Alternative_Texture & (int)TextureFlags.Night) != 0)
                 options |= SceneryMaterialOptions.NightTexture;

--- a/Source/RunActivity/Viewer3D/Common/Helpers.cs
+++ b/Source/RunActivity/Viewer3D/Common/Helpers.cs
@@ -187,7 +187,7 @@ namespace Orts.Viewer3D.Common
                 Trace.TraceWarning("Skipped unknown lighting model index {1} in shape {0}", lod.Name, lod.LightModelName);
 
             if ((options & SceneryMaterialOptions.NightLight) != 0)
-                options = (options & ~SceneryMaterialOptions.ShaderMask) | SceneryMaterialOptions.ShaderFullBright;
+                options = (options & ~(SceneryMaterialOptions.ShaderMask | SceneryMaterialOptions.BakedVertexLighting)) | SceneryMaterialOptions.ShaderFullBright;
 
             if ((lod.ESD_Alternative_Texture & (int)TextureFlags.Night) != 0)
                 options |= SceneryMaterialOptions.NightTexture;

--- a/Source/RunActivity/Viewer3D/Common/Helpers.cs
+++ b/Source/RunActivity/Viewer3D/Common/Helpers.cs
@@ -138,6 +138,7 @@ namespace Orts.Viewer3D.Common
         static readonly Dictionary<string, SceneryMaterialOptions> ShaderNames = new Dictionary<string, SceneryMaterialOptions> {
             { "Tex", SceneryMaterialOptions.None },
             { "TexDiff", SceneryMaterialOptions.Diffuse },
+            { "DetailMod2X", SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.DetailMod2X },
             { "BlendATex", SceneryMaterialOptions.AlphaBlendingBlend },
             { "BlendATexDiff", SceneryMaterialOptions.AlphaBlendingBlend | SceneryMaterialOptions.Diffuse },
             { "AddATex", SceneryMaterialOptions.AlphaBlendingAdd },

--- a/Source/RunActivity/Viewer3D/Common/Helpers.cs
+++ b/Source/RunActivity/Viewer3D/Common/Helpers.cs
@@ -139,6 +139,8 @@ namespace Orts.Viewer3D.Common
             { "Tex", SceneryMaterialOptions.None },
             { "TexDiff", SceneryMaterialOptions.Diffuse },
             { "DetailMod2X", SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.DetailMod2X },
+            { "GlossMap", SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.GlossMap },
+            { "AlphRefMap", SceneryMaterialOptions.AlphaBlendingBlend | SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.AlphRefMap },
             { "NightLight", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright | SceneryMaterialOptions.NightTexture | SceneryMaterialOptions.NightLight },
             { "nightlight", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright | SceneryMaterialOptions.NightTexture | SceneryMaterialOptions.NightLight },
             { "BlendATex", SceneryMaterialOptions.AlphaBlendingBlend },

--- a/Source/RunActivity/Viewer3D/DynamicTrack.cs
+++ b/Source/RunActivity/Viewer3D/DynamicTrack.cs
@@ -1108,7 +1108,18 @@ namespace Orts.Viewer3D
         public static void LoadMaterial(Viewer viewer, LODItem lod)
         {
             var options = Helpers.EncodeMaterialOptions(lod);
-            lod.LODMaterial = viewer.MaterialManager.Load("Scenery", Helpers.GetRouteTextureFile(viewer.Simulator, (Helpers.TextureFlags)lod.ESD_Alternative_Texture, lod.TexName), (int)options, lod.MipMapLevelOfDetailBias);
+            var multiTextureOptions = SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap | SceneryMaterialOptions.AlphRefMap;
+            var texturePath = Helpers.GetRouteTextureFile(viewer.Simulator, (Helpers.TextureFlags)lod.ESD_Alternative_Texture, lod.TexName);
+            if ((options & multiTextureOptions) != 0)
+            {
+                Trace.TraceWarning("Skipped multi-texture shader {1} in dynamic track profile item {0}; dynamic track profiles support one texture slot.", lod.Name, lod.ShaderName);
+                options &= ~multiTextureOptions;
+            }
+
+            lod.LODMaterial = viewer.MaterialManager.Load("Scenery",
+                texturePath,
+                (int)options,
+                lod.MipMapLevelOfDetailBias);
         }
 
         [CallOnThread("Loader")]

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -953,7 +953,8 @@ namespace Orts.Viewer3D
             shader.VertexLightingEnabled = (Options & SceneryMaterialOptions.BakedVertexLighting) != 0;
             var daylight = GetDaylightFactor();
             shader.VertexLightingDay = daylight;
-            shader.NightLightModifier = (Options & SceneryMaterialOptions.NightLight) != 0 ? 1 - daylight : 1;
+            // multiply by 0.4f, it is a heuristics to match MSTS look
+            shader.NightLightModifier = (Options & SceneryMaterialOptions.NightLight) != 0 ? (1 - daylight) * 0.4f : 1;
         }
 
         public override void Render(GraphicsDevice graphicsDevice, IEnumerable<RenderItem> renderItems, ref Matrix XNAViewMatrix, ref Matrix XNAProjectionMatrix)

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -940,6 +940,7 @@ namespace Orts.Viewer3D
                 {
                     shader.SetMatrix(item.XNAMatrix, ref XNAViewMatrix, ref XNAProjectionMatrix);
                     shader.ZBias = item.RenderPrimitive.ZBias;
+                    shader.UVScale = item.RenderPrimitive.UVScale;
                     ShaderPasses.Current.Apply();
 
                     // SamplerStates can only be set after the ShaderPasses.Current.Apply().
@@ -1087,7 +1088,7 @@ namespace Orts.Viewer3D
                 foreach (var item in renderItems)
                 {
                     var wvp = item.XNAMatrix * viewproj;
-                    shader.SetData(ref wvp, item.Material.GetShadowTexture());
+                    shader.SetData(ref wvp, item.Material.GetShadowTexture(), item.RenderPrimitive.UVScale);
                     ShaderPasses.Current.Apply();
                     // SamplerStates can only be set after the ShaderPasses.Current.Apply().
                     graphicsDevice.SamplerStates[0] = item.Material.GetShadowTextureAddressMode();

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -971,8 +971,8 @@ namespace Orts.Viewer3D
             shader.VertexLightingEnabled = (Options & SceneryMaterialOptions.BakedVertexLighting) != 0;
             var daylight = GetDaylightFactor();
             shader.VertexLightingDay = daylight;
-            // multiply by 0.4f, it is a heuristics to match MSTS look
-            shader.NightLightModifier = (Options & SceneryMaterialOptions.NightLight) != 0 ? (1 - daylight) * 0.4f : 1;
+            // multiply by 0.5f, it is a heuristics to match MSTS look
+            shader.NightLightModifier = (Options & SceneryMaterialOptions.NightLight) != 0 ? (1 - daylight) * 0.5f : 1;
         }
 
         public override void Render(GraphicsDevice graphicsDevice, IEnumerable<RenderItem> renderItems, ref Matrix XNAViewMatrix, ref Matrix XNAProjectionMatrix)

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -252,8 +252,8 @@ namespace Orts.Viewer3D
     public class SharedMaterialManager
     {
         readonly Viewer Viewer;
-        IDictionary<(string, string, int, float, Effect), Material> Materials = new Dictionary<(string, string, int, float, Effect), Material>();
-        IDictionary<(string, string, int, float, Effect), bool> MaterialMarks = new Dictionary<(string, string, int, float, Effect), bool>();
+        IDictionary<(string, string, string, int, float, Effect), Material> Materials = new Dictionary<(string, string, string, int, float, Effect), Material>();
+        IDictionary<(string, string, string, int, float, Effect), bool> MaterialMarks = new Dictionary<(string, string, string, int, float, Effect), bool>();
 
         public readonly LightConeShader LightConeShader;
         public readonly LightGlowShader LightGlowShader;
@@ -317,9 +317,9 @@ namespace Orts.Viewer3D
 
         }
 
-        public Material Load(string materialName, string textureName = null, int options = 0, float mipMapBias = 0f, Effect effect = null)
+        public Material Load(string materialName, string textureName = null, int options = 0, float mipMapBias = 0f, Effect effect = null, string detailTextureName = null)
         {
-            var materialKey = (materialName, textureName?.ToLowerInvariant(), options, mipMapBias, effect);
+            var materialKey = (materialName, textureName?.ToLowerInvariant(), detailTextureName?.ToLowerInvariant(), options, mipMapBias, effect);
             if (!Materials.ContainsKey(materialKey))
             {
                 switch (materialName)
@@ -352,7 +352,7 @@ namespace Orts.Viewer3D
                         Materials[materialKey] = new PrecipitationMaterial(Viewer);
                         break;
                     case "Scenery":
-                        Materials[materialKey] = new SceneryMaterial(Viewer, textureName, (SceneryMaterialOptions)options, mipMapBias);
+                        Materials[materialKey] = new SceneryMaterial(Viewer, textureName, (SceneryMaterialOptions)options, mipMapBias, detailTextureName);
                         break;
                     case "ShadowMap":
                         Materials[materialKey] = new ShadowMapMaterial(Viewer);
@@ -579,7 +579,7 @@ namespace Orts.Viewer3D
     {
         public readonly Viewer Viewer;
         public readonly string Key;
-        internal (string, string, int, float, Effect) MarkKey;
+        internal (string, string, string, int, float, Effect) MarkKey;
 
         protected Material(Viewer viewer, string key)
         {
@@ -717,6 +717,8 @@ namespace Orts.Viewer3D
         TextureAddressModeMask = 0x600,
         // Night texture
         NightTexture = 0x800,
+        // Modulate base texture with detail texture and double the result.
+        DetailMod2X = 0x1000,
         // Texture to be shown in tunnels and underground (used for 3D cab night textures)
         UndergroundTexture = 0x40000000,
     }
@@ -727,9 +729,12 @@ namespace Orts.Viewer3D
         readonly float MipMapBias;
         protected Texture2D Texture;
         private readonly string TexturePath;
+        protected Texture2D DetailTexture;
+        private readonly string DetailTexturePath;
         protected Texture2D NightTexture;
         byte AceAlphaBits;   // the number of bits in the ace file's alpha channel 
         IEnumerator<EffectPass> ShaderPassesDarkShade;
+        IEnumerator<EffectPass> ShaderPassesDetailMod2X;
         IEnumerator<EffectPass> ShaderPassesFullBright;
         IEnumerator<EffectPass> ShaderPassesHalfBright;
         IEnumerator<EffectPass> ShaderPassesImage;
@@ -742,13 +747,15 @@ namespace Orts.Viewer3D
         };
         private static readonly Dictionary<TextureAddressMode, Dictionary<float, SamplerState>> SamplerStates = new Dictionary<TextureAddressMode, Dictionary<float, SamplerState>>();
 
-        public SceneryMaterial(Viewer viewer, string texturePath, SceneryMaterialOptions options, float mipMapBias)
-            : base(viewer, String.Format("{0}:{1:X}:{2}", texturePath, options, mipMapBias))
+        public SceneryMaterial(Viewer viewer, string texturePath, SceneryMaterialOptions options, float mipMapBias, string detailTexturePath = null)
+            : base(viewer, String.Format("{0}:{1}:{2:X}:{3}", texturePath, detailTexturePath, options, mipMapBias))
         {
             Options = options;
             MipMapBias = mipMapBias;
             TexturePath = texturePath;
+            DetailTexturePath = detailTexturePath;
             Texture = SharedMaterialManager.MissingTexture;
+            DetailTexture = SharedMaterialManager.MissingTexture;
             NightTexture = SharedMaterialManager.MissingTexture;
             // <CSComment> if "trainset" is in the path (true for night textures for 3DCabs) deferred load of night textures is disabled 
             if (!String.IsNullOrEmpty(texturePath) && (Options & SceneryMaterialOptions.NightTexture) != 0 && ((!viewer.IsDaytime && !viewer.IsNighttime)
@@ -776,6 +783,9 @@ namespace Orts.Viewer3D
                 }
             }
             else Texture = Viewer.TextureManager.Get(texturePath, true);
+
+            if (!String.IsNullOrEmpty(DetailTexturePath))
+                DetailTexture = Viewer.TextureManager.Get(DetailTexturePath, true);
 
             // Record the number of bits in the alpha channel of the original ace file
             var texture = SharedMaterialManager.MissingTexture;
@@ -821,6 +831,7 @@ namespace Orts.Viewer3D
             var shader = Viewer.MaterialManager.SceneryShader;
             var level9_3 = Viewer.Settings.IsDirectXFeatureLevelIncluded(ORTS.Settings.UserSettings.DirectXFeature.Level9_3);
             if (ShaderPassesDarkShade == null) ShaderPassesDarkShade = shader.Techniques[level9_3 ? "DarkShadeLevel9_3" : "DarkShadeLevel9_1"].Passes.GetEnumerator();
+            if (ShaderPassesDetailMod2X == null) ShaderPassesDetailMod2X = shader.Techniques[level9_3 ? "DetailMod2XLevel9_3" : "DetailMod2XLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesFullBright == null) ShaderPassesFullBright = shader.Techniques[level9_3 ? "FullBrightLevel9_3" : "FullBrightLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesHalfBright == null) ShaderPassesHalfBright = shader.Techniques[level9_3 ? "HalfBrightLevel9_3" : "HalfBrightLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesImage == null) ShaderPassesImage = shader.Techniques[level9_3 ? "ImageLevel9_3" : "ImageLevel9_1"].Passes.GetEnumerator();
@@ -874,7 +885,12 @@ namespace Orts.Viewer3D
             }
 
 
-            switch (Options & SceneryMaterialOptions.ShaderMask)
+            if ((Options & SceneryMaterialOptions.DetailMod2X) != 0)
+            {
+                shader.CurrentTechnique = shader.Techniques[level9_3 ? "DetailMod2XLevel9_3" : "DetailMod2XLevel9_1"];
+                ShaderPasses = ShaderPassesDetailMod2X;
+            }
+            else switch (Options & SceneryMaterialOptions.ShaderMask)
             {
                 case SceneryMaterialOptions.ShaderImage:
                     shader.CurrentTechnique = shader.Techniques[level9_3 ? "ImageLevel9_3" : "ImageLevel9_1"];
@@ -927,6 +943,9 @@ namespace Orts.Viewer3D
                 shader.ImageTexture = Texture;
                 shader.ImageTextureIsNight = false;
             }
+
+            if ((Options & SceneryMaterialOptions.DetailMod2X) != 0)
+                shader.DetailTexture = DetailTexture;
         }
 
         public override void Render(GraphicsDevice graphicsDevice, IEnumerable<RenderItem> renderItems, ref Matrix XNAViewMatrix, ref Matrix XNAProjectionMatrix)
@@ -1030,6 +1049,7 @@ namespace Orts.Viewer3D
         public override void Mark()
         {
             Viewer.TextureManager.Mark(Texture);
+            Viewer.TextureManager.Mark(DetailTexture);
             Viewer.TextureManager.Mark(NightTexture);
             base.Mark();
         }

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -1006,13 +1006,15 @@ namespace Orts.Viewer3D
 
             bool alphaTestRequested = (Options & SceneryMaterialOptions.AlphaTest) != 0;            // the artist requested alpha testing for this material
             bool alphaBlendRequested = (Options & SceneryMaterialOptions.AlphaBlendingMask) != 0;   // the artist specified a blend capable shader
+            bool vertexAlphaRequested = (Options & SceneryMaterialOptions.BakedVertexLighting) != 0; // MSTS vertex colors may supply alpha even when the ACE has none
 
             return alphaBlendRequested                                   // the material is using a blend capable shader   
                     && (AceAlphaBits > 1                                    // and the original ace has more than 1 bit of alpha
-                          || (AceAlphaBits == 1 && !alphaTestRequested));    //  or its just 1 bit, but with no alphatesting, we must blend it anyway
+                          || (AceAlphaBits == 1 && !alphaTestRequested)      //  or its just 1 bit, but with no alphatesting, we must blend it anyway
+                          || vertexAlphaRequested);                         //  or vertex colors may provide alpha
 
             // To summarize, assuming we are using a blend capable shader ..
-            //     0 bits of alpha - never blend
+            //     0 bits of alpha - only blend if vertex colors may provide alpha
             //     1 bit of alpha - only blend if the alpha test wasn't requested
             //     >1 bit of alpha - always blend
         }

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -970,6 +970,7 @@ namespace Orts.Viewer3D
                     shader.ZBias = item.RenderPrimitive.ZBias;
                     shader.UVScale = item.RenderPrimitive.UVScale;
                     shader.DetailUVScaleRatio = item.RenderPrimitive.DetailUVScaleRatio;
+                    shader.UVOpReflectMapFull = item.RenderPrimitive.UVOpReflectMapFull;
                     ShaderPasses.Current.Apply();
 
                     // SamplerStates can only be set after the ShaderPasses.Current.Apply().
@@ -990,6 +991,7 @@ namespace Orts.Viewer3D
             shader.VertexLightingEnabled = false;
             shader.VertexLightingDay = 1;
             shader.NightLightModifier = 1;
+            shader.UVOpReflectMapFull = false;
 
             graphicsDevice.BlendState = BlendState.Opaque;
             graphicsDevice.DepthStencilState = DepthStencilState.Default;

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -723,6 +723,8 @@ namespace Orts.Viewer3D
         NightLight = 0x2000,
         // Modulate scenery with baked MSTS per-vertex lighting.
         BakedVertexLighting = 0x4000,
+        // Add a second environment-map texture to the lit base texture.
+        GlossMap = 0x8000,
         // Texture to be shown in tunnels and underground (used for 3D cab night textures)
         UndergroundTexture = 0x40000000,
     }
@@ -739,6 +741,7 @@ namespace Orts.Viewer3D
         byte AceAlphaBits;   // the number of bits in the ace file's alpha channel 
         IEnumerator<EffectPass> ShaderPassesDarkShade;
         IEnumerator<EffectPass> ShaderPassesDetailMod2X;
+        IEnumerator<EffectPass> ShaderPassesGlossMap;
         IEnumerator<EffectPass> ShaderPassesFullBright;
         IEnumerator<EffectPass> ShaderPassesHalfBright;
         IEnumerator<EffectPass> ShaderPassesImage;
@@ -836,6 +839,7 @@ namespace Orts.Viewer3D
             var level9_3 = Viewer.Settings.IsDirectXFeatureLevelIncluded(ORTS.Settings.UserSettings.DirectXFeature.Level9_3);
             if (ShaderPassesDarkShade == null) ShaderPassesDarkShade = shader.Techniques[level9_3 ? "DarkShadeLevel9_3" : "DarkShadeLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesDetailMod2X == null) ShaderPassesDetailMod2X = shader.Techniques[level9_3 ? "DetailMod2XLevel9_3" : "DetailMod2XLevel9_1"].Passes.GetEnumerator();
+            if (ShaderPassesGlossMap == null) ShaderPassesGlossMap = shader.Techniques[level9_3 ? "GlossMapLevel9_3" : "GlossMapLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesFullBright == null) ShaderPassesFullBright = shader.Techniques[level9_3 ? "FullBrightLevel9_3" : "FullBrightLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesHalfBright == null) ShaderPassesHalfBright = shader.Techniques[level9_3 ? "HalfBrightLevel9_3" : "HalfBrightLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesImage == null) ShaderPassesImage = shader.Techniques[level9_3 ? "ImageLevel9_3" : "ImageLevel9_1"].Passes.GetEnumerator();
@@ -894,6 +898,11 @@ namespace Orts.Viewer3D
                 shader.CurrentTechnique = shader.Techniques[level9_3 ? "DetailMod2XLevel9_3" : "DetailMod2XLevel9_1"];
                 ShaderPasses = ShaderPassesDetailMod2X;
             }
+            else if ((Options & SceneryMaterialOptions.GlossMap) != 0)
+            {
+                shader.CurrentTechnique = shader.Techniques[level9_3 ? "GlossMapLevel9_3" : "GlossMapLevel9_1"];
+                ShaderPasses = ShaderPassesGlossMap;
+            }
             else switch (Options & SceneryMaterialOptions.ShaderMask)
             {
                 case SceneryMaterialOptions.ShaderImage:
@@ -947,7 +956,7 @@ namespace Orts.Viewer3D
                 shader.ImageTextureIsNight = false;
             }
 
-            if ((Options & SceneryMaterialOptions.DetailMod2X) != 0)
+            if ((Options & (SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap)) != 0)
                 shader.DetailTexture = DetailTexture;
 
             shader.VertexLightingEnabled = (Options & SceneryMaterialOptions.BakedVertexLighting) != 0;
@@ -971,6 +980,7 @@ namespace Orts.Viewer3D
                     shader.UVScale = item.RenderPrimitive.UVScale;
                     shader.DetailUVScaleRatio = item.RenderPrimitive.DetailUVScaleRatio;
                     shader.UVOpReflectMapFull = item.RenderPrimitive.UVOpReflectMapFull;
+                    shader.DetailUVOpReflectMapFull = item.RenderPrimitive.DetailUVOpReflectMapFull;
                     ShaderPasses.Current.Apply();
 
                     // SamplerStates can only be set after the ShaderPasses.Current.Apply().
@@ -992,6 +1002,7 @@ namespace Orts.Viewer3D
             shader.VertexLightingDay = 1;
             shader.NightLightModifier = 1;
             shader.UVOpReflectMapFull = false;
+            shader.DetailUVOpReflectMapFull = false;
 
             graphicsDevice.BlendState = BlendState.Opaque;
             graphicsDevice.DepthStencilState = DepthStencilState.Default;

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -951,14 +951,13 @@ namespace Orts.Viewer3D
                 shader.DetailTexture = DetailTexture;
 
             shader.VertexLightingEnabled = (Options & SceneryMaterialOptions.BakedVertexLighting) != 0;
-            shader.VertexLightingDay = Viewer.MaterialManager.sunDirection.Y >= 0;
+            var daylight = GetDaylightFactor();
+            shader.VertexLightingDay = daylight;
+            shader.NightLightModifier = (Options & SceneryMaterialOptions.NightLight) != 0 ? 1 - daylight : 1;
         }
 
         public override void Render(GraphicsDevice graphicsDevice, IEnumerable<RenderItem> renderItems, ref Matrix XNAViewMatrix, ref Matrix XNAProjectionMatrix)
         {
-            if ((Options & SceneryMaterialOptions.NightLight) != 0 && !IsNightTextureActive())
-                return;
-
             var shader = Viewer.MaterialManager.SceneryShader;
 
             ShaderPasses.Reset();
@@ -987,7 +986,8 @@ namespace Orts.Viewer3D
             shader.LightingSpecular = 0;
             shader.ReferenceAlpha = 0;
             shader.VertexLightingEnabled = false;
-            shader.VertexLightingDay = true;
+            shader.VertexLightingDay = 1;
+            shader.NightLightModifier = 1;
 
             graphicsDevice.BlendState = BlendState.Opaque;
             graphicsDevice.DepthStencilState = DepthStencilState.Default;
@@ -1027,6 +1027,16 @@ namespace Orts.Viewer3D
         {
             return NightTexture != null && NightTexture != SharedMaterialManager.MissingTexture && (((Options & SceneryMaterialOptions.UndergroundTexture) != 0 &&
                 (Viewer.MaterialManager.sunDirection.Y < -0.085f || Viewer.Camera.IsUnderground)) || Viewer.MaterialManager.sunDirection.Y < 0.0f - ((float)KeyLengthRemainder()) / 5000f);
+        }
+
+        private float GetDaylightFactor()
+        {
+            if (Viewer.Camera.IsUnderground)
+                return 0;
+
+            const float startNightTrans = 0.1f;
+            const float finishNightTrans = -0.1f;
+            return MathHelper.Clamp((Viewer.MaterialManager.sunDirection.Y - finishNightTrans) / (startNightTrans - finishNightTrans), 0, 1);
         }
 
         public override SamplerState GetShadowTextureAddressMode()

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -719,6 +719,8 @@ namespace Orts.Viewer3D
         NightTexture = 0x800,
         // Modulate base texture with detail texture and double the result.
         DetailMod2X = 0x1000,
+        // Draw only when the night texture variant is active.
+        NightLight = 0x2000,
         // Texture to be shown in tunnels and underground (used for 3D cab night textures)
         UndergroundTexture = 0x40000000,
     }
@@ -932,8 +934,7 @@ namespace Orts.Viewer3D
                     throw new InvalidDataException("Options has unexpected SceneryMaterialOptions.SpecularMask value.");
             }
 
-            if (NightTexture != null && NightTexture != SharedMaterialManager.MissingTexture && (((Options & SceneryMaterialOptions.UndergroundTexture) != 0 &&
-                (Viewer.MaterialManager.sunDirection.Y < -0.085f || Viewer.Camera.IsUnderground)) || Viewer.MaterialManager.sunDirection.Y < 0.0f - ((float)KeyLengthRemainder()) / 5000f))
+            if (IsNightTextureActive())
             {
                 shader.ImageTexture = NightTexture;
                 shader.ImageTextureIsNight = true;
@@ -950,6 +951,9 @@ namespace Orts.Viewer3D
 
         public override void Render(GraphicsDevice graphicsDevice, IEnumerable<RenderItem> renderItems, ref Matrix XNAViewMatrix, ref Matrix XNAProjectionMatrix)
         {
+            if ((Options & SceneryMaterialOptions.NightLight) != 0 && !IsNightTextureActive())
+                return;
+
             var shader = Viewer.MaterialManager.SceneryShader;
 
             ShaderPasses.Reset();
@@ -988,6 +992,9 @@ namespace Orts.Viewer3D
         /// <returns></returns>
         public override bool GetBlending()
         {
+            if ((Options & SceneryMaterialOptions.NightLight) != 0)
+                return true;
+
             bool alphaTestRequested = (Options & SceneryMaterialOptions.AlphaTest) != 0;            // the artist requested alpha testing for this material
             bool alphaBlendRequested = (Options & SceneryMaterialOptions.AlphaBlendingMask) != 0;   // the artist specified a blend capable shader
 
@@ -1003,12 +1010,16 @@ namespace Orts.Viewer3D
 
         public override Texture2D GetShadowTexture()
         {
-            var timeOffset = ((float)KeyLengthRemainder()) / 5000f; // TODO for later use for pseudorandom texture switch time
-            if (NightTexture != null && NightTexture != SharedMaterialManager.MissingTexture && (((Options & SceneryMaterialOptions.UndergroundTexture) != 0 &&
-                (Viewer.MaterialManager.sunDirection.Y < -0.085f || Viewer.Camera.IsUnderground)) || Viewer.MaterialManager.sunDirection.Y < 0.0f - ((float)KeyLengthRemainder()) / 5000f))
+            if (IsNightTextureActive())
                 return NightTexture;
 
             return Texture;
+        }
+
+        private bool IsNightTextureActive()
+        {
+            return NightTexture != null && NightTexture != SharedMaterialManager.MissingTexture && (((Options & SceneryMaterialOptions.UndergroundTexture) != 0 &&
+                (Viewer.MaterialManager.sunDirection.Y < -0.085f || Viewer.Camera.IsUnderground)) || Viewer.MaterialManager.sunDirection.Y < 0.0f - ((float)KeyLengthRemainder()) / 5000f);
         }
 
         public override SamplerState GetShadowTextureAddressMode()

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -990,7 +990,6 @@ namespace Orts.Viewer3D
                     shader.DetailUVScaleRatio = item.RenderPrimitive.DetailUVScaleRatio;
                     shader.UVOpReflectMapFull = item.RenderPrimitive.UVOpReflectMapFull;
                     shader.DetailUVOpReflectMapFull = item.RenderPrimitive.DetailUVOpReflectMapFull;
-                    shader.EnvMapTransform = GetEnvMapTransform(item);
                     ShaderPasses.Current.Apply();
 
                     // SamplerStates can only be set after the ShaderPasses.Current.Apply().
@@ -1013,27 +1012,9 @@ namespace Orts.Viewer3D
             shader.NightLightModifier = 1;
             shader.UVOpReflectMapFull = false;
             shader.DetailUVOpReflectMapFull = false;
-            shader.EnvMapTransform = Matrix.Identity;
 
             graphicsDevice.BlendState = BlendState.Opaque;
             graphicsDevice.DepthStencilState = DepthStencilState.Default;
-        }
-
-        static Matrix GetEnvMapTransform(RenderItem item)
-        {
-            if (!item.RenderPrimitive.UVOpReflectMapFull && !item.RenderPrimitive.DetailUVOpReflectMapFull)
-                return Matrix.Identity;
-
-            var envMapRootMatrix = item.EnvMapRootMatrix;
-            if (Math.Abs(envMapRootMatrix.Determinant()) < 0.000001f)
-                return Matrix.Identity;
-
-            Matrix envMapRootInverse;
-            Matrix.Invert(ref envMapRootMatrix, out envMapRootInverse);
-
-            var envMapTransform = Matrix.Identity;
-            Matrix.Multiply(ref envMapRootInverse, ref item.XNAMatrix, out envMapTransform);
-            return envMapTransform;
         }
 
         /// <summary>

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -969,6 +969,7 @@ namespace Orts.Viewer3D
                     shader.SetMatrix(item.XNAMatrix, ref XNAViewMatrix, ref XNAProjectionMatrix);
                     shader.ZBias = item.RenderPrimitive.ZBias;
                     shader.UVScale = item.RenderPrimitive.UVScale;
+                    shader.DetailUVScaleRatio = item.RenderPrimitive.DetailUVScaleRatio;
                     ShaderPasses.Current.Apply();
 
                     // SamplerStates can only be set after the ShaderPasses.Current.Apply().

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -725,6 +725,8 @@ namespace Orts.Viewer3D
         BakedVertexLighting = 0x4000,
         // Add a second environment-map texture to the lit base texture.
         GlossMap = 0x8000,
+        // Blend a second environment-map texture by the inverse alpha of the base texture.
+        AlphRefMap = 0x10000,
         // Texture to be shown in tunnels and underground (used for 3D cab night textures)
         UndergroundTexture = 0x40000000,
     }
@@ -742,6 +744,7 @@ namespace Orts.Viewer3D
         IEnumerator<EffectPass> ShaderPassesDarkShade;
         IEnumerator<EffectPass> ShaderPassesDetailMod2X;
         IEnumerator<EffectPass> ShaderPassesGlossMap;
+        IEnumerator<EffectPass> ShaderPassesAlphRefMap;
         IEnumerator<EffectPass> ShaderPassesFullBright;
         IEnumerator<EffectPass> ShaderPassesHalfBright;
         IEnumerator<EffectPass> ShaderPassesImage;
@@ -840,6 +843,7 @@ namespace Orts.Viewer3D
             if (ShaderPassesDarkShade == null) ShaderPassesDarkShade = shader.Techniques[level9_3 ? "DarkShadeLevel9_3" : "DarkShadeLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesDetailMod2X == null) ShaderPassesDetailMod2X = shader.Techniques[level9_3 ? "DetailMod2XLevel9_3" : "DetailMod2XLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesGlossMap == null) ShaderPassesGlossMap = shader.Techniques[level9_3 ? "GlossMapLevel9_3" : "GlossMapLevel9_1"].Passes.GetEnumerator();
+            if (ShaderPassesAlphRefMap == null) ShaderPassesAlphRefMap = shader.Techniques[level9_3 ? "AlphRefMapLevel9_3" : "AlphRefMapLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesFullBright == null) ShaderPassesFullBright = shader.Techniques[level9_3 ? "FullBrightLevel9_3" : "FullBrightLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesHalfBright == null) ShaderPassesHalfBright = shader.Techniques[level9_3 ? "HalfBrightLevel9_3" : "HalfBrightLevel9_1"].Passes.GetEnumerator();
             if (ShaderPassesImage == null) ShaderPassesImage = shader.Techniques[level9_3 ? "ImageLevel9_3" : "ImageLevel9_1"].Passes.GetEnumerator();
@@ -903,6 +907,11 @@ namespace Orts.Viewer3D
                 shader.CurrentTechnique = shader.Techniques[level9_3 ? "GlossMapLevel9_3" : "GlossMapLevel9_1"];
                 ShaderPasses = ShaderPassesGlossMap;
             }
+            else if ((Options & SceneryMaterialOptions.AlphRefMap) != 0)
+            {
+                shader.CurrentTechnique = shader.Techniques[level9_3 ? "AlphRefMapLevel9_3" : "AlphRefMapLevel9_1"];
+                ShaderPasses = ShaderPassesAlphRefMap;
+            }
             else switch (Options & SceneryMaterialOptions.ShaderMask)
             {
                 case SceneryMaterialOptions.ShaderImage:
@@ -956,7 +965,7 @@ namespace Orts.Viewer3D
                 shader.ImageTextureIsNight = false;
             }
 
-            if ((Options & (SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap)) != 0)
+            if ((Options & (SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap | SceneryMaterialOptions.AlphRefMap)) != 0)
                 shader.DetailTexture = DetailTexture;
 
             shader.VertexLightingEnabled = (Options & SceneryMaterialOptions.BakedVertexLighting) != 0;

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -252,8 +252,8 @@ namespace Orts.Viewer3D
     public class SharedMaterialManager
     {
         readonly Viewer Viewer;
-        IDictionary<(string, string, string, int, float, Effect), Material> Materials = new Dictionary<(string, string, string, int, float, Effect), Material>();
-        IDictionary<(string, string, string, int, float, Effect), bool> MaterialMarks = new Dictionary<(string, string, string, int, float, Effect), bool>();
+        IDictionary<(string, string, string, int, float, Effect, float, int), Material> Materials = new Dictionary<(string, string, string, int, float, Effect, float, int), Material>();
+        IDictionary<(string, string, string, int, float, Effect, float, int), bool> MaterialMarks = new Dictionary<(string, string, string, int, float, Effect, float, int), bool>();
 
         public readonly LightConeShader LightConeShader;
         public readonly LightGlowShader LightGlowShader;
@@ -317,9 +317,9 @@ namespace Orts.Viewer3D
 
         }
 
-        public Material Load(string materialName, string textureName = null, int options = 0, float mipMapBias = 0f, Effect effect = null, string detailTextureName = null)
+        public Material Load(string materialName, string textureName = null, int options = 0, float mipMapBias = 0f, Effect effect = null, string detailTextureName = null, float detailMipMapBias = 0f, int detailTextureAddressMode = 1)
         {
-            var materialKey = (materialName, textureName?.ToLowerInvariant(), detailTextureName?.ToLowerInvariant(), options, mipMapBias, effect);
+            var materialKey = (materialName, textureName?.ToLowerInvariant(), detailTextureName?.ToLowerInvariant(), options, mipMapBias, effect, detailMipMapBias, detailTextureAddressMode);
             if (!Materials.ContainsKey(materialKey))
             {
                 switch (materialName)
@@ -352,7 +352,7 @@ namespace Orts.Viewer3D
                         Materials[materialKey] = new PrecipitationMaterial(Viewer);
                         break;
                     case "Scenery":
-                        Materials[materialKey] = new SceneryMaterial(Viewer, textureName, (SceneryMaterialOptions)options, mipMapBias, detailTextureName);
+                        Materials[materialKey] = new SceneryMaterial(Viewer, textureName, (SceneryMaterialOptions)options, mipMapBias, detailTextureName, detailMipMapBias, detailTextureAddressMode);
                         break;
                     case "ShadowMap":
                         Materials[materialKey] = new ShadowMapMaterial(Viewer);
@@ -579,7 +579,7 @@ namespace Orts.Viewer3D
     {
         public readonly Viewer Viewer;
         public readonly string Key;
-        internal (string, string, string, int, float, Effect) MarkKey;
+        internal (string, string, string, int, float, Effect, float, int) MarkKey;
 
         protected Material(Viewer viewer, string key)
         {
@@ -739,6 +739,8 @@ namespace Orts.Viewer3D
         private readonly string TexturePath;
         protected Texture2D DetailTexture;
         private readonly string DetailTexturePath;
+        readonly float DetailMipMapBias;
+        readonly int DetailTextureAddressMode;
         protected Texture2D NightTexture;
         byte AceAlphaBits;   // the number of bits in the ace file's alpha channel 
         IEnumerator<EffectPass> ShaderPassesDarkShade;
@@ -757,13 +759,15 @@ namespace Orts.Viewer3D
         };
         private static readonly Dictionary<TextureAddressMode, Dictionary<float, SamplerState>> SamplerStates = new Dictionary<TextureAddressMode, Dictionary<float, SamplerState>>();
 
-        public SceneryMaterial(Viewer viewer, string texturePath, SceneryMaterialOptions options, float mipMapBias, string detailTexturePath)
-            : base(viewer, String.Format("{0}:{1}:{2:X}:{3}", texturePath, detailTexturePath, options, mipMapBias))
+        public SceneryMaterial(Viewer viewer, string texturePath, SceneryMaterialOptions options, float mipMapBias, string detailTexturePath, float detailMipMapBias, int detailTextureAddressMode)
+            : base(viewer, String.Format("{0}:{1}:{2:X}:{3}:{4}:{5}", texturePath, detailTexturePath, options, mipMapBias, detailMipMapBias, detailTextureAddressMode))
         {
             Options = options;
             MipMapBias = mipMapBias;
             TexturePath = texturePath;
             DetailTexturePath = detailTexturePath;
+            DetailMipMapBias = detailMipMapBias;
+            DetailTextureAddressMode = detailTextureAddressMode;
             Texture = SharedMaterialManager.MissingTexture;
             DetailTexture = SharedMaterialManager.MissingTexture;
             NightTexture = SharedMaterialManager.MissingTexture;
@@ -994,6 +998,8 @@ namespace Orts.Viewer3D
 
                     // SamplerStates can only be set after the ShaderPasses.Current.Apply().
                     graphicsDevice.SamplerStates[0] = GetShadowTextureAddressMode();
+                    if ((Options & (SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap | SceneryMaterialOptions.AlphRefMap)) != 0)
+                        graphicsDevice.SamplerStates[1] = GetDetailTextureAddressMode();
 
                     item.RenderPrimitive.Draw(graphicsDevice);
                 }
@@ -1067,9 +1073,18 @@ namespace Orts.Viewer3D
 
         public override SamplerState GetShadowTextureAddressMode()
         {
-            var mipMapBias = MipMapBias < -1 ? -1 : MipMapBias;
+            return GetTextureAddressMode(Options, MipMapBias);
+        }
+
+        SamplerState GetDetailTextureAddressMode()
+        {
+            return GetTextureAddressMode(DetailTextureAddressMode, DetailMipMapBias);
+        }
+
+        static SamplerState GetTextureAddressMode(SceneryMaterialOptions options, float mipMapBias)
+        {
             TextureAddressMode textureAddressMode;
-            switch (Options & SceneryMaterialOptions.TextureAddressModeMask)
+            switch (options & SceneryMaterialOptions.TextureAddressModeMask)
             {
                 case SceneryMaterialOptions.TextureAddressModeWrap:
                     textureAddressMode = TextureAddressMode.Wrap; break;
@@ -1082,6 +1097,30 @@ namespace Orts.Viewer3D
                 default:
                     throw new InvalidDataException("Options has unexpected SceneryMaterialOptions.TextureAddressModeMask value.");
             }
+
+            return GetTextureAddressMode(textureAddressMode, mipMapBias);
+        }
+
+        static SamplerState GetTextureAddressMode(int textureAddressMode, float mipMapBias)
+        {
+            switch (textureAddressMode)
+            {
+                case 1:
+                    return GetTextureAddressMode(TextureAddressMode.Wrap, mipMapBias);
+                case 2:
+                    return GetTextureAddressMode(TextureAddressMode.Mirror, mipMapBias);
+                case 3:
+                    return GetTextureAddressMode(TextureAddressMode.Clamp, mipMapBias);
+                case 4:
+                    return GetTextureAddressMode(TextureAddressMode.Border, mipMapBias);
+                default:
+                    throw new InvalidDataException("Texture address mode has unexpected value.");
+            }
+        }
+
+        static SamplerState GetTextureAddressMode(TextureAddressMode textureAddressMode, float mipMapBias)
+        {
+            mipMapBias = mipMapBias < -1 ? -1 : mipMapBias;
 
             if (!SamplerStates.ContainsKey(textureAddressMode))
                 SamplerStates.Add(textureAddressMode, new Dictionary<float, SamplerState>());
@@ -1097,7 +1136,6 @@ namespace Orts.Viewer3D
                 });
 
             return SamplerStates[textureAddressMode][mipMapBias];
-
         }
 
         public override void Mark()
@@ -1267,7 +1305,7 @@ namespace Orts.Viewer3D
         public readonly int HierarchyIndex;
 
         public ScreenMaterial(Viewer viewer, string key, int hierarchyIndex)
-            : base(viewer, key, SceneryMaterialOptions.ShaderFullBright, 0, null)
+            : base(viewer, key, SceneryMaterialOptions.ShaderFullBright, 0, null, 0, 1)
         {
             HierarchyIndex = hierarchyIndex;
         }

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -990,6 +990,7 @@ namespace Orts.Viewer3D
                     shader.DetailUVScaleRatio = item.RenderPrimitive.DetailUVScaleRatio;
                     shader.UVOpReflectMapFull = item.RenderPrimitive.UVOpReflectMapFull;
                     shader.DetailUVOpReflectMapFull = item.RenderPrimitive.DetailUVOpReflectMapFull;
+                    shader.EnvMapTransform = GetEnvMapTransform(item);
                     ShaderPasses.Current.Apply();
 
                     // SamplerStates can only be set after the ShaderPasses.Current.Apply().
@@ -1012,9 +1013,27 @@ namespace Orts.Viewer3D
             shader.NightLightModifier = 1;
             shader.UVOpReflectMapFull = false;
             shader.DetailUVOpReflectMapFull = false;
+            shader.EnvMapTransform = Matrix.Identity;
 
             graphicsDevice.BlendState = BlendState.Opaque;
             graphicsDevice.DepthStencilState = DepthStencilState.Default;
+        }
+
+        static Matrix GetEnvMapTransform(RenderItem item)
+        {
+            if (!item.RenderPrimitive.UVOpReflectMapFull && !item.RenderPrimitive.DetailUVOpReflectMapFull)
+                return Matrix.Identity;
+
+            var envMapRootMatrix = item.EnvMapRootMatrix;
+            if (Math.Abs(envMapRootMatrix.Determinant()) < 0.000001f)
+                return Matrix.Identity;
+
+            Matrix envMapRootInverse;
+            Matrix.Invert(ref envMapRootMatrix, out envMapRootInverse);
+
+            var envMapTransform = Matrix.Identity;
+            Matrix.Multiply(ref envMapRootInverse, ref item.XNAMatrix, out envMapTransform);
+            return envMapTransform;
         }
 
         /// <summary>

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -757,7 +757,7 @@ namespace Orts.Viewer3D
         };
         private static readonly Dictionary<TextureAddressMode, Dictionary<float, SamplerState>> SamplerStates = new Dictionary<TextureAddressMode, Dictionary<float, SamplerState>>();
 
-        public SceneryMaterial(Viewer viewer, string texturePath, SceneryMaterialOptions options, float mipMapBias, string detailTexturePath = null)
+        public SceneryMaterial(Viewer viewer, string texturePath, SceneryMaterialOptions options, float mipMapBias, string detailTexturePath)
             : base(viewer, String.Format("{0}:{1}:{2:X}:{3}", texturePath, detailTexturePath, options, mipMapBias))
         {
             Options = options;
@@ -1267,7 +1267,7 @@ namespace Orts.Viewer3D
         public readonly int HierarchyIndex;
 
         public ScreenMaterial(Viewer viewer, string key, int hierarchyIndex)
-            : base(viewer, key, SceneryMaterialOptions.ShaderFullBright, 0)
+            : base(viewer, key, SceneryMaterialOptions.ShaderFullBright, 0, null)
         {
             HierarchyIndex = hierarchyIndex;
         }

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -721,6 +721,8 @@ namespace Orts.Viewer3D
         DetailMod2X = 0x1000,
         // Draw only when the night texture variant is active.
         NightLight = 0x2000,
+        // Modulate scenery with baked MSTS per-vertex lighting.
+        BakedVertexLighting = 0x4000,
         // Texture to be shown in tunnels and underground (used for 3D cab night textures)
         UndergroundTexture = 0x40000000,
     }
@@ -947,6 +949,9 @@ namespace Orts.Viewer3D
 
             if ((Options & SceneryMaterialOptions.DetailMod2X) != 0)
                 shader.DetailTexture = DetailTexture;
+
+            shader.VertexLightingEnabled = (Options & SceneryMaterialOptions.BakedVertexLighting) != 0;
+            shader.VertexLightingDay = Viewer.MaterialManager.sunDirection.Y >= 0;
         }
 
         public override void Render(GraphicsDevice graphicsDevice, IEnumerable<RenderItem> renderItems, ref Matrix XNAViewMatrix, ref Matrix XNAProjectionMatrix)
@@ -981,6 +986,8 @@ namespace Orts.Viewer3D
             shader.LightingDiffuse = 1;
             shader.LightingSpecular = 0;
             shader.ReferenceAlpha = 0;
+            shader.VertexLightingEnabled = false;
+            shader.VertexLightingDay = true;
 
             graphicsDevice.BlendState = BlendState.Opaque;
             graphicsDevice.DepthStencilState = DepthStencilState.Default;

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -1016,6 +1016,8 @@ namespace Orts.Viewer3D
             shader.VertexLightingEnabled = false;
             shader.VertexLightingDay = 1;
             shader.NightLightModifier = 1;
+            shader.UVScale = Vector2.One;
+            shader.DetailUVScaleRatio = Vector2.One;
             shader.UVOpReflectMapFull = false;
             shader.DetailUVOpReflectMapFull = false;
 

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -114,6 +114,7 @@ namespace Orts.Viewer3D
         public Vector2 UVScale = Vector2.One;
         public Vector2 DetailUVScaleRatio = Vector2.One;
         public bool UVOpReflectMapFull;
+        public bool DetailUVOpReflectMapFull;
 
         /// <summary>
         /// This is a sorting adjustment for primitives with similar/the same world location. Primitives with higher SortIndex values are rendered after others. Has no effect on non-blended primitives.

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -149,7 +149,6 @@ namespace Orts.Viewer3D
         public Material Material;
         public RenderPrimitive RenderPrimitive;
         public Matrix XNAMatrix;
-        public Matrix EnvMapRootMatrix;
         public ShapeFlags Flags;
         public object ItemData;
 
@@ -158,7 +157,6 @@ namespace Orts.Viewer3D
             Material = material;
             RenderPrimitive = renderPrimitive;
             XNAMatrix = xnaMatrix;
-            EnvMapRootMatrix = Matrix.Identity;
             Flags = flags;
             ItemData = itemData;
         }

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -113,6 +113,7 @@ namespace Orts.Viewer3D
 
         public Vector2 UVScale = Vector2.One;
         public Vector2 DetailUVScaleRatio = Vector2.One;
+        public bool UVOpReflectMapFull;
 
         /// <summary>
         /// This is a sorting adjustment for primitives with similar/the same world location. Primitives with higher SortIndex values are rendered after others. Has no effect on non-blended primitives.

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -149,14 +149,21 @@ namespace Orts.Viewer3D
         public Material Material;
         public RenderPrimitive RenderPrimitive;
         public Matrix XNAMatrix;
+        public Matrix EnvMapRootMatrix;
         public ShapeFlags Flags;
         public object ItemData;
 
         public RenderItem(Material material, RenderPrimitive renderPrimitive, ref Matrix xnaMatrix, ShapeFlags flags, object itemData = null)
+            : this(material, renderPrimitive, ref xnaMatrix, ref xnaMatrix, flags, itemData)
+        {
+        }
+
+        public RenderItem(Material material, RenderPrimitive renderPrimitive, ref Matrix xnaMatrix, ref Matrix envMapRootMatrix, ShapeFlags flags, object itemData = null)
         {
             Material = material;
             RenderPrimitive = renderPrimitive;
             XNAMatrix = xnaMatrix;
+            EnvMapRootMatrix = envMapRootMatrix;
             Flags = flags;
             ItemData = itemData;
         }
@@ -593,10 +600,16 @@ namespace Orts.Viewer3D
         [CallOnThread("Updater")]
         public void AddAutoPrimitive(Vector3 mstsLocation, float objectRadius, float objectViewingDistance, Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ShapeFlags flags)
         {
+            AddAutoPrimitive(mstsLocation, objectRadius, objectViewingDistance, material, primitive, group, ref xnaMatrix, ref xnaMatrix, flags);
+        }
+
+        [CallOnThread("Updater")]
+        public void AddAutoPrimitive(Vector3 mstsLocation, float objectRadius, float objectViewingDistance, Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ref Matrix envMapRootMatrix, ShapeFlags flags)
+        {
             if (float.IsPositiveInfinity(objectViewingDistance) || (Camera != null && Camera.InRange(mstsLocation, objectRadius, objectViewingDistance)))
             {
                 if (Camera != null && Camera.InFov(mstsLocation, objectRadius))
-                    AddPrimitive(material, primitive, group, ref xnaMatrix, flags);
+                    AddPrimitive(material, primitive, group, ref xnaMatrix, ref envMapRootMatrix, flags);
             }
 
             if (Game.Settings.DynamicShadows && (RenderProcess.ShadowMapCount > 0) && ((flags & ShapeFlags.ShadowCaster) != 0))
@@ -622,7 +635,19 @@ namespace Orts.Viewer3D
         }
 
         [CallOnThread("Updater")]
+        public void AddPrimitive(Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ref Matrix envMapRootMatrix, ShapeFlags flags)
+        {
+            AddPrimitive(material, primitive, group, ref xnaMatrix, ref envMapRootMatrix, flags, null);
+        }
+
+        [CallOnThread("Updater")]
         public void AddPrimitive(Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ShapeFlags flags, object itemData)
+        {
+            AddPrimitive(material, primitive, group, ref xnaMatrix, ref xnaMatrix, flags, itemData);
+        }
+
+        [CallOnThread("Updater")]
+        public void AddPrimitive(Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ref Matrix envMapRootMatrix, ShapeFlags flags, object itemData)
         {
             var getBlending = material.GetBlending();
             var blending = getBlending && material is SceneryMaterial ? PrimitiveBlendedScenery : getBlending ? PrimitiveBlended : PrimitiveNotBlended;
@@ -638,7 +663,7 @@ namespace Orts.Viewer3D
                     items = new RenderItemCollection();
                     sequence.Add(sortingMaterial, items);
                 }
-                items.Add(new RenderItem(material, primitive, ref xnaMatrix, flags, itemData));
+                items.Add(new RenderItem(material, primitive, ref xnaMatrix, ref envMapRootMatrix, flags, itemData));
             }
             if (((flags & ShapeFlags.AutoZBias) != 0) && (primitive.ZBias == 0))
                 primitive.ZBias = 1;

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -111,6 +111,8 @@ namespace Orts.Viewer3D
         // TODO: Does this actually make any real difference?
         public float ZBias;
 
+        public Vector2 UVScale = Vector2.One;
+
         /// <summary>
         /// This is a sorting adjustment for primitives with similar/the same world location. Primitives with higher SortIndex values are rendered after others. Has no effect on non-blended primitives.
         /// </summary>

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -154,16 +154,11 @@ namespace Orts.Viewer3D
         public object ItemData;
 
         public RenderItem(Material material, RenderPrimitive renderPrimitive, ref Matrix xnaMatrix, ShapeFlags flags, object itemData = null)
-            : this(material, renderPrimitive, ref xnaMatrix, ref xnaMatrix, flags, itemData)
-        {
-        }
-
-        public RenderItem(Material material, RenderPrimitive renderPrimitive, ref Matrix xnaMatrix, ref Matrix envMapRootMatrix, ShapeFlags flags, object itemData = null)
         {
             Material = material;
             RenderPrimitive = renderPrimitive;
             XNAMatrix = xnaMatrix;
-            EnvMapRootMatrix = envMapRootMatrix;
+            EnvMapRootMatrix = Matrix.Identity;
             Flags = flags;
             ItemData = itemData;
         }
@@ -600,16 +595,10 @@ namespace Orts.Viewer3D
         [CallOnThread("Updater")]
         public void AddAutoPrimitive(Vector3 mstsLocation, float objectRadius, float objectViewingDistance, Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ShapeFlags flags)
         {
-            AddAutoPrimitive(mstsLocation, objectRadius, objectViewingDistance, material, primitive, group, ref xnaMatrix, ref xnaMatrix, flags);
-        }
-
-        [CallOnThread("Updater")]
-        public void AddAutoPrimitive(Vector3 mstsLocation, float objectRadius, float objectViewingDistance, Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ref Matrix envMapRootMatrix, ShapeFlags flags)
-        {
             if (float.IsPositiveInfinity(objectViewingDistance) || (Camera != null && Camera.InRange(mstsLocation, objectRadius, objectViewingDistance)))
             {
                 if (Camera != null && Camera.InFov(mstsLocation, objectRadius))
-                    AddPrimitive(material, primitive, group, ref xnaMatrix, ref envMapRootMatrix, flags);
+                    AddPrimitive(material, primitive, group, ref xnaMatrix, flags);
             }
 
             if (Game.Settings.DynamicShadows && (RenderProcess.ShadowMapCount > 0) && ((flags & ShapeFlags.ShadowCaster) != 0))
@@ -635,19 +624,7 @@ namespace Orts.Viewer3D
         }
 
         [CallOnThread("Updater")]
-        public void AddPrimitive(Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ref Matrix envMapRootMatrix, ShapeFlags flags)
-        {
-            AddPrimitive(material, primitive, group, ref xnaMatrix, ref envMapRootMatrix, flags, null);
-        }
-
-        [CallOnThread("Updater")]
         public void AddPrimitive(Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ShapeFlags flags, object itemData)
-        {
-            AddPrimitive(material, primitive, group, ref xnaMatrix, ref xnaMatrix, flags, itemData);
-        }
-
-        [CallOnThread("Updater")]
-        public void AddPrimitive(Material material, RenderPrimitive primitive, RenderPrimitiveGroup group, ref Matrix xnaMatrix, ref Matrix envMapRootMatrix, ShapeFlags flags, object itemData)
         {
             var getBlending = material.GetBlending();
             var blending = getBlending && material is SceneryMaterial ? PrimitiveBlendedScenery : getBlending ? PrimitiveBlended : PrimitiveNotBlended;
@@ -663,7 +640,7 @@ namespace Orts.Viewer3D
                     items = new RenderItemCollection();
                     sequence.Add(sortingMaterial, items);
                 }
-                items.Add(new RenderItem(material, primitive, ref xnaMatrix, ref envMapRootMatrix, flags, itemData));
+                items.Add(new RenderItem(material, primitive, ref xnaMatrix, flags, itemData));
             }
             if (((flags & ShapeFlags.AutoZBias) != 0) && (primitive.ZBias == 0))
                 primitive.ZBias = 1;

--- a/Source/RunActivity/Viewer3D/RenderFrame.cs
+++ b/Source/RunActivity/Viewer3D/RenderFrame.cs
@@ -112,6 +112,7 @@ namespace Orts.Viewer3D
         public float ZBias;
 
         public Vector2 UVScale = Vector2.One;
+        public Vector2 DetailUVScaleRatio = Vector2.One;
 
         /// <summary>
         /// This is a sorting adjustment for primitives with similar/the same world location. Primitives with higher SortIndex values are rendered after others. Has no effect on non-blended primitives.

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -72,6 +72,7 @@ namespace Orts.Viewer3D
         readonly EffectParameter uvScale;
         readonly EffectParameter detailUVScaleRatio;
         readonly EffectParameter uvOpReflectMapFull;
+        readonly EffectParameter detailUVOpReflectMapFull;
         readonly EffectParameter vertexLightingEnabled;
         readonly EffectParameter vertexLightingDay;
         readonly EffectParameter nightLightModifier;
@@ -202,6 +203,8 @@ namespace Orts.Viewer3D
 
         public bool UVOpReflectMapFull { set { uvOpReflectMapFull.SetValue(value ? 1f : 0f); } }
 
+        public bool DetailUVOpReflectMapFull { set { detailUVOpReflectMapFull.SetValue(value ? 1f : 0f); } }
+
         public bool VertexLightingEnabled { set { vertexLightingEnabled.SetValue(value ? 1f : 0f); } }
 
         public float VertexLightingDay { set { vertexLightingDay.SetValue(value); } }
@@ -247,6 +250,7 @@ namespace Orts.Viewer3D
             uvScale = Parameters["UVScale"];
             detailUVScaleRatio = Parameters["DetailUVScaleRatio"];
             uvOpReflectMapFull = Parameters["UVOpReflectMapFull"];
+            detailUVOpReflectMapFull = Parameters["DetailUVOpReflectMapFull"];
             vertexLightingEnabled = Parameters["VertexLightingEnabled"];
             vertexLightingDay = Parameters["VertexLightingDay"];
             nightLightModifier = Parameters["NightLightModifier"];
@@ -254,6 +258,7 @@ namespace Orts.Viewer3D
             UVScale = Vector2.One;
             DetailUVScaleRatio = Vector2.One;
             UVOpReflectMapFull = false;
+            DetailUVOpReflectMapFull = false;
             VertexLightingEnabled = false;
             VertexLightingDay = 1;
             NightLightModifier = 1;

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -70,6 +70,8 @@ namespace Orts.Viewer3D
         readonly EffectParameter overlayTexture;
         readonly EffectParameter referenceAlpha;
         readonly EffectParameter uvScale;
+        readonly EffectParameter vertexLightingEnabled;
+        readonly EffectParameter vertexLightingDay;
         readonly EffectParameter overlayScale;
 
         Vector3 _eyeVector;
@@ -193,6 +195,10 @@ namespace Orts.Viewer3D
 
         public Vector2 UVScale { set { uvScale.SetValue(value); } }
 
+        public bool VertexLightingEnabled { set { vertexLightingEnabled.SetValue(value ? 1f : 0f); } }
+
+        public bool VertexLightingDay { set { vertexLightingDay.SetValue(value ? 1f : 0f); } }
+
         public float OverlayScale { set { overlayScale.SetValue(value); } }
 
         public SceneryShader(GraphicsDevice graphicsDevice)
@@ -230,8 +236,12 @@ namespace Orts.Viewer3D
             overlayTexture = Parameters["OverlayTexture"];
             referenceAlpha = Parameters["ReferenceAlpha"];
             uvScale = Parameters["UVScale"];
+            vertexLightingEnabled = Parameters["VertexLightingEnabled"];
+            vertexLightingDay = Parameters["VertexLightingDay"];
             overlayScale = Parameters["OverlayScale"];
             UVScale = Vector2.One;
+            VertexLightingEnabled = false;
+            VertexLightingDay = true;
         }
     }
 

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -68,6 +68,7 @@ namespace Orts.Viewer3D
         readonly EffectParameter imageTexture;
         readonly EffectParameter overlayTexture;
         readonly EffectParameter referenceAlpha;
+        readonly EffectParameter uvScale;
         readonly EffectParameter overlayScale;
 
         Vector3 _eyeVector;
@@ -187,6 +188,8 @@ namespace Orts.Viewer3D
 
         public int ReferenceAlpha { set { referenceAlpha.SetValue(value / 255f); } }
 
+        public Vector2 UVScale { set { uvScale.SetValue(value); } }
+
         public float OverlayScale { set { overlayScale.SetValue(value); } }
 
         public SceneryShader(GraphicsDevice graphicsDevice)
@@ -222,7 +225,9 @@ namespace Orts.Viewer3D
             imageTexture = Parameters["ImageTexture"];
             overlayTexture = Parameters["OverlayTexture"];
             referenceAlpha = Parameters["ReferenceAlpha"];
+            uvScale = Parameters["UVScale"];
             overlayScale = Parameters["OverlayScale"];
+            UVScale = Vector2.One;
         }
     }
 
@@ -232,6 +237,7 @@ namespace Orts.Viewer3D
         readonly EffectParameter worldViewProjection;
         readonly EffectParameter sideVector;
         readonly EffectParameter imageBlurStep;
+        readonly EffectParameter uvScale;
         readonly EffectParameter imageTexture;
 
         public void SetData(ref Matrix v)
@@ -240,9 +246,10 @@ namespace Orts.Viewer3D
             sideVector.SetValue(Vector3.Normalize(Vector3.Cross(eyeVector, Vector3.Down)));
         }
 
-        public void SetData(ref Matrix wvp, Texture2D texture)
+        public void SetData(ref Matrix wvp, Texture2D texture, Vector2 uvScale)
         {
             worldViewProjection.SetValue(wvp);
+            this.uvScale.SetValue(uvScale);
             imageTexture.SetValue(texture);
         }
 
@@ -263,7 +270,9 @@ namespace Orts.Viewer3D
             worldViewProjection = Parameters["WorldViewProjection"];
             sideVector = Parameters["SideVector"];
             imageBlurStep = Parameters["ImageBlurStep"];
+            uvScale = Parameters["UVScale"];
             imageTexture = Parameters["ImageTexture"];
+            uvScale.SetValue(Vector2.One);
         }
     }
 

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -72,6 +72,7 @@ namespace Orts.Viewer3D
         readonly EffectParameter uvScale;
         readonly EffectParameter vertexLightingEnabled;
         readonly EffectParameter vertexLightingDay;
+        readonly EffectParameter nightLightModifier;
         readonly EffectParameter overlayScale;
 
         Vector3 _eyeVector;
@@ -197,7 +198,9 @@ namespace Orts.Viewer3D
 
         public bool VertexLightingEnabled { set { vertexLightingEnabled.SetValue(value ? 1f : 0f); } }
 
-        public bool VertexLightingDay { set { vertexLightingDay.SetValue(value ? 1f : 0f); } }
+        public float VertexLightingDay { set { vertexLightingDay.SetValue(value); } }
+
+        public float NightLightModifier { set { nightLightModifier.SetValue(value); } }
 
         public float OverlayScale { set { overlayScale.SetValue(value); } }
 
@@ -238,10 +241,12 @@ namespace Orts.Viewer3D
             uvScale = Parameters["UVScale"];
             vertexLightingEnabled = Parameters["VertexLightingEnabled"];
             vertexLightingDay = Parameters["VertexLightingDay"];
+            nightLightModifier = Parameters["NightLightModifier"];
             overlayScale = Parameters["OverlayScale"];
             UVScale = Vector2.One;
             VertexLightingEnabled = false;
-            VertexLightingDay = true;
+            VertexLightingDay = 1;
+            NightLightModifier = 1;
         }
     }
 

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -46,6 +46,7 @@ namespace Orts.Viewer3D
         readonly EffectParameter world;
         readonly EffectParameter view;
         readonly EffectParameter projection;
+        readonly EffectParameter envMapTransform;
         readonly EffectParameter[] lightViewProjectionShadowProjection;
         readonly EffectParameter[] shadowMapTextures;
         readonly EffectParameter shadowMapLimit;
@@ -201,6 +202,8 @@ namespace Orts.Viewer3D
 
         public Vector2 DetailUVScaleRatio { set { detailUVScaleRatio.SetValue(value); } }
 
+        public Matrix EnvMapTransform { set { envMapTransform.SetValue(value); } }
+
         public bool UVOpReflectMapFull { set { uvOpReflectMapFull.SetValue(value ? 1f : 0f); } }
 
         public bool DetailUVOpReflectMapFull { set { detailUVOpReflectMapFull.SetValue(value ? 1f : 0f); } }
@@ -219,6 +222,7 @@ namespace Orts.Viewer3D
             world = Parameters["World"];
             view = Parameters["View"];
             projection = Parameters["Projection"];
+            envMapTransform = Parameters["EnvMapTransform"];
             lightViewProjectionShadowProjection = new EffectParameter[RenderProcess.ShadowMapCountMaximum];
             shadowMapTextures = new EffectParameter[RenderProcess.ShadowMapCountMaximum];
             for (var i = 0; i < RenderProcess.ShadowMapCountMaximum; i++)
@@ -257,6 +261,7 @@ namespace Orts.Viewer3D
             overlayScale = Parameters["OverlayScale"];
             UVScale = Vector2.One;
             DetailUVScaleRatio = Vector2.One;
+            EnvMapTransform = Matrix.Identity;
             UVOpReflectMapFull = false;
             DetailUVOpReflectMapFull = false;
             VertexLightingEnabled = false;

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -71,6 +71,7 @@ namespace Orts.Viewer3D
         readonly EffectParameter referenceAlpha;
         readonly EffectParameter uvScale;
         readonly EffectParameter detailUVScaleRatio;
+        readonly EffectParameter uvOpReflectMapFull;
         readonly EffectParameter vertexLightingEnabled;
         readonly EffectParameter vertexLightingDay;
         readonly EffectParameter nightLightModifier;
@@ -199,6 +200,8 @@ namespace Orts.Viewer3D
 
         public Vector2 DetailUVScaleRatio { set { detailUVScaleRatio.SetValue(value); } }
 
+        public bool UVOpReflectMapFull { set { uvOpReflectMapFull.SetValue(value ? 1f : 0f); } }
+
         public bool VertexLightingEnabled { set { vertexLightingEnabled.SetValue(value ? 1f : 0f); } }
 
         public float VertexLightingDay { set { vertexLightingDay.SetValue(value); } }
@@ -243,12 +246,14 @@ namespace Orts.Viewer3D
             referenceAlpha = Parameters["ReferenceAlpha"];
             uvScale = Parameters["UVScale"];
             detailUVScaleRatio = Parameters["DetailUVScaleRatio"];
+            uvOpReflectMapFull = Parameters["UVOpReflectMapFull"];
             vertexLightingEnabled = Parameters["VertexLightingEnabled"];
             vertexLightingDay = Parameters["VertexLightingDay"];
             nightLightModifier = Parameters["NightLightModifier"];
             overlayScale = Parameters["OverlayScale"];
             UVScale = Vector2.One;
             DetailUVScaleRatio = Vector2.One;
+            UVOpReflectMapFull = false;
             VertexLightingEnabled = false;
             VertexLightingDay = 1;
             NightLightModifier = 1;

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -70,6 +70,7 @@ namespace Orts.Viewer3D
         readonly EffectParameter overlayTexture;
         readonly EffectParameter referenceAlpha;
         readonly EffectParameter uvScale;
+        readonly EffectParameter detailUVScaleRatio;
         readonly EffectParameter vertexLightingEnabled;
         readonly EffectParameter vertexLightingDay;
         readonly EffectParameter nightLightModifier;
@@ -196,6 +197,8 @@ namespace Orts.Viewer3D
 
         public Vector2 UVScale { set { uvScale.SetValue(value); } }
 
+        public Vector2 DetailUVScaleRatio { set { detailUVScaleRatio.SetValue(value); } }
+
         public bool VertexLightingEnabled { set { vertexLightingEnabled.SetValue(value ? 1f : 0f); } }
 
         public float VertexLightingDay { set { vertexLightingDay.SetValue(value); } }
@@ -239,11 +242,13 @@ namespace Orts.Viewer3D
             overlayTexture = Parameters["OverlayTexture"];
             referenceAlpha = Parameters["ReferenceAlpha"];
             uvScale = Parameters["UVScale"];
+            detailUVScaleRatio = Parameters["DetailUVScaleRatio"];
             vertexLightingEnabled = Parameters["VertexLightingEnabled"];
             vertexLightingDay = Parameters["VertexLightingDay"];
             nightLightModifier = Parameters["NightLightModifier"];
             overlayScale = Parameters["OverlayScale"];
             UVScale = Vector2.One;
+            DetailUVScaleRatio = Vector2.One;
             VertexLightingEnabled = false;
             VertexLightingDay = 1;
             NightLightModifier = 1;

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -66,6 +66,7 @@ namespace Orts.Viewer3D
         readonly EffectParameter eyeVector;
         readonly EffectParameter sideVector;
         readonly EffectParameter imageTexture;
+        readonly EffectParameter detailTexture;
         readonly EffectParameter overlayTexture;
         readonly EffectParameter referenceAlpha;
         readonly EffectParameter uvScale;
@@ -184,6 +185,8 @@ namespace Orts.Viewer3D
 
         public Texture2D ImageTexture { set { imageTexture.SetValue(value); } }
 
+        public Texture2D DetailTexture { set { detailTexture.SetValue(value); } }
+
         public Texture2D OverlayTexture { set { overlayTexture.SetValue(value); } }
 
         public int ReferenceAlpha { set { referenceAlpha.SetValue(value / 255f); } }
@@ -223,6 +226,7 @@ namespace Orts.Viewer3D
             eyeVector = Parameters["EyeVector"];
             sideVector = Parameters["SideVector"];
             imageTexture = Parameters["ImageTexture"];
+            detailTexture = Parameters["DetailTexture"];
             overlayTexture = Parameters["OverlayTexture"];
             referenceAlpha = Parameters["ReferenceAlpha"];
             uvScale = Parameters["UVScale"];

--- a/Source/RunActivity/Viewer3D/Shaders.cs
+++ b/Source/RunActivity/Viewer3D/Shaders.cs
@@ -46,7 +46,6 @@ namespace Orts.Viewer3D
         readonly EffectParameter world;
         readonly EffectParameter view;
         readonly EffectParameter projection;
-        readonly EffectParameter envMapTransform;
         readonly EffectParameter[] lightViewProjectionShadowProjection;
         readonly EffectParameter[] shadowMapTextures;
         readonly EffectParameter shadowMapLimit;
@@ -202,8 +201,6 @@ namespace Orts.Viewer3D
 
         public Vector2 DetailUVScaleRatio { set { detailUVScaleRatio.SetValue(value); } }
 
-        public Matrix EnvMapTransform { set { envMapTransform.SetValue(value); } }
-
         public bool UVOpReflectMapFull { set { uvOpReflectMapFull.SetValue(value ? 1f : 0f); } }
 
         public bool DetailUVOpReflectMapFull { set { detailUVOpReflectMapFull.SetValue(value ? 1f : 0f); } }
@@ -222,7 +219,6 @@ namespace Orts.Viewer3D
             world = Parameters["World"];
             view = Parameters["View"];
             projection = Parameters["Projection"];
-            envMapTransform = Parameters["EnvMapTransform"];
             lightViewProjectionShadowProjection = new EffectParameter[RenderProcess.ShadowMapCountMaximum];
             shadowMapTextures = new EffectParameter[RenderProcess.ShadowMapCountMaximum];
             for (var i = 0; i < RenderProcess.ShadowMapCountMaximum; i++)
@@ -261,7 +257,6 @@ namespace Orts.Viewer3D
             overlayScale = Parameters["OverlayScale"];
             UVScale = Vector2.One;
             DetailUVScaleRatio = Vector2.One;
-            EnvMapTransform = Matrix.Identity;
             UVOpReflectMapFull = false;
             DetailUVOpReflectMapFull = false;
             VertexLightingEnabled = false;

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2716,14 +2716,17 @@ namespace Orts.Viewer3D
                     foreach (var shapePrimitive in subObject.ShapePrimitives)
                     {
                         var xnaMatrix = Matrix.Identity;
+                        var rootMatrix = Matrix.Identity;
                         var hi = shapePrimitive.HierarchyIndex;
                         if (matrixVisible != null && !matrixVisible[hi]) continue;
                         while (hi >= 0 && hi < shapePrimitive.Hierarchy.Length)
                         {
                             Matrix.Multiply(ref xnaMatrix, ref animatedXNAMatrices[hi], out xnaMatrix);
+                            rootMatrix = animatedXNAMatrices[hi];
                             hi = shapePrimitive.Hierarchy[hi];
                         }
                         Matrix.Multiply(ref xnaMatrix, ref xnaDTileTranslation, out xnaMatrix);
+                        Matrix.Multiply(ref rootMatrix, ref xnaDTileTranslation, out rootMatrix);
 
                         if (StoredResultMatrixes.ContainsKey(shapePrimitive.HierarchyIndex))
                             StoredResultMatrixes[shapePrimitive.HierarchyIndex] = xnaMatrix;
@@ -2731,7 +2734,7 @@ namespace Orts.Viewer3D
                         // TODO make shadows depend on shape overrides
 
                         var interior = (flags & ShapeFlags.Interior) != 0;
-                        frame.AddAutoPrimitive(mstsLocation, distanceDetail.ViewSphereRadius, distanceDetail.ViewingDistance * lodBias, shapePrimitive.Material, shapePrimitive, interior ? RenderPrimitiveGroup.Interior : RenderPrimitiveGroup.World, ref xnaMatrix, flags);
+                        frame.AddAutoPrimitive(mstsLocation, distanceDetail.ViewSphereRadius, distanceDetail.ViewingDistance * lodBias, shapePrimitive.Material, shapePrimitive, interior ? RenderPrimitiveGroup.Interior : RenderPrimitiveGroup.World, ref xnaMatrix, ref rootMatrix, flags);
                     }
                 }
             }

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2297,7 +2297,7 @@ namespace Orts.Viewer3D
                     }
 
                     if ((options & SceneryMaterialOptions.NightLight) != 0)
-                        options = (options & ~SceneryMaterialOptions.ShaderMask) | SceneryMaterialOptions.ShaderFullBright;
+                        options = (options & ~(SceneryMaterialOptions.ShaderMask | SceneryMaterialOptions.BakedVertexLighting)) | SceneryMaterialOptions.ShaderFullBright;
 
                     if ((textureFlags & Helpers.TextureFlags.Night) != 0)
                         options |= SceneryMaterialOptions.NightTexture;

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2193,6 +2193,7 @@ namespace Orts.Viewer3D
                 { "Tex", SceneryMaterialOptions.ShaderFullBright },
                 { "TexDiff", SceneryMaterialOptions.Diffuse },
                 { "DetailMod2X", SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.DetailMod2X },
+                { "GlossMap", SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.GlossMap },
                 { "NightLight", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright | SceneryMaterialOptions.NightTexture | SceneryMaterialOptions.NightLight },
                 { "nightlight", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright | SceneryMaterialOptions.NightTexture | SceneryMaterialOptions.NightLight },
                 { "BlendATex", SceneryMaterialOptions.AlphaBlendingBlend | SceneryMaterialOptions.ShaderFullBright},
@@ -2311,7 +2312,7 @@ namespace Orts.Viewer3D
                         var texture = sFile.shape.textures[primitiveState.tex_idxs[0]];
                         var imageName = sFile.shape.images[texture.iImage];
                         string detailTexturePath = null;
-                        if ((options & SceneryMaterialOptions.DetailMod2X) != 0)
+                        if ((options & (SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap)) != 0)
                         {
                             if (primitiveState.tex_idxs.Length > 1)
                             {
@@ -2323,12 +2324,12 @@ namespace Orts.Viewer3D
                             }
                             else if (!ShapeWarnings.Contains("detail_mod_2x_missing_texture"))
                             {
-                                Trace.TraceInformation("Skipped missing DetailMod2X detail texture first seen in shape {0}", sharedShape.FilePath);
+                                Trace.TraceInformation("Skipped missing second detail/environment texture first seen in shape {0}", sharedShape.FilePath);
                                 ShapeWarnings.Add("detail_mod_2x_missing_texture");
                             }
 
                             if (detailTexturePath == null)
-                                options &= ~SceneryMaterialOptions.DetailMod2X;
+                                options &= ~(SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap);
                         }
                         if (String.IsNullOrEmpty(sharedShape.ReferencePath))
                             material = sharedShape.Viewer.MaterialManager.Load("Scenery", Helpers.GetRouteTextureFile(sharedShape.Viewer.Simulator, textureFlags, imageName), (int)options, texture.MipMapLODBias, detailTextureName: detailTexturePath);
@@ -2369,11 +2370,13 @@ namespace Orts.Viewer3D
                     var uvScale = GetUVScale(GetUVOp(lightModelConfiguration, 0));
                     var detailUVScale = GetUVScale(GetUVOp(lightModelConfiguration, 1) ?? GetUVOp(lightModelConfiguration, 0));
                     var uvOpReflectMapFull = IsUVOpReflectMapFull(GetUVOp(lightModelConfiguration, 0));
+                    var detailUVOpReflectMapFull = IsUVOpReflectMapFull(GetUVOp(lightModelConfiguration, 1));
 
                     ShapePrimitives[primitiveIndex] = new ShapePrimitive(material, vertexBufferSet, indexData, sharedShape.Viewer.GraphicsDevice, hierarchy, vertexState.imatrix);
                     ShapePrimitives[primitiveIndex].UVScale = uvScale;
                     ShapePrimitives[primitiveIndex].DetailUVScaleRatio = GetUVScaleRatio(detailUVScale, uvScale);
                     ShapePrimitives[primitiveIndex].UVOpReflectMapFull = uvOpReflectMapFull;
+                    ShapePrimitives[primitiveIndex].DetailUVOpReflectMapFull = detailUVOpReflectMapFull;
                     ShapePrimitives[primitiveIndex].SortIndex = ++totalPrimitiveIndex;
                     ++primitiveIndex;
 #if DEBUG_SHAPE_NORMALS

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2368,10 +2368,10 @@ namespace Orts.Viewer3D
                         foreach (var index in new[] { vertex_idx.a, vertex_idx.b, vertex_idx.c })
                             indexData.Add((ushort)index);
 
-                    var uvScale = GetUVScale(lightModelConfiguration, 0);
-                    var detailUVScale = GetUVScale(lightModelConfiguration, 1);
-                    var uvOpReflectMapFull = IsUVOpReflectMapFull(lightModelConfiguration, 0);
-                    var detailUVOpReflectMapFull = IsUVOpReflectMapFull(lightModelConfiguration, 1);
+                    var uvScale = GetUVScale(GetUVOp(lightModelConfiguration, 0));
+                    var detailUVScale = GetUVScale(GetUVOp(lightModelConfiguration, 1) ?? GetUVOp(lightModelConfiguration, 0));
+                    var uvOpReflectMapFull = IsUVOpReflectMapFull(GetUVOp(lightModelConfiguration, 0));
+                    var detailUVOpReflectMapFull = IsUVOpReflectMapFull(GetUVOp(lightModelConfiguration, 1));
 
                     ShapePrimitives[primitiveIndex] = new ShapePrimitive(material, vertexBufferSet, indexData, sharedShape.Viewer.GraphicsDevice, hierarchy, vertexState.imatrix);
                     ShapePrimitives[primitiveIndex].UVScale = uvScale;
@@ -2441,18 +2441,6 @@ namespace Orts.Viewer3D
                 return textureIndex >= 0 && textureIndex < lightModelConfiguration.uv_ops.Count ? lightModelConfiguration.uv_ops[textureIndex] : null;
             }
 
-            static Vector2 GetUVScale(light_model_cfg lightModelConfiguration, int textureIndex)
-            {
-                var uvOp = GetUVOp(lightModelConfiguration, textureIndex);
-                var previousUVOp = GetUVOp(lightModelConfiguration, textureIndex - 1);
-                if (IsUVOpReflectMapFull(uvOp) && IsUVScaleOp(previousUVOp))
-                    return GetUVScale(previousUVOp);
-
-                var uvScale = GetUVScale(uvOp);
-
-                return uvOp != null || textureIndex == 0 ? uvScale : GetUVScale(lightModelConfiguration, 0);
-            }
-
             static Vector2 GetUVScale(uv_op uvOp)
             {
                 var uniformScale = uvOp as uv_op_uniformscale;
@@ -2464,16 +2452,6 @@ namespace Orts.Viewer3D
                     return new Vector2(nonUniformScale.ScaleU, nonUniformScale.ScaleV);
 
                 return Vector2.One;
-            }
-
-            static bool IsUVOpReflectMapFull(light_model_cfg lightModelConfiguration, int textureIndex)
-            {
-                return IsUVOpReflectMapFull(GetUVOp(lightModelConfiguration, textureIndex));
-            }
-
-            static bool IsUVScaleOp(uv_op uvOp)
-            {
-                return uvOp is uv_op_uniformscale || uvOp is uv_op_nonuniformscale;
             }
 
             static bool IsUVOpReflectMapFull(uv_op uvOp)

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -1973,7 +1973,7 @@ namespace Orts.Viewer3D
 
     public class SharedShape : IDisposable
     {
-        static List<string> ShapeWarnings = new List<string>();
+        static readonly HashSet<string> ShapeWarnings = new HashSet<string>();
 
         // This data is common to all instances of the shape
         public List<string> MatrixNames = new List<string>();
@@ -1983,6 +1983,7 @@ namespace Orts.Viewer3D
         public LodControl[] LodControls;
         public bool HasNightSubObj;
         public int RootSubObjectIndex = 0;
+        readonly HashSet<int> CheckedSrcUVLightConfigurations = new HashSet<int>();
         //public bool negativeBogie = false;
         public string SoundFileName = "";
         public float CustomAnimationFPS = 8;
@@ -2281,7 +2282,8 @@ namespace Orts.Viewer3D
 
                     if (lightModelConfiguration.uv_ops.Count > 0)
                     {
-                        WarnUnsupportedSrcUVIdx(sharedShape.FilePath, lightModelConfiguration);
+                        if (sharedShape.CheckedSrcUVLightConfigurations.Add(vertexState.LightCfgIdx))
+                            WarnUnsupportedSrcUVIdx(sharedShape.FilePath, lightModelConfiguration);
 
                         if (lightModelConfiguration.uv_ops[0].TexAddrMode - 1 >= 0 && lightModelConfiguration.uv_ops[0].TexAddrMode - 1 < UVTextureAddressModeMap.Length)
                             options |= UVTextureAddressModeMap[lightModelConfiguration.uv_ops[0].TexAddrMode - 1];

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2194,6 +2194,7 @@ namespace Orts.Viewer3D
                 { "TexDiff", SceneryMaterialOptions.Diffuse },
                 { "DetailMod2X", SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.DetailMod2X },
                 { "GlossMap", SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.GlossMap },
+                { "AlphRefMap", SceneryMaterialOptions.AlphaBlendingBlend | SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.AlphRefMap },
                 { "NightLight", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright | SceneryMaterialOptions.NightTexture | SceneryMaterialOptions.NightLight },
                 { "nightlight", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright | SceneryMaterialOptions.NightTexture | SceneryMaterialOptions.NightLight },
                 { "BlendATex", SceneryMaterialOptions.AlphaBlendingBlend | SceneryMaterialOptions.ShaderFullBright},
@@ -2312,7 +2313,7 @@ namespace Orts.Viewer3D
                         var texture = sFile.shape.textures[primitiveState.tex_idxs[0]];
                         var imageName = sFile.shape.images[texture.iImage];
                         string detailTexturePath = null;
-                        if ((options & (SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap)) != 0)
+                        if ((options & (SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap | SceneryMaterialOptions.AlphRefMap)) != 0)
                         {
                             if (primitiveState.tex_idxs.Length > 1)
                             {
@@ -2329,7 +2330,7 @@ namespace Orts.Viewer3D
                             }
 
                             if (detailTexturePath == null)
-                                options &= ~(SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap);
+                                options &= ~(SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap | SceneryMaterialOptions.AlphRefMap);
                         }
                         if (String.IsNullOrEmpty(sharedShape.ReferencePath))
                             material = sharedShape.Viewer.MaterialManager.Load("Scenery", Helpers.GetRouteTextureFile(sharedShape.Viewer.Simulator, textureFlags, imageName), (int)options, texture.MipMapLODBias, detailTextureName: detailTexturePath);

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -1832,21 +1832,32 @@ namespace Orts.Viewer3D
     /// </summary>
     public class MutableShapePrimitive : ShapePrimitive
     {
+        readonly SharedShape.VertexBufferSet.ShapeVertex[] VertexData;
+
         /// <remarks>
         /// Buffers cannot be expanded, so take care to properly set <paramref name="maxVertices"/> and <paramref name="maxIndices"/>,
         /// which define the maximum sizes of the vertex and index buffers, respectively.
         /// </remarks>
         public MutableShapePrimitive(Material material, int maxVertices, int maxIndices, int[] hierarchy, int hierarchyIndex)
             : base(material: material,
-                   vertexBufferSet: new SharedShape.VertexBufferSet(new VertexPositionNormalTexture[maxVertices], material.Viewer.GraphicsDevice),
+                   vertexBufferSet: new SharedShape.VertexBufferSet(maxVertices, material.Viewer.GraphicsDevice),
                    indexData: new ushort[maxIndices],
                    graphicsDevice: material.Viewer.GraphicsDevice,
                    hierarchy: hierarchy,
-                   hierarchyIndex: hierarchyIndex) { }
+                   hierarchyIndex: hierarchyIndex)
+        {
+            VertexData = new SharedShape.VertexBufferSet.ShapeVertex[maxVertices];
+        }
 
         public void SetVertexData(VertexPositionNormalTexture[] data, int minVertexIndex, int numVertices, int primitiveCount)
         {
-            VertexBuffer.SetData(SharedShape.VertexBufferSet.CreateVertexData(data));
+            for (var i = 0; i < numVertices; i++)
+            {
+                var vertex = data[minVertexIndex + i];
+                VertexData[i] = new SharedShape.VertexBufferSet.ShapeVertex(vertex.Position, vertex.Normal, vertex.TextureCoordinate, Color.White, Color.Black);
+            }
+
+            VertexBuffer.SetData(VertexData, 0, numVertices);
             PrimitiveCount = primitiveCount;
         }
 
@@ -2525,6 +2536,11 @@ namespace Orts.Viewer3D
             public VertexBufferSet(VertexPositionNormalTexture[] vertexData, GraphicsDevice graphicsDevice)
                 : this(CreateVertexData(vertexData), graphicsDevice)
             {
+            }
+
+            public VertexBufferSet(int vertexCount, GraphicsDevice graphicsDevice)
+            {
+                Buffer = new VertexBuffer(graphicsDevice, ShapeVertex.VertexDeclaration, vertexCount, BufferUsage.WriteOnly);
             }
 
             public VertexBufferSet(ShapeVertex[] vertexData, GraphicsDevice graphicsDevice)

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2368,10 +2368,10 @@ namespace Orts.Viewer3D
                         foreach (var index in new[] { vertex_idx.a, vertex_idx.b, vertex_idx.c })
                             indexData.Add((ushort)index);
 
-                    var uvScale = GetUVScale(GetUVOp(lightModelConfiguration, 0));
-                    var detailUVScale = GetUVScale(GetUVOp(lightModelConfiguration, 1) ?? GetUVOp(lightModelConfiguration, 0));
-                    var uvOpReflectMapFull = IsUVOpReflectMapFull(GetUVOp(lightModelConfiguration, 0));
-                    var detailUVOpReflectMapFull = IsUVOpReflectMapFull(GetUVOp(lightModelConfiguration, 1));
+                    var uvScale = GetUVScale(lightModelConfiguration, 0);
+                    var detailUVScale = GetUVScale(lightModelConfiguration, 1);
+                    var uvOpReflectMapFull = IsUVOpReflectMapFull(lightModelConfiguration, 0);
+                    var detailUVOpReflectMapFull = IsUVOpReflectMapFull(lightModelConfiguration, 1);
 
                     ShapePrimitives[primitiveIndex] = new ShapePrimitive(material, vertexBufferSet, indexData, sharedShape.Viewer.GraphicsDevice, hierarchy, vertexState.imatrix);
                     ShapePrimitives[primitiveIndex].UVScale = uvScale;
@@ -2438,7 +2438,19 @@ namespace Orts.Viewer3D
 
             static uv_op GetUVOp(light_model_cfg lightModelConfiguration, int textureIndex)
             {
-                return textureIndex < lightModelConfiguration.uv_ops.Count ? lightModelConfiguration.uv_ops[textureIndex] : null;
+                return textureIndex >= 0 && textureIndex < lightModelConfiguration.uv_ops.Count ? lightModelConfiguration.uv_ops[textureIndex] : null;
+            }
+
+            static Vector2 GetUVScale(light_model_cfg lightModelConfiguration, int textureIndex)
+            {
+                var uvOp = GetUVOp(lightModelConfiguration, textureIndex);
+                var previousUVOp = GetUVOp(lightModelConfiguration, textureIndex - 1);
+                if (IsUVOpReflectMapFull(uvOp) && IsUVScaleOp(previousUVOp))
+                    return GetUVScale(previousUVOp);
+
+                var uvScale = GetUVScale(uvOp);
+
+                return uvOp != null || textureIndex == 0 ? uvScale : GetUVScale(lightModelConfiguration, 0);
             }
 
             static Vector2 GetUVScale(uv_op uvOp)
@@ -2452,6 +2464,16 @@ namespace Orts.Viewer3D
                     return new Vector2(nonUniformScale.ScaleU, nonUniformScale.ScaleV);
 
                 return Vector2.One;
+            }
+
+            static bool IsUVOpReflectMapFull(light_model_cfg lightModelConfiguration, int textureIndex)
+            {
+                return IsUVOpReflectMapFull(GetUVOp(lightModelConfiguration, textureIndex));
+            }
+
+            static bool IsUVScaleOp(uv_op uvOp)
+            {
+                return uvOp is uv_op_uniformscale || uvOp is uv_op_nonuniformscale;
             }
 
             static bool IsUVOpReflectMapFull(uv_op uvOp)

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2068,7 +2068,7 @@ namespace Orts.Viewer3D
             {
                 debugShapeHierarchy.AppendFormat("  LState {0,-2}: flags={1,-8:X8} uv_ops={2,-2}\n", i, sFile.shape.light_model_cfgs[i].flags, sFile.shape.light_model_cfgs[i].uv_ops.Count);
                 for (var j = 0; j < sFile.shape.light_model_cfgs[i].uv_ops.Count; ++j)
-                    debugShapeHierarchy.AppendFormat("    UV OP {0,-2}: texture_address_mode={1,-2}\n", j, sFile.shape.light_model_cfgs[i].uv_ops[j].TexAddrMode);
+                    debugShapeHierarchy.AppendFormat("    UV OP {0,-2}: type={1,-24} texture_address_mode={2,-2}\n", j, sFile.shape.light_model_cfgs[i].uv_ops[j].GetType().Name, sFile.shape.light_model_cfgs[i].uv_ops[j].TexAddrMode);
             }
             Console.Write(debugShapeHierarchy.ToString());
 #endif
@@ -2368,10 +2368,12 @@ namespace Orts.Viewer3D
 
                     var uvScale = GetUVScale(GetUVOp(lightModelConfiguration, 0));
                     var detailUVScale = GetUVScale(GetUVOp(lightModelConfiguration, 1) ?? GetUVOp(lightModelConfiguration, 0));
+                    var uvOpReflectMapFull = IsUVOpReflectMapFull(GetUVOp(lightModelConfiguration, 0));
 
                     ShapePrimitives[primitiveIndex] = new ShapePrimitive(material, vertexBufferSet, indexData, sharedShape.Viewer.GraphicsDevice, hierarchy, vertexState.imatrix);
                     ShapePrimitives[primitiveIndex].UVScale = uvScale;
                     ShapePrimitives[primitiveIndex].DetailUVScaleRatio = GetUVScaleRatio(detailUVScale, uvScale);
+                    ShapePrimitives[primitiveIndex].UVOpReflectMapFull = uvOpReflectMapFull;
                     ShapePrimitives[primitiveIndex].SortIndex = ++totalPrimitiveIndex;
                     ++primitiveIndex;
 #if DEBUG_SHAPE_NORMALS
@@ -2446,6 +2448,11 @@ namespace Orts.Viewer3D
                     return new Vector2(nonUniformScale.ScaleU, nonUniformScale.ScaleV);
 
                 return Vector2.One;
+            }
+
+            static bool IsUVOpReflectMapFull(uv_op uvOp)
+            {
+                return uvOp is uv_op_reflectmapfull;
             }
 
             static Vector2 GetUVScaleRatio(Vector2 uvScale, Vector2 baseUVScale)

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2366,11 +2366,12 @@ namespace Orts.Viewer3D
                         foreach (var index in new[] { vertex_idx.a, vertex_idx.b, vertex_idx.c })
                             indexData.Add((ushort)index);
 
-                    var uvOp = GetPrimaryUVOp(lightModelConfiguration);
-                    var uvScale = GetUVScale(uvOp);
+                    var uvScale = GetUVScale(GetUVOp(lightModelConfiguration, 0));
+                    var detailUVScale = GetUVScale(GetUVOp(lightModelConfiguration, 1) ?? GetUVOp(lightModelConfiguration, 0));
 
                     ShapePrimitives[primitiveIndex] = new ShapePrimitive(material, vertexBufferSet, indexData, sharedShape.Viewer.GraphicsDevice, hierarchy, vertexState.imatrix);
                     ShapePrimitives[primitiveIndex].UVScale = uvScale;
+                    ShapePrimitives[primitiveIndex].DetailUVScaleRatio = GetUVScaleRatio(detailUVScale, uvScale);
                     ShapePrimitives[primitiveIndex].SortIndex = ++totalPrimitiveIndex;
                     ++primitiveIndex;
 #if DEBUG_SHAPE_NORMALS
@@ -2429,9 +2430,9 @@ namespace Orts.Viewer3D
 #endif
             }
 
-            static uv_op GetPrimaryUVOp(light_model_cfg lightModelConfiguration)
+            static uv_op GetUVOp(light_model_cfg lightModelConfiguration, int textureIndex)
             {
-                return lightModelConfiguration.uv_ops.Count > 0 ? lightModelConfiguration.uv_ops[0] : null;
+                return textureIndex < lightModelConfiguration.uv_ops.Count ? lightModelConfiguration.uv_ops[textureIndex] : null;
             }
 
             static Vector2 GetUVScale(uv_op uvOp)
@@ -2445,6 +2446,13 @@ namespace Orts.Viewer3D
                     return new Vector2(nonUniformScale.ScaleU, nonUniformScale.ScaleV);
 
                 return Vector2.One;
+            }
+
+            static Vector2 GetUVScaleRatio(Vector2 uvScale, Vector2 baseUVScale)
+            {
+                return new Vector2(
+                    baseUVScale.X != 0 ? uvScale.X / baseUVScale.X : uvScale.X,
+                    baseUVScale.Y != 0 ? uvScale.Y / baseUVScale.Y : uvScale.Y);
             }
 
             [CallOnThread("Loader")]

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -1846,7 +1846,7 @@ namespace Orts.Viewer3D
 
         public void SetVertexData(VertexPositionNormalTexture[] data, int minVertexIndex, int numVertices, int primitiveCount)
         {
-            VertexBuffer.SetData(data);
+            VertexBuffer.SetData(SharedShape.VertexBufferSet.CreateVertexData(data));
             PrimitiveCount = primitiveCount;
         }
 
@@ -2286,7 +2286,9 @@ namespace Orts.Viewer3D
                         ShapeWarnings.Add("shader_name:" + sFile.shape.shader_names[primitiveState.ishader]);
                     }
 
-                    if (12 + vertexState.LightMatIdx >= 0 && 12 + vertexState.LightMatIdx < VertexLightModeMap.Length)
+                    if (vertexState.LightMatIdx == -1)
+                        options |= SceneryMaterialOptions.BakedVertexLighting;
+                    else if (12 + vertexState.LightMatIdx >= 0 && 12 + vertexState.LightMatIdx < VertexLightModeMap.Length)
                         options |= VertexLightModeMap[12 + vertexState.LightMatIdx];
                     else if (!ShapeWarnings.Contains("lighting_model:" + vertexState.LightMatIdx))
                     {
@@ -2465,6 +2467,33 @@ namespace Orts.Viewer3D
 
         public class VertexBufferSet
         {
+            public struct ShapeVertex
+            {
+                public Vector3 Position;
+                public Vector3 Normal;
+                public Vector2 TextureCoordinate;
+                public Color Color1;
+                public Color Color2;
+
+                public ShapeVertex(Vector3 position, Vector3 normal, Vector2 textureCoordinate, Color color1, Color color2)
+                {
+                    Position = position;
+                    Normal = normal;
+                    TextureCoordinate = textureCoordinate;
+                    Color1 = color1;
+                    Color2 = color2;
+                }
+
+                public static readonly VertexDeclaration VertexDeclaration = new VertexDeclaration(new[]
+                {
+                    new VertexElement(0, VertexElementFormat.Vector3, VertexElementUsage.Position, 0),
+                    new VertexElement(sizeof(float) * 3, VertexElementFormat.Vector3, VertexElementUsage.Normal, 0),
+                    new VertexElement(sizeof(float) * 6, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 0),
+                    new VertexElement(sizeof(float) * 8, VertexElementFormat.Color, VertexElementUsage.Color, 0),
+                    new VertexElement(sizeof(float) * 8 + sizeof(uint), VertexElementFormat.Color, VertexElementUsage.Color, 1),
+                });
+            }
+
             public VertexBuffer Buffer;
 
 #if DEBUG_SHAPE_NORMALS
@@ -2475,8 +2504,13 @@ namespace Orts.Viewer3D
 #endif
 
             public VertexBufferSet(VertexPositionNormalTexture[] vertexData, GraphicsDevice graphicsDevice)
+                : this(CreateVertexData(vertexData), graphicsDevice)
             {
-                Buffer = new VertexBuffer(graphicsDevice, typeof(VertexPositionNormalTexture), vertexData.Length, BufferUsage.WriteOnly);
+            }
+
+            public VertexBufferSet(ShapeVertex[] vertexData, GraphicsDevice graphicsDevice)
+            {
+                Buffer = new VertexBuffer(graphicsDevice, ShapeVertex.VertexDeclaration, vertexData.Length, BufferUsage.WriteOnly);
                 Buffer.SetData(vertexData);
             }
 
@@ -2500,26 +2534,37 @@ namespace Orts.Viewer3D
             {
             }
 
-            static VertexPositionNormalTexture[] CreateVertexData(sub_object sub_object, shape shape)
+            public static ShapeVertex[] CreateVertexData(VertexPositionNormalTexture[] vertexData)
+            {
+                return (from vertex in vertexData
+                        select new ShapeVertex(vertex.Position, vertex.Normal, vertex.TextureCoordinate, Color.White, Color.Black)).ToArray();
+            }
+
+            static ShapeVertex[] CreateVertexData(sub_object sub_object, shape shape)
             {
                 // TODO - deal with vertex sets that have various numbers of texture coordinates - ie 0, 1, 2 etc
                 return (from vertex vertex in sub_object.vertices
-                        select XNAVertexPositionNormalTextureFromMSTS(vertex, shape)).ToArray();
+                        select XNAShapeVertexFromMSTS(vertex, shape)).ToArray();
             }
 
-            static VertexPositionNormalTexture XNAVertexPositionNormalTextureFromMSTS(vertex vertex, shape shape)
+            static ShapeVertex XNAShapeVertexFromMSTS(vertex vertex, shape shape)
             {
                 var position = shape.points[vertex.ipoint];
                 var normal = shape.normals[vertex.inormal];
                 // TODO use a simpler vertex description when no UV's in use
                 var texcoord = vertex.vertex_uvs.Length > 0 ? shape.uv_points[vertex.vertex_uvs[0]] : new uv_point(0, 0);
 
-                return new VertexPositionNormalTexture()
-                {
-                    Position = new Vector3(position.X, position.Y, -position.Z),
-                    Normal = new Vector3(normal.X, normal.Y, -normal.Z),
-                    TextureCoordinate = new Vector2(texcoord.U, texcoord.V),
-                };
+                return new ShapeVertex(
+                    new Vector3(position.X, position.Y, -position.Z),
+                    new Vector3(normal.X, normal.Y, -normal.Z),
+                    new Vector2(texcoord.U, texcoord.V),
+                    XNAColorFromMSTS(vertex.Color1),
+                    XNAColorFromMSTS(vertex.Color2));
+            }
+
+            static Color XNAColorFromMSTS(uint color)
+            {
+                return new Color((byte)(color >> 16), (byte)(color >> 8), (byte)color, (byte)(color >> 24));
             }
 
 #if DEBUG_SHAPE_NORMALS

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2716,17 +2716,14 @@ namespace Orts.Viewer3D
                     foreach (var shapePrimitive in subObject.ShapePrimitives)
                     {
                         var xnaMatrix = Matrix.Identity;
-                        var rootMatrix = Matrix.Identity;
                         var hi = shapePrimitive.HierarchyIndex;
                         if (matrixVisible != null && !matrixVisible[hi]) continue;
                         while (hi >= 0 && hi < shapePrimitive.Hierarchy.Length)
                         {
                             Matrix.Multiply(ref xnaMatrix, ref animatedXNAMatrices[hi], out xnaMatrix);
-                            rootMatrix = animatedXNAMatrices[hi];
                             hi = shapePrimitive.Hierarchy[hi];
                         }
                         Matrix.Multiply(ref xnaMatrix, ref xnaDTileTranslation, out xnaMatrix);
-                        Matrix.Multiply(ref rootMatrix, ref xnaDTileTranslation, out rootMatrix);
 
                         if (StoredResultMatrixes.ContainsKey(shapePrimitive.HierarchyIndex))
                             StoredResultMatrixes[shapePrimitive.HierarchyIndex] = xnaMatrix;
@@ -2734,7 +2731,7 @@ namespace Orts.Viewer3D
                         // TODO make shadows depend on shape overrides
 
                         var interior = (flags & ShapeFlags.Interior) != 0;
-                        frame.AddAutoPrimitive(mstsLocation, distanceDetail.ViewSphereRadius, distanceDetail.ViewingDistance * lodBias, shapePrimitive.Material, shapePrimitive, interior ? RenderPrimitiveGroup.Interior : RenderPrimitiveGroup.World, ref xnaMatrix, ref rootMatrix, flags);
+                        frame.AddAutoPrimitive(mstsLocation, distanceDetail.ViewSphereRadius, distanceDetail.ViewingDistance * lodBias, shapePrimitive.Material, shapePrimitive, interior ? RenderPrimitiveGroup.Interior : RenderPrimitiveGroup.World, ref xnaMatrix, flags);
                     }
                 }
             }

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2324,6 +2324,8 @@ namespace Orts.Viewer3D
                         var texture = sFile.shape.textures[primitiveState.tex_idxs[0]];
                         var imageName = sFile.shape.images[texture.iImage];
                         string detailTexturePath = null;
+                        var detailTextureAddressMode = 1;
+                        var detailMipMapBias = 0f;
                         if ((options & (SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap | SceneryMaterialOptions.AlphRefMap)) != 0)
                         {
                             if (primitiveState.tex_idxs.Length > 1)
@@ -2333,6 +2335,16 @@ namespace Orts.Viewer3D
                                 detailTexturePath = String.IsNullOrEmpty(sharedShape.ReferencePath)
                                     ? Helpers.GetRouteTextureFile(sharedShape.Viewer.Simulator, textureFlags, detailImageName)
                                     : Helpers.GetTextureFile(sharedShape.Viewer.Simulator, textureFlags, sharedShape.ReferencePath, detailImageName);
+                                detailMipMapBias = detailTexture.MipMapLODBias;
+
+                                if (lightModelConfiguration.uv_ops.Count > 1)
+                                    if (lightModelConfiguration.uv_ops[1].TexAddrMode - 1 >= 0 && lightModelConfiguration.uv_ops[1].TexAddrMode - 1 < UVTextureAddressModeMap.Length)
+                                        detailTextureAddressMode = lightModelConfiguration.uv_ops[1].TexAddrMode;
+                                    else if (!ShapeWarnings.Contains("texture_addressing_mode_1:" + lightModelConfiguration.uv_ops[1].TexAddrMode))
+                                    {
+                                        Trace.TraceInformation("Skipped unknown texture addressing mode {1} for second texture stage first seen in shape {0}", sharedShape.FilePath, lightModelConfiguration.uv_ops[1].TexAddrMode);
+                                        ShapeWarnings.Add("texture_addressing_mode_1:" + lightModelConfiguration.uv_ops[1].TexAddrMode);
+                                    }
                             }
                             else if (!ShapeWarnings.Contains("detail_mod_2x_missing_texture"))
                             {
@@ -2344,9 +2356,9 @@ namespace Orts.Viewer3D
                                 options &= ~(SceneryMaterialOptions.DetailMod2X | SceneryMaterialOptions.GlossMap | SceneryMaterialOptions.AlphRefMap);
                         }
                         if (String.IsNullOrEmpty(sharedShape.ReferencePath))
-                            material = sharedShape.Viewer.MaterialManager.Load("Scenery", Helpers.GetRouteTextureFile(sharedShape.Viewer.Simulator, textureFlags, imageName), (int)options, texture.MipMapLODBias, detailTextureName: detailTexturePath);
+                            material = sharedShape.Viewer.MaterialManager.Load("Scenery", Helpers.GetRouteTextureFile(sharedShape.Viewer.Simulator, textureFlags, imageName), (int)options, texture.MipMapLODBias, detailTextureName: detailTexturePath, detailMipMapBias: detailMipMapBias, detailTextureAddressMode: detailTextureAddressMode);
                         else
-                            material = sharedShape.Viewer.MaterialManager.Load("Scenery", Helpers.GetTextureFile(sharedShape.Viewer.Simulator, textureFlags, sharedShape.ReferencePath, imageName), (int)options, texture.MipMapLODBias, detailTextureName: detailTexturePath);
+                            material = sharedShape.Viewer.MaterialManager.Load("Scenery", Helpers.GetTextureFile(sharedShape.Viewer.Simulator, textureFlags, sharedShape.ReferencePath, imageName), (int)options, texture.MipMapLODBias, detailTextureName: detailTexturePath, detailMipMapBias: detailMipMapBias, detailTextureAddressMode: detailTextureAddressMode);
                     }
                     else
                     {

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2338,7 +2338,11 @@ namespace Orts.Viewer3D
                         foreach (var index in new[] { vertex_idx.a, vertex_idx.b, vertex_idx.c })
                             indexData.Add((ushort)index);
 
+                    var uvOp = GetPrimaryUVOp(lightModelConfiguration);
+                    var uvScale = GetUVScale(uvOp);
+
                     ShapePrimitives[primitiveIndex] = new ShapePrimitive(material, vertexBufferSet, indexData, sharedShape.Viewer.GraphicsDevice, hierarchy, vertexState.imatrix);
+                    ShapePrimitives[primitiveIndex].UVScale = uvScale;
                     ShapePrimitives[primitiveIndex].SortIndex = ++totalPrimitiveIndex;
                     ++primitiveIndex;
 #if DEBUG_SHAPE_NORMALS
@@ -2395,6 +2399,24 @@ namespace Orts.Viewer3D
 #if DEBUG_SHAPE_HIERARCHY
                 Console.Write(debugShapeHierarchy.ToString());
 #endif
+            }
+
+            static uv_op GetPrimaryUVOp(light_model_cfg lightModelConfiguration)
+            {
+                return lightModelConfiguration.uv_ops.Count > 0 ? lightModelConfiguration.uv_ops[0] : null;
+            }
+
+            static Vector2 GetUVScale(uv_op uvOp)
+            {
+                var uniformScale = uvOp as uv_op_uniformscale;
+                if (uniformScale != null)
+                    return new Vector2(uniformScale.Scale, uniformScale.Scale);
+
+                var nonUniformScale = uvOp as uv_op_nonuniformscale;
+                if (nonUniformScale != null)
+                    return new Vector2(nonUniformScale.ScaleU, nonUniformScale.ScaleV);
+
+                return Vector2.One;
             }
 
             [CallOnThread("Loader")]

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2193,6 +2193,8 @@ namespace Orts.Viewer3D
                 { "Tex", SceneryMaterialOptions.ShaderFullBright },
                 { "TexDiff", SceneryMaterialOptions.Diffuse },
                 { "DetailMod2X", SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.DetailMod2X },
+                { "NightLight", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright | SceneryMaterialOptions.NightTexture | SceneryMaterialOptions.NightLight },
+                { "nightlight", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright | SceneryMaterialOptions.NightTexture | SceneryMaterialOptions.NightLight },
                 { "BlendATex", SceneryMaterialOptions.AlphaBlendingBlend | SceneryMaterialOptions.ShaderFullBright},
                 { "BlendATexDiff", SceneryMaterialOptions.AlphaBlendingBlend | SceneryMaterialOptions.Diffuse },
                 { "AddATex", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright},
@@ -2291,6 +2293,9 @@ namespace Orts.Viewer3D
                         Trace.TraceInformation("Skipped unknown lighting model index {1} first seen in shape {0}", sharedShape.FilePath, vertexState.LightMatIdx);
                         ShapeWarnings.Add("lighting_model:" + vertexState.LightMatIdx);
                     }
+
+                    if ((options & SceneryMaterialOptions.NightLight) != 0)
+                        options = (options & ~SceneryMaterialOptions.ShaderMask) | SceneryMaterialOptions.ShaderFullBright;
 
                     if ((textureFlags & Helpers.TextureFlags.Night) != 0)
                         options |= SceneryMaterialOptions.NightTexture;

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2192,6 +2192,7 @@ namespace Orts.Viewer3D
             static readonly Dictionary<string, SceneryMaterialOptions> ShaderNames = new Dictionary<string, SceneryMaterialOptions> {
                 { "Tex", SceneryMaterialOptions.ShaderFullBright },
                 { "TexDiff", SceneryMaterialOptions.Diffuse },
+                { "DetailMod2X", SceneryMaterialOptions.Diffuse | SceneryMaterialOptions.DetailMod2X },
                 { "BlendATex", SceneryMaterialOptions.AlphaBlendingBlend | SceneryMaterialOptions.ShaderFullBright},
                 { "BlendATexDiff", SceneryMaterialOptions.AlphaBlendingBlend | SceneryMaterialOptions.Diffuse },
                 { "AddATex", SceneryMaterialOptions.AlphaBlendingAdd | SceneryMaterialOptions.ShaderFullBright},
@@ -2302,10 +2303,30 @@ namespace Orts.Viewer3D
                     {
                         var texture = sFile.shape.textures[primitiveState.tex_idxs[0]];
                         var imageName = sFile.shape.images[texture.iImage];
+                        string detailTexturePath = null;
+                        if ((options & SceneryMaterialOptions.DetailMod2X) != 0)
+                        {
+                            if (primitiveState.tex_idxs.Length > 1)
+                            {
+                                var detailTexture = sFile.shape.textures[primitiveState.tex_idxs[1]];
+                                var detailImageName = sFile.shape.images[detailTexture.iImage];
+                                detailTexturePath = String.IsNullOrEmpty(sharedShape.ReferencePath)
+                                    ? Helpers.GetRouteTextureFile(sharedShape.Viewer.Simulator, textureFlags, detailImageName)
+                                    : Helpers.GetTextureFile(sharedShape.Viewer.Simulator, textureFlags, sharedShape.ReferencePath, detailImageName);
+                            }
+                            else if (!ShapeWarnings.Contains("detail_mod_2x_missing_texture"))
+                            {
+                                Trace.TraceInformation("Skipped missing DetailMod2X detail texture first seen in shape {0}", sharedShape.FilePath);
+                                ShapeWarnings.Add("detail_mod_2x_missing_texture");
+                            }
+
+                            if (detailTexturePath == null)
+                                options &= ~SceneryMaterialOptions.DetailMod2X;
+                        }
                         if (String.IsNullOrEmpty(sharedShape.ReferencePath))
-                            material = sharedShape.Viewer.MaterialManager.Load("Scenery", Helpers.GetRouteTextureFile(sharedShape.Viewer.Simulator, textureFlags, imageName), (int)options, texture.MipMapLODBias);
+                            material = sharedShape.Viewer.MaterialManager.Load("Scenery", Helpers.GetRouteTextureFile(sharedShape.Viewer.Simulator, textureFlags, imageName), (int)options, texture.MipMapLODBias, detailTextureName: detailTexturePath);
                         else
-                            material = sharedShape.Viewer.MaterialManager.Load("Scenery", Helpers.GetTextureFile(sharedShape.Viewer.Simulator, textureFlags, sharedShape.ReferencePath, imageName), (int)options, texture.MipMapLODBias);
+                            material = sharedShape.Viewer.MaterialManager.Load("Scenery", Helpers.GetTextureFile(sharedShape.Viewer.Simulator, textureFlags, sharedShape.ReferencePath, imageName), (int)options, texture.MipMapLODBias, detailTextureName: detailTexturePath);
                     }
                     else
                     {

--- a/Source/RunActivity/Viewer3D/Shapes.cs
+++ b/Source/RunActivity/Viewer3D/Shapes.cs
@@ -2280,6 +2280,9 @@ namespace Orts.Viewer3D
                     }
 
                     if (lightModelConfiguration.uv_ops.Count > 0)
+                    {
+                        WarnUnsupportedSrcUVIdx(sharedShape.FilePath, lightModelConfiguration);
+
                         if (lightModelConfiguration.uv_ops[0].TexAddrMode - 1 >= 0 && lightModelConfiguration.uv_ops[0].TexAddrMode - 1 < UVTextureAddressModeMap.Length)
                             options |= UVTextureAddressModeMap[lightModelConfiguration.uv_ops[0].TexAddrMode - 1];
                         else if (!ShapeWarnings.Contains("texture_addressing_mode:" + lightModelConfiguration.uv_ops[0].TexAddrMode))
@@ -2287,6 +2290,7 @@ namespace Orts.Viewer3D
                             Trace.TraceInformation("Skipped unknown texture addressing mode {1} first seen in shape {0}", sharedShape.FilePath, lightModelConfiguration.uv_ops[0].TexAddrMode);
                             ShapeWarnings.Add("texture_addressing_mode:" + lightModelConfiguration.uv_ops[0].TexAddrMode);
                         }
+                    }
 
                     if (primitiveState.alphatestmode == 1)
                         options |= SceneryMaterialOptions.AlphaTest;
@@ -2462,6 +2466,41 @@ namespace Orts.Viewer3D
             static uv_op GetUVOp(light_model_cfg lightModelConfiguration, int textureIndex)
             {
                 return textureIndex >= 0 && textureIndex < lightModelConfiguration.uv_ops.Count ? lightModelConfiguration.uv_ops[textureIndex] : null;
+            }
+
+            static void WarnUnsupportedSrcUVIdx(string shapeFilePath, light_model_cfg lightModelConfiguration)
+            {
+                for (var i = 0; i < lightModelConfiguration.uv_ops.Count; ++i)
+                {
+                    var uvOp = lightModelConfiguration.uv_ops[i];
+                    var srcUVIdx = GetSrcUVIdx(uvOp);
+                    if (srcUVIdx == null || srcUVIdx == 0)
+                        continue;
+
+                    var warningKey = String.Format("uv_op_src_uv_idx:{0}:{1}", uvOp.GetType().Name, srcUVIdx);
+                    if (ShapeWarnings.Contains(warningKey))
+                        continue;
+
+                    Trace.TraceInformation("Unsupported SrcUVIdx {2} for {1} first seen in shape {0}; Open Rails currently uses vertex_uvs[0].", shapeFilePath, uvOp.GetType().Name, srcUVIdx);
+                    ShapeWarnings.Add(warningKey);
+                }
+            }
+
+            static int? GetSrcUVIdx(uv_op uvOp)
+            {
+                var copy = uvOp as uv_op_copy;
+                if (copy != null)
+                    return copy.SrcUVIdx;
+
+                var uniformScale = uvOp as uv_op_uniformscale;
+                if (uniformScale != null)
+                    return uniformScale.SrcUVIdx;
+
+                var nonUniformScale = uvOp as uv_op_nonuniformscale;
+                if (nonUniformScale != null)
+                    return nonUniformScale.SrcUVIdx;
+
+                return null;
             }
 
             static Vector2 GetUVScale(uv_op uvOp)

--- a/Source/RunActivity/Viewer3D/Water.cs
+++ b/Source/RunActivity/Viewer3D/Water.cs
@@ -174,8 +174,8 @@ namespace Orts.Viewer3D
         {
             var shader = Viewer.MaterialManager.SceneryShader;
             var level9_3 = Viewer.Settings.IsDirectXFeatureLevelIncluded(ORTS.Settings.UserSettings.DirectXFeature.Level9_3);
-            shader.CurrentTechnique = shader.Techniques[level9_3 ? "ImageLevel9_3" : "ImageLevel9_1"];
-            if (ShaderPasses == null) ShaderPasses = shader.Techniques[level9_3 ? "ImageLevel9_3" : "ImageLevel9_1"].Passes.GetEnumerator();
+            shader.CurrentTechnique = shader.Techniques[level9_3 ? "ImageNoColorLevel9_3" : "ImageNoColorLevel9_1"];
+            if (ShaderPasses == null) ShaderPasses = shader.Techniques[level9_3 ? "ImageNoColorLevel9_3" : "ImageNoColorLevel9_1"].Passes.GetEnumerator();
             shader.ImageTexture = WaterTexture;
             shader.ReferenceAlpha = 10;
 


### PR DESCRIPTION
## Summary

This PR improves MSTS shape/material compatibility in the 3D viewer, primarily to support older TML Studios add-ons such as U-Bahn and Linie 51. Until now, much of the distinctive tunnel and station lighting in these routes was lost in Open Rails because several MSTS rendering features they relied on were not implemented.

Some of these features, especially `GlossMap`, were also used more broadly in MSTS content and may be useful for future content as well.

- Added support for `uv_op_uniformscale`, `uv_op_nonuniformscale`, and `uv_op_reflectmapfull`.
- Added scenery shader support for `DetailMod2X`, `GlossMap`, `AlphRefMap`, and `nightlight` / `NightLight`.
- Added support for baked per-vertex lighting, vertex colors, and vertex alpha in MSTS shapes. For vertex colors to be used, `lightMatIdx` must be set to `-1`; this is the third parameter of the corresponding `vtx_state` entry in the shape file.
- Added second texture-stage handling for detail/environment maps, including independent UV scale, address mode, and mipmap bias.
- Updated shadow rendering to respect UV scaling.

| Shader | Description |
| --- | --- |
| **DetailMod2X** | Uses two texture slots. The textures are multiplied together and the result is multiplied by two. Works similarly to terrain rendering. |
| **GlossMap** | Uses two texture slots: one for the base texture and one for an additive reflection layer. See: https://web.archive.org/web/20231210194836/https://msts.steam4me.net/tutorials/supershine.html |
| **AlphRefMap** | Similar to `GlossMap`, but with alpha support. Discovered in TML's `app.fbk`. |
| **nightlight**, **NightLight** | Uses additive blending modulated by inverse daylight, making the material visible primarily at night. TML used it for glowing windows. Discovered in their `.fbk` files. TML uses the lowercase `nightlight` spelling; support for both that spelling and the conventional PascalCase `NightLight` variant was added. |

## Result

Older add-ons relying on MSTS-specific UV operations, detail/gloss/reflection shaders, night lighting, and baked vertex colors should now render much closer to their original MSTS appearance. These capabilities also become available for newly created content.
