### PR TITLE
Fix exception when opening Car Ops (F9) for the first time while Free Cam (8) is active.

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainCarOperationsWindow.cs
@@ -584,11 +584,10 @@ namespace Orts.Viewer3D.Popups
                 if (!Owner.Viewer.FirstLoop || Owner.Viewer.IsCameraPositionUpdated)
                 {
                     Owner.Viewer.CameraF9Reference = Owner.Viewer.FrontCamera.IsCameraFront;
-                    var currentCameraCarID = Owner.Viewer.Camera.AttachedCar.CarID;
                     var currentCameraPosition = 0;
-                    if (PlayerTrain != null)
+                    if (PlayerTrain != null && Owner.Viewer.Camera.AttachedCar != null)
                     {
-                        currentCameraPosition = PlayerTrain.Cars.TakeWhile(x => x.CarID != currentCameraCarID).Count();
+                        currentCameraPosition = PlayerTrain.Cars.TakeWhile(x => x.CarID != Owner.Viewer.Camera.AttachedCar.CarID).Count();
                     }
 
                     Owner.Viewer.FirstLoop = true;


### PR DESCRIPTION
This fixes a NullReferenceException when opening the Train Car Operations window (F9) the first time while the Free Roam Camera (8) is active. 

The bug does not exist for the Web page version.

The cause is that on the first open (with free roam camera), `Owner.Viewer.Camera.AttachedCar` is null.

PS: The code in the affected block would benefit from some simplifications. But that is deferred to later.