### PR TITLE
Replace Thread.Abort with cancellation in the route image fetch

### DIFF
--- a/Source/Menu/ContentForm.cs
+++ b/Source/Menu/ContentForm.cs
@@ -46,7 +46,7 @@ namespace Menu
         private string AutoInstallRouteName;
 
         private readonly string ImageTempFilename;
-        private Thread ImageThread;
+        private CancellationTokenSource ImageCancellation;
         private readonly string InfoTempFilename;
 
         private bool AutoInstallClosingBlocked;
@@ -276,38 +276,62 @@ namespace Menu
 
             if (!string.IsNullOrEmpty(AutoInstallRoutes[AutoInstallRouteName].Image))
             {
-                if (ImageThread != null)
-                {
-                    if (ImageThread.IsAlive)
-                    {
-                        ImageThread.Abort();
-                    }
-                }
+                // Cancel any fetch still in flight. This was ImageThread.Abort(), which always throws
+                // PlatformNotSupportedException on .NET 5 and later, so moving through the route list
+                // faster than an image could be fetched brought the menu down.
+                ImageCancellation?.Cancel();
+                ImageCancellation?.Dispose();
+                ImageCancellation = new CancellationTokenSource();
+                CancellationToken token = ImageCancellation.Token;
 
-                // use a thread as grabbing the picture from the web might take a few seconds
-                ImageThread = new Thread(() =>
-                {
-                    // wait one second as the user might scroll through the list
-                    Stopwatch sw = Stopwatch.StartNew();
-                    while (sw.ElapsedMilliseconds <= 1000) { }
+                // Capture these now: the fields change as the user moves through the list, so a fetch
+                // started earlier must not pick up a later route's values.
+                string imageUrl = AutoInstallRoutes[AutoInstallRouteName].Image;
+                string imageFilename = ImageTempFilename;
 
+                // grabbing the picture from the web might take a few seconds, so do it off the UI thread
+                _ = Task.Run(async () =>
+                {
                     try
                     {
+                        // wait one second as the user might scroll through the list
+                        await Task.Delay(1000, token).ConfigureAwait(false);
+
                         using (WebClient myWebClient = new WebClient())
-                                {
-                            myWebClient.DownloadFile(AutoInstallRoutes[AutoInstallRouteName].Image, ImageTempFilename);
-                            }
-                        if (File.Exists(ImageTempFilename))
+                        using (token.Register(myWebClient.CancelAsync))
                         {
-                            pictureBoxAutoInstallRoute.Image = new Bitmap(ImageTempFilename);
+                            await myWebClient.DownloadFileTaskAsync(imageUrl, imageFilename).ConfigureAwait(false);
                         }
+                        token.ThrowIfCancellationRequested();
+
+                        // Decode from a copy held in memory. Constructing a Bitmap from the path keeps
+                        // the file locked for the lifetime of the image, which made every later download
+                        // to that same temporary file fail silently.
+                        Image image;
+                        using (MemoryStream imageStream = new MemoryStream(File.ReadAllBytes(imageFilename)))
+                            image = new Bitmap(imageStream);
+
+                        // The picture box belongs to the UI thread.
+                        pictureBoxAutoInstallRoute.BeginInvoke((MethodInvoker)delegate
+                        {
+                            if (token.IsCancellationRequested)
+                            {
+                                image.Dispose();
+                                return;
+                            }
+                            pictureBoxAutoInstallRoute.Image?.Dispose();
+                            pictureBoxAutoInstallRoute.Image = image;
+                        });
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // superseded by a later selection
                     }
                     catch
                     {
                         // route lives whithout a picture, not such a problem
                     }
                 });
-                ImageThread.Start();
             }
 
             // text box with description
@@ -1824,6 +1848,10 @@ namespace Menu
 
             try
             {
+                // Stop any image fetch still running, so it cannot touch the form after it closes.
+                ImageCancellation?.Cancel();
+                ImageCancellation?.Dispose();
+                ImageCancellation = null;
                 if (pictureBoxAutoInstallRoute.Image != null)
                 {
                     pictureBoxAutoInstallRoute.Image.Dispose();


### PR DESCRIPTION
## Problem

Scrolling through the Auto Install route list brings down the menu.

Selecting a route that has an image starts a thread to fetch it. Selecting another one while that fetch is still running calls `ImageThread.Abort()` (`ContentForm.cs:283`). `Thread.Abort` always throws `PlatformNotSupportedException` on .NET 5 and later — the build already says so:

```
ContentForm.cs(283,25): warning SYSLIB0006: 'Thread.Abort()' is obsolete:
    'Thread.Abort is not supported and throws PlatformNotSupportedException.'
```

**This is not a race.** The fetch thread opens with a one-second busy-wait (`:292`, `while (sw.ElapsedMilliseconds <= 1000) { }`), so `IsAlive` is reliably true — arrow-keying down the list is enough to hit it.

`dataGridViewAutoInstall_SelectionChanged` has no `try`/`catch`; the `try` at `:294` is inside the *new* thread's lambda and starts later. There is no `Application.ThreadException` or `AppDomain.UnhandledException` handler anywhere in `Source`, so this reaches the default unhandled-exception dialog. Choosing **Continue** leaves the tab unusable, because `DisableAutoInstallButtons()` ran at `:265` but `EnableAutoInstalButtons()` at `:318` is never reached.

Measured over 40 rapid selection changes: the old pattern threw on **39 of 40**; the replacement throws on **none**, with 39 fetches superseded and exactly one — the final selection — completing.

## Changes

All within this one handler:

- The thread and `Abort` become a `CancellationTokenSource` and a `Task`; selecting another route cancels the previous fetch cooperatively.
- The one-second busy-wait, which spun a core, becomes `Task.Delay`.
- **The route URL is captured before the fetch starts.** It was read from `AutoInstallRouteName` *inside* the thread, a field the UI mutates as the user moves through the list, so a slow fetch could download the image for a route the user had already moved off.
- **The image is assigned through `BeginInvoke`.** The picture box was written directly from the fetch thread, which is not a supported way to touch a WinForms control.
- **The bitmap is decoded from a copy of the bytes rather than from the path.** Constructing a `Bitmap` from the file keeps it locked for the lifetime of the image, and every route reuses the same temporary file — so every later download to it failed, silently, in the catch that lets a route live without a picture.
- The token source is cancelled and disposed when the form closes, so a fetch in flight cannot touch the form afterwards.

## Verification

- Solution builds and the `SYSLIB0006` warning is gone; 212/212 unit tests pass.
- The 39/40 → 0/40 figures above come from a harness reproducing the cancel/restart pattern in isolation.
- The crash itself was confirmed separately: `Thread.Abort()` on a live thread under `net6.0-windows` throws `PlatformNotSupportedException: Thread abort is not supported on this platform.`

## Notes for reviewers

- **This has not been exercised end to end.** It is a WinForms path needing a live UI and network, which I could not drive headlessly. The crash and the cancellation pattern are measured; the **UI marshalling and the bitmap change are argued from the code, not observed in the running menu**. They would benefit from a look by someone who can drive the dialog — in particular, whether the picture box still updates as expected when moving slowly through the list.
- The bitmap/file-lock change is a behaviour fix rather than a crash fix. It is here because the cancellation rework touches the same block and leaving the lock in place would keep the replacement from working properly. Happy to split it out.
- `WebClient` is obsolete on .NET 6 (`SYSLIB0014`) and ideally becomes `HttpClient`, but that is pre-existing and used elsewhere in this file, so I left it alone.
- This change is larger than 10 lines, so per `Docs/Contributing.md` it needs a linked Launchpad bug before approval. I have no Launchpad account — please let me know the bug number. Open report 2148143 ("F9 Menu Causing Crash") is *not* this, despite the similar-sounding title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
