### PR TITLE
Russian localization update

### DIFF
--- a/Source/Locales/Contrib/ru.po
+++ b/Source/Locales/Contrib/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2023-12-16 11:02:39+0300\n"
-"PO-Revision-Date: 2024-09-20 12:46+0300\n"
+"PO-Revision-Date: 2026-08-12 15:21+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/AboutActEdit.cs:17
 #: ../../Contrib/ActivityEditor/ActivityEditor/AboutActEdit.Designer.cs:89
@@ -41,7 +41,7 @@ msgstr "Утилита предназначена для создания сце
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/AboutActEdit.Designer.cs:111
 msgid "&OK"
-msgstr "&Ясно"
+msgstr "&OK"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/AboutActEdit.Designer.cs:148
 msgid "Version 0.1"
@@ -71,7 +71,7 @@ msgstr "Продолжительность"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/ActionProperties/ControlStartProperties.Designer.cs:85
 msgid "Pre-delay :"
-msgstr "Предварительная задержка :"
+msgstr "Предварительная задержка:"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/ActionProperties/ControlStartProperties.Designer.cs:100
 msgid "ControlStartProperties"
@@ -106,7 +106,7 @@ msgstr ""
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/ActionProperties/HornProperties.Designer.cs:55
 msgid "Delay :"
-msgstr "Задержка :"
+msgstr "Задержка:"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/ActionProperties/HornProperties.Designer.cs:72
 msgid "Required Trigger Distance :"
@@ -154,24 +154,24 @@ msgstr "Описание"
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:283
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:422
 msgid "Consist :"
-msgstr "Состав :"
+msgstr "Состав:"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:212
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:329
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:439
 msgid "Description :"
-msgstr "Описание :"
+msgstr "Описание:"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:228
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:320
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:455
 msgid "Activity Name : "
-msgstr "Название сценария : "
+msgstr "Название сценария: "
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:238
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:249
 msgid "Traffic Description"
-msgstr "Описание движения"
+msgstr "Описание траффика"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/StartActivity.Designer.cs:464
 msgid "StartActivity"
@@ -179,7 +179,7 @@ msgstr "Начать сценарий"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/WaitActivity.Designer.cs:67
 msgid "Give your description :"
-msgstr "Введите описание :"
+msgstr "Введите описание:"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/WaitActivity.Designer.cs:76
 msgid "Environment"
@@ -187,7 +187,7 @@ msgstr "Окружение"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/WaitActivity.Designer.cs:105
 msgid "Place Name : "
-msgstr "Название места : "
+msgstr "Название места: "
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Activity/WaitActivity.Designer.cs:115
 msgid "WAIT Activity Description"
@@ -222,7 +222,7 @@ msgstr "Сценарий"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.Designer.cs:142
 msgid "Traffic"
-msgstr "Движение"
+msgstr "Траффик"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.Designer.cs:153
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/SimpleTextEd.Designer.cs:70
@@ -300,7 +300,7 @@ msgstr "Параметры станции"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.Designer.cs:388
 msgid "Add Tag"
-msgstr "Добавить метку"
+msgstr "Добавить тег"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.Designer.cs:398
 msgid "Add Station"
@@ -336,7 +336,7 @@ msgstr "Точка действия"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.Designer.cs:506
 msgid "Action Check"
-msgstr "Проверить взаимодействие"
+msgstr "Проверить действие"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.Designer.cs:516
 msgid "toolStripButton10"
@@ -344,15 +344,15 @@ msgstr ""
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.Designer.cs:135
 msgid "Click to start new Activity Description (not ready)"
-msgstr "Создать описание сценария (not ready)"
+msgstr "Создать описание сценария (пока нельзя)"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.Designer.cs:143
 msgid "Click to create new Traffic description (not ready)"
-msgstr "Создать описания движения (not ready)"
+msgstr "Создать описания движения (пока нельзя)"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.Designer.cs:176
 msgid "Click to load an existing OR Activity (not ready)"
-msgstr "Закрузить существующий сценарий ОРТС (not ready)"
+msgstr "Закрузить существующий сценарий ОРТС (пока нельзя)"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/ActEditor.Designer.cs:184
 msgid "Click to Edit Metadata for a specified route"
@@ -378,7 +378,7 @@ msgstr "x"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/Viewer2D.cs:2041
 msgid "Tag"
-msgstr "Метка"
+msgstr "Тег"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Engine/Viewer2D.cs:2107
 msgid "Station"
@@ -398,15 +398,15 @@ msgstr "Показывать маркеры платформ"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Preference/Options.Designer.cs:190
 msgid "Zoom level :"
-msgstr "Степень увеличения :"
+msgstr "Уровень масштаба:"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Preference/Options.Designer.cs:200
 msgid "Size of snap circle :"
-msgstr "Размер круга привязки :"
+msgstr "Размер зоны привязки:"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Preference/Options.Designer.cs:209
 msgid "Show Snap circle"
-msgstr "Показать круг привязки"
+msgstr "Показать зону привязки"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Preference/Options.Designer.cs:220
 msgid "Show all Signal"
@@ -439,11 +439,11 @@ msgstr "Искать"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Preference/Options.Designer.cs:342
 msgid "MSTS Path :"
-msgstr "Путь к MSTS:"
+msgstr "Путь к сборке MSTS:"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Preference/Options.Designer.cs:358
 msgid "Debug Options"
-msgstr "Параметры Отладки"
+msgstr "Параметры отладки"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Preference/Options.Designer.cs:368
 msgid "Show Snap Track Info"
@@ -498,11 +498,11 @@ msgstr ""
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/BufferInterface.Designer.cs:73
 msgid "Buffer Label : "
-msgstr ""
+msgstr "Имя буфера: "
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/BufferInterface.Designer.cs:93
 msgid "Buffer Direction : "
-msgstr ""
+msgstr "Направление буфера: "
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/BufferInterface.Designer.cs:128
 msgid "BufferInterface"
@@ -514,15 +514,15 @@ msgstr "Ещё не реализовано"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/ConnectorInterface.Designer.cs:67
 msgid "Connection Direction : "
-msgstr ""
+msgstr "Направление соединения: "
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/ConnectorInterface.Designer.cs:87
 msgid "Connection Label : "
-msgstr ""
+msgstr "Имя соединения: "
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/ConnectorInterface.Designer.cs:130
 msgid "Station Route Interface"
-msgstr ""
+msgstr "Интерфейс станции"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/StationDisplay.cs:39
 msgid "Please Load Paths:"
@@ -558,7 +558,7 @@ msgstr "Предельная длина платформ"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/StationDisplay.Designer.cs:196
 msgid "Max. Siding Length"
-msgstr "Предельная длина ст.путей"
+msgstr "Предельная длина ст. путей"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/StationDisplay.Designer.cs:207
 msgid "Number of Platform"
@@ -574,7 +574,7 @@ msgstr "Предельная длина путей разъезда"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/StationDisplay.Designer.cs:248
 msgid "Load Paths"
-msgstr "Загружаю маршруты"
+msgstr "Загрузить маршруты"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/StationDisplay.Designer.cs:260
 msgid "label7"
@@ -582,7 +582,7 @@ msgstr ""
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/TrackSegmentInterface.Designer.cs:60
 msgid "Segment Label : "
-msgstr ""
+msgstr "Имя сегмента: "
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Route%20Metadata/TrackSegmentInterface.Designer.cs:71
 msgid "TrackSegmentInterface"
@@ -590,7 +590,7 @@ msgstr ""
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Wizard/ActivityDescr.cs:96
 msgid "Activity Editor: Create new activity"
-msgstr "Редактор сценариев: Создать новый сценарий"
+msgstr "Редактор сценариев: создать новый сценарий"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Wizard/ActivityDescr.cs:106
 #: ../../Contrib/ActivityEditor/ActivityEditor/Wizard/SelectRoute.cs:69
@@ -603,15 +603,15 @@ msgstr "Название сценария"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Wizard/SelectRoute.cs:48
 msgid "Route Configuration: Select Route"
-msgstr "Конфигурация полигона: Выберите полигон"
+msgstr "Конфигурация полигона: выберите полигон"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Wizard/TrainInfo.cs:175
 msgid "Activity Editor: Specify Train Info"
-msgstr "Редактор сценариев: Введите информацию о поезде"
+msgstr "Редактор сценариев: введите информацию о поезде"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Wizard/TrainInfo.cs:194
 msgid "Select Train Consist"
-msgstr "Выберите сотав поезда"
+msgstr "Выберите состав поезда"
 
 #: ../../Contrib/ActivityEditor/ActivityEditor/Wizard/TrainInfo.cs:211
 msgid "Train Name (Opt.)"
@@ -641,7 +641,7 @@ msgstr "Загрузка..."
 
 #: ../../Contrib/ContentManager/ContentManagerGUI.Designer.cs:115
 msgid "Open Rails Content Manager"
-msgstr "Организатор наполнения"
+msgstr "Менеджер контента OR"
 
 #: ../../Contrib/TrackViewer/TrackViewer.cs:629
 msgid "The path you are working on has un-saved changes.\n"
@@ -657,7 +657,7 @@ msgid ""
 "Route cannot be loaded.\n"
 "Extension {0} is not supported"
 msgstr ""
-"Полигон не загрузить.\n"
+"Ошибка загрузки полигона.\n"
 "Расширение {0} не поддерживается"
 
 #: ../../Contrib/TrackViewer/TrackViewer.cs:741
@@ -666,7 +666,7 @@ msgid ""
 "Route cannot be loaded.\n"
 "{0} does not exist"
 msgstr ""
-"Полигон не загрузить.\n"
+"Ошибка загрузки полигона.\n"
 "{0} не существует"
 
 #: ../../Contrib/TrackViewer/TrackViewer.cs:747
@@ -676,7 +676,7 @@ msgid ""
 "While trying to open {0} the folder {1} was inferred as (MSTS or similar) "
 "install folder but does not contain expected files"
 msgstr ""
-"Полигон не удалось загрузить.\n"
+"Ошибка загрузки полигона.\n"
 "При открытии {0} папки {1}, где подразумевалось наличие МСТС-контента, не "
 "обнаружены соответствующие файлы"
 
@@ -686,7 +686,7 @@ msgid ""
 "Route cannot be loaded.\n"
 "{0} somehow could not be translated into a loadable route"
 msgstr ""
-"Полигон не удалось загрузить.\n"
+"Ошибка загрузки полигона.\n"
 "{0} не удалось преобразовать в загружаемый маршрут"
 
 #: ../../Contrib/TrackViewer/TrackViewer.cs:813
@@ -695,7 +695,7 @@ msgid ""
 "The install directory needs to contain ROUTES, GLOBAL, ..."
 msgstr ""
 "Директория некорректна.\n"
-"Директория сборки должна содржать субдиректории ROUTES, GLOBAL, ..."
+"Директория сборки должна содержать папки ROUTES, GLOBAL и т.д."
 
 #: ../../Contrib/TrackViewer/TrackViewer.cs:887
 msgid "Loading route..."
@@ -736,7 +736,7 @@ msgid ""
 "broken nodes, and save the modified path. "
 msgstr ""
 "Сейчас будут загружены все *.pat-файлы данного полигона, чтобы попытаться "
-"исправить все битые точки, а затем-сохранить изменённые маршруты. "
+"исправить все битые точки, а затем сохранить изменённые маршруты. "
 
 #: ../../Contrib/TrackViewer/TrackViewer.cs:1103
 msgid "Potentially it will therefore change all .pat files on disc."
@@ -764,11 +764,11 @@ msgstr "Цвет маршрута (боковой путь)"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:140
 msgid "Select color for multi-colored straight tracks"
-msgstr "Окраска цветных рельсов-прямые участки"
+msgstr "Цвет цветных путей - прямые участки"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:141
 msgid "Select color for multi-colored curved tracks"
-msgstr "Окраска цветных рельсов-криволинейные участки"
+msgstr "Цвет цветных путей - кривые участки"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:142
 msgid "Select color for mono-colored tracks"
@@ -776,23 +776,23 @@ msgstr "Цвет одноцветных путей"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:143
 msgid "Select color for tracks on terrain"
-msgstr "Цвет путей на грунте"
+msgstr "Цвет путей на поверхности"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:145
 msgid "Select color for multi-colored straight roads"
-msgstr "Окраска цветных дорог-прямые участки"
+msgstr "Цвет цветных дорог - прямые участки"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:146
 msgid "Select color for multi-colored curved roads"
-msgstr "Окраска цветных дорог-криволинейные участки"
+msgstr "Цвет цветных дорог - кривые участки"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:147
 msgid "Select color for mono-colored roads"
-msgstr "Цвет дорог"
+msgstr "Цвет одноцветных дорог"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:148
 msgid "Select color for roads on terrain"
-msgstr "Цвет дорог на грунте"
+msgstr "Цвет дорог на поверхности"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:156
 msgid "Select background color"
@@ -832,7 +832,7 @@ msgstr "Цвет ограничений скорости"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:218
 msgid "Select event color"
-msgstr "Выберите цвет для события"
+msgstr "Цвет событий"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawColors.cs:297
 msgid "Select other-paths color"
@@ -841,7 +841,7 @@ msgstr "Цвет прочих маршрутов"
 #: ../../Contrib/TrackViewer/Drawing/DrawTerrain.cs:625
 #, csharp-format
 msgid "Loading terrain ace-files {0}-{1} (scaled down with a factor {2})"
-msgstr "Загружаются текстуры грунта {0}-{1} (уменьшено на коэфициент {2})"
+msgstr "Загружаются текстуры поверхности {0}-{1} (уменьшено в {2} раз)"
 
 #: ../../Contrib/TrackViewer/Drawing/DrawTerrain.cs:651
 msgid "Rescaling previously loaded ace-files"
@@ -857,7 +857,7 @@ msgstr "Загрузка базы путей *.tdb ..."
 
 #: ../../Contrib/TrackViewer/Drawing/DrawTrackDB.cs:73
 msgid "Loading tsection.dat ..."
-msgstr "Загрузка базы звеньев (файл tsection.dat) ..."
+msgstr "Загрузка секций пути (tsection.dat) ..."
 
 #: ../../Contrib/TrackViewer/Drawing/DrawTrackDB.cs:87
 msgid "Loading road track database .rdb ..."
@@ -865,27 +865,27 @@ msgstr "Загрузка базы дорог *.rdb ..."
 
 #: ../../Contrib/TrackViewer/Drawing/DrawTrackDB.cs:366
 msgid "Finding the angles to draw signals, endnodes, ..."
-msgstr "Отрисовка сигналов, тупиков..."
+msgstr "Отрисовка сигналов и тупиков..."
 
 #: ../../Contrib/TrackViewer/Drawing/Labels/DrawLabels.cs:266
 msgid "The .json file could not be read properly."
-msgstr "*.json-файл не удалось прочитать корректно."
+msgstr "Файл .json не удалось прочитать корректно."
 
 #: ../../Contrib/TrackViewer/Drawing/Labels/DrawLabels.cs:278
 msgid "Some labels could not be read properly."
-msgstr "Часть бирок не удалось прочитать корректно."
+msgstr "Часть меток не удалось прочитать корректно."
 
 #: ../../Contrib/TrackViewer/Drawing/Labels/DrawLabels.cs:285
 msgid "None of the labels could be read properly"
-msgstr "Ни одной бирки не удалось прочитать корректно"
+msgstr "Ни одной метки не удалось прочитать корректно"
 
 #: ../../Contrib/TrackViewer/Drawing/Labels/DrawLabels.cs:289
 msgid "There were no labels read"
-msgstr "Бирок не обнаружено"
+msgstr "Меток не обнаружено"
 
 #: ../../Contrib/TrackViewer/Editing/AutoFixAllPaths.xaml.cs:76
 msgid "Processing .pat file "
-msgstr "Обработка *.pat-файлаe "
+msgstr "Обработка *.pat-файла "
 
 #: ../../Contrib/TrackViewer/Editing/EditorActions.cs:180
 msgid "Place start point"
@@ -905,11 +905,11 @@ msgstr "Изменить направление"
 
 #: ../../Contrib/TrackViewer/Editing/EditorActions.cs:295
 msgid "Place end point"
-msgstr "Задать точку финша"
+msgstr "Задать конец маршрута"
 
 #: ../../Contrib/TrackViewer/Editing/EditorActions.cs:334
 msgid "Remove end point"
-msgstr "Убрать точку финиша"
+msgstr "Убрать конец маршрута"
 
 #: ../../Contrib/TrackViewer/Editing/EditorActions.cs:360
 msgid "Place reversal point"
@@ -958,15 +958,15 @@ msgstr "Очистить продолжение маршрута"
 
 #: ../../Contrib/TrackViewer/Editing/EditorActions.cs:951
 msgid "Cut path here and store its tail"
-msgstr "Разделить маршрут на части в этой точке"
+msgstr "Разделить маршрут и сохранить конечную часть"
 
 #: ../../Contrib/TrackViewer/Editing/EditorActions.cs:1005
 msgid "Auto-fix broken points"
-msgstr "Авто-исправление битых точек"
+msgstr "Автоисправление битых точек"
 
 #: ../../Contrib/TrackViewer/Editing/EditorActions.cs:1113
 msgid "Reconnect to tail"
-msgstr "Воссоединить с окончанием"
+msgstr "Присоединить окончание"
 
 #: ../../Contrib/TrackViewer/Editing/EditorActions.cs:1174
 msgid "Reconnect passing path"
@@ -985,7 +985,7 @@ msgid ""
 "The selected path contains no or only 1 node. The current path was not "
 "extended."
 msgstr ""
-"Выбранный маршрут содержит менее двух узлов. Текуший маршрут невозможно "
+"Выбранный маршрут содержит менее двух узлов. Текущий маршрут невозможно "
 "продлить."
 
 #: ../../Contrib/TrackViewer/Editing/PathEditor.cs:800
@@ -997,20 +997,20 @@ msgid ""
 "The selected path has been added as tail. It was not possible to reconnect "
 "automatically."
 msgstr ""
-"Выбранный маршрут был добавлен в конец существующего но автоматическое "
+"Выбранный маршрут был добавлен в конец существующего, но автоматическое "
 "объединение не удалось."
 
 #: ../../Contrib/TrackViewer/Editing/PathEditor.cs:847
 msgid "Reversing broken paths is not supported"
-msgstr "Обращение битых маршрутов не поддерживается"
+msgstr "Реверс битых маршрутов не поддерживается"
 
 #: ../../Contrib/TrackViewer/Editing/PathEditor.cs:852
 msgid "Reversing a path without start node is not supported"
-msgstr "Обращение маршрута без стартовой точки не поддерживается"
+msgstr "Реверс маршрута без стартовой точки не поддерживается"
 
 #: ../../Contrib/TrackViewer/Editing/PathEditor.cs:857
 msgid "Reversing a path without end node is not supported"
-msgstr "Обращение маршрута без финишной точки не поддерживается"
+msgstr "Реверс маршрута без финишной точки не поддерживается"
 
 #: ../../Contrib/TrackViewer/Editing/SavePatFile.cs:84
 msgid ""
@@ -1026,7 +1026,7 @@ msgstr "* Не определена конечная точка маршрута
 
 #: ../../Contrib/TrackViewer/Editing/SavePatFile.cs:93
 msgid "* The path has a stored and not-yet reconnected tail"
-msgstr "* Маршрут имеет сохраненное, но еще не подключённое окончание"
+msgstr "* Маршрут имеет сохраненное, но еще не присоединенное окончание"
 
 #: ../../Contrib/TrackViewer/Editing/SavePatFile.cs:97
 msgid "The current path is not finished:"
@@ -1034,15 +1034,15 @@ msgstr "Текущий маршрут не завершён:"
 
 #: ../../Contrib/TrackViewer/Editing/SavePatFile.cs:110
 msgid "Saving broken paths might not always work correctly."
-msgstr "Сохранение битых маршрутов может не работать корректно."
+msgstr "Сохранение битых маршрутов может работать некорректно."
 
 #: ../../Contrib/TrackViewer/Editing/SavePatFile.cs:111
 msgid "The MSTS format for defining broken paths is not understood very well."
-msgstr "Формат описания битых путей в MSTS не очень хорошо понятен."
+msgstr "Способ описания битых маршрутов в MSTS известен не полностью."
 
 #: ../../Contrib/TrackViewer/Editing/SavePatFile.cs:112
 msgid "Reopening it in TrackViewer, however, is likely to work."
-msgstr "Возможно, повторное открытие в TrackViewer, будет результативно."
+msgstr "Возможно, повторное открытие в TrackViewer сработает."
 
 #: ../../Contrib/TrackViewer/Editing/TrainpathNode.cs:270
 msgid "Set as invalid in .pat file"
@@ -1054,7 +1054,7 @@ msgstr "Ближайшая стрелка слишком далеко"
 
 #: ../../Contrib/TrackViewer/Editing/TrainpathNode.cs:274
 msgid "Not able to place node on track"
-msgstr "Точка не принадлежит маршруту"
+msgstr "Невозможно добавить точку на путь"
 
 #: ../../Contrib/TrackViewer/Editing/TrainpathNode.cs:276
 msgid "Dangling siding node"
@@ -1105,7 +1105,7 @@ msgstr "<Путь>"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:620
 msgid "ctrl-R\tReload the route\n"
-msgstr "ctrl-R\tПерезагрузить полигон\n"
+msgstr "ctrl+R\tПерезагрузить полигон\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:621
 msgid "Q\tQuit\n"
@@ -1117,7 +1117,7 @@ msgstr "=\tПриближать непрерывно\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:624
 msgid "shift-=\tZoom-in\n"
-msgstr "shift-=\tПриблизить на 1 шаг\n"
+msgstr "shift+=\tПриблизить на 1 шаг\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:625
 msgid "-\tZoom-out (and keep zooming)\n"
@@ -1125,7 +1125,7 @@ msgstr "-\tОтдалять непрерывно\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:626
 msgid "shift--\tZoom-out\n"
-msgstr "shift--\tОтдалить на 1 шаг\n"
+msgstr "shift+-\tОтдалить на 1 шаг\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:627
 msgid "Z\tZoom to tile\n"
@@ -1133,7 +1133,7 @@ msgstr "Z\tВместить тайл в экран\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:628
 msgid "M\tToggle zoom center\n"
-msgstr "M\tВыбор фокуса зумирования\n"
+msgstr "M\tИзменить центр масштабирования\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:629
 msgid "R\tZoom reset\n"
@@ -1141,11 +1141,11 @@ msgstr "R\tВместить полигон в экран\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:630
 msgid "L\tAdd label\n"
-msgstr "L\tСоздать бирку\n"
+msgstr "L\tСоздать метку\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:632
 msgid "shift-C\t\tShift center to current mouse location\n"
-msgstr "shift-C\tЦентрировать по курсору мыши\n"
+msgstr "shift+C\tЦентрировать по курсору мыши\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:633
 msgid "left arrow\tShift left\n"
@@ -1165,23 +1165,23 @@ msgstr "↑\tСдвиг вверх\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:638
 msgid "F5\tShow speed-limits\n"
-msgstr "F5\tПоказать огр.скорости\n"
+msgstr "F5\tПоказать ограничения скорости\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:639
 msgid "shift-F5\tShow mileposts\n"
-msgstr "shift-F5\tПоказать пикеты\n"
+msgstr "shift+F5\tПоказать пикеты\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:640
 msgid "F6\tShow terrain\n"
-msgstr "F6\tПоказать грунт\n"
+msgstr "F6\tПоказать поверхность\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:641
 msgid "ctrl-F6\tShow DM terrain\n"
-msgstr "ctrl-F6\tShow DM terrain\n"
+msgstr "ctrl+F6\tПоказать текстуры далёких гор\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:642
 msgid "shift-F6\tShow terrain patch lines\n"
-msgstr "shift-F6\tПоказать линии сшивки текстур грунта\n"
+msgstr "shift+F6\tПоказать линии сшивки текстур\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:643
 msgid "F7\tshow signals\n"
@@ -1193,7 +1193,7 @@ msgstr "F8\tПоказать платформы\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:645
 msgid "shift-F8\tShow platform-names\n"
-msgstr "shift-F8\tПоказать названия платформ\n"
+msgstr "shift+F8\tПоказать названия платформ\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:646
 msgid "F9\tShow sidings\n"
@@ -1201,7 +1201,7 @@ msgstr "F9\tПоказать боковые пути\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:647
 msgid "shift-F9\tShow siding-names\n"
-msgstr "shift-F9\tПоказать названия путей\n"
+msgstr "shift+F9\tПоказать названия путей\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:648
 msgid "F10\tHighlight tracks\n"
@@ -1209,7 +1209,7 @@ msgstr "F10\tПодсвечивать секции пути\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:649
 msgid "shift-F10\tHighlight items\n"
-msgstr "shift-F10\tПодсвечивать объекты\n"
+msgstr "shift+F10\tПодсвечивать объекты\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:650
 msgid "F11\tShow path\n"
@@ -1217,7 +1217,7 @@ msgstr "F11\tПоказывать маршруты\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:651
 msgid "shift-F11\tShow raw path\n"
-msgstr "shift-F11\tПоказывать схему маршрутов\n"
+msgstr "shift+F11\tПоказывать схему маршрутов\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:653
 msgid "C\t\tShift to center of current path node\n"
@@ -1233,11 +1233,11 @@ msgstr "PgDn\t\tСкрыть участок маршрута\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:656
 msgid "shift-PgUp\tShow the full path\n"
-msgstr "shift-PgUp\tОтображать весь маршрут\n"
+msgstr "shift+PgUp\tОтображать весь маршрут\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:657
 msgid "shift-PgDn\tShow only start point of path\n"
-msgstr "shift-PgDn\tОтображать только начало маршрута\n"
+msgstr "shift+PgDn\tОтображать только начало маршрута\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:658
 msgid "E\t\tPlace end-point\n"
@@ -1249,19 +1249,19 @@ msgstr "W\t\tЗадать точку ожидания\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:660
 msgid "ctrl-Z\t\tUndo in path editor\n"
-msgstr "ctrl-Z\t\tОтменить в редакторе маршрута\n"
+msgstr "ctrl+Z\t\tОтменить в редакторе маршрута\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:661
 msgid "ctrl-Y\t\tRedo in path editor\n"
-msgstr "ctrl-Y\t\tПрименить в редакторе маршрута\n"
+msgstr "ctrl+Y\t\tПовторить в редакторе маршрута\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:663
 msgid "alt-?\t\tVarious keys to open submenus\n"
-msgstr "alt-?\t\tКлавиши доступа в подменю\n"
+msgstr "alt+?\t\tКлавиши доступа в подменю\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:665
 msgid "mouse-right click\tOn event shows event message\n"
-msgstr "щелчок правой клавишей мыши\t по событию отобразит сообщение\n"
+msgstr "щелчок правой клавишей мыши\tпо событию отобразит сообщение\n"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml.cs:666
 msgid "Keyboard shortcuts"
@@ -1298,15 +1298,15 @@ msgstr "Документация"
 
 #: ../../Contrib/TrackViewer/Drawing/Labels/EditLabel.xaml:4
 msgid "Label"
-msgstr "Бирка"
+msgstr "Метка"
 
 #: ../../Contrib/TrackViewer/Drawing/Labels/EditLabel.xaml:14
 msgid "Delete label"
-msgstr "Удалить бирку"
+msgstr "Удалить метку"
 
 #: ../../Contrib/TrackViewer/Editing/AutoFixAllPaths.xaml:4
 msgid "Result of auto correcting all paths"
-msgstr "Результат авто-исправления всех маршрутов"
+msgstr "Результат автоисправления всех маршрутов"
 
 #: ../../Contrib/TrackViewer/Editing/AutoFixAllPaths.xaml:19
 msgid ""
@@ -1318,7 +1318,7 @@ msgstr ""
 
 #: ../../Contrib/TrackViewer/Editing/AutoFixAllPaths.xaml:23
 msgid "directly"
-msgstr "полностью"
+msgstr "без подтверждения"
 
 #: ../../Contrib/TrackViewer/Editing/AutoFixAllPaths.xaml:24
 msgid "individually with confirmation"
@@ -1384,7 +1384,7 @@ msgstr "секунд"
 
 #: ../../Contrib/TrackViewer/Editing/WaitPointDialog.xaml:15
 msgid "Openrails advanced shunting options:"
-msgstr "Более сложные манёвры:"
+msgstr "Опции манёвров только для OR:"
 
 #: ../../Contrib/TrackViewer/Editing/WaitPointDialog.xaml:19
 msgid "Wait until:  "
@@ -1420,7 +1420,7 @@ msgstr "Сцепка и расцепка"
 
 #: ../../Contrib/TrackViewer/Editing/WaitPointDialog.xaml:40
 msgid "AI train request to pass red signal"
-msgstr "Другой поезд запросил проследование зпрещающего сигнала"
+msgstr "Другой поезд запросил проследование запрещающего сигнала"
 
 #: ../../Contrib/TrackViewer/Editing/WaitPointDialog.xaml:44
 msgid "Blow horn for"
@@ -1428,7 +1428,7 @@ msgstr "Подавать сигнал"
 
 #: ../../Contrib/TrackViewer/Editing/WaitPointDialog.xaml:46
 msgid "seconds.  11 = American horn sequence."
-msgstr "секунд.  11 = американская последовательность."
+msgstr "секунд.  11 = американская схема гудков."
 
 #: ../../Contrib/TrackViewer/Editing/WaitPointDialog.xaml:50
 msgid "Wait time code as decimal ="
@@ -1440,7 +1440,7 @@ msgstr "00000"
 
 #: ../../Contrib/TrackViewer/Editing/WaitPointDialog.xaml:52
 msgid "hexadecimal ="
-msgstr "в шестнадцатиричном ="
+msgstr "в шестнадцатеричном ="
 
 #: ../../Contrib/TrackViewer/Editing/WaitPointDialog.xaml:53
 msgid "0000"
@@ -1455,8 +1455,8 @@ msgid ""
 "Save the data of the chart in json format into a .js file.The saved data can "
 "then be used to show the chart on an HTML5 canvas."
 msgstr ""
-"Сохранить эту диаграмму в формате json (*.js-файл). Сохранённые данные "
-"возможно просматрвать в HTML5 canvas."
+"Сохранить диаграмму в формате json (*.js-файл). Сохранённые данные можно "
+"просматривать на HTML5 canvas."
 
 #: ../../Contrib/TrackViewer/Editing/Charts/PathChartWindow.xaml:62
 msgid "Save json"
@@ -1469,15 +1469,15 @@ msgstr "Сохранить профиль пути в формате json в *.j
 #: ../../Contrib/TrackViewer/Editing/Charts/PathChartWindow.xaml:67
 msgid "The saved data can then be used to show the chart on an HTML5 canvas."
 msgstr ""
-"Эти данные можно использовать для просмотра профиля пути в HTML5 canvas."
+"Эти данные можно использовать для просмотра профиля пути на HTML5 canvas."
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:7
 msgid "_File"
-msgstr "_Файл"
+msgstr "Файл (F)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:8
 msgid "(Re)load route (ctrl-R)"
-msgstr "(Пере)загрузить полигон (ctrl-R)"
+msgstr "(Пере)загрузить полигон (ctrl+R)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:10
 msgid "Select install folder"
@@ -1517,7 +1517,7 @@ msgstr "Выйти (Q)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:23
 msgid "_View"
-msgstr "_Вид"
+msgstr "Вид (V)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:24
 msgid "Center around station"
@@ -1541,7 +1541,7 @@ msgstr "Выбраный маршрут (F11)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:36
 msgid "Show raw path from .pat file (shift-F11)"
-msgstr "Схема маршрута из .pat-файла (shift-F11)"
+msgstr "Схема маршрута из .pat-файла (shift+F11)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:38
 msgid "Track Coloring"
@@ -1573,31 +1573,31 @@ msgstr "Сетку"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:46
 msgid "Show scale ruler"
-msgstr "Линейный масштаб"
+msgstr "Линейку"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:47
 msgid "Show longitude/latitude"
-msgstr "Широту/долготу"
+msgstr "Широту и долготу"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:49
 msgid "Labels"
-msgstr "Бирки"
+msgstr "Метки"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:50
 msgid "Show labels"
-msgstr "Показать бирки"
+msgstr "Показать метки"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:50
 msgid "For adding a label, press L"
-msgstr "Чтобы добавить бирку, нажмите L"
+msgstr "Чтобы добавить метку, нажмите L"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:51
 msgid "Load labels"
-msgstr "Загрузить бирки"
+msgstr "Загрузить метки"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:52
 msgid "Save labels"
-msgstr "Сохранить бирки"
+msgstr "Сохранить метки"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:55
 msgid "Save current zoom"
@@ -1629,7 +1629,7 @@ msgstr "Сглаживание (нужна перезагрузка)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:65
 msgid "Track _items"
-msgstr "Объекты"
+msgstr "Объекты (I)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:66
 msgid "Show all items"
@@ -1641,11 +1641,11 @@ msgstr "Скрыть все объекты"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:68
 msgid "Highlight items (shift-F10)"
-msgstr "Подсвечивать объекты (shift-F10)"
+msgstr "Подсвечивать объекты (shift+F10)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:69
 msgid "Junctions/ends"
-msgstr "Сопряжения/концы путей"
+msgstr "Сопряжения и концы путей"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:70
 msgid "Show junctions"
@@ -1669,7 +1669,7 @@ msgstr "Отображать маркеры путей (F9)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:76
 msgid "Show siding names (shift-F9)"
-msgstr "Отображать названия путей (shift-F9)"
+msgstr "Отображать названия путей (shift+F9)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:78
 msgid "Platforms"
@@ -1681,15 +1681,15 @@ msgstr "Отображать маркеры платформ (F8)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:80
 msgid "Show platform names (shift-F8)"
-msgstr "Отображать названия платформ (shift-F8)"
+msgstr "Отображать названия платформ (shift+F8)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:81
 msgid "Show station names (shift-F8)"
-msgstr "Отображать имена станций (shift-F8)"
+msgstr "Отображать имена станций (shift+F8)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:83
 msgid "Interactives"
-msgstr "Объекты взаимодействия"
+msgstr "Взаимодействие с игроком"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:84
 msgid "Show signals (F7)"
@@ -1705,7 +1705,7 @@ msgstr "Отображать переезды"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:87
 msgid "Show hazards"
-msgstr "Отображать угрозы"
+msgstr "Отображать опасности"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:88
 msgid "Show fuel/pickups"
@@ -1734,7 +1734,7 @@ msgstr "Отображать ограничения скорости (F5)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:95
 msgid "Show mileposts (shift-F5)"
-msgstr "Отображать пикеты (shift-F5)"
+msgstr "Отображать пикеты (shift+F5)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:97
 msgid "Roads"
@@ -1746,7 +1746,7 @@ msgstr "Отображать дороги"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:99
 msgid "Show car spawners"
-msgstr "Отображать генераторы движения"
+msgstr "Отображать точки генерации автомобилей"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:100
 msgid "Show road crossings"
@@ -1754,7 +1754,7 @@ msgstr "Отображать перекрёстки"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:103
 msgid "_Statusbar"
-msgstr "_Статус-строка"
+msgstr "Строка состояния (S)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:104
 msgid "Show vector section info"
@@ -1770,7 +1770,7 @@ msgstr "Сведения о маршруте"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:110
 msgid "Show terrain info"
-msgstr "Сведения о грунте"
+msgstr "Сведения о поверхности"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:112
 msgid "Show signal info"
@@ -1782,11 +1782,11 @@ msgstr "Названия платформ/станций"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:119
 msgid "_Preferences"
-msgstr "_Настройки"
+msgstr "Настройки (P)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:120
 msgid "Zooming is centered on mouse (M)"
-msgstr "Фокус зумирования центрируется мышью (M)"
+msgstr "Центр масштабирования под указателем мыши (M)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:122
 msgid "Use miles i.s.o. meters"
@@ -1794,7 +1794,7 @@ msgstr "Использовать мили вместо метров"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:123
 msgid "Select language"
-msgstr "Выбрать язык"
+msgstr "Set language / Выбрать язык"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:128
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:155
@@ -1818,7 +1818,7 @@ msgstr "Использовать Shift+PgUp для продления маршр
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:134
 msgid "Path-_Editor"
-msgstr "Работа_ с маршрутами"
+msgstr "Маршруты (E)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:135
 msgid "==Supporting MSTS paths only=="
@@ -1858,35 +1858,35 @@ msgstr "Редактировать метаданные маршрута"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:153
 msgid "Reverse path"
-msgstr "Обратить маршрут"
+msgstr "Развернуть маршрут"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:160
 msgid "Auto-fix all broken nodes"
-msgstr "Авто-исправление всех \"битых\" узлов"
+msgstr "Автоисправление всех \"битых\" узлов"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:161
 msgid "Auto-fix all broken paths"
-msgstr "Авто-исправление всех \"битых\" маршрутов"
+msgstr "Автоисправление всех \"битых\" маршрутов"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:163
 msgid "_Terrain"
-msgstr "_Ландшафт"
+msgstr "Ландшафт (T)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:164
 msgid "Show terrain textures (F6)"
-msgstr "Отображать текстуры грунта (F6)"
+msgstr "Отображать текстуры поверхности (F6)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:165
 msgid "Show DM terrain textures (ctrl-F6)"
-msgstr "Отображать текстуры грунта гор (ctrl-F6)"
+msgstr "Отображать текстуры далёких гор (ctrl+F6)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:166
 msgid "Show patch lines (shift-F6)"
-msgstr "Отображать линии сшивки текстур (shift-F6)"
+msgstr "Отображать линии сшивки текстур (shift+F6)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:168
 msgid "Memory reduction options"
-msgstr "Варианты экономии памяти"
+msgstr "Способы экономии памяти"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:169
 msgid "No reduction"
@@ -1898,23 +1898,23 @@ msgstr "Автоматически"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:171
 msgid "Reduce by linear factor 2"
-msgstr "Уменьшить на линейный коэффициент 2"
+msgstr "Уменьшить в 2 раза"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:172
 msgid "Reduce by linear factor 4"
-msgstr "Уменьшить на линейный коэффициент 4"
+msgstr "Уменьшить в 4 раза"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:173
 msgid "Reduce by linear factor 8"
-msgstr "Уменьшить на линейный коэффициент 8"
+msgstr "Уменьшить в 8 раз"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:174
 msgid "Reduce by linear factor 16"
-msgstr "Уменьшить на линейный коэффициент 16"
+msgstr "Уменьшить в 16 раз"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:177
 msgid "_Help"
-msgstr "_Инфо"
+msgstr "Справка (H)"
 
 #: ../../Contrib/TrackViewer/UserInterface/MenuControl.xaml:178
 msgid "Shortcuts"
@@ -1926,7 +1926,7 @@ msgstr "О программе"
 
 #: ../../Contrib/TrackViewer/UserInterface/OtherPathsWindow.xaml:8
 msgid "Select paths to draw"
-msgstr "Выберите маршруты для отображения"
+msgstr "Выберите отображаемые маршруты"
 
 #: ../../Contrib/TrackViewer/UserInterface/OtherPathsWindow.xaml:12
 msgid "Clear all"
@@ -1939,15 +1939,15 @@ msgstr "Поиск"
 
 #: ../../Contrib/TrackViewer/UserInterface/StatusBarControl.xaml:33
 msgid "Shows tileX and tileZ of the world location at the mouse pointer"
-msgstr "Координаты квадрата под указателем мыши"
+msgstr "Координаты тайла под указателем мыши"
 
 #: ../../Contrib/TrackViewer/UserInterface/StatusBarControl.xaml:41
 msgid "Shows X-coordinate (without tileX) at the mouse pointer"
-msgstr "Долгота точки под указателем мыши"
+msgstr "Координата X точки на тайле под указателем мыши"
 
 #: ../../Contrib/TrackViewer/UserInterface/StatusBarControl.xaml:48
 msgid "Shows Z-coordinate (without tileZ) at the mouse pointer"
-msgstr "Широта точки под указателем мыши"
+msgstr "Координата Y точки на тайле под указателем мыши"
 
 #: ../../Contrib/TrackViewer/UserInterface/StatusBarControl.xaml:54
 msgid "Trackindex"

--- a/Source/Locales/Menu/ru.po
+++ b/Source/Locales/Menu/ru.po
@@ -2,20 +2,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2025-01-02 01:26:58+0300\n"
-"PO-Revision-Date: 2025-01-04 11:28+0300\n"
+"PO-Revision-Date: 2026-08-25 21:53+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"X-Generator: Poedit 3.0\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.9\n"
 
 #: ../../Menu/ContentForm.cs:260 ../../Menu/DownloadContentForm.cs:173
 msgid "Main Path where route is to be installed"
-msgstr "Путь для установки полигона"
+msgstr "Установить в"
 
 #: ../../Menu/ContentForm.cs:290 ../../Menu/ContentForm.cs:295
 #: ../../Menu/DownloadContentForm.cs:556 ../../Menu/DownloadContentForm.cs:561
@@ -28,7 +28,7 @@ msgstr "скриншоты"
 
 #: ../../Menu/ContentForm.cs:307 ../../Menu/DownloadContentForm.cs:573
 msgid "Downloadable: GitHub format"
-msgstr "Доступно с ГитХаб"
+msgstr "Доступно с GitHub.com"
 
 #: ../../Menu/ContentForm.cs:308 ../../Menu/DownloadContentForm.cs:574
 msgid "From:"
@@ -36,7 +36,7 @@ msgstr "Адрес:"
 
 #: ../../Menu/ContentForm.cs:317
 msgid "<p>Downloadable: zip format<br>"
-msgstr "<p>Доступно: в формате zip<br>"
+msgstr "<p>Доступно в формате zip<br>"
 
 #: ../../Menu/ContentForm.cs:333 ../../Menu/ContentForm.Designer.cs:126
 #: ../../Menu/DownloadContentForm.cs:599
@@ -72,7 +72,7 @@ msgstr "Не требуется"
 #: ../../Menu/ContentForm.cs:348 ../../Menu/ContentForm.Designer.cs:297
 #: ../../Menu/DownloadContentForm.cs:614
 msgid "Installation profile"
-msgstr "Профиль установки"
+msgstr "Параметры установки"
 
 #: ../../Menu/ContentForm.cs:349 ../../Menu/ContentForm.Designer.cs:118
 #: ../../Menu/ContentForm.Designer.cs:385 ../../Menu/DownloadContentForm.cs:616
@@ -96,11 +96,11 @@ msgstr "Состав"
 
 #: ../../Menu/ContentForm.cs:356 ../../Menu/DownloadContentForm.cs:619
 msgid "Starting at"
-msgstr "Отправление из"
+msgstr "Начало маршрута:"
 
 #: ../../Menu/ContentForm.cs:358 ../../Menu/DownloadContentForm.cs:620
 msgid "Heading to"
-msgstr "Прибытие в"
+msgstr "Завершение маршрута:"
 
 #: ../../Menu/ContentForm.cs:360 ../../Menu/DownloadContentForm.cs:621
 #: ../../Menu/Options.cs:223 ../../Menu/ResumeForm.Designer.cs:380
@@ -133,8 +133,8 @@ msgstr "Если это так - Вы действуете на свой стр�
 msgid ""
 "Get a git expert at your desk or just Delete and Install the route again."
 msgstr ""
-"Воспользуйтест приложением для работы с ГитХаб, или переустановите полигон "
-"заново."
+"Воспользуйтесь git-клиентом (при необходимости запросите помощь) или "
+"переустановите полигон заново."
 
 #: ../../Menu/ContentForm.cs:401 ../../Menu/ContentForm.cs:513
 #: ../../Menu/ContentForm.cs:547 ../../Menu/ContentForm.cs:558
@@ -178,15 +178,15 @@ msgstr "Добавленных файлов не найдено"
 
 #: ../../Menu/ContentForm.cs:443 ../../Menu/DownloadContentForm.cs:699
 msgid "Changed local file(s) after the install (git status)"
-msgstr "Файлы изменены после установки (Гит)"
+msgstr "Файлы изменены после установки (git)"
 
 #: ../../Menu/ContentForm.cs:458 ../../Menu/DownloadContentForm.cs:714
 msgid "Added local file(s) after the install (git status)"
-msgstr "Файлы добавлены после установки (Гит)"
+msgstr "Файлы добавлены после установки (git)"
 
 #: ../../Menu/ContentForm.cs:473 ../../Menu/DownloadContentForm.cs:729
 msgid "Remote GitHub Updates available:"
-msgstr "Доступны обновления с ГитХаб:"
+msgstr "Доступны обновления с GitHub:"
 
 #: ../../Menu/ContentForm.cs:490 ../../Menu/ContentForm.cs:898
 #: ../../Menu/DownloadContentForm.cs:746 ../../Menu/DownloadContentForm.cs:981
@@ -233,7 +233,7 @@ msgstr "Путь для установки полигона"
 #: ../../Menu/ContentForm.cs:335 ../../Menu/ContentForm.cs:336
 #: ../../Menu/ContentForm.cs:337
 msgid "- "
-msgstr ""
+msgstr "- "
 
 #: ../../Menu/ContentForm.cs:311 ../../Menu/ContentForm.cs:321
 #: ../../Menu/DownloadContentForm.cs:577 ../../Menu/DownloadContentForm.cs:587
@@ -259,12 +259,12 @@ msgstr "Папка {0} не существует"
 #: ../../Menu/ContentForm.cs:400 ../../Menu/DownloadContentForm.cs:656
 #, csharp-format
 msgid "Error opening html page {0} in browser. Error: {1}"
-msgstr "Не удалось открыть веб-страницу {0} в браузере: Ошибка {1}"
+msgstr "Не удалось открыть веб-страницу {0} в браузере: ошибка {1}"
 
 #: ../../Menu/ContentForm.cs:482 ../../Menu/DownloadContentForm.cs:738
 #, csharp-format
 msgid "On {0} by {1}"
-msgstr ""
+msgstr "На {0} из {1}"
 
 #: ../../Menu/ContentForm.cs:512 ../../Menu/DownloadContentForm.cs:200
 #, csharp-format
@@ -277,7 +277,7 @@ msgid ""
 "Not enough diskspace on drive {0} ({1}), available {2} kB, needed {3} kB, "
 "still continue?"
 msgstr ""
-"Недостаточно места на диске {0} ({1}), имеется {2} kB, нужно {3} kB. "
+"Недостаточно места на диске {0} ({1}): свободно {2} кБ, нужно {3} кБ. "
 "Продолжить?"
 
 #: ../../Menu/ContentForm.cs:557 ../../Menu/DownloadContentForm.cs:245
@@ -302,12 +302,12 @@ msgstr "Ошибка при загрузке с ГитХаб: {0}"
 #: ../../Menu/ContentForm.cs:736 ../../Menu/DownloadContentForm.cs:421
 #, csharp-format
 msgid "Error during download zipfile {0}: {1}"
-msgstr "Ошибка при скачивании зип-архива {0}: {1}"
+msgstr "Ошибка при скачивании zip архива {0}: {1}"
 
 #: ../../Menu/ContentForm.cs:755 ../../Menu/DownloadContentForm.cs:440
 #, csharp-format
 msgid "Error during unzip zipfile {0}: {1}"
-msgstr "Ошибка при распаковке архива {0}: {1}"
+msgstr "Ошибка при распаковке zip архива {0}: {1}"
 
 #: ../../Menu/ContentForm.cs:932 ../../Menu/DownloadContentForm.cs:1015
 #, csharp-format
@@ -329,7 +329,7 @@ msgstr "В папке \"{0}\" есть измененные, или добавл
 #: ../../Menu/ContentForm.cs:1354 ../../Menu/DownloadContentForm.cs:1239
 #, csharp-format
 msgid "Error during GitHub pull, updates might not be installed, error: {0}"
-msgstr "Ошибка при обращении к ГитХаб: возможно, обновление не прошло: {0}"
+msgstr "Ошибка при обращении к ГитХаб - возможно, обновление не прошло: {0}"
 
 #: ../../Menu/ContentForm.Designer.cs:145
 #: ../../Menu/DownloadContentForm.Designer.cs:122
@@ -340,7 +340,7 @@ msgstr "Путь для установки:"
 #: ../../Menu/ContentForm.Designer.cs:306
 #: ../../Menu/DownloadContentForm.Designer.cs:138
 msgid "Browse..."
-msgstr "Просмотр..."
+msgstr "Изменить"
 
 #: ../../Menu/ContentForm.Designer.cs:172
 #: ../../Menu/DownloadContentForm.Designer.cs:149
@@ -357,7 +357,7 @@ msgstr "Инфо"
 #: ../../Menu/DownloadContentForm.Designer.cs:189
 #: ../../Menu/ResumeForm.Designer.cs:150
 msgid "Delete"
-msgstr "Убрать"
+msgstr "Удалить"
 
 #: ../../Menu/ContentForm.Designer.cs:223
 #: ../../Menu/DownloadContentForm.Designer.cs:199
@@ -382,7 +382,7 @@ msgstr "Путь:"
 
 #: ../../Menu/ContentForm.Designer.cs:355
 msgid "Add..."
-msgstr "Добавить..."
+msgstr "Добавить"
 
 #: ../../Menu/ContentForm.Designer.cs:405 ../../Menu/Options.Designer.cs:351
 #: ../../Menu/TestingForm.Designer.cs:87
@@ -414,7 +414,7 @@ msgstr "Скачать контент"
 
 #: ../../Menu/ImportExportSaveForm.cs:52
 msgid "Save Packs"
-msgstr "Пакеты Сохранений"
+msgstr "Пакеты сохранений"
 
 #: ../../Menu/ImportExportSaveForm.cs:52
 msgid "All files"
@@ -423,24 +423,24 @@ msgstr "Все файлы"
 #: ../../Menu/ImportExportSaveForm.cs:63
 #, csharp-format
 msgid "Save Pack '{0}' imported successfully."
-msgstr "Пакет Сохранений '{0}' успешно импортирован."
+msgstr "Пакет сохранений '{0}' успешно импортирован."
 
 #: ../../Menu/ImportExportSaveForm.cs:87
 #, csharp-format
 msgid "Save Pack '{0}' exported successfully."
-msgstr "Пакет Сохранений '{0}' успешно экспортирован."
+msgstr "Пакет сохранений '{0}' успешно экспортирован."
 
 #: ../../Menu/ImportExportSaveForm.cs:113
 #, csharp-format
 msgid "Save Pack folder contains {0} save pack:"
 msgid_plural "Save Pack folder contains {0} save packs:"
-msgstr[0] "Папка с Пакетами Сохранений содержит {0} Пакет Сохранений:"
-msgstr[1] "Папка с Пакетами Сохранения содержит {0} Пакета Сохранения:"
-msgstr[2] "Папка с Пакетами Сохранения содержит {0} Пакетов Сохранения:"
+msgstr[0] "Папка с пакетами сохранений содержит {0} пакет сохранений:"
+msgstr[1] "Папка с пакетами сохранения содержит {0} пакета сохранений:"
+msgstr[2] "Папка с пакетами сохранений содержит {0} пакетов сохранений:"
 
 #: ../../Menu/ImportExportSaveForm.Designer.cs:39
 msgid "Open Save Packs folder"
-msgstr "Открыть папку с Пакетами Сохранений"
+msgstr "Открыть папку с пакетами"
 
 #: ../../Menu/ImportExportSaveForm.Designer.cs:49
 msgid "Export to Save Pack"
@@ -448,7 +448,7 @@ msgstr "Экспорт в пакет сохранений"
 
 #: ../../Menu/ImportExportSaveForm.Designer.cs:59
 msgid "Import Save Pack"
-msgstr "Импорт Пакета Сохранений"
+msgstr "Импорт пакета сохранений"
 
 #: ../../Menu/ImportExportSaveForm.Designer.cs:93
 msgid "Import and export saved games"
@@ -565,7 +565,7 @@ msgid ""
 "User name must be 4-10 characters long, cannot contain space, ', \" or - and "
 "must not start with a digit."
 msgstr ""
-"Имя должно содержать 4-10 символов, кроме пробела, апострофа, кавычек и "
+"Ваше имя должно содержать 4-10 символов, кроме пробела, апострофа, кавычек и "
 "дефиса и не должно начинаться с цифры."
 
 #: ../../Menu/MainForm.cs:1139
@@ -575,7 +575,7 @@ msgstr "Инструктаж"
 #: ../../Menu/MainForm.cs:1128
 #, csharp-format
 msgid "Route: {0}"
-msgstr "Игровой полигон {0}"
+msgstr "Игровой полигон: {0}"
 
 #: ../../Menu/MainForm.cs:1134 ../../Menu/MainForm.cs:1166
 #, csharp-format
@@ -595,12 +595,12 @@ msgstr "Маршрут: {0}"
 #: ../../Menu/MainForm.cs:1144
 #, csharp-format
 msgid "Starting at: {0}"
-msgstr "Отправление из: {0}"
+msgstr "Начало маршрута: {0}"
 
 #: ../../Menu/MainForm.cs:1145
 #, csharp-format
 msgid "Heading to: {0}"
-msgstr "Прибытие в: {0}"
+msgstr "Окончание маршрута: {0}"
 
 #: ../../Menu/MainForm.cs:1152
 #, csharp-format
@@ -640,7 +640,9 @@ msgstr "Настройки"
 
 #: ../../Menu/MainForm.Designer.cs:174
 msgid "Resume/ Replay..."
-msgstr "Сохранения..."
+msgstr ""
+"Продолжить\n"
+"сессию"
 
 #: ../../Menu/MainForm.Designer.cs:183
 msgid "Tools ▼"
@@ -656,7 +658,7 @@ msgstr "Имя игрока:"
 
 #: ../../Menu/MainForm.Designer.cs:275
 msgid "Multiplayer"
-msgstr "Многопользовательский режим"
+msgstr " Многопользовательский режим "
 
 #: ../../Menu/MainForm.Designer.cs:283
 msgid "Server"
@@ -672,11 +674,11 @@ msgstr "Начать МП"
 
 #: ../../Menu/MainForm.Designer.cs:316
 msgid "Resume MP"
-msgstr "Продолж"
+msgstr "Продолж."
 
 #: ../../Menu/MainForm.Designer.cs:329
 msgid "Singleplayer"
-msgstr "Обычный"
+msgstr " Обычный "
 
 #: ../../Menu/MainForm.Designer.cs:339
 msgid "Installation profile:"
@@ -688,7 +690,7 @@ msgstr "Документы ▼"
 
 #: ../../Menu/MainForm.Designer.cs:396
 msgid "Mode:"
-msgstr "Режим:"
+msgstr "Режим движения поездов:"
 
 #: ../../Menu/MainForm.Designer.cs:417
 msgid "Timetable"
@@ -708,19 +710,19 @@ msgstr "Состав:"
 
 #: ../../Menu/MainForm.Designer.cs:528
 msgid "Starting at:"
-msgstr "Отправление из:"
+msgstr "Начало маршрута:"
 
 #: ../../Menu/MainForm.Designer.cs:552
 msgid "Heading to:"
-msgstr "Прибытие в:"
+msgstr "Окончание маршрута:"
 
 #: ../../Menu/MainForm.Designer.cs:575
 msgid "Duration:"
-msgstr "Длит-ность:"
+msgstr "Длится:"
 
 #: ../../Menu/MainForm.Designer.cs:585
 msgid "Time:"
-msgstr "Время:"
+msgstr "Начало:"
 
 #: ../../Menu/MainForm.Designer.cs:633 ../../Menu/MainForm.Designer.cs:801
 msgid "Weather:"
@@ -752,7 +754,7 @@ msgstr "День:"
 
 #: ../../Menu/MainForm.Designer.cs:856
 msgid "Timetable set:"
-msgstr "Расписание:"
+msgstr "График:"
 
 #: ../../Menu/MainForm.Designer.cs:863 ../../Menu/Options.cs:245
 #: ../../Menu/TestingForm.Designer.cs:314
@@ -761,11 +763,11 @@ msgstr "Предварительная проверка"
 
 #: ../../Menu/MainForm.Designer.cs:889
 msgid "1"
-msgstr ""
+msgstr "1"
 
 #: ../../Menu/MainForm.Designer.cs:903 ../../Menu/MainForm.Designer.cs:915
 msgid "Notifications published by Open Rails"
-msgstr "Уведомления об Open Rails"
+msgstr "Уведомления от Open Rails"
 
 #: ../../Menu/Options.cs:96
 msgid "Player's location"
@@ -785,7 +787,7 @@ msgstr "Имперские (Британия)"
 
 #: ../../Menu/Options.cs:106
 msgid "Automatic"
-msgstr "Авто"
+msgstr "Выбрать автоматически"
 
 #: ../../Menu/Options.cs:107
 msgid "bar"
@@ -821,7 +823,7 @@ msgstr "пробел"
 
 #: ../../Menu/Options.cs:201
 msgid "route"
-msgstr "по описанию полигона"
+msgstr "как на полигоне"
 
 #: ../../Menu/Options.cs:202
 msgid "m/s"
@@ -865,7 +867,7 @@ msgstr "Пройденный путь"
 
 #: ../../Menu/Options.cs:231
 msgid "Throttle %"
-msgstr "Тяга %"
+msgstr "Тяга, %"
 
 #: ../../Menu/Options.cs:232
 msgid "Brake Cyl Press"
@@ -873,7 +875,7 @@ msgstr "Давление в ТЦ"
 
 #: ../../Menu/Options.cs:233
 msgid "Dyn Brake %"
-msgstr "Динамич. торможение %"
+msgstr "Динамич. торможение, %"
 
 #: ../../Menu/Options.cs:234
 msgid "Gear Setting"
@@ -1011,7 +1013,7 @@ msgstr "Полная детализация (+{0}%)"
 
 #: ../../Menu/Options.Designer.cs:327
 msgid "Brake pipe charging rate (PSI/s)             "
-msgstr "Темп зарядки Тормозной магистрали (PSI/s)             "
+msgstr "Темп зарядки тормозной магистрали (PSI/s)             "
 
 #: ../../Menu/Options.Designer.cs:338
 msgid "Graduated release air brakes                                "
@@ -1030,7 +1032,7 @@ msgstr "Общие"
 
 #: ../../Menu/Options.Designer.cs:431
 msgid "Interval :"
-msgstr "Каджые:"
+msgstr "каджые:"
 
 #: ../../Menu/Options.Designer.cs:441
 msgid "60 mins"
@@ -1046,7 +1048,7 @@ msgstr "15 минут"
 
 #: ../../Menu/Options.Designer.cs:476
 msgid "Auto save"
-msgstr "Автосохрять"
+msgstr "Сохранять"
 
 #: ../../Menu/Options.Designer.cs:583
 msgid "Overspeed monitor                                                     "
@@ -1055,8 +1057,8 @@ msgstr "Контроль скорости                                       
 #: ../../Menu/Options.Designer.cs:595
 msgid "Use TCS scripts                                              "
 msgstr ""
-"Включить скрипты Систем безопасности "
-"движения                                              "
+"Включить скрипты устройств "
+"безопасности                                              "
 
 #: ../../Menu/Options.Designer.cs:608
 msgid "Other units                        "
@@ -1098,7 +1100,7 @@ msgstr "Вид"
 
 #: ../../Menu/Options.Designer.cs:883
 msgid "Default detail (+0%)"
-msgstr "Детализация по умолчанию (+0%)"
+msgstr "По умолчанию (+0%)"
 
 #: ../../Menu/Options.Designer.cs:1061
 msgid "Level of detail bias:"
@@ -1138,11 +1140,11 @@ msgstr "YYY"
 
 #: ../../Menu/Options.Designer.cs:1193
 msgid "Model instancing"
-msgstr "Создавать примеры моделей"
+msgstr "Отрисовка одинаковых моделей в 1 проход"
 
 #: ../../Menu/Options.Designer.cs:1223
 msgid "Vertical sync"
-msgstr "Вертикальная синхронизация"
+msgstr "Синхронизация с частотой обновления монитора"
 
 #: ../../Menu/Options.Designer.cs:1235
 msgid "Viewing distance (km)"
@@ -1150,7 +1152,7 @@ msgstr "Дальность видимости (км)"
 
 #: ../../Menu/Options.Designer.cs:1276
 msgid "Distant mountains"
-msgstr "Горы"
+msgstr "Далёкие горы"
 
 #: ../../Menu/Options.Designer.cs:1289
 msgid "Viewing distance (m)"
@@ -1178,7 +1180,7 @@ msgstr "Реализм"
 
 #: ../../Menu/Options.Designer.cs:1441
 msgid "Electric - power connected"
-msgstr "Электровоз - включён"
+msgstr "Электровоз - под напряжением"
 
 #: ../../Menu/Options.Designer.cs:1451
 msgid "At game start, locomotives have:"
@@ -1186,7 +1188,7 @@ msgstr "При старте симуляции:"
 
 #: ../../Menu/Options.Designer.cs:1460
 msgid "Diesel - engine(s) started"
-msgstr "Тепловоз - ДВС заведен(ы)"
+msgstr "Тепловоз - ДВС запущен(ы)"
 
 #: ../../Menu/Options.Designer.cs:1474
 msgid "Activity Options"
@@ -1198,7 +1200,7 @@ msgstr "Расчёт пути и места скрещения"
 
 #: ../../Menu/Options.Designer.cs:1495
 msgid "Open/close doors in AI trains"
-msgstr "Управляемые компьютером двери"
+msgstr "Открывать двери на встречных поездах"
 
 #: ../../Menu/Options.Designer.cs:1506
 msgid "Forced red at station stops"
@@ -1218,7 +1220,7 @@ msgstr "Безопасная скорость зависит от радиуса
 
 #: ../../Menu/Options.Designer.cs:1546
 msgid "Break couplers"
-msgstr "Разрушение сцепок"
+msgstr "Разрешить обрывы сцепок"
 
 #: ../../Menu/Options.Designer.cs:1556
 msgid "Advanced adhesion model"
@@ -1234,7 +1236,7 @@ msgstr "Экспорт"
 
 #: ../../Menu/Options.Designer.cs:1594 ../../Menu/Options.Designer.cs:2352
 msgid "Defaults"
-msgstr "Умолчания"
+msgstr "Стандартные"
 
 #: ../../Menu/Options.Designer.cs:1606 ../../Menu/Options.Designer.cs:2363
 msgid "Check"
@@ -1274,7 +1276,7 @@ msgstr "Запись данных о производительности пар
 
 #: ../../Menu/Options.Designer.cs:1753
 msgid "Verbose ENG/WAG configuration messages"
-msgstr "Подробные сообщения конфигурации *eng и *wag файлов"
+msgstr "Подробные сообщения о конфигурации .eng и .wag файлов"
 
 #: ../../Menu/Options.Designer.cs:1768
 msgid "RailDriver"
@@ -1282,7 +1284,7 @@ msgstr "РэйлДрайвер"
 
 #: ../../Menu/Options.Designer.cs:1807
 msgid "Reverse Levers"
-msgstr "Обратить рычаги"
+msgstr "Обратить рукоятки"
 
 #: ../../Menu/Options.Designer.cs:1817
 msgid "Reverse Independent Brake Direction"
@@ -1330,11 +1332,11 @@ msgstr "Автонастройка под требуемую производи�
 
 #: ../../Menu/Options.Designer.cs:2053
 msgid "Web server port"
-msgstr "Номер порта ВЭБ-сервера"
+msgstr "Номер порта веб-сервера"
 
 #: ../../Menu/Options.Designer.cs:2109
 msgid "Messages suppressed       "
-msgstr "Сообщения не выводятся       "
+msgstr "Отключить подсказки       "
 
 #: ../../Menu/Options.Designer.cs:2131
 msgid "Use glass for in-game windows"
@@ -1427,7 +1429,7 @@ msgstr "Возвышение (старый вариант)"
 
 #: ../../Menu/Options.Designer.cs:2613
 msgid "Superelevation"
-msgstr "Возвышение"
+msgstr "Возвышение в кривых"
 
 #: ../../Menu/Options.Designer.cs:1683
 msgid ""
@@ -1437,7 +1439,7 @@ msgid ""
 msgstr ""
 "Использовать регистратор данных для записи протокола поездки (внутриигровая "
 "команда: F12).\r\n"
-"Пожалуйста, помните, что размер файла дампа растет входе поездки!"
+"Пожалуйста, помните, что размер файла дампа растет в ходе поездки!"
 
 #: ../../Menu/Options.Designer.cs:731
 msgid ""
@@ -1521,9 +1523,9 @@ msgid ""
 "system when gauge data is missing from the route. Set to the most common "
 "track gauge used on your route."
 msgstr ""
-"Расстояние между рельсами в миллиметрах, для расчёта возвышения, если для "
-"полигона нет данных о колее. Задайте наиболее типичную для этого полигона "
-"ширину колеи."
+"Расстояние между рельсами в миллиметрах для расчёта возвышения, если на "
+"полигоне не задана колея. Укажите самую типичную для этого полигона ширину "
+"колеи."
 
 #: ../../Menu/Options.Designer.cs:2601
 msgid ""
@@ -1553,7 +1555,7 @@ msgstr ""
 msgid ""
 "Press any RailDriver button to Assign. Press Backspace to remove an "
 "assignment."
-msgstr "Нажмите кнопку на РД для назначения, либо Бэкспэйс - для отмены."
+msgstr "Нажмите кнопку на РД для назначения, либо Бэкспэйс для отмены."
 
 #: ../../Menu/ResumeForm.cs:155
 msgid "Explore in Activity Mode"
@@ -1561,7 +1563,7 @@ msgstr "Исследовать в режиме сценария"
 
 #: ../../Menu/ResumeForm.cs:155 ../../Menu/ResumeForm.cs:190
 msgid "Explore Route"
-msgstr "Исследовать полигон"
+msgstr "Исследовать полигон без ограничений"
 
 #: ../../Menu/ResumeForm.cs:237
 msgid ""
@@ -1621,11 +1623,13 @@ msgstr "Убрать все устаревшие сохранения"
 
 #: ../../Menu/ResumeForm.Designer.cs:195
 msgid "Import/ export"
-msgstr "Импорт/ экспорт"
+msgstr ""
+"Импорт/\n"
+"экспорт"
 
 #: ../../Menu/ResumeForm.Designer.cs:211
 msgid "Invalid saves"
-msgstr "Устаревшие сохранения"
+msgstr " Устаревшие сохранения "
 
 #: ../../Menu/ResumeForm.Designer.cs:256
 msgid "Replay from previous save"
@@ -1633,11 +1637,11 @@ msgstr "С прошлого сохранения"
 
 #: ../../Menu/ResumeForm.Designer.cs:266
 msgid "Replay from start"
-msgstr "Повтор от начала"
+msgstr "Повтор с начала"
 
 #: ../../Menu/ResumeForm.Designer.cs:279
 msgid "Pause replay at end"
-msgstr "Приостановить по окончании"
+msgstr "Поставить на паузу в конце"
 
 #: ../../Menu/ResumeForm.Designer.cs:291
 msgid "Pause seconds before end:"
@@ -1645,7 +1649,7 @@ msgstr "Приостановить за ... секунд до окончания
 
 #: ../../Menu/ResumeForm.Designer.cs:431
 msgid "Saved Games"
-msgstr "Сохранения"
+msgstr "Сохраненные сессии"
 
 #: ../../Menu/ResumeForm.Designer.cs:355
 msgid "File"

--- a/Source/Locales/ORTS.Common/ru.po
+++ b/Source/Locales/ORTS.Common/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2024-11-02 19:42:02+0300\n"
-"PO-Revision-Date: 2025-01-04 12:14+0300\n"
+"PO-Revision-Date: 2026-08-12 15:15+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"X-Generator: Poedit 3.0\n"
+"X-Generator: Poedit 3.9\n"
 
 #: ../../ORTS.Common/Conversions.cs:535
 msgid "m"
@@ -75,7 +75,7 @@ msgstr "фунт/дюйм²"
 
 #: ../../ORTS.Common/Conversions.cs:550
 msgid "inHg"
-msgstr "дюйм.Hg"
+msgstr "дюйм рт.с."
 
 #: ../../ORTS.Common/Conversions.cs:551
 msgid "kgf/cm²"
@@ -91,7 +91,7 @@ msgstr "л/мин"
 
 #: ../../ORTS.Common/Conversions.cs:554
 msgid "cfm"
-msgstr "фут^3/мин"
+msgstr "фут³/мин"
 
 #: ../../ORTS.Common/Conversions.cs:555
 msgid "kg"
@@ -103,11 +103,11 @@ msgstr "т"
 
 #: ../../ORTS.Common/Conversions.cs:557
 msgid "t-uk"
-msgstr "т-Брит"
+msgstr "брит. т"
 
 #: ../../ORTS.Common/Conversions.cs:558
 msgid "t-us"
-msgstr "т-США"
+msgstr "т. США"
 
 #: ../../ORTS.Common/Conversions.cs:559
 msgid "lb"
@@ -131,11 +131,11 @@ msgstr "л"
 
 #: ../../ORTS.Common/Conversions.cs:564
 msgid "g-uk"
-msgstr "галл-Брит"
+msgstr "брит. галлон"
 
 #: ../../ORTS.Common/Conversions.cs:565
 msgid "g-us"
-msgstr "галл-США"
+msgstr "галлон США"
 
 #: ../../ORTS.Common/Conversions.cs:566
 msgid "rpm"
@@ -151,7 +151,7 @@ msgstr "л.с."
 
 #: ../../ORTS.Common/Conversions.cs:569
 msgid "bhp"
-msgstr "Брит.л.с."
+msgstr "брит. л.с."
 
 #: ../../ORTS.Common/Conversions.cs:570
 msgid "kJ"
@@ -163,7 +163,7 @@ msgstr "МДж"
 
 #: ../../ORTS.Common/Conversions.cs:572
 msgid "BTU"
-msgstr "БТУ"
+msgstr "БТЕ"
 
 #: ../../ORTS.Common/Conversions.cs:573
 msgid "°C"
@@ -213,819 +213,819 @@ msgstr "Нейтраль"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:28
 msgid "Game Pause Menu"
-msgstr "Игра Меню паузы"
+msgstr "Игра: Меню паузы"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:29
 msgid "Game Save"
-msgstr "Игра Создать сохранение"
+msgstr "Игра: Создать сохранение"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:30
 msgid "Game Quit"
-msgstr "Игра Выйти из игры"
+msgstr "Игра: Выйти из игры"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:31
 msgid "Game Pause"
-msgstr "Игра Приостановить игру"
+msgstr "Игра: Приостановить игру"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:32
 msgid "Game Screenshot"
-msgstr "Игра Снимок экрана"
+msgstr "Игра: Снимок экрана"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:33
 msgid "Game Fullscreen"
-msgstr "Игра На весь экран"
+msgstr "Игра: На весь экран"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:34
 msgid "Game External Controller (RailDriver)"
-msgstr "Игра Выносной пульт (RailDriver)"
+msgstr "Игра: Выносной пульт (RailDriver)"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:35
 msgid "Game Switch Ahead"
-msgstr "Стрелка Перевести стрелку впереди"
+msgstr "Стрелка: Перевести стрелку впереди"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:36
 msgid "Game Switch Behind"
-msgstr "Стрелка Перевести стрелку сзади"
+msgstr "Стрелка: Перевести стрелку сзади"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:37
 msgid "Game Switch Picked"
-msgstr "Стрелка Показ выбранной стрелки/сигнала"
+msgstr "Стрелка: Показ выбранной стрелки/сигнала"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:38
 msgid "Game Signal Picked"
-msgstr "Сигнал Показать выбранный"
+msgstr "Сигнал: Показать выбранный"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:39
 msgid "Game Switch With Mouse"
-msgstr "Стрелка Перевод стрелки мышью"
+msgstr "Стрелка: Перевод стрелки мышью"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:40
 msgid "Game Uncouple With Mouse"
-msgstr "Поезд Расцепка мышью"
+msgstr "Поезд: Расцепка мышью"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:41
 msgid "Game Change Cab"
-msgstr "Поезд Смена поста управления"
+msgstr "Поезд: Смена поста управления"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:42
 msgid "Game Request Control"
-msgstr "Поезд Взять управление на себя"
+msgstr "Поезд: Взять управление на себя"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:43
 msgid "Game Multi Player Dispatcher"
-msgstr "Диспетчер Создать окно диспетчера"
+msgstr "Диспетчер: Создать окно диспетчера мультиплеера"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:44
 msgid "Game Multi Player Texting"
-msgstr "Связь Текстовое сообщение в мультиплеере"
+msgstr "Связь: Текстовое сообщение в мультиплеере"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:45
 msgid "Game Switch Manual Mode"
-msgstr "АЛС Маневровый/Автоматический режим"
+msgstr "АЛС: Маневровый/Автоматический режим"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:46
 msgid "Game Reset Out Of Control Mode"
-msgstr "ЭПК Повернуть ключ"
+msgstr "ЭПК: Повернуть ключ"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:47
 msgid "Game Clear Signal Forward"
-msgstr "Диспетчер Запрос открытия сигнала впереди"
+msgstr "Диспетчер: Запрос открытия сигнала впереди"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:48
 msgid "Game Clear Signal Backward"
-msgstr "Диспетчер Запрос открытия сигнала сзади"
+msgstr "Диспетчер: Запрос открытия сигнала сзади"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:49
 msgid "Game Reset Signal Forward"
-msgstr "Диспетчер Сброс сигнала впереди"
+msgstr "Диспетчер: Сброс сигнала впереди"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:50
 msgid "Game Reset Signal Backward"
-msgstr "Диспетчер Сброс сигнала сзади"
+msgstr "Диспетчер: Сброс сигнала сзади"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:51
 msgid "Game Autopilot Mode"
-msgstr "Автопилот Включить"
+msgstr "Автоведение: Включить"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:52
 msgid "Game Suspend Old Player"
-msgstr "Автопилот Приостановить предыдущий поезд"
+msgstr "Автоведение: Приостановить предыдущий поезд"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:54
 msgid "Display Next Window Tab"
-msgstr "Помощь Листать вкладки/варианты"
+msgstr "Помощь: Листать вкладки/варианты"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:55
 msgid "Display Help Window"
-msgstr "Помощь Открыть справочник"
+msgstr "Помощь: Открыть справочник"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:56
 msgid "Display Track Monitor Window"
-msgstr "Помощь Монитор путевой обстановки"
+msgstr "Помощь: Монитор путевой обстановки"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:57
 msgid "Display HUD"
-msgstr "Помощь Индикация параметров"
+msgstr "Помощь: Индикация параметров"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:58
 msgid "Display Train Driving Window"
-msgstr "Помощь Состояние поезда"
+msgstr "Помощь: Состояние поезда"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:59
 msgid "Display Multi Player Window"
-msgstr "Помощь Открыть окно мультиплеера"
+msgstr "Помощь: Открыть окно мультиплеера"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:60
 msgid "Display Car Labels"
-msgstr "Помощь Номера поездов/вагогов"
+msgstr "Помощь: Номера поездов/вагонов"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:61
 msgid "Display Station Labels"
-msgstr "Помощь Названия платформ/путей"
+msgstr "Помощь: Названия платформ/путей"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:62
 msgid "Display Switch Window"
-msgstr "Помощь Положение стрелок"
+msgstr "Помощь: Положение стрелок"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:63
 msgid "Display Train Operations Window"
-msgstr "Помощь Действия с поездом (составитель)"
+msgstr "Помощь: Действия с поездом (составитель)"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:64
 msgid "Display Train Car Operations Window"
-msgstr "Помощь Действия с поездом (составитель)"
+msgstr "Помощь: Действия с поездом (составитель)"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:65
 msgid "Display Train Dpu Window"
-msgstr "Помощь управление толкачами"
+msgstr "Помощь: управление толкачами"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:66
 msgid "Display Next Station Window"
-msgstr "Помощь Время проследования станций"
+msgstr "Помощь: Время проследования станций"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:67
 msgid "Display Compass Window"
-msgstr "Помощь Компас и координаты"
+msgstr "Помощь: Компас и координаты"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:68
 msgid "Display Train List Window"
-msgstr "Помощь Список поездов на полигоне"
+msgstr "Помощь: Список поездов на полигоне"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:69
 msgid "Display EOT List Window"
-msgstr "Помощь Окно ЕОТ"
+msgstr "Помощь: Окно ЕОТ"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:70
 msgid "Display Control Rectangles"
-msgstr "Помощь Области управления мышью"
+msgstr "Помощь: Области управления мышью"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:72
 msgid "Debug Speed Up"
-msgstr "Отладка Скорость симуляции +"
+msgstr "Отладка: Скорость симуляции +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:73
 msgid "Debug Speed Down"
-msgstr "Отладка Скорость симуляции -"
+msgstr "Отладка: Скорость симуляции -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:74
 msgid "Debug Speed Reset"
-msgstr "Отладка Скорость симуляции в норму"
+msgstr "Отладка: Скорость симуляции по умолчанию"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:75
 msgid "Debug Overcast Increase"
-msgstr "Отладка Облачность +"
+msgstr "Отладка: Облачность +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:76
 msgid "Debug Overcast Decrease"
-msgstr "Отладка Облачность -"
+msgstr "Отладка: Облачность -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:77
 msgid "Debug Fog Increase"
-msgstr "Отладка Туман +"
+msgstr "Отладка: Туман +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:78
 msgid "Debug Fog Decrease"
-msgstr "Отладка Туман -"
+msgstr "Отладка: Туман -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:79
 msgid "Debug Precipitation Increase"
-msgstr "Отладка Осадки +"
+msgstr "Отладка: Осадки +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:80
 msgid "Debug Precipitation Decrease"
-msgstr "Отладка Осадки -"
+msgstr "Отладка: Осадки -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:81
 msgid "Debug Precipitation Liquidity Increase"
-msgstr "Отладка Влажность осадков +"
+msgstr "Отладка: Влажность осадков +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:82
 msgid "Debug Precipitation Liquidity Decrease"
-msgstr "Отладка Влажность осадков -"
+msgstr "Отладка: Влажность осадков -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:83
 msgid "Debug Daylight Offset Increase"
-msgstr "Отладка Солнцестояние +"
+msgstr "Отладка: Солнечный полдень +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:84
 msgid "Debug Daylight Offset Decrease"
-msgstr "Отладка Солнцестояние -"
+msgstr "Отладка: Солнечный полдень -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:85
 msgid "Debug Weather Change"
-msgstr "Отладка Смена погоды"
+msgstr "Отладка: Смена погоды"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:86
 msgid "Debug Clock Forwards"
-msgstr "Отладка Игровые часы вперёд"
+msgstr "Отладка: Игровые часы вперёд"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:87
 msgid "Debug Clock Backwards"
-msgstr "Отладка Игровые часы назад"
+msgstr "Отладка: Игровые часы назад"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:88
 msgid "Debug Logger"
-msgstr "Отладка Запись параметров"
+msgstr "Отладка: Запись параметров"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:89
 msgid "Debug Lock Shadows"
-msgstr "Отладка Отключить динамические тени"
+msgstr "Отладка: Отключить динамические тени"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:90
 msgid "Debug Dump Keyboard Map"
-msgstr "Отладка Записать назначения клавиш"
+msgstr "Отладка: Записать назначения клавиш"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:91
 msgid "Debug Log Render Frame"
-msgstr "Отладка Log Render Frame"
+msgstr "Отладка: Log Render Frame"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:92
 msgid "Debug Tracks"
-msgstr "Отладка Показ секций пути"
+msgstr "Отладка: Показ секций пути"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:93
 msgid "Debug Signalling"
-msgstr "Отладка Показ резервирования пути"
+msgstr "Отладка: Показ резервирования пути"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:94
 msgid "Debug Reset Wheel Slip"
-msgstr "Отладка Прекратить боксование"
+msgstr "Отладка: Прекратить боксование"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:95
 msgid "Debug Toggle Advanced Adhesion"
-msgstr "Отладка Сложная модель сцепления"
+msgstr "Отладка: Сложная модель сцепления"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:96
 msgid "Debug Sound Form"
-msgstr "Отладка Окно диагностики звука"
+msgstr "Отладка: Окно диагностики звука"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:97
 msgid "Debug Physics Form"
-msgstr "Отладка Physics Form"
+msgstr "Отладка: Окно динамики поезда"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:98
 msgid "Debug Toggle Confirmations"
-msgstr "Отладка Подтверждения управляющих воздействий"
+msgstr "Отладка: Подтверждения управляющих воздействий"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:100
 msgid "Camera Cab"
-msgstr "Кабина Основной вид"
+msgstr "Кабина: Основной вид"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:101
 msgid "Camera Change Passenger Viewpoint"
-msgstr "Кабина Прочие виды"
+msgstr "Кабина: Прочие виды"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:102
 msgid "Camera Change 3DCab Viewpoint"
-msgstr "Кабина смена места в 3D кабине"
+msgstr "Кабина: смена места в 3D кабине"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:103
 msgid "Camera Toggle 3D Cab"
-msgstr "Кабина Показать 2D/3D"
+msgstr "Кабина: Показать 2D/3D"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:104
 msgid "Camera Toggle Show Cab"
-msgstr "Кабина Показать/скрыть"
+msgstr "Кабина: Показать/скрыть"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:105
 msgid "Camera Toggle Letterbox Cab"
-msgstr "Кабина Показать целиком"
+msgstr "Кабина: Показать целиком"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:106
 msgid "Camera Head Out Forward"
-msgstr "Вид из окна вправо"
+msgstr "Кабина: Вид из окна вправо"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:107
 msgid "Camera Head Out Backward"
-msgstr "Вид из окна влево"
+msgstr "Кабина: Вид из окна влево"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:108
 msgid "Camera Outside Front"
-msgstr "Вид на голову поезда"
+msgstr "Вид: На голову поезда"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:109
 msgid "Camera Outside Rear"
-msgstr "Вид на хвост поезда"
+msgstr "Вид: На хвост поезда"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:110
 msgid "Camera Trackside"
-msgstr "Вид с обочины"
+msgstr "Вид: С обочины"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:111
 msgid "Camera SpecialTracksidePoint"
-msgstr "Вид со стороны, особый"
+msgstr "Вид: Внешний с заданной точки"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:112
 msgid "Camera Passenger"
-msgstr "Вид изнутри"
+msgstr "Вид: Из салона"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:113
 msgid "Camera Brakeman"
-msgstr "Вид с подножки (составитель)"
+msgstr "Вид: С подножки (составитель)"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:114
 msgid "Camera Free"
-msgstr "Вид Свободная камера"
+msgstr "Вид: Свободная камера"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:115
 msgid "Camera Previous Free"
-msgstr "Вид Предыдущая свободная камера"
+msgstr "Вид: Предыдущая свободная камера"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:116
 msgid "Camera Reset"
-msgstr "Вид Сбросить настройки текущей камеры"
+msgstr "Вид: Сбросить настройки текущей камеры"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:117
 msgid "Camera Move Fast"
-msgstr "Камера Ускоренное перемещение"
+msgstr "Камера: Ускоренное перемещение"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:118
 msgid "Camera Move Slow"
-msgstr "Камера Замедленное перемещение"
+msgstr "Камера: Замедленное перемещение"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:119
 msgid "Camera Pan (Rotate) Left"
-msgstr "Камера сдвиг (поворот) влево"
+msgstr "Камера: Сдвиг (поворот) влево"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:120
 msgid "Camera Pan (Rotate) Right"
-msgstr "Камера сдвиг (поворот) вправо"
+msgstr "Камера: Сдвиг (поворот) вправо"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:121
 msgid "Camera Pan (Rotate) Up"
-msgstr "Камера сдвиг (поворот) вверх"
+msgstr "Камера: Сдвиг (поворот) вверх"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:122
 msgid "Camera Pan (Rotate) Down"
-msgstr "Камера сдвиг (поворот) вниз"
+msgstr "Камера: Сдвиг (поворот) вниз"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:123
 msgid "Camera Zoom In (Move Z)"
-msgstr "Камера наезд (сдвиг вперёд)"
+msgstr "Камера: наезд (сдвиг вперёд)"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:124
 msgid "Camera Zoom Out (Move Z)"
-msgstr "Камера отъезд (сдвиг назад)"
+msgstr "Камера: отъезд (сдвиг назад)"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:125
 msgid "Camera Rotate (Pan) Left"
-msgstr "Камера Поворот/сдвиг влево"
+msgstr "Камера: Поворот/сдвиг влево"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:126
 msgid "Camera Rotate (Pan) Right"
-msgstr "Камера Поворот/сдвиг вправо"
+msgstr "Камера: Поворот/сдвиг вправо"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:127
 msgid "Camera Rotate (Pan) Up"
-msgstr "Камера Поворот/сдвиг вверх"
+msgstr "Камера: Поворот/сдвиг вверх"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:128
 msgid "Camera Rotate (Pan) Down"
-msgstr "Камера Поворот/сдвиг вниз"
+msgstr "Камера: Поворот/сдвиг вниз"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:129
 msgid "Camera Car Next"
-msgstr "Фокус на следующий вагон"
+msgstr "Камера: Фокус на следующий вагон"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:130
 msgid "Camera Car Previous"
-msgstr "Фокус на предыдущий вагон"
+msgstr "Камера: Фокус на предыдущий вагон"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:131
 msgid "Camera Car First"
-msgstr "Фокус на первый вагон"
+msgstr "Камера: Фокус на первый вагон"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:132
 msgid "Camera Car Last"
-msgstr "Фокус на последний вагон"
+msgstr "Камера: Фокус на последний вагон"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:133
 msgid "Camera Jumping Trains"
-msgstr "Фокус на другие поезда"
+msgstr "Камера: Фокус на другие поезда"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:134
 msgid "Camera Jump Back Player"
-msgstr "Фокус на поезд игрока"
+msgstr "Камера: Фокус на поезд игрока"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:135
 msgid "Camera Jump See Switch"
-msgstr "Фокус на стрелку"
+msgstr "Камера: Фокус на стрелку"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:136
 msgid "Camera Vibrate"
-msgstr "Вид Раскачка вагонов"
+msgstr "Камера: Раскачка вагонов"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:137
 msgid "Camera Scroll Right"
-msgstr "Камера Сдвиг вправо"
+msgstr "Камера: Прокрутка вправо"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:138
 msgid "Camera Scroll Left"
-msgstr "Камера Сдвиг влево"
+msgstr "Камера: Прокрутка влево"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:139
 msgid "Camera Browse Backwards"
-msgstr "Камера перелететь к голове поезда"
+msgstr "Камера: Перелететь к голове поезда"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:140
 msgid "Camera Browse Forwards"
-msgstr "Камера перелететь к хвосту поезда"
+msgstr "Камера: Перелететь к хвосту поезда"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:142
 msgid "Control Forwards"
-msgstr "Ручки Реверсор Вперёд"
+msgstr "Управление: Реверсор Вперёд"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:143
 msgid "Control Backwards"
-msgstr "Ручки Реверсор Назад"
+msgstr "Управление: Реверсор Назад"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:144
 msgid "Control Throttle Increase"
-msgstr "Ручки Контроллер +"
+msgstr "Управление: Контроллер +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:145
 msgid "Control Throttle Decrease"
-msgstr "Ручки Контроллер  -"
+msgstr "Управление: Контроллер  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:146
 msgid "Control Throttle Zero"
-msgstr "Ручки Контроллер Выключить"
+msgstr "Управление: Контроллер: сброс позиций"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:147
 msgid "Control Gear Up"
-msgstr "Ручки Передача +"
+msgstr "Управление: Передача +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:148
 msgid "Control Gear Down"
-msgstr "Ручки Передача  -"
+msgstr "Управление: Передача  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:149
 msgid "Control Train Brake Increase"
-msgstr "Ручки Тормоза поезда +"
+msgstr "Управление: Тормоза поезда +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:150
 msgid "Control Train Brake Decrease"
-msgstr "Ручки Тормоза поезда  -"
+msgstr "Управление: Тормоза поезда  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:151
 msgid "Control Train Brake Zero"
-msgstr "Ручки Тормоза поезда на нейтраль"
+msgstr "Управление: Отпуск поездного тормоза"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:152
 msgid "Control Engine Brake Increase"
-msgstr "Ручки Локомотивный тормоз +"
+msgstr "Управление: Локомотивный тормоз +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:153
 msgid "Control Engine Brake Decrease"
-msgstr "Ручки Локомотивный тормоз  -"
+msgstr "Управление: Локомотивный тормоз  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:154
 msgid "Control Brakeman Brake Increase"
-msgstr "Ручки Ручные тормоза вагонов +"
+msgstr "Управление: Ручные тормоза вагонов +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:155
 msgid "Control Brakeman Brake Decrease"
-msgstr "Ручки Ручные тормоза вагонов  -"
+msgstr "Управление: Ручные тормоза вагонов  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:156
 msgid "Control Dynamic Brake Increase"
-msgstr "Ручки Электродинамический тормоз +"
+msgstr "Управление: Электродинамический тормоз +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:157
 msgid "Control Dynamic Brake Decrease"
-msgstr "Ручки Электродинамический тормоз  -"
+msgstr "Управление: Электродинамический тормоз  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:158
 msgid "Control Bail Off"
-msgstr "Ручки Отпустить независимый тормоз"
+msgstr "Управление: Отпустить локомотивный тормоз"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:159
 msgid "Control Brake Quick Release"
-msgstr "Кнопка Быстрый отпуск АТ"
+msgstr "Управление: Быстрый отпуск АТ"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:160
 msgid "Control Brake Overcharge"
-msgstr "Кнопка Сверхзарядка ТМ"
+msgstr "Управление: Сверхзарядка ТМ"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:161
 msgid "Control Initialize Brakes"
-msgstr "Тормоза восстановить мгновенно"
+msgstr "Управление: Тормоза восстановить мгновенно"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:162
 msgid "Control Handbrake Full"
-msgstr "Ручн.Тормоз на локомотиве - затянуть"
+msgstr "Управление: Ручн.Тормоз на локомотиве - затянуть"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:163
 msgid "Control Handbrake None"
-msgstr "Ручн.Тормоз на локомотиве - отпустить"
+msgstr "Управление: Ручн.Тормоз на локомотиве - отпустить"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:164
 msgid "Control Odometer Show/Hide"
-msgstr "Одометр показать/скрыть"
+msgstr "Управление: Одометр показать/скрыть"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:165
 msgid "Control Odometer Reset"
-msgstr "Одометр сбросить на ноль"
+msgstr "Управление: Одометр сбросить на ноль"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:166
 msgid "Control Odometer Direction"
-msgstr "Одометр отсчёт вперёд/назад"
+msgstr "Управление: Одометр отсчёт вперёд/назад"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:167
 msgid "Control Retainers On"
-msgstr "Ретейнеры Вкл"
+msgstr "Управление: Ретейнеры Вкл"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:168
 msgid "Control Retainers Off"
-msgstr "Ретейнеры Откл"
+msgstr "Управление: Ретейнеры Откл"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:169
 msgid "Control Brake Hose Connect"
-msgstr "Рукава Соединить"
+msgstr "Управление: Соединить тормозные рукава"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:170
 msgid "Control Brake Hose Disconnect"
-msgstr "Рукава Разъединить"
+msgstr "Управление: Разъединить тормозные рукава"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:171
 msgid "Control Alerter"
-msgstr "Кнопки Бдительность"
+msgstr "Управление: Кнопка бдительности"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:172
 msgid "Control Emergency Push Button"
-msgstr "Кнопки Аварийный останов"
+msgstr "Управление: Кнопка аварийного останова"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:173
 msgid "Control EOT Emergency Brake"
-msgstr "Кнопки Стоп-кран"
+msgstr "Управление: Стоп-кран"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:174
 msgid "Control Sander"
-msgstr "Кнопки Пескоподача"
+msgstr "Управление: Подача песка кратковременно"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:175
 msgid "Control Sander Toggle"
-msgstr "Кнопки Пескоподача постоянно"
+msgstr "Управление: Подача песка постоянно"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:176
 msgid "Control Wiper"
-msgstr "Кнопки Стеклоочистители"
+msgstr "Управление: Стеклоочистители"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:177
 msgid "Control Horn"
-msgstr "Кнопки Тифон"
+msgstr "Управление: Тифон"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:178
 msgid "Control Bell"
-msgstr "Кнопки Сигнал малой громкости"
+msgstr "Управление: Свисток"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:179
 msgid "Control Bell Toggle"
-msgstr "Кнопки Сигнал малой громкости-постоянно"
+msgstr "Управление: Свисток постоянно"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:180
 msgid "Control Door Left"
-msgstr "Двери Левые"
+msgstr "Управление: Левые двери"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:181
 msgid "Control Door Right"
-msgstr "Двери Правые"
+msgstr "Управление: Правые двери"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:182
 msgid "Control Mirror"
-msgstr "Зеркала раскр/закр"
+msgstr "Управление: Зеркала раскрыть/закрыть"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:183
 msgid "Control Light"
-msgstr "Освещение кабины"
+msgstr "Управление: Освещение кабины"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:184
 msgid "Control Pantograph 1"
-msgstr "Токоприёмник №1"
+msgstr "Управление: Токоприёмник №1"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:185
 msgid "Control Pantograph 2"
-msgstr "Токоприёмник №2"
+msgstr "Управление: Токоприёмник №2"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:186
 msgid "Control Pantograph 3"
-msgstr "Токоприёмник №3"
+msgstr "Управление: Токоприёмник №3"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:187
 msgid "Control Pantograph 4"
-msgstr "Токоприёмник №4"
+msgstr "Управление: Токоприёмник №4"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:188
 msgid "Control Window Left"
-msgstr "Окно Левое"
+msgstr "Управление: Левое окно"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:189
 msgid "Control Window Right"
-msgstr "Окно Правое"
+msgstr "Управление: Правое окно"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:190
 msgid "Control Battery Close"
-msgstr "АБ Рубильник ВКЛ"
+msgstr "Управление: АБ включить"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:191
 msgid "Control Battery Open"
-msgstr "АБ Рубильник ОТКЛ"
+msgstr "Управление: АБ отключить"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:192
 msgid "Control Master Key"
-msgstr "ВУ Вкл/Откл"
+msgstr "Управление: ВУ Вкл/Откл"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:193
 msgid "Control Service Retention"
-msgstr "АВ Цепи управления Вкл"
+msgstr "Управление: АВ цепей управления Вкл"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:194
 msgid "Control Service Retention Cancellation"
-msgstr "АВ Цепи управления Откл"
+msgstr "Управление: АВ цепей управления Откл"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:195
 msgid "Control Circuit Breaker Closing Order"
-msgstr "Гл.Выключатель Вкл"
+msgstr "Управление: Гл. выключатель Вкл"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:196
 msgid "Control Circuit Breaker Opening Order"
-msgstr "Гл.Выключатель Откл"
+msgstr "Управление: Гл. выключатель Откл"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:197
 msgid "Control Circuit Breaker Closing Authorization"
-msgstr "Гл.Выключатель Возврат"
+msgstr "Управление: Гл. выключатель Разрешить включение"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:198
 msgid "Control Traction Cut-Off Relay Closing Order"
-msgstr "РП Возврат"
+msgstr "Управление: РП Возврат"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:199
 msgid "Control Traction Cut-Off Relay Opening Order"
-msgstr "РП Разрешение откл"
+msgstr "Управление: РП Отключить"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:200
 msgid "Control Traction Cut-Off Relay Closing Authorization"
-msgstr "РП Разрешение вкл"
+msgstr "Управление: РП Разрешить возврат"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:201
 msgid "Control Electric Train Supply"
-msgstr "Электро-отопление Вкл/Откл"
+msgstr "Управление: Электроотопление Вкл/Откл"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:202
 msgid "Control Diesel Player"
-msgstr "ДВС первый: запуск/останов"
+msgstr "Управление: ДВС первый: запуск/останов"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:203
 msgid "Control Diesel Helper"
-msgstr "ДВС остальные: запуск/останов"
+msgstr "Управление: ДВС остальные: запуск/останов"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:204
 msgid "Control Headlight Increase"
-msgstr "Огни  +"
+msgstr "Управление: Огни +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:205
 msgid "Control Headlight Decrease"
-msgstr "Огни   -"
+msgstr "Управление: Огни -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:206
 msgid "Control Injector 1 Increase"
-msgstr "Паровоз Инжектор 1, вода +"
+msgstr "Паровоз: Инжектор 1, вода +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:207
 msgid "Control Injector 1 Decrease"
-msgstr "Паровоз Инжектор 1, вода  -"
+msgstr "Паровоз: Инжектор 1, вода  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:208
 msgid "Control Injector 1"
-msgstr "Паровоз Инжектор 1, пар"
+msgstr "Паровоз: Инжектор 1, пар"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:209
 msgid "Control Injector 2 Increase"
-msgstr "Паровоз Инжектор 2, вода +"
+msgstr "Паровоз: Инжектор 2, вода +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:210
 msgid "Control Injector 2 Decrease"
-msgstr "Паровоз Инжектор 2, вода  -"
+msgstr "Паровоз: Инжектор 2, вода  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:211
 msgid "Control Injector 2"
-msgstr "Паровоз Инжектор 2, пар"
+msgstr "Паровоз: Инжектор 2, пар"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:212
 msgid "Control Blowdown Valve"
-msgstr "Паровоз Вентиль продувки"
+msgstr "Паровоз: Вентиль продувки"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:213
 msgid "Control Blower Increase"
-msgstr "Паровоз Сифон +"
+msgstr "Паровоз: Сифон +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:214
 msgid "Control Blower Decrease"
-msgstr "Паровоз Сифон  -"
+msgstr "Паровоз: Сифон  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:215
 msgid "Control Steam Heat Increase"
-msgstr "Паровоз Пар на отопление +"
+msgstr "Паровоз: Паровое отопление +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:216
 msgid "Control Steam Heat Decrease"
-msgstr "Паровоз Пар на отопление  -"
+msgstr "Паровоз: Паровое отопление  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:217
 msgid "Control Steam Booster Air Valve"
-msgstr "Бустер Подача воздуха"
+msgstr "Бустер: Воздух к пусковому аппарату вкл./выкл."
 
 #: ../../ORTS.Common/Input/UserCommand.cs:218
 msgid "Control Steam Booster Idle Valve"
-msgstr "Бустер Клапан выбега"
+msgstr "Бустер: Продувательный клапан откр./закр."
 
 #: ../../ORTS.Common/Input/UserCommand.cs:219
 msgid "Control Steam Booster Latch"
-msgstr "Бустер Подача пара"
+msgstr "Бустер: Регулятор откр./закр."
 
 #: ../../ORTS.Common/Input/UserCommand.cs:220
 msgid "Control Damper Increase"
-msgstr "Паровоз Поддувало +"
+msgstr "Паровоз: Поддувало +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:221
 msgid "Control Damper Decrease"
-msgstr "Паровоз Поддувало  -"
+msgstr "Паровоз: Поддувало  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:222
 msgid "Control Firebox Open"
-msgstr "Паровоз Топка Открыть"
+msgstr "Паровоз: Открытие топки"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:223
 msgid "Control Firebox Close"
-msgstr "Паровоз Топка Закрыть"
+msgstr "Паровоз: Закрытие топки"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:224
 msgid "Control Firing Rate Increase"
-msgstr "Паровоз Подача топлива +"
+msgstr "Паровоз: Подача топлива +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:225
 msgid "Control Firing Rate Decrease"
-msgstr "Паровоз Подача топлива  -"
+msgstr "Паровоз: Подача топлива  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:226
 msgid "Control Fire Shovel Full"
-msgstr "Паровоз Подача топлива максимум"
+msgstr "Паровоз: Подача топлива на максимум"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:227
 msgid "Control Cylinder Cocks"
-msgstr "Паровоз Продувка цилиндров"
+msgstr "Паровоз: Продувка цилиндров"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:228
 msgid "Control Large Ejector Increase"
-msgstr "Паровоз Бол. эжектор +"
+msgstr "Паровоз: Бол. эжектор +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:229
 msgid "Control Large Ejector Decrease"
-msgstr "Паровоз Бол. эжектор  -"
+msgstr "Паровоз: Бол. эжектор  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:230
 msgid "Control Small Ejector Increase"
-msgstr "Паровоз Мал. эжектор +"
+msgstr "Паровоз: Мал. эжектор +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:231
 msgid "Control Small Ejector Decrease"
-msgstr "Паровоз Мал. эжектор  -"
+msgstr "Паровоз: Мал. эжектор  -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:232
 msgid "Control Vacuum Exhauster"
-msgstr "Паровоз Эксгаустер"
+msgstr "Паровоз: Тормозной вакуумный насос"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:233
 msgid "Control Cylinder Compound"
-msgstr "Паровоз Байпас компаунда"
+msgstr "Паровоз: Байпас компаунда"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:234
 msgid "Control Firing"
-msgstr "Автркочегар вкл/откл"
+msgstr "Паровоз: Автокочегар вкл/откл"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:235
 msgid "Control Refill"
-msgstr "Экипировка активировать"
+msgstr "Экипировка: Активировать"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:236
 msgid "Control Discrete Unload"
@@ -1033,131 +1033,131 @@ msgstr "Разгрузка по отдельности"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:237
 msgid "Control Water Scoop"
-msgstr "Черпак поднять/опустить"
+msgstr "Экипировка: Черпак поднять/опустить"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:238
 msgid "Control ImmediateRefill"
-msgstr "Экипировка мгновенно"
+msgstr "Экипировка: мгновенно"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:239
 msgid "Control Turntable Clockwise"
-msgstr "Повор.круг по часовой"
+msgstr "Повор.круг: по часовой"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:240
 msgid "Control Turntable Counterclockwise"
-msgstr "Повор.круг против часовой"
+msgstr "Повор.круг: против часовой"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:241
 msgid "Control Generic Item 1"
-msgstr "Тумблеры №1"
+msgstr "Управление: Тумблеры №1"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:242
 msgid "Control Generic Item 2"
-msgstr "Тумблеры №2"
+msgstr "Управление: Тумблеры №2"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:243
 msgid "Control TCS Generic 1"
-msgstr "КЛУБ Кнопка №1"
+msgstr "КЛУБ: Кнопка №1"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:244
 msgid "Control TCS Generic 2"
-msgstr "КЛУБ Кнопка №2"
+msgstr "КЛУБ: Кнопка №2"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:245
 msgid "Control Cab Radio"
-msgstr "Радиостанция Вкл/Откл"
+msgstr "Радиостанция: Вкл/Откл"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:246
 msgid "Control AI Fire On"
-msgstr "Автокочегар Топить"
+msgstr "Автокочегар: Включен"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:247
 msgid "Control AI Fire Off"
-msgstr "Автокочегар Не топить"
+msgstr "Автокочегар: Выклчюен"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:248
 msgid "Control AI Fire Reset"
-msgstr "Автокочегар Сброс"
+msgstr "Автокочегар: Сброс"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:251
 msgid "Control Speed Regulator Mode Increase"
-msgstr "САУТ Регулятор скорости +"
+msgstr "САУТ: Регулятор скорости +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:252
 msgid "Control Speed Regulator Mode Descrease"
-msgstr "САУТ Регулятор скорости -"
+msgstr "САУТ: Регулятор скорости -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:253
 msgid "Control Selected Speed Increase"
-msgstr "САУТ Целевая скорость +"
+msgstr "САУТ: Целевая скорость +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:254
 msgid "Control Selected Speed Decrease"
-msgstr "САУТ Целевая скорость -"
+msgstr "САУТ: Целевая скорость -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:255
 msgid "Control Speed Regulator Max Acceleration Increase"
-msgstr "САУТ Предельное ускорение +"
+msgstr "САУТ: Ограничение силы тяги +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:256
 msgid "Control Speed Regulator Max Acceleration Decrease"
-msgstr "САУТ Предельное ускорение -"
+msgstr "САУТ: Ограничение силы тяги -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:257
 msgid "Control Number Of Axles Increase"
-msgstr "САУТ Число осей +"
+msgstr "САУТ: Число осей +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:258
 msgid "Control Number Of Axles Decrease"
-msgstr "САУТ Число осей -"
+msgstr "САУТ: Число осей -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:259
 msgid "Control Restricted Speed Zone Active"
-msgstr "САУТ Участок с ограничением скорости"
+msgstr "САУТ: Участок с ограничением скорости"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:260
 msgid "Control Cruise Control Mode Increase"
-msgstr "САУТ Режим +"
+msgstr "САУТ: Режим +"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:261
 msgid "Control Cruise Control Mode Decrease"
-msgstr "САУТ Режим -"
+msgstr "САУТ: Режим -"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:262
 msgid "Control Train Type Change (Passenger/Cargo)"
-msgstr "САУТ Режим (Пасс/Груз)"
+msgstr "САУТ: Режим (Пасс/Груз)"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:263
 msgid "Control Selected Speed To Zero"
-msgstr "САУТ Целевая скорость в ноль"
+msgstr "САУТ: Целевая скорость в ноль"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:265
 msgid "Control DP Move To Front"
-msgstr "Толкач передний"
+msgstr "Толкач: выбрать передний"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:266
 msgid "Control DP Move To Back"
-msgstr "Толкач задний"
+msgstr "Толкач: выбрать задний"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:267
 msgid "Control DP Traction"
-msgstr "Толкач толкать"
+msgstr "Толкач: подталкивание"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:268
 msgid "Control DP Idle"
-msgstr "Толкач выбег"
+msgstr "Толкач: выбег"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:269
 msgid "Control DP Brake"
-msgstr "Толкач тормозить"
+msgstr "Толкач: торможение"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:270
 msgid "Control DP More"
-msgstr "Толкач больше"
+msgstr "Толкач: больше"
 
 #: ../../ORTS.Common/Input/UserCommand.cs:271
 msgid "Control DP Less"
-msgstr "Толкач меньше"
+msgstr "Толкач: меньше"
 
 #~ msgid "Display Basic HUD Toggle"
 #~ msgstr "Помощь Расширеная/базовая индикация"

--- a/Source/Locales/ORTS.Menu/ru.po
+++ b/Source/Locales/ORTS.Menu/ru.po
@@ -2,20 +2,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2021-01-16 15:50:25+0300\n"
-"PO-Revision-Date: 2021-01-16 16:01+0300\n"
+"PO-Revision-Date: 2026-08-12 02:37+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #: ../../ORTS.Menu/Activities.cs:47
 msgid "- Explore Route -"
-msgstr "- Исследовать полигон -"
+msgstr "- Исследовать полигон без ограничений -"
 
 #: ../../ORTS.Menu/Activities.cs:51
 msgid "+ Explore in Activity Mode +"
@@ -63,9 +63,9 @@ msgstr "Локомотив '{0}' исключён."
 #: ../../ORTS.Menu/Paths.cs:168
 #, csharp-format
 msgid "Start at: {0}"
-msgstr "Отправление из: {0}"
+msgstr "Начало маршрута: {0}"
 
 #: ../../ORTS.Menu/Paths.cs:169
 #, csharp-format
 msgid "Heading to: {0}"
-msgstr "Прибытие в: {0}"
+msgstr "Окончание маршрута: {0}"

--- a/Source/Locales/ORTS.Settings/ru.po
+++ b/Source/Locales/ORTS.Settings/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2023-10-07 15:41:50+0300\n"
-"PO-Revision-Date: 2023-10-07 16:31+0300\n"
+"PO-Revision-Date: 2026-08-12 02:41+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -11,22 +11,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #: ../../ORTS.Settings/InputSettings.cs:564
 #, csharp-format
 msgid "{0} requires and is modified by Shift"
-msgstr "для модификации {0} нужен Shift"
+msgstr "требуется {0}, включается по Shift"
 
 #: ../../ORTS.Settings/InputSettings.cs:566
 #, csharp-format
 msgid "{0} requires and is modified by Control"
-msgstr "для модификации {0} нужен Control"
+msgstr "требуется {0}, включается по Ctrl"
 
 #: ../../ORTS.Settings/InputSettings.cs:568
 #, csharp-format
 msgid "{0} requires and is modified by Alt"
-msgstr "для модификации {0} нужен Alt"
+msgstr "требуется {0}, включается по Alt"
 
 #: ../../ORTS.Settings/InputSettings.cs:599
 #, csharp-format
@@ -35,23 +35,23 @@ msgstr "{2} одновременно назначено для {0} и {1}"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:15
 msgid "Reverser Neutral"
-msgstr "Реверсор Нейтраль"
+msgstr "Реверсор: Нейтраль"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:16
 msgid "Reverser Full Reversed"
-msgstr "Реверсор Полный Назад"
+msgstr "Реверсор: Полный назад"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:17
 msgid "Reverser Full Forward"
-msgstr "Реверсор Полный Вперёд"
+msgstr "Реверсор: Полный вперёд"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:18
 msgid "Throttle Idle"
-msgstr "Контроллер 0"
+msgstr "Контроллер: 0"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:19
 msgid "Full Throttle"
-msgstr "Контроллер 100%"
+msgstr "Контроллер: 100%"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:20
 msgid "Dynamic Brake"
@@ -99,43 +99,43 @@ msgstr "Отпуск ЛТ вкл. (в тормозном положении)"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:31
 msgid "Rotary Switch 1-Position 1(OFF)"
-msgstr "Пакетник 1 - позиция 1(Откл)"
+msgstr "Пакетник 1 - позиция 1 (Откл)"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:32
 msgid "Rotary Switch 1-Position 2(SLOW)"
-msgstr "Пакетник 1 - позиция 2(Медл)"
+msgstr "Пакетник 1 - позиция 2 (Медл)"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:33
 msgid "Rotary Switch 1-Position 3(FULL)"
-msgstr "Пакетник 1 - позиция 3(Быстр)"
+msgstr "Пакетник 1 - позиция 3 (Быстр)"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:34
 msgid "Rotary Switch 2-Position 1(OFF)"
-msgstr "Пакетник 2 - позиция 1(Откл)"
+msgstr "Пакетник 2 - позиция 1 (Откл)"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:35
 msgid "Rotary Switch 2-Position 2(DIM)"
-msgstr "Пакетник 2 - позиция 2(Тускло)"
+msgstr "Пакетник 2 - позиция 2 (Тускло)"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:36
 msgid "Rotary Switch 2-Position 3(FULL)"
-msgstr "Пакетник 2 - позиция 3(Ярко)"
+msgstr "Пакетник 2 - позиция 3 (Ярко)"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:37
 msgid "Reverse Reverser Direction"
-msgstr "Обратить направление Реверсора"
+msgstr "Обратить направление реверсора"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:38
 msgid "Reverse Throttle Direction"
-msgstr "Обратить направление Контроллера"
+msgstr "Обратить направление контроллера"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:39
 msgid "Reverse Auto Brake Direction"
-msgstr "Обратить направление Крана Машиниста"
+msgstr "Обратить направление крана машиниста"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:40
 msgid "Reverse Independent Brake Direction"
-msgstr "Обратить направление Крана независимого тормоза"
+msgstr "Обратить направление крана независимого тормоза"
 
 #: ../../ORTS.Settings/RailDriverSettings.cs:41
 msgid "Full Range Throttle"

--- a/Source/Locales/Orts.Simulation/ru.po
+++ b/Source/Locales/Orts.Simulation/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2024-12-01 14:05:10+0300\n"
-"PO-Revision-Date: 2024-12-01 15:11+0300\n"
+"PO-Revision-Date: 2026-08-12 15:34+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:379
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/AirSinglePipe.cs:143
@@ -61,11 +61,11 @@ msgstr "Сброс ЭПК"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:391
 msgid "Cont. Service"
-msgstr "Рег.разрядка"
+msgstr "Рег. разрядка"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:392
 msgid "Full Service"
-msgstr "Полн.Служ"
+msgstr "Полн. служ."
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:393
 msgid "Minimum Reduction"
@@ -77,31 +77,31 @@ msgstr "Перекрыша СП"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:395
 msgid "Str. Brk. Release On:"
-msgstr "Прямод.Торм. Отпуск Вкл:"
+msgstr "Прямод. торм. Отпуск Вкл:"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:396
 msgid "Str. Brk. Release Off:"
-msgstr "Прямод.Торм. Отпуск Откл:"
+msgstr "Прямод. торм. Отпуск Откл:"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:397
 msgid "Str. Brk. Release:"
-msgstr "Прямод.Торм. Отпуск:"
+msgstr "Прямод. торм. Отпуск:"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:398
 msgid "Str. Brk. Lap:"
-msgstr "Прямод.Торм. Перекрыша:"
+msgstr "Прямод. торм. Перекрыша:"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:399
 msgid "Str. Brk. Apply:"
-msgstr "Прямод.Торм. Торм:"
+msgstr "Прямод. торм. Торм:"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:400
 msgid "Str. Brk. Apply All:"
-msgstr "Прямод.Торм. Торм.Полн:"
+msgstr "Прямод. торм. Торм. Полн:"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:401
 msgid "Str. Brk. Emerg:"
-msgstr "Прямод.Торм. Экстренн:"
+msgstr "Прямод. торм. Экстренн:"
 
 #: ../../Orts.Simulation/Common/Scripting/BrakeController.cs:402
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:245
@@ -251,7 +251,7 @@ msgstr "Гол. вагон"
 #: ../../Orts.Simulation/Common/Scripting/PowerSupply/PowerSupply.cs:166
 msgctxt "PowerSupply"
 msgid "Off"
-msgstr "Снято"
+msgstr "Откл"
 
 #. Context: PowerSupply
 #: ../../Orts.Simulation/Common/Scripting/PowerSupply/PowerSupply.cs:167
@@ -745,7 +745,7 @@ msgstr "Поддувало"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:217
 msgid "Firebox Door"
-msgstr "Топка"
+msgstr "Дверца топки"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:218
 msgid "Firing Rate"
@@ -785,15 +785,15 @@ msgstr "ход"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:224
 msgid "Steam Booster Latch"
-msgstr "Защёлка бустера"
+msgstr "Регулятор бустера"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:224
 msgid "opened"
-msgstr "открыта"
+msgstr "открыт"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:224
 msgid "locked"
-msgstr "закрыта"
+msgstr "закрыт"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:225
 msgid "Cylinder Compound"
@@ -879,7 +879,7 @@ msgstr "Независ. тормоз"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:236
 msgid "Brakeman Brake"
-msgstr "Тормозильщик Тормозить"
+msgstr "Тормозильщики"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:237
 msgid "Dynamic Brake"
@@ -895,7 +895,7 @@ msgstr "заблокировано. Поставьте реверсор в не�
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:238
 msgid "Emergency Brake"
-msgstr "Экстренное"
+msgstr "Экстренный тормоз"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:239
 msgid "disengage"
@@ -947,12 +947,12 @@ msgstr "Выпуск"
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:242
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/BrakeSystem.cs:117
 msgid "High Pressure"
-msgstr "Выс.Давление"
+msgstr "Выс. давление"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:242
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/BrakeSystem.cs:118
 msgid "Low Pressure"
-msgstr "Низк.Давление"
+msgstr "Низк. давление"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:242
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/BrakeSystem.cs:119
@@ -997,7 +997,7 @@ msgstr "гудит"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:251
 msgid "Bell"
-msgstr "Сигн.мал.громк"
+msgstr "Сигн. мал. громк"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:251
 msgid "ring"
@@ -1063,11 +1063,11 @@ msgstr "Участок с огр. скорости"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:263
 msgid "Doors Left"
-msgstr "Лев.двери"
+msgstr "Лев. двери"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:264
 msgid "Doors Right"
-msgstr "Прав.двери"
+msgstr "Прав. двери"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:265
 msgid "Mirror"
@@ -1118,7 +1118,7 @@ msgstr "Скорость симуляции"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:272
 msgid "reset"
-msgstr "нормальная"
+msgstr "вернуть обычную"
 
 #: ../../Orts.Simulation/Simulation/Confirmer.cs:273
 msgid "Uncouple After"
@@ -1323,7 +1323,7 @@ msgstr "Не повернуть. Проверьте контроллер, рев
 
 #: ../../Orts.Simulation/Simulation/Transfertables.cs:296
 msgid "Train partially on transfertable, can't transfer"
-msgstr "Часть состава не на столе, переставлять нельзя"
+msgstr "Часть состава не на трансбордере, переставлять нельзя"
 
 #: ../../Orts.Simulation/Simulation/Transfertables.cs:327
 msgid "Transfertable starting transferring train"
@@ -1340,7 +1340,7 @@ msgstr "поворотный круг"
 
 #: ../../Orts.Simulation/Simulation/Turntables.cs:213
 msgid "transfertable"
-msgstr "передаточную платформу"
+msgstr "трасбордер"
 
 #: ../../Orts.Simulation/Simulation/Turntables.cs:232
 #: ../../Orts.Simulation/Simulation/Turntables.cs:273
@@ -1410,7 +1410,8 @@ msgstr "Сцепка перегружена!"
 msgid ""
 "The steam usage has exceeded the capacity of the steam boiler. Steam boiler "
 "locked out."
-msgstr "Расход пара превысил производительность котла."
+msgstr ""
+"Расход пара превысил производительность котла. Выплавлены контрольные пробки."
 
 #: ../../Orts.Simulation/Simulation/Physics/Train.cs:7119
 #: ../../Orts.Simulation/Simulation/Physics/Train.cs:7124
@@ -1441,7 +1442,7 @@ msgstr "Стрелок не обнаружено"
 
 #: ../../Orts.Simulation/Simulation/Physics/Train.cs:10360
 msgid "You cannot enter manual mode when autopiloted"
-msgstr "На автопилоте нельзя перейти в маневровый режим"
+msgstr "При автоведении нельзя перейти в маневровый режим"
 
 #: ../../Orts.Simulation/Simulation/Physics/Train.cs:10365
 msgid "You cannot use this command for pathless trains"
@@ -1590,7 +1591,7 @@ msgstr "ДВС"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:962
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:351
 msgid "Battery switch"
-msgstr "Руб.АкБ"
+msgstr "Выключатель АБ"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:963
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:966
@@ -1621,7 +1622,7 @@ msgstr "Откл"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:971
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:360
 msgid "Electric train supply"
-msgstr "Эл.Отоп"
+msgstr "Эл. отопл."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:986
 msgid "N"
@@ -1636,7 +1637,7 @@ msgstr "Топливо"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:382
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8215
 msgid "StHeat:"
-msgstr "ПарОтоп:"
+msgstr "Пар. отопл.:"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:999
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:1009
@@ -1647,24 +1648,24 @@ msgstr "ПарОтоп:"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8821
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8836
 msgid "Press"
-msgstr "Давл"
+msgstr "Давл."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:1001
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:385
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8218
 msgid "StTemp"
-msgstr "Темп.пара"
+msgstr "Темп. пара"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:1003
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:387
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8220
 msgid "StUse"
-msgstr "Расх.пара"
+msgstr "Расх. пара"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:1006
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:390
 msgid "WaterLvl"
-msgstr "Зап.воды"
+msgstr "Ур. воды"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:1008
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:392
@@ -1676,7 +1677,7 @@ msgstr "Хвост:"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:395
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8226
 msgid "Temp"
-msgstr "Тепрер"
+msgstr "Темрер"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:1013
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:397
@@ -1763,7 +1764,7 @@ msgstr "Управл"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:1241
 msgid "Tractive Effort"
-msgstr "Тягов.Усилие"
+msgstr "Тягов. усилие"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSDieselLocomotive.cs:1252
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs:398
@@ -1812,7 +1813,7 @@ msgstr "Выбег"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:346
 msgid "Pantographs"
-msgstr "Токосъёмники"
+msgstr "Токоприёмники"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSElectricLocomotive.cs:373
 msgid "TCS"
@@ -1904,23 +1905,23 @@ msgstr "Горение нормализовано. Кочегар может н�
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:4631
 msgid "Grate limit exceeded - boiler heat rate cannot increase."
-msgstr "Колосник забит-мощность котла больше не увеличить."
+msgstr "Достигнут предел форсировки - мощность котла нельзя увеличить."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:4639
 msgid "Grate limit return to normal."
-msgstr "Колосник очищается."
+msgstr "Форсировка в рабочих пределах."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7021
 msgid "Water level dropped too far. Plug has fused and loco has failed."
-msgstr "Выкипело слишком много воды-котёл вышел из строя."
+msgstr "Низкий уровень воды. Выплавлены контрольные пробки."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7028
 msgid "Boiler overfull and priming."
-msgstr "Котёл переполнен."
+msgstr "Котёл переполнен, заброс воды в цилиндры."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7034
 msgid "Boiler no longer priming."
-msgstr "Уровень в котле нормализовался."
+msgstr "Уровень воды в норме, заброс прекратился."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7803
 msgid "Fixed gear"
@@ -1940,11 +1941,11 @@ msgstr "Водомерное стекло"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7809
 msgid "(safe range)"
-msgstr "Раб.интервал"
+msgstr "Раб. интервал"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7813
 msgid "Boiler water level"
-msgstr "Воды в котле"
+msgstr "Уровень воды в котле"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7813
 msgid "(absolute)"
@@ -2016,7 +2017,7 @@ msgstr "Топливо"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7857
 msgid "FuelCal"
-msgstr "Кал.топл"
+msgstr "Кал. топл"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7862
 msgid "Adj:"
@@ -2024,11 +2025,11 @@ msgstr "Поправки:"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7863
 msgid "CylEff"
-msgstr "Эфф.Цил"
+msgstr "Эфф. цил."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7865
 msgid "PortOpen"
-msgstr "L вп.окна"
+msgstr "L вп. окна"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7869
 msgid "Steam Production"
@@ -2044,11 +2045,11 @@ msgstr "Воды"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7877
 msgid "MaxOutp"
-msgstr "Макс.отд"
+msgstr "Макс. отд."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7878
 msgid "BoilerEff"
-msgstr "Эффективн"
+msgstr "Эффективн."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7886
 msgid "Heat:"
@@ -2156,7 +2157,7 @@ msgstr "Турбоген"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7943
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8005
 msgid "OilHeat"
-msgstr "Нефть"
+msgstr "Форсунки"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7945
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7974
@@ -2206,23 +2207,23 @@ msgstr "Ход"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8117
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8138
 msgid "Cutoff"
-msgstr "Отсечное"
+msgstr "Отсечка"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8059
 msgid "Lead"
-msgstr ""
+msgstr "Предвар."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8061
 msgid "ExhLap"
-msgstr "ВыпПер"
+msgstr "Пер. вып."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8063
 msgid "StLap"
-msgstr "ВпПер"
+msgstr "Пер. вп."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8065
 msgid "AdvAng"
-msgstr "УгОпер"
+msgstr "Уг. опереж."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8074
 msgid "CylEvts:"
@@ -2234,7 +2235,7 @@ msgstr "Отсечка"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8079
 msgid "CylComp"
-msgstr "Компаунд"
+msgstr "Комп."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8081
 msgid "CyAdmis"
@@ -2242,7 +2243,7 @@ msgstr "Впуск"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8092
 msgid "PressHP:"
-msgstr "Давление Iст:"
+msgstr "Давл. ЦВД"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8093
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8113
@@ -2276,11 +2277,11 @@ msgstr "Остаточн"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8123
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8144
 msgid "MEP"
-msgstr "Ср.Эфф"
+msgstr "Ср. эфф."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8112
 msgid "PressLP:"
-msgstr "Давление IIст:"
+msgstr "Давл. ЦНД"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8131
 msgid "Press:"
@@ -2314,7 +2315,7 @@ msgstr "Закрыт"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8154
 msgid "Plug"
-msgstr "Заглушка"
+msgstr "Пробка"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8155
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8157
@@ -2414,7 +2415,7 @@ msgstr "Нет"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8156
 msgid "Prime"
-msgstr "Выброс"
+msgstr "Заброс"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8158
 msgid "Comp"
@@ -2430,11 +2431,11 @@ msgstr "Буст.Вкл"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8164
 msgid "BoostGear"
-msgstr "ПовышПер"
+msgstr "Буст.муфта"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8170
 msgid "Boost:"
-msgstr "Форсир:"
+msgstr "Бустер:"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8171
 msgid "GearT"
@@ -2500,7 +2501,7 @@ msgstr "Горение:"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8267
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8285
 msgid "MaxFireR"
-msgstr "МаксПод"
+msgstr "Макс. под."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8269
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8287
@@ -2510,30 +2511,30 @@ msgstr "Подача"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8271
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8289
 msgid "BurnRate"
-msgstr "Ск.Сгор"
+msgstr "Скор. cгор."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8281
 msgid "Ideal"
-msgstr "Идеальн"
+msgstr "Идеальн."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8283
 msgid "Actual"
-msgstr "Фактич"
+msgstr "Фактич."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8291
 msgid "Combust"
-msgstr "Уд.Сгор"
+msgstr "Сгорание"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8295
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8457
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8481
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8506
 msgid "GrLimit"
-msgstr "Огр.Кол"
+msgstr "Предел ф."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8299
 msgid "MaxBurn"
-msgstr "Макс-Возм"
+msgstr "Макс. сгор."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8341
 msgid "Pump:"
@@ -2596,7 +2597,7 @@ msgstr "Вода(доп)"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8419
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8435
 msgid "Steam"
-msgstr "Пар,исп"
+msgstr "Пар, исп."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8387
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8405
@@ -2608,7 +2609,7 @@ msgstr "Пар всего"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8397
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs:455
 msgid "Oil"
-msgstr "Масло"
+msgstr "Топливо"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8413
 msgid "Wood"
@@ -2616,7 +2617,7 @@ msgstr "Дрова"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8447
 msgid "OilOut"
-msgstr "Нефть кончилась"
+msgstr "Нет топлива"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8449
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8473
@@ -2640,13 +2641,13 @@ msgstr "Форсир"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8483
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8508
 msgid "FireOn"
-msgstr "Подн.пар"
+msgstr "Подн. пар"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8461
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8485
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8510
 msgid "FireOff"
-msgstr "Сбр.пар"
+msgstr "Сбр. пар"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8463
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8487
@@ -2670,13 +2671,13 @@ msgstr "Производительность"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8522
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8572
 msgid "Power:"
-msgstr "Мощн:"
+msgstr "Мощн.:"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8523
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8575
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8585
 msgid "MaxInd"
-msgstr "Макс.Инд"
+msgstr "Макс. инд."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8525
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8577
@@ -2703,36 +2704,36 @@ msgstr "Усилие:"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8604
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8621
 msgid "TheorTE"
-msgstr "ТеорТУ"
+msgstr "Теор. ТУ"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8536
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8623
 msgid "StartTE"
-msgstr "ТрогТУ"
+msgstr "ТУ трог."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8538
 msgid "TE"
-msgstr "ФактТУ"
+msgstr "Факт. ТУ"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8540
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8627
 msgid "Draw"
-msgstr "СцепТУ"
+msgstr "ТУ на крюке"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8542
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8629
 msgid "CritSpeed"
-msgstr "Крит.Ск"
+msgstr "Крит. скор."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8544
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8631
 msgid "SpdLmt"
-msgstr "ПределСк"
+msgstr "Пред. скор."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8548
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8640
 msgid "Move:"
-msgstr "Движ:"
+msgstr "Движ.:"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8549
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8641
@@ -2742,17 +2743,17 @@ msgstr "Поршень"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8551
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8608
 msgid "DrvWhl"
-msgstr "ВедКол"
+msgstr "Сц. КП"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8553
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8643
 msgid "MF-Gear"
-msgstr "Перед.Ч"
+msgstr "Перед. ч."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8558
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8647
 msgid "Max-SpdF"
-msgstr "МаксКоэфСк"
+msgstr "Пуск. скор."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8584
 msgid "PowerTot:"
@@ -2761,12 +2762,12 @@ msgstr "Мощн. общ:"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8606
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8625
 msgid "AvTE"
-msgstr "СрТУ"
+msgstr "Сред. ТУ"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8611
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8633
 msgid "Hammer"
-msgstr ""
+msgstr "Небаланс"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8620
 msgid "ForceTot:"
@@ -2878,12 +2879,12 @@ msgstr "Трогание:"
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8775
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8789
 msgid "CyPressL"
-msgstr "ЛевЦил"
+msgstr "Давл. ЛЦ"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8777
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8791
 msgid "CyPressR"
-msgstr "ПравЦил"
+msgstr "Давл. ПЦ"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8779
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8793
@@ -2939,7 +2940,7 @@ msgstr "Вак:"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8856
 msgid "Pump"
-msgstr "Нагн"
+msgstr "Насос"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8862
 msgid "Leak:"
@@ -2967,11 +2968,11 @@ msgstr "Мин"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8883
 msgid "WaVel"
-msgstr ""
+msgstr "Скор. воды"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8885
 msgid "Drag"
-msgstr ""
+msgstr "Сопр. воды"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8887
 msgid "WaterU"
@@ -2979,7 +2980,7 @@ msgstr ""
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8889
 msgid "Input"
-msgstr ""
+msgstr "Подача"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:8891
 msgid "Total"
@@ -3000,7 +3001,7 @@ msgstr "Автокочегар прекратил подачу топлива"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:9799
 msgid "AI Fireman has been reset"
-msgstr "\"Автокочегар - сброс\""
+msgstr "Автокочегар в исходном состоянии"
 
 #. Context: HUD
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSSteamLocomotive.cs:7875
@@ -3010,7 +3011,7 @@ msgstr "\"Автокочегар - сброс\""
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/SteamEngine.cs:216
 msgctxt "HUD"
 msgid "Power"
-msgstr "Мощн"
+msgstr "Мощн."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs:2234
 msgid "Starting unload"
@@ -3149,7 +3150,7 @@ msgstr "Открыты"
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/SingleTransferPipe.cs:99
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/VacuumSinglePipe.cs:148
 msgid "EOT"
-msgstr "ХВ"
+msgstr "Хв."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/ManualBraking.cs:241
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/Brakes/MSTS/ManualBraking.cs:248
@@ -3191,7 +3192,7 @@ msgstr "Температура"
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs:402
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/SteamEngine.cs:221
 msgid "Oil Pressure"
-msgstr "Давл.Масла"
+msgstr "Давл. масла"
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs:416
 msgid " "
@@ -3203,7 +3204,7 @@ msgstr "ДВС заглох из-за недостаточной скорост�
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/DieselEngine.cs:1232
 msgid "Diesel Engine has stalled due to overspeed."
-msgstr "ДВС заглох из-за превышенной скорости."
+msgstr "ДВС заглох из-за превышения скорости."
 
 #: ../../Orts.Simulation/Simulation/RollingStocks/SubSystems/PowerSupplies/Pantograph.cs:371
 msgid "Pantograph raised even though this route is not electrified"
@@ -3244,12 +3245,12 @@ msgstr "Ожидание прибытия поезда: "
 #: ../../Orts.Simulation/Simulation/Timetables/TTTrain.cs:10402
 #: ../../Orts.Simulation/Simulation/Timetables/TTTrain.cs:10433
 msgid ", backward"
-msgstr "сзади"
+msgstr ", назад"
 
 #: ../../Orts.Simulation/Simulation/Timetables/TTTrain.cs:10417
 #: ../../Orts.Simulation/Simulation/Timetables/TTTrain.cs:10433
 msgid ", forward"
-msgstr "спереди"
+msgstr ", вперёд"
 
 #: ../../Orts.Simulation/Simulation/Timetables/TTTrain.cs:10426
 #: ../../Orts.Simulation/Simulation/Timetables/TTTrain.cs:10434

--- a/Source/Locales/RunActivity/ru.po
+++ b/Source/Locales/RunActivity/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2024-12-01 14:05:14+0300\n"
-"PO-Revision-Date: 2024-12-01 15:17+0300\n"
+"PO-Revision-Date: 2026-08-12 15:45+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #: ../../RunActivity/Viewer3D/Cameras.cs:601
 msgid "Free"
@@ -19,11 +19,11 @@ msgstr "Свободная"
 
 #: ../../RunActivity/Viewer3D/Cameras.cs:1000
 msgid "Outside Front"
-msgstr "Наружная-голова"
+msgstr "Наружная (голова)"
 
 #: ../../RunActivity/Viewer3D/Cameras.cs:1000
 msgid "Outside Rear"
-msgstr "Наружная-хвост"
+msgstr "Наружная (хвост)"
 
 #: ../../RunActivity/Viewer3D/Cameras.cs:1564
 msgid "Brakeman"
@@ -88,11 +88,11 @@ msgstr "Нет кабины"
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:972
 msgid "In MP, use Alt-F4 to quit directly"
-msgstr "Чтобы сразу выйти из мультиплеереа, нажмите Alt-F4"
+msgstr "Чтобы сразу выйти из мультиплеера, нажмите Alt-F4"
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1004
 msgid "Automatic platform and siding labels visible."
-msgstr "Отображены названия используемых поездом платформ и путей ."
+msgstr "Отображены названия используемых поездом платформ и путей."
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1007
 msgid "Platform and siding labels visible."
@@ -108,7 +108,7 @@ msgstr "Названия путей отображаются."
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1019
 msgid "Platform and siding labels hidden."
-msgstr "Названия платформ и путей не отображаются."
+msgstr "Названия платформ и путей скрыты."
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1030
 msgid "Train labels visible."
@@ -120,15 +120,15 @@ msgstr "Номера вагонов отображаются."
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1039
 msgid "Train and car labels hidden."
-msgstr "Номера поездов и вагонов не отображаются."
+msgstr "Номера поездов и вагонов скрыты."
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1095
 msgid "This car doesn't have a 2D cab"
-msgstr "Эта модель не снабжена 2D кабиной"
+msgstr "У этой модели нет 2D кабины"
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1099
 msgid "This car doesn't have a 3D cab"
-msgstr "Эта модель не снабжена 3D кабиной"
+msgstr "У этой модели нет 3D кабины"
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1146
 msgid "messages suppressed"
@@ -140,7 +140,7 @@ msgstr "Все сообщения отображаются"
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1315
 msgid "Switched to player control"
-msgstr "Автопилот отключён"
+msgstr "Автоведение отключено"
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1322
 msgid "You can't switch from manual to autopilot mode"
@@ -148,11 +148,11 @@ msgstr "Невозможно перейти на автопилот"
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:1328
 msgid "Switched to autopilot"
-msgstr "Автопилот включён"
+msgstr "Автоведение включено"
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:2004
 msgid "Game saved"
-msgstr "Сохранение создано"
+msgstr "Сессия сохранена"
 
 #: ../../RunActivity/Viewer3D/Viewer.cs:357
 #, csharp-format
@@ -296,7 +296,7 @@ msgstr "Кэш звука"
 
 #: ../../RunActivity/Viewer3D/Debugging/SoundDebugForm.Designer.cs:484
 msgid "AL Sources"
-msgstr "Ист.Звука"
+msgstr "Ист. звука"
 
 #: ../../RunActivity/Viewer3D/Debugging/SoundDebugForm.Designer.cs:513
 msgid "Sound Debug"
@@ -310,7 +310,7 @@ msgstr "Сообщение выбранному игроку"
 #: ../../RunActivity/Viewer3D/Map/MapForm.cs:177
 #: ../../RunActivity/Viewer3D/Map/MapForm.Designer.cs:822
 msgid "Reply to the selected player"
-msgstr "Отв. выбранным"
+msgstr "Ответ выбранным"
 
 #: ../../RunActivity/Viewer3D/Map/MapForm.cs:179
 #: ../../RunActivity/Viewer3D/Map/MapForm.Designer.cs:842
@@ -638,11 +638,11 @@ msgstr "Вагон №"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:91
 msgid "Unset Handbrake"
-msgstr "Отп.Ручн.тормоз"
+msgstr "Отп. ручн. тормоз"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:93
 msgid "Set Handbrake"
-msgstr "Вкл.Ручн.тормоз"
+msgstr "Вкл. ручн. тормоз"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:100
 msgid "Power Off"
@@ -663,19 +663,19 @@ msgstr "Подключить к СМЕ"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:116
 msgid "Battery Switch Off"
-msgstr "Откл.АБ"
+msgstr "Откл. АБ"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:118
 msgid "Battery Switch On"
-msgstr "Подкл.АБ"
+msgstr "Подкл. АБ"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:123
 msgid "Disonnect Electric Train Supply"
-msgstr "Отсоед. Магистраль отопл"
+msgstr "Отсоед. магистраль отопления"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:125
 msgid "Connect Electric Train Supply"
-msgstr "Подсоед. Магистраль отопл"
+msgstr "Подсоед. магистраль отопления"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:131
 msgid "Disconnect Front Brake Hose"
@@ -695,27 +695,27 @@ msgstr "Соединить рукав сзади"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:149
 msgid "Close Front Angle Cock"
-msgstr "Закр.передн.конц.кран"
+msgstr "Закр. передн. конц. кран"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:151
 msgid "Open Front Angle Cock"
-msgstr "Откр.передн.конц.кран"
+msgstr "Откр. передн. конц. кран"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:158
 msgid "Close Rear Angle Cock"
-msgstr "Закр.задн.конц.кран"
+msgstr "Закр. задний конц. кран"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:160
 msgid "Open Rear Angle Cock"
-msgstr "Откр.задн.конц.кран"
+msgstr "Откр. задний конц. кран"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:167
 msgid "Close Bleed Off Valve"
-msgstr "Закр.Трёхходовой кран"
+msgstr "Закр. трёхходовой кран"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:169
 msgid "Open Bleed Off Valve"
-msgstr "Откр.Трёхходовой кран"
+msgstr "Откр. трёхходовой кран"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:174
 msgid "Close window"
@@ -794,7 +794,7 @@ msgstr "Кабель отопления спереди разъединен"
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:331
 #: ../../RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs:1021
 msgid "This car doesn't have an ETS system"
-msgstr "Вагон не оборудован электро-отоплением"
+msgstr "Вагон не оборудован электроотоплением"
 
 #: ../../RunActivity/Viewer3D/Popups/CarOperationsWindow.cs:340
 #: ../../RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs:791
@@ -870,7 +870,7 @@ msgstr "Долг:"
 
 #: ../../RunActivity/Viewer3D/Popups/ComposeMessage.cs:32
 msgid "Compose Message (e.g.   receiver1, receiver2: message body)"
-msgstr "Напишите сообщение (напр.   адресат1, адресат2, текст сообщения)"
+msgstr "Напишите сообщение (напр.  адресат1, адресат2: текст сообщения)"
 
 #: ../../RunActivity/Viewer3D/Popups/EOTListWindow.cs:39
 msgid "EOT List"
@@ -929,7 +929,7 @@ msgstr "Прибытие"
 #: ../../RunActivity/Viewer3D/Popups/NextStationWindow.cs:80
 #: ../../RunActivity/Viewer3D/Popups/NextStationWindow.cs:82
 msgid "Actual"
-msgstr "По факту"
+msgstr "Фактич."
 
 #: ../../RunActivity/Viewer3D/Popups/HelpWindow.cs:124
 #: ../../RunActivity/Viewer3D/Popups/NextStationWindow.cs:81
@@ -1130,12 +1130,12 @@ msgstr "Сила тяги"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:117
 msgid "Num of substeps"
-msgstr "Число подшагов"
+msgstr "Число ступеней"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:120
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1453
 msgid "Memory"
-msgstr "Исп.памяти"
+msgstr "Исп. памяти"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:121
 msgid "GCs"
@@ -1148,22 +1148,22 @@ msgstr "Время кадра"
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:123
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1467
 msgid "Render process"
-msgstr "Обраб.графики"
+msgstr "Обраб. графики"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:124
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1468
 msgid "Updater process"
-msgstr "Обраб.обновления"
+msgstr "Обраб. обновлений"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:125
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1469
 msgid "Loader process"
-msgstr "Обраб.вывода"
+msgstr "Работа загрузчика"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:126
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1470
 msgid "Sound process"
-msgstr "Обраб.звука"
+msgstr "Обраб. звука"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:424
 msgid "Version"
@@ -1264,7 +1264,7 @@ msgstr "Динамич. тормоз"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:466
 msgid "Cruise control status"
-msgstr "Состояние КК"
+msgstr "Состояние САУТ"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:469
 msgid "Speed target"
@@ -1290,7 +1290,7 @@ msgstr "Кадров в секунду"
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:84
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:913
 msgid "Autopilot"
-msgstr "Автопилот"
+msgstr "Автоведение"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:483
 msgid "Wheel slip"
@@ -1306,11 +1306,11 @@ msgstr "Юз"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:494
 msgid "Sander blocked"
-msgstr "Пескоподача заблокирована"
+msgstr "Подача песка заблокирована"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:496
 msgid "Sander on"
-msgstr "Пескоподача включена"
+msgstr "Подача песка включена"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:507
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:1598
@@ -1346,7 +1346,7 @@ msgstr "Диспетчер"
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:521
 #: ../../RunActivity/Viewer3D/Popups/MultiPlayerWindow.cs:346
 msgid "Client"
-msgstr "Клиент"
+msgstr "Машинист"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:530
 msgid "CONSIST INFORMATION"
@@ -1512,33 +1512,33 @@ msgstr "№"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:764
 msgid "MainPS"
-msgstr "Гл.цепи"
+msgstr "Гл. цепи"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:765
 msgid "AuxPS"
-msgstr "Всп.цепи"
+msgstr "Всп. цепи"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:766
 #: ../../RunActivity/Viewer3D/Popups/TrainCarOperationsViewerWindow.cs:1211
 #: ../../RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs:1169
 msgid "Battery"
-msgstr "Акк.Бат"
+msgstr "Акк. бат."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:767
 msgid "LowVoltPS"
-msgstr "Низк.цепи"
+msgstr "Низк. цепи"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:768
 msgid "CabPS"
-msgstr "Цепи упр"
+msgstr "Цепи упр."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:769
 msgid "ETS"
-msgstr "Эл.отопл"
+msgstr "Эл. отопл."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:770
 msgid "ETSCable"
-msgstr "Каб.отопл"
+msgstr "Кабель отоп."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:797
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:810
@@ -1579,12 +1579,12 @@ msgstr "вкл"
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:903
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:913
 msgid "Large Ejector"
-msgstr "Бол.эжектор"
+msgstr "Бол. эжектор"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:890
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:915
 msgid "Small Ejector"
-msgstr "Мал.эжектор"
+msgstr "Мал. эжектор"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:892
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:917
@@ -1610,7 +1610,7 @@ msgstr "ТЦ"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:928
 msgid "Air Vol"
-msgstr "Объём Возд"
+msgstr "Объём воздуха"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:940
 msgid "No compressor or reservoir fitted"
@@ -1655,29 +1655,29 @@ msgstr "ТМ"
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1091
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1122
 msgid "Handbrk"
-msgstr "Руч.тор"
+msgstr "Ручн. тор."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1009
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1029
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1092
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1123
 msgid "Conn"
-msgstr "Магистр"
+msgstr "Магистр."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1010
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1030
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1093
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1124
 msgid "AnglCock"
-msgstr "Конц.кран"
+msgstr "Конц. кран"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1021
 msgid "VacRes"
-msgstr "Вак.Рез"
+msgstr "Вак. Рез"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1050
 msgid "Brk"
-msgstr "Тормож"
+msgstr "Тормож."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1082
 msgid "SrvPipe"
@@ -1720,7 +1720,7 @@ msgstr "ВР"
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1094
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1125
 msgid "BleedOff"
-msgstr "Трёхх.кран"
+msgstr "Трёхх. кран"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1116
 msgid "MRPipe"
@@ -1752,7 +1752,7 @@ msgstr "Торм.сила на ободе"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1165
 msgid "Number of substeps"
-msgstr "Промежут.ступеней"
+msgstr "Промежут. ступеней"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1166
 msgid "Wheel Adh. (Max)"
@@ -1802,11 +1802,11 @@ msgstr "Поезд"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1215
 msgid "Result"
-msgstr "Результирующий"
+msgstr "Суммарно"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1222
 msgid "Total"
-msgstr "Результ"
+msgstr "Итого"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1223
 msgid "Motive"
@@ -1822,7 +1822,7 @@ msgstr "Трение"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1226
 msgid "Gravity"
-msgstr "Вес"
+msgstr "Уклон"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1227
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1235
@@ -1848,19 +1848,19 @@ msgstr "Масса"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1236
 msgid "Superelev"
-msgstr "Возвыш"
+msgstr "Возвыш."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1237
 msgid "Brk Frict."
-msgstr "Тр.торм."
+msgstr "Тр. торм."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1238
 msgid "Brk Slide"
-msgstr "Скольжен"
+msgstr "Скольжен."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1239
 msgid "Bear Temp"
-msgstr "Темп.подш"
+msgstr "Темп. подш."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1241
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:134
@@ -1868,7 +1868,7 @@ msgstr "Темп.подш"
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:1567
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:1581
 msgid "DerailCoeff"
-msgstr ""
+msgstr "Запас устойч."
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1293
 msgid "DISPATCHER INFORMATION : active trains : "
@@ -1964,11 +1964,11 @@ msgstr "Память видео"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1456
 msgid "Adapter"
-msgstr "Графич.адаптер"
+msgstr "Графич. адаптер"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1461
 msgid "Shadow maps"
-msgstr "Схемы теней"
+msgstr "Карты теней"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1463
 msgid "Shadow primitives"
@@ -2026,15 +2026,15 @@ msgid ""
 "{0:F0} FPS (50th/95th/99th percentiles {1:F1} / {2:F1} / {3:F1} ms, DirectX "
 "feature level >= {4})"
 msgstr ""
-"{0:F0} кадров/сек (50й/95й/99й percentiles {1:F1} / {2:F1} / {3:F1} мс, "
-"DirectX feature level >= {4})"
+"{0:F0} кадров/сек (50й/95й/99й перцентиль {1:F1} / {2:F1} / {3:F1} мс, "
+"уровень детализ. DirectX >= {4})"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1453
 #, csharp-format
 msgid ""
 "{3}, {4}, {5}, {6} ({7:F0} kB/frame allocated, {0:F0}/{1:F0}/{2:F0} GCs)"
 msgstr ""
-"{3}, {4}, {5}, {6} ({7:F0} kB/frame распределено, {0:F0}/{1:F0}/{2:F0} GCs)"
+"{3}, {4}, {5}, {6} ({7:F0} кБ/кадр распределено, {0:F0}/{1:F0}/{2:F0} GCs)"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1454
 #, csharp-format
@@ -2042,11 +2042,13 @@ msgid ""
 "{0:F0} MB private, {1:F0} MB working set, {2:F0} MB private working set, "
 "{3:F0} MB managed, {4:F0} MB virtual"
 msgstr ""
+"{0:F0} MB private, {1:F0} MB working set, {2:F0} MB private working set, "
+"{3:F0} MB managed, {4:F0} MB virtual"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1455
 #, csharp-format
 msgid "{0:F0} MB committed, {1:F0} MB dedicated, {2:F0} MB shared"
-msgstr ""
+msgstr "{0:F0} МБ выделено, {1:F0} МБ собственная, {2:F0} МБ общая"
 
 #: ../../RunActivity/Viewer3D/Popups/HUDWindow.cs:1456
 #, csharp-format
@@ -2252,7 +2254,7 @@ msgstr "Выйти из {1} ({0})"
 #: ../../RunActivity/Viewer3D/Popups/QuitWindow.cs:51
 #, csharp-format
 msgid "Save your game ({0})"
-msgstr "Сохранить игру ({0})"
+msgstr "Сохранить сессию ({0})"
 
 #: ../../RunActivity/Viewer3D/Popups/QuitWindow.cs:59
 #, csharp-format
@@ -2588,7 +2590,7 @@ msgstr "А/кочегар"
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:120
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:84
 msgid "AUTO"
-msgstr "А/пилот"
+msgstr "САУТ"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:121
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:85
@@ -2605,7 +2607,7 @@ msgstr "АБ"
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:86
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:766
 msgid "Blowndown valve"
-msgstr "Эверласт"
+msgstr "Эверластинг"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:122
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:86
@@ -2651,7 +2653,7 @@ msgstr "УРОВ"
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:90
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:841
 msgid "Booster air valve"
-msgstr "Воздушный вентиль бустера"
+msgstr "Вентиль пуска бустера"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:126
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:90
@@ -2663,7 +2665,7 @@ msgstr "Б.возд"
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:91
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:867
 msgid "Booster idle valve"
-msgstr "Вентиль холостого хода бустера"
+msgstr "Продувательный клапан бустера"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:127
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:91
@@ -2675,7 +2677,7 @@ msgstr "ВХХБ"
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:92
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:890
 msgid "Booster latch"
-msgstr "Защёлка бустера"
+msgstr "Регулятор бустера"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:128
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:92
@@ -2697,16 +2699,16 @@ msgstr "БУСТ"
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:130
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:1341
 msgid "CCStatus"
-msgstr "Режим КК"
+msgstr "Автоведение"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:130
 msgid "CCST"
-msgstr "КК"
+msgstr "САУТ"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:131
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:94
 msgid "Circuit breaker"
-msgstr "Главн Выключ"
+msgstr "Главн. выключ."
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:131
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:94
@@ -2732,7 +2734,7 @@ msgstr "РЕВЕРС"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:134
 msgid "DRLC"
-msgstr ""
+msgstr "ДвЛок"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:135
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:97
@@ -2779,12 +2781,12 @@ msgstr "Загрузка топки"
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:140
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:102
 msgid "FIRE"
-msgstr "ОТАПЛ"
+msgstr "ОТОПЛ"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:141
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:103
 msgid "Fixed gear"
-msgstr "Редукторный"
+msgstr "Простой редуктор"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:141
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:143
@@ -2819,12 +2821,12 @@ msgstr "УКЛОН"
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:967
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:981
 msgid "Grate limit"
-msgstr "Пред.Колосн"
+msgstr "Предел форсир."
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:145
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:107
 msgid "GRAT"
-msgstr "Колосн"
+msgstr "КОЛОСН"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:147
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:108
@@ -2850,12 +2852,12 @@ msgstr "ПрУс"
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:109
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:675
 msgid "Pantographs"
-msgstr "Токосъёмники"
+msgstr "Токоприемники"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:149
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:109
 msgid "PANT"
-msgstr "Т/Пр"
+msgstr "Т/пр"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:151
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:111
@@ -2973,7 +2975,7 @@ msgstr "служебное"
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:170
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:129
 msgid "Apply"
-msgstr "Применить"
+msgstr "Тормозить"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:171
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:130
@@ -3022,7 +3024,7 @@ msgstr "Кнопка аварийного останова"
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:175
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:133
 msgid "EmerBPB"
-msgstr "КнАвОст"
+msgstr "Кн. ав. ост."
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:176
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:134
@@ -3093,7 +3095,7 @@ msgstr "Бокс"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:182
 msgid "Vac. Cont. Service"
-msgstr ""
+msgstr "Вак.т.-перекрыша"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:182
 msgid "Vac.Serv"
@@ -3236,7 +3238,7 @@ msgstr "Голова"
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:1043
 #: ../../RunActivity/Viewer3D/WebServices/TrainDrivingDisplay.cs:597
 msgid "Setup"
-msgstr "Подг"
+msgstr "Подгот"
 
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:1127
 #: ../../RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs:1182
@@ -3407,7 +3409,7 @@ msgstr ""
 
 #: ../../RunActivity/Viewer3D/Processes/GameStateRunActivity.cs:379
 msgid "Game save is not allowed during container load/unload"
-msgstr "Сохранение игры запрещено во время погрузки/выгрузки"
+msgstr "Сохранение сессии запрещено во время погрузки/выгрузки"
 
 #: ../../RunActivity/Viewer3D/Processes/GameStateRunActivity.cs:1306
 #, csharp-format
@@ -3444,11 +3446,11 @@ msgstr "песок"
 
 #: ../../RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs:452
 msgid "freight-general"
-msgstr "общие грузы"
+msgstr "прочие грузы"
 
 #: ../../RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs:453
 msgid "freight-livestock"
-msgstr "животные"
+msgstr "скот"
 
 #: ../../RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs:454
 msgid "freight-fuel"
@@ -3657,7 +3659,7 @@ msgstr "Открыть сигнал впереди"
 #: ../../RunActivity/Viewer3D/WebServices/SwitchPanel/SwitchOnPanelDefinition.cs:186
 msgctxt "SwitchPanel"
 msgid "Autopilot"
-msgstr "Автопилот"
+msgstr "Автоведение"
 
 #. Context: SwitchPanel
 #: ../../RunActivity/Viewer3D/WebServices/SwitchPanel/SwitchOnPanelDefinition.cs:189
@@ -3801,13 +3803,13 @@ msgstr "Рубильник АБ"
 #: ../../RunActivity/Viewer3D/WebServices/SwitchPanel/SwitchOnPanelDefinition.cs:258
 msgctxt "SwitchPanel"
 msgid "Master Key"
-msgstr "Выкл.упр"
+msgstr "Выкл. упр."
 
 #. Context: SwitchPanel
 #: ../../RunActivity/Viewer3D/WebServices/SwitchPanel/SwitchOnPanelDefinition.cs:261
 msgctxt "SwitchPanel"
 msgid "Circuit Breaker"
-msgstr "Главн Выключ"
+msgstr "Главн. выключ."
 
 #. Context: SwitchPanel
 #: ../../RunActivity/Viewer3D/WebServices/SwitchPanel/SwitchOnPanelDefinition.cs:264


### PR DESCRIPTION
A number of small edits improving russian localization are proposed.

The objectives of edits are:
- following official grammar
- improving lexical consistency and following character limits
- clarifying some menu elements
- making a few terms more precise, including those related to steam locos

Discussion: https://www.elvastower.com/forums/index.php?/topic/34158-%d1%81%d0%b2%d0%be%d0%b1%d0%be%d0%b4%d0%bd%d0%b0%d1%8f-%d0%ba%d0%be%d0%bb%d0%b5%d1%8f-the-discussion-of-russian-localization/