### PR TITLE
Validate table dimensions in InterpolatorDiesel2D

### DIFF
--- a/Source/Orts.Parsers.Msts/Interpolator.cs
+++ b/Source/Orts.Parsers.Msts/Interpolator.cs
@@ -325,6 +325,9 @@ namespace Orts.Parsers.Msts
         public int Size;       // number of values populated
         int PrevIndex;  // used to speed up repeated evaluations with similar x values
         bool HasNegativeValues; // set when negative Y values present (e.g. in old triphase locos)
+        // Upper bound on the row count a table may declare. Real tractive-effort tables have at most a few
+        // hundred rows, so this is generous; it exists only to stop a malformed file sizing an allocation.
+        const int MaximumRows = 10000;
         public InterpolatorDiesel2D(int n)
         {
             X = new float[n];
@@ -349,10 +352,15 @@ namespace Orts.Parsers.Msts
             {
                 stf.MustMatch("(");
                 int numOfRows = stf.ReadInt(0);
-                if (numOfRows < 2)
+                if (numOfRows < 2 || numOfRows > MaximumRows)
                 {
                     STFException.TraceWarning(stf, "Interpolator must have at least two rows.");
                     errorFound = true;
+                    // This value sizes the arrays allocated below and bounds the table read loop, so it
+                    // cannot be left as read from the file: a negative count threw OverflowException and a
+                    // large one committed gigabytes before failing. Zero keeps both safe, and errorFound
+                    // already records that this interpolator will not work correctly.
+                    numOfRows = 0;
                 }
                 int numOfColumns = stf.ReadInt(0);
                 string header = stf.ReadString().ToLower();
@@ -393,6 +401,7 @@ namespace Orts.Parsers.Msts
                                 {
                                     STFException.TraceWarning(stf, "Interpolator throttle vs. num of columns mismatch. (missing some throttle values)");
                                     errorFound = true;
+                                    break;      // there is no interpolator to store this column in
                                 }
                                 ilist[j][x] = stf.ReadFloat(STFReader.UNITS.Force, 0);
                                 numofData++;
@@ -413,6 +422,13 @@ namespace Orts.Parsers.Msts
                         {
                             STFException.TraceWarning(stf, "Interpolator has found a mismatch between num of rows declared and num of rows given.");
                             errorFound = true;
+                        }
+                        if (checkMe.GetSize() < 1)
+                        {
+                            // MinX()/MaxX() read X[0] and X[Size-1], which are outside the array when no
+                            // rows were populated - previously an IndexOutOfRangeException here.
+                            errorFound = true;
+                            continue;
                         }
                         float dx = (checkMe.MaxX() - checkMe.MinX()) * 0.1f;
                         if (dx <= 0f)


### PR DESCRIPTION
## Problem

A malformed `ORTSTractionCharacteristics` block crashes or hangs the simulator while loading an activity.

In `InterpolatorDiesel2D(STFReader, tab: true)` the row and column counts are read straight from the content file and then used to size arrays and bound loops, without being checked. The existing code already *notices* several of these problems — it warns and sets `errorFound` — but then carries on and uses the bad value anyway.

Four distinct failures, all reproduced by feeding the block to `new InterpolatorDiesel2D(stf, tab: true)`:

| Input | Result |
|---|---|
| `( -1 3 throttle ( 0 0.5 ) table ( 0 1 2 ) )` | `OverflowException` in `Interpolator..ctor` — `new float[-1]` |
| `( 2000000000 3 throttle ( 0 0.5 ) table ( 0 1 2 ) )` | **No exception — commits ~8 GB and thrashes the machine.** Killed at 3 GB resident and still climbing |
| `( 2 5 throttle ( 0 ) table ( 0 1 2 3 4 1 1 2 3 4 ) )` | `ArgumentOutOfRangeException` indexing `ilist[j]` at `:397` |
| `( 0 3 throttle ( 0 0.5 ) table ( ) )` | `IndexOutOfRangeException` in `Interpolator.MaxX` — reads `X[Size-1]`, i.e. `X[-1]`, when no rows were populated |

The huge-but-allocatable case is the worst, because it is not a clean crash. A row count below the CLR maximum array length is genuinely attempted, so the player sees the simulator freeze and the machine start swapping, with no error at all.

Nothing on the load path catches any of these. `Simulator` rethrows when the offending file is the player's first wagon, so one bad `.eng` aborts the activity with a fatal dialog that names no file.

## Changes

The fix keeps this constructor's deliberately tolerant design — it warns and yields a degraded interpolator rather than throwing:

- A row count outside `2..MaximumRows` is warned about as before, then forced to `0` so it cannot size an allocation or bound a loop. `MaximumRows` is 10000, far above the few hundred rows a real tractive-effort table uses; it exists only to stop a malformed file driving the allocation. Happy to change the value if you have a better bound in mind.
- The throttle/column mismatch branch now `break`s out of the column loop instead of falling through into `ilist[j]`. It already warned that there was no interpolator for that column.
- The consistency check skips `MinX()`/`MaxX()` when no rows were populated, since both index outside the array in that case.

`errorFound` is set on every one of these paths, so the existing `"Errors found in the Interpolator definition!!!"` warning still fires exactly as before.

## Scope

Only the `tab: true` branch is touched. It is reached solely from `engine(ortstractioncharacteristics`. The `tab: false` branch used by `ORTSMaxTractiveForceCurves` and `ORTSDynamicBrakeForceCurves` sizes itself from the values actually read and is unchanged.

`Interpolator(STFReader)` has a superficially similar shape but derives its size from the count of values actually read, so it cannot over-allocate. Left alone.

## Verification

- All four cases above now parse without throwing.
- A valid table still parses and interpolates correctly. For a 2×3 table `( 2 3 throttle ( 0 1 ) table ( 0 100 200 10 50 150 ) )`, `Get()` returns 100 / 200 / 50 / 150 at the corners and 125 interpolated at the midpoint.
- Solution builds; 212/212 unit tests pass.

## Notes for reviewers

- **The positive check is synthetic.** I had no content using `ORTSTractionCharacteristics` available locally — of 2274 `.eng`/`.wag` files in the route I tested against, zero use it (63 use the untouched `tab: false` blocks). So the change cannot regress that content, but I also cannot claim it has been validated against a real add-on that exercises this path. If someone has such a locomotive to hand, that would be a worthwhile extra check.
- I could not file a Launchpad bug for this (no account). This change is larger than 10 lines, so per `Docs/Contributing.md` it needs a linked report before it can be approved — please let me know the bug number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
