### PR TITLE
Report an empty timetable file instead of crashing

### DIFF
--- a/Source/Orts.Parsers.OR/TimetableReader.cs
+++ b/Source/Orts.Parsers.OR/TimetableReader.cs
@@ -38,6 +38,14 @@ namespace Orts.Parsers.OR
             {
                 var readLine = filestream.ReadLine();
 
+                // ReadLine() returns null for an empty file and "" for a blank first line. Indexing
+                // either one threw NullReferenceException or IndexOutOfRangeException, naming neither
+                // the file nor the problem. Report it the same way as an unrecognised separator below.
+                if (string.IsNullOrEmpty(readLine)) // Fatal error
+                {
+                    throw new InvalidDataException($"Empty timetable {filePath}");
+                }
+
                 // Extract the separator character from start of the first line.
                 char separator = readLine[0];
 

--- a/Source/Tests/Orts.Parsers.OR/TimetableReaderTests.cs
+++ b/Source/Tests/Orts.Parsers.OR/TimetableReaderTests.cs
@@ -57,6 +57,25 @@ namespace Tests.Orts.Parsers.OR
         }
 
         [Fact]
+        public static void RejectEmptyFile()
+        {
+            // An empty file gives ReadLine() == null; a blank first line gives "". Indexing either
+            // used to throw NullReferenceException / IndexOutOfRangeException out of the constructor.
+            using (var file = new TestFile(""))
+            {
+                Assert.Throws<InvalidDataException>(() => {
+                    var tr = new TimetableReader(file.FileName);
+                });
+            }
+            using (var file = new TestFile("\n;b;c;d"))
+            {
+                Assert.Throws<InvalidDataException>(() => {
+                    var tr = new TimetableReader(file.FileName);
+                });
+            }
+        }
+
+        [Fact]
         public static void ParseStructure()
         {
             using (var file = new TestFile(";b;c;d\n1;2;3\nA;B;C;D;E"))


### PR DESCRIPTION
## Problem

An empty or blank-first-line timetable file kills timetable mode with an exception that names neither the file nor the problem.

`TimetableReader` takes the separator from the first character of the first line without checking that there is one (`TimetableReader.cs:39-42`):

```csharp
var readLine = filestream.ReadLine();

// Extract the separator character from start of the first line.
char separator = readLine[0];
```

`ReadLine()` returns `null` for a zero-byte file and `""` for a blank first line, so this throws `NullReferenceException` or `IndexOutOfRangeException` respectively. Neither this constructor nor `ProcessTimetable` catches them.

A zero-byte `.timetable_or` is exactly what an interrupted download or a failed save leaves behind, so this is reachable without any hand-editing.

## Change

The constructor already rejects an unrecognised separator three lines later with `InvalidDataException` and a message naming the file:

```csharp
throw new InvalidDataException($"Expected separators are {validSeparators} and tab but found '{separator}' as first character of timetable {filePath}");
```

An empty file now reports the same way, so this introduces no new exception type for callers to handle — it turns an anonymous `NullReferenceException` into the reader's own documented error, naming the file.

## Tests

Adds `TimetableReaderTests.RejectEmptyFile`, covering both the zero-byte and blank-first-line cases, in the style of the existing `DetectSeparator` test.

Confirmed the test actually catches the defect by running it against the unpatched reader:

```
Failed Tests.Orts.Parsers.OR.TimetableReaderTests.RejectEmptyFile
  Assert.Throws() Failure
  Expected: typeof(System.IO.InvalidDataException)
  Actual:   typeof(System.NullReferenceException)
```

Solution builds; 213/213 unit tests pass.

## Notes for reviewers

- This is under 10 lines of production code, so I believe it does not need a linked Launchpad bug under `Docs/Contributing.md` — please tell me if you would still like one.
- There are four open Launchpad reports about timetable-mode crashes (2160152, 2105220, 2153089, 2116772). I have **not** established that any of them is this defect; I mention them only because this is cheap to rule in or out against those reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
