### PR TITLE
Parse degF values safely and culture-invariantly in STFReader

### DIFF
--- a/Source/Orts.Parsers.Msts/STFReader.cs
+++ b/Source/Orts.Parsers.Msts/STFReader.cs
@@ -1156,9 +1156,17 @@ namespace Orts.Parsers.Msts
                     case "": return 1.0;
                     case "degc": return 1;
                     case "degf":  // For degF we have a complex calculation process that require conversion from a string, calculation of equivalent degC, and then conversion back to a string
-                        float TempConstant = Convert.ToSingle(constant);
+                        // Parse defensively and with the same invariant format the caller uses. This was
+                        // Convert.ToSingle, which threw FormatException when the numeric part was missing
+                        // or malformed - "MaxTemperature ( degF )" leaves constant empty. Leaving constant
+                        // untouched lets ReadFloat handle and report it the same way as any other value.
+                        if (!float.TryParse(constant, parseNum, parseNFI, out float TempConstant))
+                            return 1;
                         float Temperature = (TempConstant - 32f) * (100f / 180f);
-                        constant = Convert.ToString(Temperature);
+                        // Write back with the invariant format too: Convert.ToString used the current
+                        // culture, so on a locale with a comma decimal separator the converted value could
+                        // not be read back correctly by the caller's invariant float.TryParse.
+                        constant = Temperature.ToString(parseNFI);
                         return 1;
                 }
             }


### PR DESCRIPTION
## Problem

The `degF` branch of `ParseUnitSuffix` is the only place in `STFReader.cs` that uses `Convert.To*` rather than `TryParse`. It has two defects.

### 1. A missing or malformed number throws

`ParseUnitSuffix` has already split the value into its numeric part and its suffix by the time this branch runs, so a stanza such as `MaxTemperature ( degF )` leaves the constant empty and `Convert.ToSingle("")` throws:

```
FormatException: Input string was not in a correct format.
   at Orts.Parsers.Msts.STFReader.ParseUnitSuffix in STFReader.cs:1159
```

`-degF` fails the same way, leaving `"-"`.

Nothing on the load path catches this, so a single mistyped temperature in an `.eng` aborts the activity. Live consumers are `MSTSDieselLocomotive.cs:220`, `DieselEngine.cs:1020/1023/1024`, `MSTSSteamLocomotive.cs:1068` and `MSTSWagon.cs:1346`.

Every other numeric path in this file (`ReadInt`, `ReadUInt`, `ReadFloat`, `ReadDouble`) uses `TryParse` with a trace-warning fallback, so this is a lone exception to the file's own convention.

### 2. The converted value is written back in the current culture

This is the more insidious half. The caller parses the constant with `NumberFormatInfo.InvariantInfo` and `NumberStyles.AllowThousands` (`STFReader.cs:616`, `:1696-1697`), but `Convert.ToString(Temperature)` formats using the **current** culture. On any locale with a comma decimal separator, the comma is then interpreted as a *thousands* separator rather than rejected — so the value is silently multiplied instead of failing loudly.

Demonstrating this needs a `degF` value whose `degC` result is not a whole number; `212degF` and `32degF` land on exact integers and round-trip fine either way, which is presumably why this has gone unnoticed. `100degF` is 37.777779 °C:

```
de-DE / fr-FR, old round-trip:
  Convert.ToString -> "37,77778" -> invariant parse -> 3777778
```

37.78 °C read back as **3 777 778 °C**, with nothing reported.

## Changes

- Parse with `float.TryParse` using the same `parseNum`/`parseNFI` the rest of the file uses. On failure the constant is left untouched, which lets `ReadFloat` report it exactly as it reports any other unparseable value, instead of throwing.
- Write the converted value back with the invariant format the caller reads it with.

## Verification

- Both malformed cases (`( degF )`, `( -degF )`) now parse without throwing.
- Valid values convert correctly under `en-US`, `de-DE` and `fr-FR`: `212degF` → 100.00 and `100degF` → 37.7778 in all three.
- Solution builds; 212/212 unit tests pass.

## Notes for reviewers

- Defect 2 is a behaviour fix rather than a crash fix, but it is on the same three lines and the same root cause (unsafe string↔number conversion in this branch), so I have kept them together. Say the word if you would rather see them split.
- Worth knowing: `Convert.ToString` on a float is used in a handful of other places in the tree. I have not audited them here, but the same locale trap may apply where the result is later parsed with an invariant format.
- I could not file a Launchpad bug for this (no account). Per `Docs/Contributing.md` this needs a linked report before approval — please let me know the bug number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
